### PR TITLE
rkt: do simple discovery before meta discovery.

### DIFF
--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -70,15 +70,18 @@ func runFetch(args []string) (exit int) {
 // fetchImage will take an image as either a URL or a name string and import it
 // into the store if found.
 func fetchImage(img string, ds *cas.Store, ks *keystore.Keystore) (string, error) {
+	if globalFlags.InsecureSkipVerify {
+		fmt.Printf("rkt: warning: signature verification has been disabled\n")
+	}
 	u, err := url.Parse(img)
 	if err == nil && u.Scheme == "" {
 		if app := newDiscoveryApp(img); app != nil {
 			fmt.Printf("rkt: starting to discover app img %s\n", img)
-			ep, err := discovery.DiscoverEndpoints(*app, true)
+			eps, err := discovery.DiscoverEndpoints(*app, true)
 			if err != nil {
 				return "", err
 			}
-			return fetchImageFromEndpoints(ep, ds, ks)
+			return fetchImageFromEndpoints(eps, ds, ks)
 		}
 	}
 	if err != nil {
@@ -90,9 +93,16 @@ func fetchImage(img string, ds *cas.Store, ks *keystore.Keystore) (string, error
 	return fetchImageFromURL(u.String(), ds, ks)
 }
 
-func fetchImageFromEndpoints(ep *discovery.Endpoints, ds *cas.Store, ks *keystore.Keystore) (string, error) {
-	rem := cas.NewRemote(ep.ACIEndpoints[0].ACI, ep.ACIEndpoints[0].Sig)
-	return downloadImage(rem, ds, ks)
+func fetchImageFromEndpoints(eps *discovery.Endpoints, ds *cas.Store, ks *keystore.Keystore) (string, error) {
+	for i := 0; i < len(eps.ACIEndpoints); i++ {
+		rem := cas.NewRemote(eps.ACIEndpoints[i].ACI, eps.ACIEndpoints[i].Sig)
+		if blobkey, err := downloadImage(rem, ds, ks); err != nil {
+			fmt.Printf("rkt: failed to fetch image from url %q: %v\n", eps.ACIEndpoints[i].ACI, err)
+		} else {
+			return blobkey, nil
+		}
+	}
+	return "", fmt.Errorf("image fetching failed")
 }
 
 func fetchImageFromURL(imgurl string, ds *cas.Store, ks *keystore.Keystore) (string, error) {
@@ -102,9 +112,6 @@ func fetchImageFromURL(imgurl string, ds *cas.Store, ks *keystore.Keystore) (str
 
 func downloadImage(rem *cas.Remote, ds *cas.Store, ks *keystore.Keystore) (string, error) {
 	fmt.Printf("rkt: starting to fetch img from %s\n", rem.ACIURL)
-	if globalFlags.InsecureSkipVerify {
-		fmt.Printf("rkt: warning: signature verification has been disabled\n")
-	}
 	err := ds.ReadIndex(rem)
 	if err != nil && rem.BlobKey == "" {
 		entity, aciFile, err := rem.Download(*ds, ks)

--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -91,7 +91,7 @@ func fetchImage(img string, ds *cas.Store, ks *keystore.Keystore) (string, error
 }
 
 func fetchImageFromEndpoints(ep *discovery.Endpoints, ds *cas.Store, ks *keystore.Keystore) (string, error) {
-	rem := cas.NewRemote(ep.ACI[0], ep.Sig[0])
+	rem := cas.NewRemote(ep.ACIEndpoints[0].ACI, ep.ACIEndpoints[0].Sig)
 	return downloadImage(rem, ds, ks)
 }
 

--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -110,32 +110,33 @@ func TestFetchImage(t *testing.T) {
 
 	ks, ksPath, err := keystore.NewTestKeystore()
 	if err != nil {
-		t.Errorf("unexpected error %v", err)
+		t.Errorf("unexpected error: %v", err)
 	}
 	defer os.RemoveAll(ksPath)
 
 	key := keystoretest.KeyMap["example.com/app"]
 	if _, err := ks.StoreTrustedKeyPrefix("example.com/app", bytes.NewBufferString(key.ArmoredPublicKey)); err != nil {
-		t.Fatalf("unexpected error %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	aci, err := util.NewACI("example.com/app")
 	if err != nil {
-		t.Fatalf("unexpected error %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
+	defer aci.Close()
 
 	// Rewind the ACI
 	if _, err := aci.Seek(0, 0); err != nil {
-		t.Fatalf("unexpected error %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	sig, err := util.NewDetachedSignature(key.ArmoredPrivateKey, aci)
 	if err != nil {
-		t.Fatalf("unexpected error %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Rewind the ACI.
 	if _, err := aci.Seek(0, 0); err != nil {
-		t.Fatalf("unexpected error %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -151,7 +152,97 @@ func TestFetchImage(t *testing.T) {
 	defer ts.Close()
 	_, err = fetchImage(fmt.Sprintf("%s/app.aci", ts.URL), ds, ks)
 	if err != nil {
-		t.Fatalf("unexpected error %v", err)
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFetchImageFromEndpoints(t *testing.T) {
+	dir, err := ioutil.TempDir("", "fetch-image")
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds := cas.NewStore(dir)
+	defer ds.Dump(false)
+
+	ks, ksPath, err := keystore.NewTestKeystore()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer os.RemoveAll(ksPath)
+
+	key := keystoretest.KeyMap["example.com/app"]
+	if _, err := ks.StoreTrustedKeyPrefix("example.com/app", bytes.NewBufferString(key.ArmoredPublicKey)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	aci, err := util.NewACI("example.com/app")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer aci.Close()
+
+	// Rewind the ACI
+	if _, err := aci.Seek(0, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sig, err := util.NewDetachedSignature(key.ArmoredPrivateKey, aci)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Rewind the ACI.
+	if _, err := aci.Seek(0, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/existingaci.aci":
+			io.Copy(w, aci)
+			return
+		case "/existingaci.sig":
+			io.Copy(w, sig)
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer ts.Close()
+	eps := &discovery.Endpoints{
+		ACIEndpoints: []discovery.ACIEndpoint{
+			discovery.ACIEndpoint{
+				ACI: fmt.Sprintf("%s/notexistingaci.aci", ts.URL),
+				Sig: fmt.Sprintf("%s/notexistingaci.sig", ts.URL),
+			},
+			discovery.ACIEndpoint{
+				ACI: fmt.Sprintf("%s/existingaci.aci", ts.URL),
+				Sig: fmt.Sprintf("%s/existingaci.sig", ts.URL),
+			},
+		},
+	}
+	_, err = fetchImageFromEndpoints(eps, ds, ks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Test missing images
+	eps = &discovery.Endpoints{
+		ACIEndpoints: []discovery.ACIEndpoint{
+			discovery.ACIEndpoint{
+				ACI: fmt.Sprintf("%s/notexistingaci.aci", ts.URL),
+				Sig: fmt.Sprintf("%s/notexistingaci.sig", ts.URL),
+			},
+			discovery.ACIEndpoint{
+				ACI: fmt.Sprintf("%s/notexistingaci2.aci", ts.URL),
+				Sig: fmt.Sprintf("%s/notexistingaci2.sig", ts.URL),
+			},
+		},
+	}
+	_, err = fetchImageFromEndpoints(eps, ds, ks)
+	if err == nil {
+		t.Fatalf("expected error fetching from endpoints")
 	}
 }
 


### PR DESCRIPTION
Last patch is the interesting one (the previous one is provided #382)

This patch should be committed together with appc/spec#118.

It generates discovery endpoints trying first simplediscovery and then metadiscovery. It reports a message if simple or meta discovery returns an error.
