### PR TITLE
rkt: add -local flag to run/prepare.

### DIFF
--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -57,6 +57,7 @@ func init() {
 	prepareFlags.BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	prepareFlags.BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
 	prepareFlags.Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
+	prepareFlags.BoolVar(&flagLocal, "local", false, "use only local images (do not discover or download from remote URLs)")
 }
 
 func runPrepare(args []string) (exit int) {
@@ -105,6 +106,7 @@ func runPrepare(args []string) (exit int) {
 			insecureSkipVerify: globalFlags.InsecureSkipVerify,
 			debug:              globalFlags.Debug,
 		},
+		local: flagLocal,
 	}
 	s1img, err := fn.findImage(flagStage1Image, "", false)
 	if err != nil {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -59,6 +59,7 @@ End the image arguments with a lone "---" to resume argument parsing.`,
 	flagExplicitEnv envMap
 	flagInteractive bool
 	flagNoOverlay   bool
+	flagLocal       bool
 )
 
 func init() {
@@ -81,6 +82,7 @@ func init() {
 	runFlags.Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
 	runFlags.BoolVar(&flagInteractive, "interactive", false, "run pod interactively")
 	runFlags.Var((*appAsc)(&rktApps), "signature", "local signature file to use in validating the preceding image")
+	runFlags.BoolVar(&flagLocal, "local", false, "use only local images (do not discover or download from remote URLs)")
 	flagVolumes = volumeList{}
 	flagPorts = portList{}
 }
@@ -135,6 +137,7 @@ func runRun(args []string) (exit int) {
 			insecureSkipVerify: globalFlags.InsecureSkipVerify,
 			debug:              globalFlags.Debug,
 		},
+		local: flagLocal,
 	}
 	s1img, err := fn.findImage(flagStage1Image, "", false)
 	if err != nil {


### PR DESCRIPTION
This patch adds a -local flag to use only local images (if available) from the
local store.
    
If the provided image name is a URL-like app name (like coreos.com/etcd:2.0.9)
then discovery is disabled and the image is searched in the store using
cas.GetACI.
    
If the provided image name has an "http", "https", "docker" scheme it will avoid
downloading if it's not in the store (not existing in the remote table).
    
This can be useful to use rkt in offline mode or to just simply avoid
downloading.