### PR TITLE
rkt: add command to remove one or more images from the store.

### DIFF
--- a/rkt/rmimage.go
+++ b/rkt/rmimage.go
@@ -1,0 +1,151 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/coreos/rkt/store"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+var (
+	cmdRmImage = &Command{
+		Name:    "rmimage",
+		Summary: "Remove image(s) with the given key(s) from the local store",
+		Usage:   "IMAGEID...",
+		Run:     runRmImage,
+		Flags:   &rmImageFlags,
+	}
+	rmImageFlags flag.FlagSet
+)
+
+func init() {
+	commands = append(commands, cmdRmImage)
+}
+
+func runRmImage(args []string) (exit int) {
+	if len(args) < 1 {
+		stderr("rkt: Must provide at least one image key")
+		return 1
+	}
+
+	s, err := store.NewStore(globalFlags.Dir)
+	if err != nil {
+		stderr("rkt: cannot open store: %v\n", err)
+		return 1
+	}
+
+	referencedImgs, err := getReferencedImgs(s)
+	if err != nil {
+		stderr("rkt: cannot get referenced images: %v\n", err)
+		return 1
+	}
+
+	//TODO(sgotti) Which return code to use when the removal fails only for some images?
+	done := 0
+	errors := 0
+	staleErrors := 0
+	for _, pkey := range args {
+		errors++
+		h, err := types.NewHash(pkey)
+		if err != nil {
+			stderr("rkt: wrong imageID %q: %v\n", pkey, err)
+			continue
+		}
+		key, err := s.ResolveKey(h.String())
+		if err != nil {
+			stderr("rkt: imageID %q not valid: %v\n", pkey, err)
+			continue
+		}
+		if key == "" {
+			stderr("rkt: imageID %q doesn't exists\n", pkey)
+			continue
+		}
+
+		err = s.RemoveACI(key)
+		if err != nil {
+			if serr, ok := err.(*store.StoreRemovalError); ok {
+				staleErrors++
+				stderr("rkt: some files cannot be removed for imageID %q: %v\n", pkey, serr)
+			} else {
+				stderr("rkt: error removing aci for imageID %q: %v\n", pkey, err)
+			}
+			continue
+		}
+		stdout("rkt: successfully removed aci for imageID: %q\n", pkey)
+
+		// Remove the treestore only if the image isn't referenced by
+		// some containers
+		// TODO(sgotti) there's a windows between getting refenced
+		// images and this check where a new container could be
+		// prepared/runned with this image. To avoid this a global lock
+		// is needed.
+		if _, ok := referencedImgs[key]; ok {
+			stderr("rkt: imageID is referenced by some containers, cannot remove the tree store")
+			continue
+		} else {
+			err = s.RemoveTreeStore(key)
+			if err != nil {
+				staleErrors++
+				stderr("rkt: error removing treestore for imageID %q: %v\n", pkey, err)
+				continue
+			}
+		}
+		errors--
+		done++
+	}
+
+	if done > 0 {
+		stdout("rkt: %d image(s) successfully removed\n", done)
+	}
+	if errors > 0 {
+		stdout("rkt: %d image(s) cannot be removed\n", errors)
+	}
+	if staleErrors > 0 {
+		stdout("rkt: %d image(s) removed but left some stale files\n", staleErrors)
+	}
+	return 0
+}
+
+func getReferencedImgs(s *store.Store) (map[string]struct{}, error) {
+	imgs := map[string]struct{}{}
+	walkErrors := []error{}
+	// Consider pods in preparing, prepared, run, exitedgarbage state
+	if err := walkPods(includeMostDirs, func(p *pod) {
+		appImgs, err := p.getAppsHashes()
+		if err != nil {
+			// Ignore errors reading/parsing pod file
+			return
+		}
+		for _, appImg := range appImgs {
+			key, err := s.ResolveKey(appImg.String())
+			if err != nil && err != store.ErrKeyNotFound {
+				walkErrors = append(walkErrors, fmt.Errorf("bad imageID %q in pod definition: %v", appImg.String(), err))
+				return
+			}
+			imgs[key] = struct{}{}
+		}
+	}); err != nil {
+		return nil, fmt.Errorf("failed to get pod handles: %v", err)
+	}
+	if len(walkErrors) > 0 {
+		return nil, fmt.Errorf("errors occured walking pods. errors: %v", walkErrors)
+
+	}
+	return imgs, nil
+}

--- a/store/remote.go
+++ b/store/remote.go
@@ -70,3 +70,12 @@ func WriteRemote(tx *sql.Tx, remote *Remote) error {
 	}
 	return nil
 }
+
+// RemoveRemote removes the remote with the given blobKey.
+func RemoveRemote(tx *sql.Tx, blobKey string) error {
+	_, err := tx.Exec("DELETE FROM remote WHERE blobkey == $1", blobKey)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/store/store.go
+++ b/store/store.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha512"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -58,6 +59,10 @@ var diskvStores = [...]string{
 	"blob",
 	"imageManifest",
 }
+
+var (
+	ErrKeyNotFound = errors.New("no keys found")
+)
 
 // Store encapsulates a content-addressable-storage for storing ACIs on disk.
 type Store struct {
@@ -220,7 +225,7 @@ func (s Store) ResolveKey(key string) (string, error) {
 
 	keyCount := len(aciInfos)
 	if keyCount == 0 {
-		return "", fmt.Errorf("no keys found")
+		return "", ErrKeyNotFound
 	}
 	if keyCount != 1 {
 		return "", fmt.Errorf("ambiguous key: %q", key)


### PR DESCRIPTION
This should go after #571 and the interesting commits are the last two.

This adds a new command `rkt rmimage` to remove one or more images from the
store providing a key uniquely resolvable.

The logic is to firstly remove transactional data (the rows in the aciinfo and
remote db tables for the given key) and then remove non transactional data (the
diskv blob and imageManifest stores).

The tree store is removed separately and only if an image hash related to the
tree store key isn't referenced by any preparing/prepared/running pod.
This means that an image can be removed (from the db and the blob/imageManifest
stores) but not from the treestore.

As removal of non transactional data can fail for multiple reasons some data
can remain stale, the same applies if the treestore can't be removed because
referenced by a pod.
A future patch will provide a cas gc to clean the stale files and unreferenced
treestores.

Example:

```
$ rkt rmimage sha512-aa244c542b1b631bbd616bc266909b sha512-aaa wronghash
rkt: successfully removed aci for key: "sha512-aa244c542b1b631bbd616bc266909b"
rkt: key "sha512-aaa" not valid: no keys found
rkt: wrong key "wronghash": badly formatted hash string
rkt: 1 image(s) successfully removed
rkt: 2 image(s) cannot be removed
```
