### PR TITLE
store: add cache-control and etag handling

### DIFF
--- a/Documentation/getting-started-guide.md
+++ b/Documentation/getting-started-guide.md
@@ -152,3 +152,4 @@ Open a new terminal and run the following command:
 $ curl 127.0.0.1:5000
 hello
 ```
+

--- a/cas/cache_control.go
+++ b/cas/cache_control.go
@@ -1,70 +1,63 @@
 package cas
 
 import (
-    "time"
-    "strings"
-    "strconv"
-    )
+	"strconv"
+	"strings"
+	"time"
+)
 
 type CacheControl struct {
-    // MaxAge<0 means don't use cached image, equivalently 'Max-Age: 0'
-    // MaxAge>0 means Max-Age attribute present and given in seconds
-    // MaxAge=0 means no 'Max-Age' attribute specified.
-    MaxAge    int
-    NoStore   bool
-    NoCache   bool
-    Freshness  time.Time
+	// MaxAge<=0 means don't use cached image, equivalently 'Max-Age: 0'
+	// MaxAge>0 means Max-Age attribute present and given in seconds
+	MaxAge     int
+	Downloaded time.Time
 }
 
 func NewCache(headerValue string) *CacheControl {
-    cc := &CacheControl{}
+	cc := &CacheControl{}
+	cc.Downloaded = time.Now()
+	cc.MaxAge = 0
 
-    cc.Freshness = time.Now()
-    cc.NoStore = false
-    cc.NoCache = false
-    cc.MaxAge = -1
+	if len(headerValue) > 0 {
+		parts := strings.Split(headerValue, " ")
+		for i := 0; i < len(parts); i++ {
+			attr, val := parts[i], ""
+			if j := strings.Index(attr, "="); j >= 0 {
+				attr, val = attr[:j], attr[j+1:]
+			}
+			lowerAttr := strings.ToLower(attr)
 
-    if len(headerValue) > 0 {
-      parts := strings.Split(headerValue, " ")
-      for i := 0; i < len(parts); i++ {
-        attr, val := parts[i], ""
-        if j := strings.Index(attr, "="); j >= 0 {
-          attr, val = attr[:j], attr[j+1:]
-        }
-        lowerAttr := strings.ToLower(attr)
-
-        switch lowerAttr {
-          case "no-store":
-            cc.NoStore = true
-            continue
-          case "no-cache":
-            cc.NoCache = true
-            continue
-          case "max-age":
-            secs, err := strconv.Atoi(val)
-            if err != nil || secs != 0 && val[0] == '0' {
-              break
-            }
-            if secs <= 0 {
-              cc.MaxAge = -1
-              cc.NoCache = true
-            } else {
-              cc.MaxAge = secs
-            }
-            continue
-        }
-      }
-    }
-    return cc
+			switch lowerAttr {
+			case "no-store":
+				cc.MaxAge = 0
+				continue
+			case "no-cache":
+				cc.MaxAge = 0
+				continue
+			case "max-age":
+				secs, err := strconv.Atoi(val)
+				if err != nil || secs != 0 && val[0] == '0' {
+					break
+				}
+				if secs <= 0 {
+					cc.MaxAge = 0
+				} else {
+					cc.MaxAge = secs
+				}
+				continue
+			}
+		}
+	}
+	return cc
 }
 
 func (cc CacheControl) UseCachedImage() bool {
-    // Return True if a valid image exists in the cache, otherwise
-    // return False.
-    freshnessLifetime := int(time.Now().Sub(cc.Freshness).Seconds())
-    if ((cc.MaxAge > -1 && freshnessLifetime < cc.MaxAge) && !cc.NoStore && !cc.NoCache) {
-        return true
-    }
+	// Return True if a valid image exists in the cache, otherwise
+	// return False.
+	freshnessLifetime := int(time.Now().Sub(cc.Downloaded).Seconds())
+	if cc.MaxAge > 0 && freshnessLifetime < cc.MaxAge {
+		return true
+	}
 
-    return false
+	return false
 }

--- a/cas/cache_control.go
+++ b/cas/cache_control.go
@@ -1,0 +1,70 @@
+package cas
+
+import (
+    "time"
+    "strings"
+    "strconv"
+    )
+
+type CacheControl struct {
+    // MaxAge<0 means don't use cached image, equivalently 'Max-Age: 0'
+    // MaxAge>0 means Max-Age attribute present and given in seconds
+    // MaxAge=0 means no 'Max-Age' attribute specified.
+    MaxAge    int
+    NoStore   bool
+    NoCache   bool
+    Freshness  time.Time
+}
+
+func NewCache(headerValue string) *CacheControl {
+    cc := &CacheControl{}
+
+    cc.Freshness = time.Now()
+    cc.NoStore = false
+    cc.NoCache = false
+    cc.MaxAge = -1
+
+    if len(headerValue) > 0 {
+      parts := strings.Split(headerValue, " ")
+      for i := 0; i < len(parts); i++ {
+        attr, val := parts[i], ""
+        if j := strings.Index(attr, "="); j >= 0 {
+          attr, val = attr[:j], attr[j+1:]
+        }
+        lowerAttr := strings.ToLower(attr)
+
+        switch lowerAttr {
+          case "no-store":
+            cc.NoStore = true
+            continue
+          case "no-cache":
+            cc.NoCache = true
+            continue
+          case "max-age":
+            secs, err := strconv.Atoi(val)
+            if err != nil || secs != 0 && val[0] == '0' {
+              break
+            }
+            if secs <= 0 {
+              cc.MaxAge = -1
+              cc.NoCache = true
+            } else {
+              cc.MaxAge = secs
+            }
+            continue
+        }
+      }
+    }
+    return cc
+}
+
+func (cc CacheControl) UseCachedImage() bool {
+    // Return True if a valid image exists in the cache, otherwise
+    // return False.
+    freshnessLifetime := int(time.Now().Sub(cc.Freshness).Seconds())
+    if ((cc.MaxAge > -1 && freshnessLifetime < cc.MaxAge) && !cc.NoStore && !cc.NoCache) {
+        return true
+    }
+
+    return false
+}

--- a/cas/cache_control_test.go
+++ b/cas/cache_control_test.go
@@ -1,76 +1,28 @@
 package cas
 
 import (
-  "io/ioutil"
-  "os"
-  "testing"
-  "time"
-
-  "github.com/coreos/rocket/cas"
-  )
-
-const tstprefix = "cache-test"
-const tstremote = "https://github.com/coreos/etcd/releases/download/v0.5.0-alpha.4/etcd-v0.5.0-alpha.4-linux-amd64.aci"
+	"testing"
+	"time"
+)
 
 func TestCacheControl(t *testing.T) {
-  cc1 := NewCache("max-age=10 no-cache no-store")
-  if !cc1.NoStore {
-    t.Errorf("expected a no-store header argument for cache-control")
-  }
-  if !cc1.NoCache {
-    t.Errorf("expected a no-cache header argument for cache-control")
-  }
-  if cc1.MaxAge != 10 {
-    t.Errorf("expected max-age header argument for cache-control")
-  }
+	cc1 := NewCache("max-age=10")
+	if cc1.MaxAge != 10 {
+		t.Errorf("expected max-age header argument for cache-control")
+	}
+	cc1 = NewCache("no-cache")
+	if cc1.MaxAge != 0 {
+		t.Errorf("expected max-age to be 0")
+	}
+	cc1 = NewCache("no-store")
+	if cc1.MaxAge != 0 {
+		t.Errorf("expected max-age to be 0")
+	}
 
-  cc2 := NewCache("max-age=10")
-  // Sleep during 11 seconds
-  time.Sleep(11000 * time.Millisecond)
-  if cc2.UseCachedImage() {
-    t.Errorf("expected max-age header argument to be expired after sleep time")
-  }
-  if cc2.NoStore {
-    t.Errorf("unexpected a no-store header argument to be false")
-  }
-  if cc2.NoCache {
-    t.Errorf("unexpected a no-cache header argument to be false")
-  }
-}
-
-func TestImageCacheControl(t *testing.T) {
-  dir, err := ioutil.TempDir("", tstprefix)
-  if err != nil {
-    t.Fatalf("error creating tempdir: %v", err)
-  }
-  defer os.RemoveAll(dir)
-  ds := NewStore(dir)
-
-  rem := NewRemote("wrongEndpoint", []string{})
-  rem, err = rem.Download(*ds)
-  if rem != nil && err == nil {
-    t.Fatalf("expected error when downloading an image")
-  }
-
-  rem = NewRemote(tstremote, []string{})
-  rem, err = rem.Download(*ds)
-  if err != nil {
-    t.Fatalf("Error downloading: %v\n", err)
-  }
-
-  if rem.ETag == "" {
-    t.Errorf("expected remote to have a ETag header argument")
-  }
-  if rem.Blob == "" {
-    t.Errorf("expected remote to download an image")
-  }
-  if rem.CacheControl.NoStore {
-    t.Errorf("expected a no-store header argument to be false")
-  }
-  if rem.CacheControl.NoCache {
-    t.Errorf("expected a no-cache header argument to be false")
-  }
-  if rem.CacheControl.MaxAge <= 0 {
-    t.Errorf("expected max-age header argument to be greater than 0")
-  }
+	cc1 = NewCache("max-age=10")
+	// Sleep during 11 seconds
+	time.Sleep(11000 * time.Millisecond)
+	if cc1.UseCachedImage() {
+		t.Errorf("expected max-age header argument to be expired after sleep time")
+	}
 }

--- a/cas/cache_control_test.go
+++ b/cas/cache_control_test.go
@@ -1,0 +1,76 @@
+package cas
+
+import (
+  "io/ioutil"
+  "os"
+  "testing"
+  "time"
+
+  "github.com/coreos/rocket/cas"
+  )
+
+const tstprefix = "cache-test"
+const tstremote = "https://github.com/coreos/etcd/releases/download/v0.5.0-alpha.4/etcd-v0.5.0-alpha.4-linux-amd64.aci"
+
+func TestCacheControl(t *testing.T) {
+  cc1 := NewCache("max-age=10 no-cache no-store")
+  if !cc1.NoStore {
+    t.Errorf("expected a no-store header argument for cache-control")
+  }
+  if !cc1.NoCache {
+    t.Errorf("expected a no-cache header argument for cache-control")
+  }
+  if cc1.MaxAge != 10 {
+    t.Errorf("expected max-age header argument for cache-control")
+  }
+
+  cc2 := NewCache("max-age=10")
+  // Sleep during 11 seconds
+  time.Sleep(11000 * time.Millisecond)
+  if cc2.UseCachedImage() {
+    t.Errorf("expected max-age header argument to be expired after sleep time")
+  }
+  if cc2.NoStore {
+    t.Errorf("unexpected a no-store header argument to be false")
+  }
+  if cc2.NoCache {
+    t.Errorf("unexpected a no-cache header argument to be false")
+  }
+}
+
+func TestImageCacheControl(t *testing.T) {
+  dir, err := ioutil.TempDir("", tstprefix)
+  if err != nil {
+    t.Fatalf("error creating tempdir: %v", err)
+  }
+  defer os.RemoveAll(dir)
+  ds := NewStore(dir)
+
+  rem := NewRemote("wrongEndpoint", []string{})
+  rem, err = rem.Download(*ds)
+  if rem != nil && err == nil {
+    t.Fatalf("expected error when downloading an image")
+  }
+
+  rem = NewRemote(tstremote, []string{})
+  rem, err = rem.Download(*ds)
+  if err != nil {
+    t.Fatalf("Error downloading: %v\n", err)
+  }
+
+  if rem.ETag == "" {
+    t.Errorf("expected remote to have a ETag header argument")
+  }
+  if rem.Blob == "" {
+    t.Errorf("expected remote to download an image")
+  }
+  if rem.CacheControl.NoStore {
+    t.Errorf("expected a no-store header argument to be false")
+  }
+  if rem.CacheControl.NoCache {
+    t.Errorf("expected a no-cache header argument to be false")
+  }
+  if rem.CacheControl.MaxAge <= 0 {
+    t.Errorf("expected max-age header argument to be greater than 0")
+  }
+}

--- a/cas/cas_test.go
+++ b/cas/cas_test.go
@@ -206,6 +206,7 @@ func TestGetAci(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 	ds, err := NewStore(dir)
+
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -346,9 +347,9 @@ func TestTreeStore(t *testing.T) {
 
 	imj := `
 		{
-		    "acKind": "ImageManifest",
-		    "acVersion": "0.5.1",
-		    "name": "example.com/test01"
+				"acKind": "ImageManifest",
+				"acVersion": "0.5.1",
+				"name": "example.com/test01"
 		}
 	`
 
@@ -449,5 +450,4 @@ func TestTreeStore(t *testing.T) {
 	if err == nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
 }

--- a/cas/remote.go
+++ b/cas/remote.go
@@ -12,61 +12,224 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package cas implements a content-addressable-store on disk.
-// It leverages the `diskv` package to store items in a simple
-// key-value blob store: https://github.com/peterbourgon/diskv
 package cas
 
-import "database/sql"
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
 
-func NewRemote(aciurl, sigurl string) *Remote {
-	r := &Remote{
-		ACIURL: aciurl,
-		SigURL: sigurl,
+	"github.com/coreos/rocket/pkg/keystore"
+
+	"github.com/appc/spec/aci"
+	"github.com/appc/spec/schema/types"
+	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/mitchellh/ioprogress"
+	"github.com/coreos/rocket/Godeps/_workspace/src/golang.org/x/crypto/openpgp"
+	)
+
+	func NewRemote(aciurl, sigurl string) *Remote {
+		r := &Remote{
+			ACIURL: aciurl,
+			SigURL: sigurl,
+		}
+		return r
 	}
-	return r
-}
 
-type Remote struct {
-	ACIURL string
-	SigURL string
-	ETag   string
-	// The key in the blob store under which the ACI has been saved.
-	BlobKey string
-}
-
-// GetRemote tries to retrieve a remote with the given aciURL. found will be
-// false if remote doesn't exist.
-func GetRemote(tx *sql.Tx, aciURL string) (remote *Remote, found bool, err error) {
-	remote = &Remote{}
-	rows, err := tx.Query("SELECT sigurl, etag, blobkey FROM remote WHERE aciurl == $1", aciURL)
-	if err != nil {
-		return nil, false, err
+	type Remote struct {
+		ACIURL string
+		SigURL string
+		ETag   string
+		// The key in the blob store under which the ACI has been saved.
+		BlobKey string
 	}
-	for rows.Next() {
-		found = true
-		if err := rows.Scan(&remote.SigURL, &remote.ETag, &remote.BlobKey); err != nil {
-			return nil, false, err
+
+	func (r Remote) Marshal() []byte {
+		m, _ := json.Marshal(r)
+		return m
+	}
+
+	func (r *Remote) Unmarshal(data []byte) {
+		err := json.Unmarshal(data, r)
+		if err != nil {
+			panic(err)
 		}
 	}
-	if err := rows.Err(); err != nil {
-		return nil, false, err
+
+	func (r Remote) Hash() string {
+		return types.NewHashSHA512([]byte(r.ACIURL)).String()
 	}
 
-	return remote, found, err
+	func (r Remote) Type() int64 {
+		return remoteType
+	}
+
+	// Download downloads and verifies the remote ACI.
+	// If Keystore is nil signature verification will be skipped.
+	// Download returns the signer, an *os.File representing the ACI, and an error if any.
+	// err will be nil if the ACI downloads successfully and the ACI is verified.
+	func (r Remote) Download(ds Store, ks *keystore.Keystore) (*openpgp.Entity, *os.File, error) {
+		var entity *openpgp.Entity
+		var err error
+		acif, err := downloadACI(ds, r.ACIURL)
+		if err != nil {
+			return nil, acif, fmt.Errorf("error downloading the aci image: %v", err)
+		}
+
+		if ks != nil {
+			sigTempFile, err := downloadSignatureFile(r.SigURL)
+			if err != nil {
+				return nil, acif, fmt.Errorf("error downloading the signature file: %v", err)
+			}
+			defer sigTempFile.Close()
+			defer os.Remove(sigTempFile.Name())
+
+			manifest, err := aci.ManifestFromImage(acif)
+			if err != nil {
+				return nil, acif, err
+			}
+
+			if _, err := acif.Seek(0, 0); err != nil {
+				return nil, acif, err
+			}
+			if _, err := sigTempFile.Seek(0, 0); err != nil {
+				return nil, acif, err
+			}
+			if entity, err = ks.CheckSignature(manifest.Name.String(), acif, sigTempFile); err != nil {
+				return nil, acif, err
+			}
+		}
+
+		if _, err := acif.Seek(0, 0); err != nil {
+			return nil, acif, err
+		}
+		return entity, acif, nil
+	}
+
+
+// TODO: add locking
+// Store stores the ACI represented by r in the target data store.
+func (r Remote) Store(ds Store, aci io.Reader, latest bool) (*Remote, error) {
+	key, err := ds.WriteACI(aci, latest)
+	if err != nil {
+		return nil, err
+	}
+	r.BlobKey = key
+	err = ds.WriteRemote(&r)
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
 }
 
-// WriteRemote adds or updates the provided Remote.
-func WriteRemote(tx *sql.Tx, remote *Remote) error {
-	// ql doesn't have an INSERT OR UPDATE function so
-	// it's faster to remove and reinsert the row
-	_, err := tx.Exec("DELETE FROM remote WHERE aciurl == $1", remote.ACIURL)
-	if err != nil {
-		return err
-	}
-	_, err = tx.Exec("INSERT INTO remote VALUES ($1, $2, $3, $4)", remote.ACIURL, remote.SigURL, remote.ETag, remote.BlobKey)
-	if err != nil {
-		return err
-	}
-	return nil
+// downloadACI gets the aci specified at aciurl
+func downloadACI(ds Store, aciurl string) (*os.File, error) {
+	return downloadHTTP(aciurl, "ACI", ds.tmpFile)
 }
+
+// downloadSignatureFile gets the signature specified at sigurl
+func downloadSignatureFile(sigurl string) (*os.File, error) {
+	getTemp := func() (*os.File, error) {
+		return ioutil.TempFile("", "")
+	}
+
+	return downloadHTTP(sigurl, "signature", getTemp)
+}
+
+// downloadHTTP retrieves url, creating a temp file using getTempFile
+// file:// http:// and https:// urls supported
+func downloadHTTP(url, label string, getTempFile func() (*os.File, error)) (*os.File, error) {
+	tmp, err := getTempFile()
+	if err != nil {
+		return nil, fmt.Errorf("error downloading %s: %v", label, err)
+	}
+	defer func() {
+		if err != nil {
+			return nil, err
+		}
+		r.BlobKey = key
+		ds.WriteIndex(&r)
+		return &r, nil
+	}
+
+	func downloadACI(ds Store, aciurl string) (*os.File, error) {
+		res, err := http.Get(aciurl)
+		if err != nil {
+			return nil, err
+		}
+		defer res.Body.Close()
+
+		prefix := "Downloading aci"
+		fmtBytesSize := 18
+		barSize := int64(80 - len(prefix) - fmtBytesSize)
+		bar := ioprogress.DrawTextFormatBar(barSize)
+		fmtfunc := func(progress, total int64) string {
+			return fmt.Sprintf(
+				"%s: %s %s",
+				prefix,
+				bar(progress, total),
+				ioprogress.DrawTextFormatBytes(progress, total),
+				)
+			}
+
+			reader := &ioprogress.Reader{
+				Reader:       res.Body,
+				Size:         res.ContentLength,
+				DrawFunc:     ioprogress.DrawTerminalf(os.Stdout, fmtfunc),
+				DrawInterval: time.Second,
+			}
+
+			// TODO(jonboulle): handle http more robustly (redirects?)
+			if res.StatusCode != http.StatusOK {
+				return nil, fmt.Errorf("bad HTTP status code: %d", res.StatusCode)
+			}
+
+			aciTempFile, err := ds.tmpFile()
+			if err != nil {
+				return nil, fmt.Errorf("error downloading aci: %v", err)
+			}
+
+			if _, err := io.Copy(aciTempFile, reader); err != nil {
+				aciTempFile.Close()
+				os.Remove(aciTempFile.Name())
+				return nil, fmt.Errorf("error copying temp aci: %v", err)
+			}
+			if err := aciTempFile.Sync(); err != nil {
+				aciTempFile.Close()
+				os.Remove(aciTempFile.Name())
+				return nil, fmt.Errorf("error writing temp aci: %v", err)
+			}
+			return aciTempFile, nil
+		}
+
+		func downloadSignatureFile(sigurl string) (*os.File, error) {
+			sig, err := ioutil.TempFile("", "")
+			if err != nil {
+				return nil, fmt.Errorf("error downloading signature: %v", err)
+			}
+			res, err := http.Get(sigurl)
+			if err != nil {
+				return nil, fmt.Errorf("error downloading signature: %v", err)
+			}
+			defer res.Body.Close()
+
+			// TODO(jonboulle): handle http more robustly (redirects?)
+			if res.StatusCode != http.StatusOK {
+				return nil, fmt.Errorf("bad HTTP status code: %d", res.StatusCode)
+			}
+
+			if _, err := io.Copy(sig, res.Body); err != nil {
+				sig.Close()
+				os.Remove(sig.Name())
+				return nil, fmt.Errorf("error copying signature: %v", err)
+			}
+			if err := sig.Sync(); err != nil {
+				sig.Close()
+				os.Remove(sig.Name())
+				return nil, fmt.Errorf("error writing signature: %v", err)
+			}
+			return sig, nil
+		}

--- a/cas/remote.go
+++ b/cas/remote.go
@@ -12,224 +12,66 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package cas implements a content-addressable-store on disk.
+// It leverages the `diskv` package to store items in a simple
+// key-value blob store: https://github.com/peterbourgon/diskv
 package cas
 
-import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"os"
-	"time"
+import "database/sql"
 
-	"github.com/coreos/rocket/pkg/keystore"
-
-	"github.com/appc/spec/aci"
-	"github.com/appc/spec/schema/types"
-	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/mitchellh/ioprogress"
-	"github.com/coreos/rocket/Godeps/_workspace/src/golang.org/x/crypto/openpgp"
-	)
-
-	func NewRemote(aciurl, sigurl string) *Remote {
-		r := &Remote{
-			ACIURL: aciurl,
-			SigURL: sigurl,
-		}
-		return r
+func NewRemote(aciurl, sigurl string) *Remote {
+	r := &Remote{
+		ACIURL: aciurl,
+		SigURL: sigurl,
 	}
-
-	type Remote struct {
-		ACIURL string
-		SigURL string
-		ETag   string
-		// The key in the blob store under which the ACI has been saved.
-		BlobKey string
-	}
-
-	func (r Remote) Marshal() []byte {
-		m, _ := json.Marshal(r)
-		return m
-	}
-
-	func (r *Remote) Unmarshal(data []byte) {
-		err := json.Unmarshal(data, r)
-		if err != nil {
-			panic(err)
-		}
-	}
-
-	func (r Remote) Hash() string {
-		return types.NewHashSHA512([]byte(r.ACIURL)).String()
-	}
-
-	func (r Remote) Type() int64 {
-		return remoteType
-	}
-
-	// Download downloads and verifies the remote ACI.
-	// If Keystore is nil signature verification will be skipped.
-	// Download returns the signer, an *os.File representing the ACI, and an error if any.
-	// err will be nil if the ACI downloads successfully and the ACI is verified.
-	func (r Remote) Download(ds Store, ks *keystore.Keystore) (*openpgp.Entity, *os.File, error) {
-		var entity *openpgp.Entity
-		var err error
-		acif, err := downloadACI(ds, r.ACIURL)
-		if err != nil {
-			return nil, acif, fmt.Errorf("error downloading the aci image: %v", err)
-		}
-
-		if ks != nil {
-			sigTempFile, err := downloadSignatureFile(r.SigURL)
-			if err != nil {
-				return nil, acif, fmt.Errorf("error downloading the signature file: %v", err)
-			}
-			defer sigTempFile.Close()
-			defer os.Remove(sigTempFile.Name())
-
-			manifest, err := aci.ManifestFromImage(acif)
-			if err != nil {
-				return nil, acif, err
-			}
-
-			if _, err := acif.Seek(0, 0); err != nil {
-				return nil, acif, err
-			}
-			if _, err := sigTempFile.Seek(0, 0); err != nil {
-				return nil, acif, err
-			}
-			if entity, err = ks.CheckSignature(manifest.Name.String(), acif, sigTempFile); err != nil {
-				return nil, acif, err
-			}
-		}
-
-		if _, err := acif.Seek(0, 0); err != nil {
-			return nil, acif, err
-		}
-		return entity, acif, nil
-	}
-
-
-// TODO: add locking
-// Store stores the ACI represented by r in the target data store.
-func (r Remote) Store(ds Store, aci io.Reader, latest bool) (*Remote, error) {
-	key, err := ds.WriteACI(aci, latest)
-	if err != nil {
-		return nil, err
-	}
-	r.BlobKey = key
-	err = ds.WriteRemote(&r)
-	if err != nil {
-		return nil, err
-	}
-	return &r, nil
+	return r
 }
 
-// downloadACI gets the aci specified at aciurl
-func downloadACI(ds Store, aciurl string) (*os.File, error) {
-	return downloadHTTP(aciurl, "ACI", ds.tmpFile)
+type Remote struct {
+	ACIURL string
+	SigURL string
+	ETag   string
+	// The key in the blob store under which the ACI has been saved.
+	BlobKey      string
+	CacheControl *CacheControl
 }
 
-// downloadSignatureFile gets the signature specified at sigurl
-func downloadSignatureFile(sigurl string) (*os.File, error) {
-	getTemp := func() (*os.File, error) {
-		return ioutil.TempFile("", "")
-	}
-
-	return downloadHTTP(sigurl, "signature", getTemp)
-}
-
-// downloadHTTP retrieves url, creating a temp file using getTempFile
-// file:// http:// and https:// urls supported
-func downloadHTTP(url, label string, getTempFile func() (*os.File, error)) (*os.File, error) {
-	tmp, err := getTempFile()
+// GetRemote tries to retrieve a remote with the given aciURL. found will be
+// false if remote doesn't exist.
+func GetRemote(tx *sql.Tx, aciURL string) (remote *Remote, found bool, err error) {
+	remote = &Remote{}
+	rows, err := tx.Query("SELECT sigurl, etag, blobkey, maxage, downloaded FROM remote WHERE aciurl == $1", aciURL)
 	if err != nil {
-		return nil, fmt.Errorf("error downloading %s: %v", label, err)
+		return nil, false, err
 	}
-	defer func() {
-		if err != nil {
-			return nil, err
+	for rows.Next() {
+		found = true
+		cc := &CacheControl{}
+		if err := rows.Scan(&remote.SigURL, &remote.ETag, &remote.BlobKey, &cc.MaxAge, &cc.Downloaded); err != nil {
+			return nil, false, err
 		}
-		r.BlobKey = key
-		ds.WriteIndex(&r)
-		return &r, nil
+		remote.CacheControl = cc
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
 	}
 
-	func downloadACI(ds Store, aciurl string) (*os.File, error) {
-		res, err := http.Get(aciurl)
+	return remote, found, err
+}
+
+// WriteRemote adds or updates the provided Remote.
+func WriteRemote(tx *sql.Tx, remote *Remote) error {
+	// ql doesn't have an INSERT OR UPDATE function so
+	// it's faster to remove and reinsert the row
+	_, err := tx.Exec("DELETE FROM remote WHERE aciurl == $1", remote.ACIURL)
+	if err != nil {
+		return err
+	}
+	if remote.CacheControl != nil {
+		_, err = tx.Exec("INSERT INTO remote VALUES ($1, $2, $3, $4, $5, $6)", remote.ACIURL, remote.SigURL, remote.ETag, remote.BlobKey, remote.CacheControl.MaxAge, remote.CacheControl.Downloaded)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		defer res.Body.Close()
-
-		prefix := "Downloading aci"
-		fmtBytesSize := 18
-		barSize := int64(80 - len(prefix) - fmtBytesSize)
-		bar := ioprogress.DrawTextFormatBar(barSize)
-		fmtfunc := func(progress, total int64) string {
-			return fmt.Sprintf(
-				"%s: %s %s",
-				prefix,
-				bar(progress, total),
-				ioprogress.DrawTextFormatBytes(progress, total),
-				)
-			}
-
-			reader := &ioprogress.Reader{
-				Reader:       res.Body,
-				Size:         res.ContentLength,
-				DrawFunc:     ioprogress.DrawTerminalf(os.Stdout, fmtfunc),
-				DrawInterval: time.Second,
-			}
-
-			// TODO(jonboulle): handle http more robustly (redirects?)
-			if res.StatusCode != http.StatusOK {
-				return nil, fmt.Errorf("bad HTTP status code: %d", res.StatusCode)
-			}
-
-			aciTempFile, err := ds.tmpFile()
-			if err != nil {
-				return nil, fmt.Errorf("error downloading aci: %v", err)
-			}
-
-			if _, err := io.Copy(aciTempFile, reader); err != nil {
-				aciTempFile.Close()
-				os.Remove(aciTempFile.Name())
-				return nil, fmt.Errorf("error copying temp aci: %v", err)
-			}
-			if err := aciTempFile.Sync(); err != nil {
-				aciTempFile.Close()
-				os.Remove(aciTempFile.Name())
-				return nil, fmt.Errorf("error writing temp aci: %v", err)
-			}
-			return aciTempFile, nil
-		}
-
-		func downloadSignatureFile(sigurl string) (*os.File, error) {
-			sig, err := ioutil.TempFile("", "")
-			if err != nil {
-				return nil, fmt.Errorf("error downloading signature: %v", err)
-			}
-			res, err := http.Get(sigurl)
-			if err != nil {
-				return nil, fmt.Errorf("error downloading signature: %v", err)
-			}
-			defer res.Body.Close()
-
-			// TODO(jonboulle): handle http more robustly (redirects?)
-			if res.StatusCode != http.StatusOK {
-				return nil, fmt.Errorf("bad HTTP status code: %d", res.StatusCode)
-			}
-
-			if _, err := io.Copy(sig, res.Body); err != nil {
-				sig.Close()
-				os.Remove(sig.Name())
-				return nil, fmt.Errorf("error copying signature: %v", err)
-			}
-			if err := sig.Sync(); err != nil {
-				sig.Close()
-				os.Remove(sig.Name())
-				return nil, fmt.Errorf("error writing signature: %v", err)
-			}
-			return sig, nil
-		}
+	}
+	return nil
+}

--- a/cas/remote_test.go
+++ b/cas/remote_test.go
@@ -39,6 +39,7 @@ func TestNewRemote(t *testing.T) {
 	// Create our first Remote, and simulate Store() to create row in the table
 	na := NewRemote(u1, "")
 	na.BlobKey = data
+	na.CacheControl = NewCache("max-age=10")
 	ds.WriteRemote(na)
 
 	// Get a new remote w the same parameters, reading from table should be fine

--- a/cas/schema.go
+++ b/cas/schema.go
@@ -17,7 +17,7 @@ var dbCreateStmts = [...]string{
 	fmt.Sprintf("INSERT INTO version VALUES (%d)", dbVersion),
 
 	// remote table. The primary key is "aciurl".
-	"CREATE TABLE IF NOT EXISTS remote (aciurl string, sigurl string, etag string, blobkey string);",
+	"CREATE TABLE IF NOT EXISTS remote (aciurl string, sigurl string, etag string, blobkey string, maxage int, downloaded time);",
 	"CREATE UNIQUE INDEX IF NOT EXISTS aciurlidx ON remote (aciurl)",
 
 	// aciinfo table. The primary key is "blobkey" and it matches the key used to save that aci in the blob store

--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -1,17 +1,3 @@
-// Copyright 2014 CoreOS, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package main
 
 import (

--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -199,7 +199,6 @@ func TestDownloading(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
-		rem := cas.NewRemote(tt.ACIURL, tt.SigURL)
 		rem.BlobKey = key
 		err = ds.WriteRemote(rem)
 		if err != nil {

--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -34,6 +35,10 @@ import (
 
 	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/discovery"
 	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+const (
+	StatusNotModified = 304
 )
 
 func TestNewDiscoveryApp(t *testing.T) {
@@ -183,7 +188,8 @@ func TestDownloading(t *testing.T) {
 		if tt.hit == true && !ok {
 			t.Fatalf("expected a hit got a miss")
 		}
-		_, aciFile, err := download(tt.ACIURL, tt.SigURL, ds, nil)
+		rem := cas.NewRemote(tt.ACIURL, tt.SigURL)
+		_, aciFile, _, err := download(rem, ds, nil)
 		if err != nil {
 			t.Fatalf("error downloading aci: %v", err)
 		}
@@ -263,6 +269,109 @@ func TestFetchImage(t *testing.T) {
 	_, err = fetchImage(fmt.Sprintf("%s/app.aci", ts.URL), ds, ks, true)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+}
+
+func TestFetchImageCache(t *testing.T) {
+	dir, err := ioutil.TempDir("", "fetch-image-cache")
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds, err := cas.NewStore(dir)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	defer ds.Dump(false)
+
+	ks, ksPath, err := keystore.NewTestKeystore()
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	defer os.RemoveAll(ksPath)
+
+	key := keystoretest.KeyMap["example.com/app"]
+	if _, err := ks.StoreTrustedKeyPrefix("example.com/app", bytes.NewBufferString(key.ArmoredPublicKey)); err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	a, err := aci.NewBasicACI(dir, "example.com/app")
+	defer a.Close()
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	// Rewind the ACI
+	if _, err := a.Seek(0, 0); err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	sig, err := aci.NewDetachedSignature(key.ArmoredPrivateKey, a)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	// Rewind the ACI.
+	if _, err := a.Seek(0, 0); err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch filepath.Ext(r.URL.Path) {
+		case ".aci":
+			w.Header().Set("Cache-Control", "max-age=10")
+			w.Header().Set("ETag", "123456789")
+			if cc := r.Header.Get("If-None-Match"); cc == "123456789" {
+				w.WriteHeader(StatusNotModified)
+			} else {
+				io.Copy(w, a)
+			}
+			return
+		case ".sig":
+			io.Copy(w, sig)
+			return
+		}
+	}))
+	defer ts.Close()
+
+	urlRemote, _ := url.Parse(fmt.Sprintf("%s/app.aci", ts.URL))
+	blobKey, err := downloadImage(urlRemote.String(), ascURLFromImgURL(urlRemote.String()), "", ds, nil, true)
+	if err != nil {
+		t.Fatalf("Error downloading image from: %v\n", err)
+	}
+	if blobKey == "" {
+		t.Errorf("expected remote to download an image")
+	}
+	// Recover Remote information for validation
+	rem, _, err := ds.GetRemote(urlRemote.String())
+	if err != nil {
+		t.Fatalf("Error getting remote info: %v\n", err)
+	}
+	if rem.ETag != "123456789" {
+		t.Errorf("expected remote to have a ETag header argument")
+	}
+	if rem.CacheControl.MaxAge != 10 {
+		t.Errorf("expected max-age header argument to be '10'")
+	}
+
+	// Test download of a cached image when using If-None-Match header
+	cachedBlobKey := rem.BlobKey
+	rem.BlobKey, err = downloadImage(urlRemote.String(), ascURLFromImgURL(urlRemote.String()), "", ds, ks, true)
+	if err != nil {
+		t.Fatalf("Error downloading image from %s: %v\n", ts.URL, err)
+	}
+	if rem.BlobKey != cachedBlobKey {
+		t.Errorf("expected remote to download an image")
+	}
+	// Recover Remote information for validation
+	rem, _, err = ds.GetRemote(urlRemote.String())
+	if err != nil {
+		t.Fatalf("Error getting remote info: %v\n", err)
+	}
+	if rem.ETag != "123456789" {
+		t.Errorf("expected remote to have a ETag header argument")
+	}
+	if rem.CacheControl.MaxAge != 10 {
+		t.Errorf("expected max-age header argument to be '10'")
 	}
 }
 


### PR DESCRIPTION
Essentially this PR extracts the Cache-Control and ETag headers and store them in the remote object. Then if we execute a fetch or run command, this implementation checks whether the image needs to be updated based on the Cache-Control stored info, and if so it fetches a new version from the URL.

TODO:  Test If-None-Match HTTP requests works as expected against a server side that handles ETags.

Fixes  #199 