### PR TITLE
rkt: fetch images dependencies.

### DIFF
--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -79,6 +79,7 @@ func runFetch(args []string) (exit int) {
 			insecureSkipVerify: globalFlags.InsecureSkipVerify,
 			debug:              globalFlags.Debug,
 		},
+		withDeps: true,
 	}
 
 	err = rktApps.Walk(func(app *apps.App) error {

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -106,7 +106,8 @@ func runPrepare(args []string) (exit int) {
 			insecureSkipVerify: globalFlags.InsecureSkipVerify,
 			debug:              globalFlags.Debug,
 		},
-		local: flagLocal,
+		local:    flagLocal,
+		withDeps: false,
 	}
 	s1img, err := fn.findImage(flagStage1Image, "", false)
 	if err != nil {
@@ -115,6 +116,7 @@ func runPrepare(args []string) (exit int) {
 	}
 
 	fn.ks = getKeystore()
+	fn.withDeps = true
 	if err := fn.findImages(&rktApps); err != nil {
 		stderr("%v", err)
 		return 1

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -137,7 +137,8 @@ func runRun(args []string) (exit int) {
 			insecureSkipVerify: globalFlags.InsecureSkipVerify,
 			debug:              globalFlags.Debug,
 		},
-		local: flagLocal,
+		local:    flagLocal,
+		withDeps: false,
 	}
 	s1img, err := fn.findImage(flagStage1Image, "", false)
 	if err != nil {
@@ -146,6 +147,7 @@ func runRun(args []string) (exit int) {
 	}
 
 	fn.ks = getKeystore()
+	fn.withDeps = true
 	if err := fn.findImages(&rktApps); err != nil {
 		stderr("%v", err)
 		return 1


### PR DESCRIPTION
After fetching an image also fetch recursively all its dependencies.
Dependencies needs to be resolved using discovery as the unique useful
informations (as per spec) are the app name and the labels.

Image fetching and dependencies fetching could be done in a single function but
they are left split in two functions as sometimes, for example when importing
images from disk, it'll be useful to disable dependencies fetching.

By now, findImage in rkt/run.go will call fetchImage with withDep = true.

For testing there'll be the need of faking discovery. By now its quite difficult
to fake the meta discovery mechanism. There'll be the need of something like
appc/spec#110

This will probably clash with #509.
