### PR TITLE
cas: rename to store

### DIFF
--- a/rkt/enter.go
+++ b/rkt/enter.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
-	"github.com/coreos/rkt/cas"
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/stage0"
+	"github.com/coreos/rkt/store"
 )
 
 var (
@@ -89,7 +89,7 @@ func runEnter(args []string) (exit int) {
 		return 1
 	}
 
-	ds, err := cas.NewStore(globalFlags.Dir)
+	ds, err := store.NewStore(globalFlags.Dir)
 	if err != nil {
 		stderr("Cannot open store: %v", err)
 		return 1

--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -21,8 +21,8 @@ import (
 	"runtime"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
-	"github.com/coreos/rkt/cas"
 	"github.com/coreos/rkt/common/apps"
+	"github.com/coreos/rkt/store"
 )
 
 const (
@@ -59,7 +59,7 @@ func runFetch(args []string) (exit int) {
 		return 1
 	}
 
-	ds, err := cas.NewStore(globalFlags.Dir)
+	ds, err := store.NewStore(globalFlags.Dir)
 	if err != nil {
 		stderr("fetch: cannot open store: %v", err)
 		return 1

--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -27,10 +27,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/coreos/rkt/cas"
 	"github.com/coreos/rkt/pkg/aci"
 	"github.com/coreos/rkt/pkg/keystore"
 	"github.com/coreos/rkt/pkg/keystore/keystoretest"
+	"github.com/coreos/rkt/store"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/discovery"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
@@ -167,7 +167,7 @@ func TestDownloading(t *testing.T) {
 		{ts.URL, "", body, true},
 	}
 
-	ds, err := cas.NewStore(dir)
+	ds, err := store.NewStore(dir)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -198,7 +198,7 @@ func TestDownloading(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
-		rem := cas.NewRemote(tt.ACIURL, tt.SigURL)
+		rem := store.NewRemote(tt.ACIURL, tt.SigURL)
 		rem.BlobKey = key
 		err = ds.WriteRemote(rem)
 		if err != nil {
@@ -215,7 +215,7 @@ func TestFetchImage(t *testing.T) {
 		t.Fatalf("error creating tempdir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	ds, err := cas.NewStore(dir)
+	ds, err := store.NewStore(dir)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -32,13 +32,13 @@ import (
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/mitchellh/ioprogress"
 	"github.com/coreos/rkt/Godeps/_workspace/src/golang.org/x/crypto/openpgp"
-	"github.com/coreos/rkt/cas"
 	"github.com/coreos/rkt/common/apps"
 	"github.com/coreos/rkt/pkg/keystore"
+	"github.com/coreos/rkt/store"
 )
 
 type imageActionData struct {
-	ds                 *cas.Store
+	ds                 *store.Store
 	ks                 *keystore.Keystore
 	insecureSkipVerify bool
 	debug              bool
@@ -217,7 +217,7 @@ func (f *fetcher) fetchImageFrom(aciURL, ascURL, scheme string, ascFile *os.File
 		}
 
 		if scheme != "file" {
-			rem = cas.NewRemote(aciURL, ascURL)
+			rem = store.NewRemote(aciURL, ascURL)
 			rem.BlobKey = key
 			err = f.ds.WriteRemote(rem)
 			if err != nil {

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -23,9 +23,9 @@ import (
 	"os"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
-	"github.com/coreos/rkt/cas"
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/stage0"
+	"github.com/coreos/rkt/store"
 )
 
 var (
@@ -86,7 +86,7 @@ func runPrepare(args []string) (exit int) {
 		}
 	}
 
-	ds, err := cas.NewStore(globalFlags.Dir)
+	ds, err := store.NewStore(globalFlags.Dir)
 	if err != nil {
 		stderr("prepare: cannot open store: %v", err)
 		return 1

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -27,9 +27,9 @@ import (
 	"strings"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
-	"github.com/coreos/rkt/cas"
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/stage0"
+	"github.com/coreos/rkt/store"
 )
 
 var (
@@ -118,7 +118,7 @@ func runRun(args []string) (exit int) {
 		return 1
 	}
 
-	ds, err := cas.NewStore(globalFlags.Dir)
+	ds, err := store.NewStore(globalFlags.Dir)
 	if err != nil {
 		stderr("run: cannot open store: %v", err)
 		return 1

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -21,8 +21,8 @@ import (
 	"io/ioutil"
 	"log"
 
-	"github.com/coreos/rkt/cas"
 	"github.com/coreos/rkt/stage0"
+	"github.com/coreos/rkt/store"
 )
 
 const (
@@ -70,7 +70,7 @@ func runRunPrepared(args []string) (exit int) {
 		}
 	}
 
-	ds, err := cas.NewStore(globalFlags.Dir)
+	ds, err := store.NewStore(globalFlags.Dir)
 	if err != nil {
 		stderr("prepared-run: cannot open store: %v", err)
 		return 1

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -38,11 +38,11 @@ import (
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
-	"github.com/coreos/rkt/cas"
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/common/apps"
 	"github.com/coreos/rkt/pkg/aci"
 	"github.com/coreos/rkt/pkg/sys"
+	"github.com/coreos/rkt/store"
 	"github.com/coreos/rkt/version"
 )
 
@@ -70,10 +70,10 @@ type RunConfig struct {
 
 // configuration shared by both Run and Prepare
 type CommonConfig struct {
-	Store       *cas.Store  // store containing all of the configured application images
-	Stage1Image types.Hash  // stage1 image containing usable /init and /enter entrypoints
-	UUID        *types.UUID // UUID of the pod
-	PodsDir     string      // root directory for rocket pods
+	Store       *store.Store // store containing all of the configured application images
+	Stage1Image types.Hash   // stage1 image containing usable /init and /enter entrypoints
+	UUID        *types.UUID  // UUID of the pod
+	PodsDir     string       // root directory for rocket pods
 	Debug       bool
 }
 

--- a/store/aciinfo.go
+++ b/store/aciinfo.go
@@ -1,4 +1,4 @@
-package cas
+package store
 
 import (
 	"database/sql"

--- a/store/aciinfo_test.go
+++ b/store/aciinfo_test.go
@@ -1,4 +1,4 @@
-package cas
+package store
 
 import (
 	"database/sql"

--- a/store/db.go
+++ b/store/db.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cas
+package store
 
 import (
 	"database/sql"

--- a/store/remote.go
+++ b/store/remote.go
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package cas implements a content-addressable-store on disk.
+// Package store implements a content-addressable-store on disk.
 // It leverages the `diskv` package to store items in a simple
 // key-value blob store: https://github.com/peterbourgon/diskv
-package cas
+package store
 
 import "database/sql"
 

--- a/store/remote_test.go
+++ b/store/remote_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cas
+package store
 
 import (
 	"io/ioutil"

--- a/store/schema.go
+++ b/store/schema.go
@@ -1,4 +1,4 @@
-package cas
+package store
 
 import (
 	"database/sql"

--- a/store/store.go
+++ b/store/store.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cas
+package store
 
 import (
 	"bufio"

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cas
+package store
 
 import (
 	"archive/tar"
@@ -29,7 +29,7 @@ import (
 	"github.com/coreos/rkt/pkg/aci"
 )
 
-const tstprefix = "cas-test"
+const tstprefix = "store-test"
 
 func TestBlobStore(t *testing.T) {
 	dir, err := ioutil.TempDir("", tstprefix)

--- a/store/tree.go
+++ b/store/tree.go
@@ -1,4 +1,4 @@
-package cas
+package store
 
 import (
 	"archive/tar"

--- a/store/tree_test.go
+++ b/store/tree_test.go
@@ -1,4 +1,4 @@
-package cas
+package store
 
 import (
 	"archive/tar"

--- a/store/utils.go
+++ b/store/utils.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cas
+package store
 
 import (
 	"compress/bzip2"

--- a/store/z_last_test.go
+++ b/store/z_last_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package cas
+package store
 
 import (
 	"runtime"

--- a/test
+++ b/test
@@ -6,15 +6,15 @@
 #
 # Run tests for one package
 #
-# PKG=./cas ./test
-# PKG=cas ./test
+# PKG=./store ./test
+# PKG=store ./test
 
 # Invoke ./cover for HTML output
 COVER=${COVER:-"-cover"}
 
 source ./build
 
-TESTABLE_AND_FORMATTABLE="cas pkg/keystore pkg/lock pkg/tar rkt stage1/init"
+TESTABLE_AND_FORMATTABLE="pkg/keystore pkg/lock pkg/tar rkt stage1/init store"
 FORMATTABLE="$TESTABLE_AND_FORMATTABLE common networking stage0/run.go version"
 
 # user has not provided PKG override


### PR DESCRIPTION
The cas package implements more than just a CAS, so this patch gives it
a suitably generic name.

Fixes #707

(Go newbie here, let me know if I missed anything!)