### PR TITLE
rkt: add command to list images in the store.

### DIFF
--- a/rkt/imageslist.go
+++ b/rkt/imageslist.go
@@ -1,0 +1,223 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/coreos/rkt/store"
+)
+
+const (
+	defaultTimeLayout = "2006-01-02 15:04:05.999 -0700 MST"
+
+	keyField        = "key"
+	appNameField    = "appname"
+	importTimeField = "importtime"
+	latestField     = "latest"
+)
+
+var (
+	// map of valid fields and related flag value
+	imagesAllFields = map[string]struct{}{
+		keyField:        struct{}{},
+		appNameField:    struct{}{},
+		importTimeField: struct{}{},
+		latestField:     struct{}{},
+	}
+
+	// map of valid fields and related header name
+	ImagesFieldHeaderMap = map[string]string{
+		keyField:        "KEY",
+		appNameField:    "APPNAME",
+		importTimeField: "IMPORTTIME",
+		latestField:     "LATEST",
+	}
+
+	// map of valid sort fields containing the mapping between the provided field name
+	// and the related aciinfo's field name.
+	ImagesFieldAciInfoMap = map[string]string{
+		keyField:        "blobkey",
+		appNameField:    "appname",
+		importTimeField: "importtime",
+		latestField:     "latest",
+	}
+
+	ImagesSortableFields = map[string]struct{}{
+		appNameField:    struct{}{},
+		importTimeField: struct{}{},
+	}
+)
+
+type ImagesFields []string
+
+func (ifs *ImagesFields) Set(s string) error {
+	*ifs = []string{}
+	fields := strings.Split(s, ",")
+	seen := map[string]struct{}{}
+	for _, f := range fields {
+		// accept any case
+		f = strings.ToLower(f)
+		_, ok := imagesAllFields[f]
+		if !ok {
+			return fmt.Errorf("unknown field %q", f)
+		}
+		if _, ok := seen[f]; ok {
+			return fmt.Errorf("duplicated field %q", f)
+		}
+		*ifs = append(*ifs, f)
+		seen[f] = struct{}{}
+	}
+
+	return nil
+}
+
+func (ifs *ImagesFields) String() string {
+	return strings.Join(*ifs, ",")
+}
+
+type ImagesSortFields []string
+
+func (isf *ImagesSortFields) Set(s string) error {
+	*isf = []string{}
+	fields := strings.Split(s, ",")
+	seen := map[string]struct{}{}
+	for _, f := range fields {
+		// accept any case
+		f = strings.ToLower(f)
+		_, ok := ImagesSortableFields[f]
+		if !ok {
+			return fmt.Errorf("unknown field %q", f)
+		}
+		if _, ok := seen[f]; ok {
+			return fmt.Errorf("duplicated field %q", f)
+		}
+		*isf = append(*isf, f)
+		seen[f] = struct{}{}
+	}
+
+	return nil
+}
+
+func (isf *ImagesSortFields) String() string {
+	return strings.Join(*isf, ",")
+}
+
+type ImagesSortAsc bool
+
+func (isa *ImagesSortAsc) Set(s string) error {
+	switch s {
+	case "asc":
+		*isa = true
+	case "desc":
+		*isa = false
+	default:
+		return fmt.Errorf("wrong sort order")
+	}
+	return nil
+}
+
+func (isa *ImagesSortAsc) String() string {
+	if *isa {
+		return "asc"
+	}
+	return "desc"
+}
+
+var (
+	cmdImages = &Command{
+		Name:    "images",
+		Summary: "List images in the local store",
+		Usage:   "",
+		Run:     runImages,
+		Flags:   &imagesFlags,
+	}
+	imagesFlags          flag.FlagSet
+	flagImagesFields     ImagesFields
+	flagImagesSortFields ImagesSortFields
+	flagImagesSortAsc    ImagesSortAsc
+)
+
+func init() {
+	// Set defaults
+	flagImagesFields = []string{keyField, appNameField, importTimeField, latestField}
+	flagImagesSortFields = []string{importTimeField}
+	flagImagesSortAsc = true
+
+	commands = append(commands, cmdImages)
+	imagesFlags.Var(&flagImagesFields, "fields", `comma separated list of fields to display. Accepted values: "key", "appname", "importtime", "latest"`)
+	imagesFlags.Var(&flagImagesSortFields, "sort", `sort the output according to the provided comma separated list of fields. Accepted valies: "appname", "importtime"`)
+	imagesFlags.Var(&flagImagesSortAsc, "order", `choose the sorting order if at least one sort field is provided (--sort). Accepted values: "asc", "desc"`)
+	imagesFlags.BoolVar(&flagNoLegend, "no-legend", false, "suppress a legend with the list")
+}
+
+func runImages(args []string) (exit int) {
+	if !flagNoLegend {
+		headerFields := []string{}
+		for _, f := range flagImagesFields {
+			headerFields = append(headerFields, ImagesFieldHeaderMap[f])
+		}
+		fmt.Fprintf(tabOut, "%s\n", strings.Join(headerFields, "\t"))
+	}
+
+	s, err := store.NewStore(globalFlags.Dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fetch: cannot open store: %v\n", err)
+		return 1
+	}
+
+	sortAciinfoFields := []string{}
+	for _, f := range flagImagesSortFields {
+		sortAciinfoFields = append(sortAciinfoFields, ImagesFieldAciInfoMap[f])
+	}
+	aciInfos, err := s.GetAllACIInfos(sortAciinfoFields, bool(flagImagesSortAsc))
+	if err != nil {
+		stderr("Unable to get aci infos: %v", err)
+		return
+	}
+
+	for _, aciInfo := range aciInfos {
+		im, err := s.GetImageManifest(aciInfo.BlobKey)
+		if err != nil {
+			// ignore aciInfo with missing image manifest as it can be deleted in the meantime
+			continue
+		}
+		version, ok := im.Labels.Get("version")
+		for _, f := range flagImagesFields {
+			switch f {
+			case keyField:
+				fmt.Fprintf(tabOut, "%s", aciInfo.BlobKey)
+			case appNameField:
+				fmt.Fprintf(tabOut, "%s", aciInfo.AppName)
+				if ok {
+					fmt.Fprintf(tabOut, ":%s", version)
+				}
+			case importTimeField:
+				fmt.Fprintf(tabOut, "%s", aciInfo.ImportTime.Format(defaultTimeLayout))
+			case latestField:
+				fmt.Fprintf(tabOut, "%t", aciInfo.Latest)
+			}
+			fmt.Fprintf(tabOut, "\t")
+
+		}
+		fmt.Fprintf(tabOut, "\n")
+	}
+
+	tabOut.Flush()
+	return 0
+}

--- a/store/store.go
+++ b/store/store.go
@@ -504,6 +504,16 @@ nextKey:
 	return "", fmt.Errorf("aci not found")
 }
 
+func (ds Store) GetAllACIInfos(sortfields []string, ascending bool) ([]*ACIInfo, error) {
+	aciInfos := []*ACIInfo{}
+	err := ds.db.Do(func(tx *sql.Tx) error {
+		var err error
+		aciInfos, err = GetAllACIInfos(tx, sortfields, ascending)
+		return err
+	})
+	return aciInfos, err
+}
+
 func (s Store) Dump(hex bool) {
 	for _, s := range s.stores {
 		var keyCount int


### PR DESCRIPTION
This adds a new command "rkt images" to display the images in the store.

The -fields option let the user provide a comma separated list of fields to display. Accepted values: "key", "appname", "importtime", "latest".
The -sort option permits to sort the output according to the provided comma separated list of fields. Accepted values: "appname", "importtime".
The ordering is ascending by default but can be configured with the -order=[asc|desc] option.

By default all the available fields ("key", "appname", "importtime", "latest") are displayed sorted by ascending "importtime".

If the image has a version label its written in the app name (with the ":$version" format).

In future additional options can be provided:
* show all the labels
* define displayed time format (for example human format like "3 days ago").
* filter by field value.

Examples:

```
$ rkt images
KEY                                                                     APP NAME                               IMPORT TIME                             LATEST
sha512-fa1cb92dc276b0f9bedf87981e61ecde93cc16432d2441f23aa006a42bb873df coreos.com/etcd:v2.0.5                 2015-03-01 16:18:38.951 +0100 CET       false
sha512-683438b100a48aead6c37e4f581105713763bb41c3f995ad58a2cc49eb744d68 test                                   2015-03-01 16:53:47.45 +0100 CET        false
sha512-8cf2956f26035ac7d34b78722b8a738fae74acfe29b18db0a92ed44bbcfd2958 coreos.com/rocket/stage1:0.0.1         2015-03-01 17:02:34.636 +0100 CET       false
sha512-d6bb5eb2c30cd12d305192c395f783d7039136a7484f2e07761323a39a0915b6 coreos.com/rocket/stage1:0.0.1         2015-03-10 12:03:26.57 +0100 CET        false
```

```
$ rkt images -sort="appname,importtime" -order=desc -fields="importtime,appname,latest"
IMPORT TIME                             APP NAME                              LATEST
2015-03-01 16:53:47.45 +0100 CET        test                                  false
2015-03-10 12:03:26.57 +0100 CET        coreos.com/rocket/stage1:0.0.1        false
2015-03-01 17:02:34.636 +0100 CET       coreos.com/rocket/stage1:0.0.1        false
2015-03-01 16:18:38.951 +0100 CET       coreos.com/etcd:v2.0.5                false
```
