### PR TITLE
net: add option to expose ports on hosts

### DIFF
--- a/Documentation/networking.md
+++ b/Documentation/networking.md
@@ -123,6 +123,28 @@ Additional configuration fields:
 
 [Coming soon](https://github.com/coreos/rkt/issues/558)
 
+## Exposing container ports on the host
+Apps declare their public ports in the image manifest file.
+A user can expose some or all of these ports to the host when running a pod.
+Doing so allows services inside the pods to be reachable through the host's IP address.
+
+The example below demonstrates an image manifest snippet declaring a single port:
+```
+"ports": [
+	{
+		"name": "http",
+		"port": 80,
+		"protocol": "tcp"
+	}
+]
+```
+
+The pod's TCP port 80 can be mapped to an arbitrary port on the host during rkt invocation:
+```
+$ rkt run --private-net --port=http:8888 myapp.aci
+````
+Now, any traffic arriving on host's TCP port 8888 will be forwarded to the pod on port 80.
+
 ### Overriding default network
 If a network has a name "default", it will override the default network added
 by rkt. It is strongly recommended that such network also has type "veth" as

--- a/networking/portfwd.go
+++ b/networking/portfwd.go
@@ -1,0 +1,105 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networking
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/coreos/go-iptables/iptables"
+)
+
+func (e *podEnv) forwardPorts(fps []ForwardedPort, defIP net.IP) error {
+	if len(fps) == 0 {
+		return nil
+	}
+
+	ipt, err := iptables.New()
+	if err != nil {
+		return err
+	}
+
+	// Create a separate chain for this pod. This helps with debugging
+	// and makes it easier to cleanup
+	chain := e.portFwdChain()
+
+	if err = ipt.NewChain("nat", chain); err != nil {
+		return err
+	}
+
+	rule := e.portFwdRuleSpec(chain)
+
+	// outside traffic hitting this host
+	if err = ipt.AppendUnique("nat", "PREROUTING", rule...); err != nil {
+		return err
+	}
+
+	// traffic originating on this host
+	if err = ipt.AppendUnique("nat", "OUTPUT", rule...); err != nil {
+		return err
+	}
+
+	for _, p := range fps {
+		if err = forwardPort(ipt, chain, &p, defIP); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func forwardPort(ipt *iptables.IPTables, chain string, p *ForwardedPort, defIP net.IP) error {
+	dst := fmt.Sprintf("%v:%v", defIP, p.PodPort)
+	dport := strconv.Itoa(int(p.HostPort))
+
+	return ipt.AppendUnique("nat", chain, "-p", p.Protocol, "--dport", dport, "-j", "DNAT", "--to-destination", dst)
+}
+
+func (e *podEnv) unforwardPorts() error {
+	ipt, err := iptables.New()
+	if err != nil {
+		return err
+	}
+
+	chain := e.portFwdChain()
+
+	rule := e.portFwdRuleSpec(chain)
+
+	// outside traffic hitting this hot
+	if err = ipt.Delete("nat", "PREROUTING", rule...); err != nil {
+		return err
+	}
+
+	// traffic originating on this host
+	if err = ipt.Delete("nat", "OUTPUT", rule...); err != nil {
+		return err
+	}
+
+	// there should be no references, delete the chain
+	if err = ipt.ClearChain("nat", chain); err != nil {
+		return err
+	}
+
+	return ipt.DeleteChain("nat", chain)
+}
+
+func (e *podEnv) portFwdChain() string {
+	return "RKT-PFWD-" + e.podID.String()[0:8]
+}
+
+func (e *podEnv) portFwdRuleSpec(chain string) []string {
+	return []string{"-m", "addrtype", "--dst-type", "LOCAL", "-j", chain}
+}

--- a/rkt/cli_apps_test.go
+++ b/rkt/cli_apps_test.go
@@ -19,6 +19,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
 func TestParseAppArgs(t *testing.T) {
@@ -77,4 +79,61 @@ func TestParseAppArgs(t *testing.T) {
 		}
 	}
 
+}
+
+func TestParsePortFlag(t *testing.T) {
+	tests := []struct {
+		in  string
+		ex  types.ExposedPort
+		err bool
+	}{
+		{
+			in: "foo:123",
+			ex: types.ExposedPort{
+				Name:     "foo",
+				HostPort: 123,
+			},
+			err: false,
+		},
+		{
+			in:  "f$o:123",
+			ex:  types.ExposedPort{},
+			err: true,
+		},
+		{
+			in:  "foo:12345",
+			ex:  types.ExposedPort{},
+			err: true,
+		},
+	}
+
+	for _, tt := range tests {
+		pl := portList{}
+		err := pl.Set(tt.in)
+
+		if err != nil {
+			if !tt.err {
+				t.Errorf("%q failed to parse: %v", tt.in, err)
+			}
+			return
+		}
+
+		if tt.err {
+			t.Errorf("%q unexpectedly parsed", tt.in)
+			return
+		}
+
+		if len(pl) == 0 {
+			t.Errorf("%q parsed into a empty list", tt.in)
+			return
+		}
+
+		if pl[0].Name != tt.ex.Name {
+			t.Errorf("%q parsed but Name mismatch: got %v, expected %v", tt.in, pl[0].Name, tt.ex.Name)
+		}
+
+		if pl[0].HostPort != tt.ex.HostPort {
+			t.Errorf("%q parsed but HostPort mismatch: got %v, expected %v", tt.in, pl[0].HostPort, tt.ex.HostPort)
+		}
+	}
 }

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -51,6 +51,7 @@ func init() {
 	commands = append(commands, cmdPrepare)
 	prepareFlags.StringVar(&flagStage1Image, "stage1-image", defaultStage1Image, `image to use as stage1. Local paths and http/https URLs are supported. If empty, rkt will look for a file called "stage1.aci" in the same directory as rkt itself`)
 	prepareFlags.Var(&flagVolumes, "volume", "volumes to mount into the pod")
+	prepareFlags.Var(&flagPorts, "port", "ports to expose on the host (requires --private-net)")
 	prepareFlags.BoolVar(&flagQuiet, "quiet", false, "suppress superfluous output on stdout, print only the UUID on success")
 	prepareFlags.BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	prepareFlags.BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
@@ -116,6 +117,7 @@ func runPrepare(args []string) (exit int) {
 			UUID:        p.uuid,
 		},
 		Volumes:     []types.Volume(flagVolumes),
+		Ports:       []types.ExposedPort(flagPorts),
 		InheritEnv:  flagInheritEnv,
 		ExplicitEnv: flagExplicitEnv.Strings(),
 		UseOverlay:  !flagNoOverlay && common.SupportsOverlay(),

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -50,11 +50,12 @@ import (
 type PrepareConfig struct {
 	CommonConfig
 	// TODO(jonboulle): These images are partially-populated hashes, this should be clarified.
-	Apps        *apps.Apps     // apps to prepare
-	InheritEnv  bool           // inherit parent environment into apps
-	ExplicitEnv []string       // always set these environment variables for all the apps
-	Volumes     []types.Volume // list of volumes that rkt can provide to applications
-	UseOverlay  bool           // prepare pod with overlay fs
+	Apps        *apps.Apps          // apps to prepare
+	InheritEnv  bool                // inherit parent environment into apps
+	ExplicitEnv []string            // always set these environment variables for all the apps
+	Volumes     []types.Volume      // list of volumes that rkt can provide to applications
+	Ports       []types.ExposedPort // list of ports that rkt will expose on the host
+	UseOverlay  bool                // prepare pod with overlay fs
 }
 
 // configuration parameters needed by Run
@@ -167,6 +168,7 @@ func Prepare(cfg PrepareConfig, dir string, uuid *types.UUID) error {
 	// TODO(jonboulle): check that app mountpoint expectations are
 	// satisfied here, rather than waiting for stage1
 	cm.Volumes = cfg.Volumes
+	cm.Ports = cfg.Ports
 
 	cdoc, err := json.Marshal(cm)
 	if err != nil {


### PR DESCRIPTION
Ports that were defined in app manifest can be
exposed via --port=name:host-port option on cmd line.
For example, given app manifest with ports entry:
{
    "name": "http",
    "port": 80,
    "protocol": "tcp"
}

rkt run --private-net --port=http:8888 myapp.aci
will forward traffic from host's tcp port 8888 to
container's port 80.

Fixes #624