### PR TITLE
WIP: functional testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ gopath/
 *.sw[ponm]
 .DS_Store
 .vagrant
+tests/image/rootfs/
+tests/inspect/inspect
+tests/*.aci
+tests/*.log

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -25,33 +25,33 @@
 		},
 		{
 			"ImportPath": "github.com/appc/spec/aci",
-			"Comment": "v0.5.1",
-			"Rev": "9a448f73b7fa765a60eade4bcca41e18bfe613aa"
+			"Comment": "v0.5.1-24-gab87c4e",
+			"Rev": "ab87c4ea3a9e51c357bfbd544044572b838385f5"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/actool",
-			"Comment": "v0.5.1",
-			"Rev": "9a448f73b7fa765a60eade4bcca41e18bfe613aa"
+			"Comment": "v0.5.1-24-gab87c4e",
+			"Rev": "ab87c4ea3a9e51c357bfbd544044572b838385f5"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/discovery",
-			"Comment": "v0.5.1",
-			"Rev": "9a448f73b7fa765a60eade4bcca41e18bfe613aa"
+			"Comment": "v0.5.1-24-gab87c4e",
+			"Rev": "ab87c4ea3a9e51c357bfbd544044572b838385f5"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/acirenderer",
-			"Comment": "v0.5.1",
-			"Rev": "9a448f73b7fa765a60eade4bcca41e18bfe613aa"
+			"Comment": "v0.5.1-24-gab87c4e",
+			"Rev": "ab87c4ea3a9e51c357bfbd544044572b838385f5"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/tarheader",
-			"Comment": "v0.5.1",
-			"Rev": "9a448f73b7fa765a60eade4bcca41e18bfe613aa"
+			"Comment": "v0.5.1-24-gab87c4e",
+			"Rev": "ab87c4ea3a9e51c357bfbd544044572b838385f5"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/schema",
-			"Comment": "v0.5.1",
-			"Rev": "9a448f73b7fa765a60eade4bcca41e18bfe613aa"
+			"Comment": "v0.5.1-24-gab87c4e",
+			"Rev": "ab87c4ea3a9e51c357bfbd544044572b838385f5"
 		},
 		{
 			"ImportPath": "github.com/camlistore/lock",

--- a/Godeps/_workspace/src/github.com/appc/spec/actool/actool.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/actool/actool.go
@@ -47,8 +47,10 @@ func init() {
 	out.Init(os.Stdout, 0, 8, 1, '\t', 0)
 	commands = []*Command{
 		cmdBuild,
+		cmdCatManifest,
 		cmdDiscover,
 		cmdHelp,
+		cmdPatchManifest,
 		cmdValidate,
 		cmdVersion,
 	}

--- a/Godeps/_workspace/src/github.com/appc/spec/actool/manifest.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/actool/manifest.go
@@ -1,0 +1,387 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/aci"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+var (
+	inputFile  string
+	outputFile string
+
+	patchNocompress   bool
+	patchOverwrite    bool
+	patchReplace      bool
+	patchManifestFile string
+	patchName         string
+	patchExec         string
+	patchUser         string
+	patchGroup        string
+	patchCaps         string
+	patchMounts       string
+
+	catPrettyPrint bool
+
+	cmdPatchManifest = &Command{
+		Name:        "patch-manifest",
+		Description: `Copy an ACI and patch its manifest.`,
+		Summary:     "Copy an ACI and patch its manifest (experimental)",
+		Usage: `
+		  [--manifest=MANIFEST_FILE]
+		  [--name=example.com/app]
+		  [--exec="/app --debug"]
+		  [--user=uid] [--group=gid]
+		  [--capability=CAP_SYS_ADMIN,CAP_NET_ADMIN]
+		  [--mounts=work,path=/opt,readOnly=true[:work2,...]]
+		  [--replace]
+		  INPUT_ACI_FILE
+		  [OUTPUT_ACI_FILE]`,
+		Run: runPatchManifest,
+	}
+	cmdCatManifest = &Command{
+		Name:        "cat-manifest",
+		Description: `Print the manifest from an ACI.`,
+		Summary:     "Print the manifest from an ACI",
+		Usage:       ` [--pretty-print] ACI_FILE`,
+		Run:         runCatManifest,
+	}
+)
+
+func init() {
+	cmdPatchManifest.Flags.BoolVar(&patchOverwrite, "overwrite", false, "Overwrite target file if it already exists")
+	cmdPatchManifest.Flags.BoolVar(&patchNocompress, "no-compression", false, "Do not gzip-compress the produced ACI")
+	cmdPatchManifest.Flags.BoolVar(&patchReplace, "replace", false, "Replace the input file")
+
+	cmdPatchManifest.Flags.StringVar(&patchManifestFile, "manifest", "", "Replace image manifest with this file. Incompatible with other replace options.")
+	cmdPatchManifest.Flags.StringVar(&patchName, "name", "", "Replace name")
+	cmdPatchManifest.Flags.StringVar(&patchExec, "exec", "", "Replace the command line to launch the executable")
+	cmdPatchManifest.Flags.StringVar(&patchUser, "user", "", "Replace user")
+	cmdPatchManifest.Flags.StringVar(&patchGroup, "group", "", "Replace group")
+	cmdPatchManifest.Flags.StringVar(&patchCaps, "capability", "", "Replace capability")
+	cmdPatchManifest.Flags.StringVar(&patchMounts, "mounts", "", "Replace mount points")
+
+	cmdCatManifest.Flags.BoolVar(&catPrettyPrint, "pretty-print", false, "Print with better style")
+}
+
+func getIsolatorStr(name, value string) string {
+	return fmt.Sprintf(`
+                {
+                    "name": "%s",
+                    "value": { %s }
+                }`, name, value)
+}
+
+func patchManifest(im *schema.ImageManifest) error {
+
+	if patchName != "" {
+		name, err := types.NewACName(patchName)
+		if err != nil {
+			return err
+		}
+		im.Name = *name
+	}
+
+	if patchExec != "" {
+		im.App.Exec = strings.Split(patchExec, " ")
+	}
+
+	if patchUser != "" {
+		im.App.User = patchUser
+	}
+	if patchGroup != "" {
+		im.App.Group = patchGroup
+	}
+
+	if patchCaps != "" {
+		app := im.App
+		if app == nil {
+			return fmt.Errorf("no app in the manifest")
+		}
+		isolator := app.Isolators.GetByName(types.LinuxCapabilitiesRetainSetName)
+		if isolator != nil {
+			return fmt.Errorf("isolator already exists")
+		}
+
+		// Instantiate a Isolator with the content specified by the --capability
+		// parameter.
+
+		// TODO: Instead of creating a JSON and then unmarshalling it, the isolator
+		// should be instantiated directory. But it requires a constructor, see:
+		// https://github.com/appc/spec/issues/268
+		capsList := strings.Split(patchCaps, ",")
+		caps := fmt.Sprintf(`"set": ["%s"]`, strings.Join(capsList, `", "`))
+		isolatorStr := getIsolatorStr(types.LinuxCapabilitiesRetainSetName, caps)
+		isolator = &types.Isolator{}
+		err := isolator.UnmarshalJSON([]byte(isolatorStr))
+		if err != nil {
+			return err
+		}
+		app.Isolators = append(app.Isolators, *isolator)
+	}
+
+	if patchMounts != "" {
+		app := im.App
+		if app == nil {
+			return fmt.Errorf("no app in the manifest")
+		}
+		mounts := strings.Split(patchMounts, ":")
+		for _, m := range mounts {
+			mountPoint, err := types.MountPointFromString(m)
+			if err != nil {
+				return fmt.Errorf("cannot parse mount point %q", m)
+			}
+			app.MountPoints = append(app.MountPoints, *mountPoint)
+		}
+	}
+	return nil
+}
+
+// extractManifest iterates over the tar reader and locate the manifest. Once
+// located, the manifest can be printed, replaced or patched.
+func extractManifest(tr *tar.Reader, tw *tar.Writer, printManifest bool, newManifest []byte) error {
+Tar:
+	for {
+		hdr, err := tr.Next()
+		switch err {
+		case io.EOF:
+			break Tar
+		case nil:
+			if filepath.Clean(hdr.Name) == aci.ManifestFile {
+				var new_bytes []byte
+
+				bytes, err := ioutil.ReadAll(tr)
+				if err != nil {
+					return err
+				}
+
+				if printManifest && !catPrettyPrint {
+					fmt.Println(string(bytes))
+				}
+
+				im := &schema.ImageManifest{}
+				err = im.UnmarshalJSON(bytes)
+				if err != nil {
+					return err
+				}
+
+				if printManifest && catPrettyPrint {
+					output, err := json.MarshalIndent(im, "", "    ")
+					if err != nil {
+						return err
+					}
+					fmt.Println(string(output))
+				}
+
+				if tw == nil {
+					return nil
+				}
+
+				if len(newManifest) == 0 {
+					err = patchManifest(im)
+					if err != nil {
+						return err
+					}
+
+					new_bytes, err = im.MarshalJSON()
+					if err != nil {
+						return err
+					}
+				} else {
+					new_bytes = newManifest
+				}
+
+				hdr.Size = int64(len(new_bytes))
+				err = tw.WriteHeader(hdr)
+				if err != nil {
+					return err
+				}
+
+				_, err = tw.Write(new_bytes)
+				if err != nil {
+					return err
+				}
+			} else if tw != nil {
+				err := tw.WriteHeader(hdr)
+				if err != nil {
+					return err
+				}
+				_, err = io.Copy(tw, tr)
+				if err != nil {
+					return err
+				}
+			}
+		default:
+			return fmt.Errorf("error reading tarball: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func runPatchManifest(args []string) (exit int) {
+	var fh *os.File
+	var err error
+
+	if patchReplace && patchOverwrite {
+		stderr("patch-manifest: Cannot use both --replace and --overwrite")
+		return 1
+	}
+	if !patchReplace && len(args) != 2 {
+		stderr("patch-manifest: Must provide input and output files (or use --replace)")
+		return 1
+	}
+	if patchReplace && len(args) != 1 {
+		stderr("patch-manifest: Must provide one file")
+		return 1
+	}
+	if patchManifestFile != "" && (patchName != "" || patchExec != "" || patchUser != "" || patchGroup != "" || patchCaps != "" || patchMounts != "") {
+		stderr("patch-manifest: --manifest is incompatible with other manifest editing options")
+		return 1
+	}
+
+	inputFile = args[0]
+
+	// Prepare output writer
+
+	if patchReplace {
+		fh, err = ioutil.TempFile(path.Dir(inputFile), ".actool-tmp."+path.Base(inputFile)+"-")
+		if err != nil {
+			stderr("patch-manifest: Cannot create temporary file: %v", err)
+			return 1
+		}
+	} else {
+		outputFile = args[1]
+
+		ext := filepath.Ext(outputFile)
+		if ext != schema.ACIExtension {
+			stderr("patch-manifest: Extension must be %s (given %s)", schema.ACIExtension, ext)
+			return 1
+		}
+
+		mode := os.O_CREATE | os.O_WRONLY
+		if patchOverwrite {
+			mode |= os.O_TRUNC
+		} else {
+			mode |= os.O_EXCL
+		}
+
+		fh, err = os.OpenFile(outputFile, mode, 0644)
+		if err != nil {
+			if os.IsExist(err) {
+				stderr("patch-manifest: Output file exists (try --overwrite)")
+			} else {
+				stderr("patch-manifest: Unable to open output %s: %v", outputFile, err)
+			}
+			return 1
+		}
+	}
+
+	var gw *gzip.Writer
+	var w io.WriteCloser = fh
+	if !patchNocompress {
+		gw = gzip.NewWriter(fh)
+		w = gw
+	}
+	tw := tar.NewWriter(w)
+
+	defer func() {
+		tw.Close()
+		if !patchNocompress {
+			gw.Close()
+		}
+		fh.Close()
+		if exit != 0 && !patchOverwrite {
+			os.Remove(fh.Name())
+		}
+	}()
+
+	// Prepare input reader
+
+	input, err := os.Open(inputFile)
+	if err != nil {
+		stderr("patch-manifest: Cannot open %s: %v", inputFile, err)
+		return 1
+	}
+	defer input.Close()
+
+	tr, err := aci.NewCompressedTarReader(input)
+	if err != nil {
+		stderr("patch-manifest: Cannot extract %s: %v", inputFile, err)
+		return 1
+	}
+
+	var newManifest []byte
+
+	if patchManifestFile != "" {
+		mr, err := os.Open(patchManifestFile)
+		if err != nil {
+			stderr("patch-manifest: Cannot open %s: %v", patchManifestFile, err)
+			return 1
+		}
+		defer input.Close()
+
+		newManifest, err = ioutil.ReadAll(mr)
+		if err != nil {
+			stderr("patch-manifest: Cannot read %s: %v", patchManifestFile, err)
+			return 1
+		}
+	}
+
+	err = extractManifest(tr, tw, false, newManifest)
+	if err != nil {
+		stderr("patch-manifest: Unable to read %s: %v", inputFile, err)
+		return 1
+	}
+
+	if patchReplace {
+		err = os.Rename(fh.Name(), inputFile)
+		if err != nil {
+			stderr("patch-manifest: Cannot rename %q to %q: %v", fh.Name, inputFile, err)
+			return 1
+		}
+	}
+
+	return
+}
+
+func runCatManifest(args []string) (exit int) {
+	if len(args) != 1 {
+		stderr("cat-manifest: Must provide one file")
+		return 1
+	}
+
+	inputFile = args[0]
+
+	input, err := os.Open(inputFile)
+	if err != nil {
+		stderr("cat-manifest: Cannot open %s: %v", inputFile, err)
+		return 1
+	}
+	defer input.Close()
+
+	tr, err := aci.NewCompressedTarReader(input)
+	if err != nil {
+		stderr("cat-manifest: Cannot extract %s: %v", inputFile, err)
+		return 1
+	}
+
+	err = extractManifest(tr, nil, true, nil)
+	if err != nil {
+		stderr("cat-manifest: Unable to read %s: %v", inputFile, err)
+		return 1
+	}
+
+	return
+}

--- a/Godeps/_workspace/src/github.com/appc/spec/actool/validate.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/actool/validate.go
@@ -30,7 +30,7 @@ var (
 		Usage:       "[--type=TYPE] FILE...",
 		Run:         runValidate,
 	}
-	types = []string{
+	validateTypes = []string{
 		typeAppImage,
 		typeImageLayout,
 		typeManifest,
@@ -39,7 +39,7 @@ var (
 
 func init() {
 	cmdValidate.Flags.StringVar(&valType, "type", "",
-		fmt.Sprintf(`Type of file to validate. If unset, actool will try to detect the type. One of "%s"`, strings.Join(types, ",")))
+		fmt.Sprintf(`Type of file to validate. If unset, actool will try to detect the type. One of "%s"`, strings.Join(validateTypes, ",")))
 }
 
 func runValidate(args []string) (exit int) {

--- a/Godeps/_workspace/src/github.com/appc/spec/discovery/parse.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/discovery/parse.go
@@ -65,3 +65,12 @@ func NewAppFromString(app string) (*App, error) {
 	}
 	return a, nil
 }
+
+// String returns the URL-like image name
+func (a *App) String() string {
+	img := a.Name.String()
+	for n, v := range a.Labels {
+		img += fmt.Sprintf(",%s=%s", n, v)
+	}
+	return img
+}

--- a/Godeps/_workspace/src/github.com/appc/spec/discovery/parse_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/discovery/parse_test.go
@@ -74,3 +74,48 @@ func TestNewAppFromString(t *testing.T) {
 		}
 	}
 }
+
+func TestAppString(t *testing.T) {
+	tests := []struct {
+		a   *App
+		out string
+	}{
+		{
+			&App{
+				Name:   "example.com/reduce-worker",
+				Labels: map[types.ACName]string{},
+			},
+			"example.com/reduce-worker",
+		},
+		{
+			&App{
+				Name: "example.com/reduce-worker",
+				Labels: map[types.ACName]string{
+					"version": "1.0.0",
+				},
+			},
+			"example.com/reduce-worker:1.0.0",
+		},
+		{
+			&App{
+				Name: "example.com/reduce-worker",
+				Labels: map[types.ACName]string{
+					"channel": "alpha",
+					"label":   "value",
+				},
+			},
+			"example.com/reduce-worker,channel=alpha,label=value",
+		},
+	}
+	for i, tt := range tests {
+		appString := tt.a.String()
+
+		g, err := NewAppFromString(appString)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(g, tt.a) {
+			t.Errorf("#%d: got %#v, want %#v", i, g, tt.a)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/appc/spec/pkg/acirenderer/acirenderer.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/pkg/acirenderer/acirenderer.go
@@ -139,6 +139,7 @@ func getACIFiles(img Image, ap ACIProvider, allFiles map[string]struct{}, pwlm m
 	hash := sha512.New()
 	r := io.TeeReader(rs, hash)
 
+	thispwlm := pwlToMap(img.Im.PathWhitelist)
 	ra := &ACIFiles{FileMap: make(map[string]struct{})}
 	if err = Walk(tar.NewReader(r), func(hdr *tar.Header) error {
 		name := hdr.Name
@@ -153,7 +154,6 @@ func getACIFiles(img Image, ap ACIProvider, allFiles map[string]struct{}, pwlm m
 		// If the file is a directory continue also if not in PathWhiteList
 		if hdr.Typeflag != tar.TypeDir {
 			if len(img.Im.PathWhitelist) > 0 {
-				thispwlm := pwlToMap(img.Im.PathWhitelist)
 				if _, ok := thispwlm[cleanName]; !ok {
 					return nil
 				}
@@ -199,8 +199,7 @@ func pwlToMap(pwl []string) map[string]struct{} {
 	}
 	m := make(map[string]struct{}, len(pwl))
 	for _, name := range pwl {
-		cleanName := filepath.Clean(name)
-		relpath := filepath.Join("rootfs/", cleanName)
+		relpath := filepath.Join("rootfs", name)
 		m[relpath] = struct{}{}
 	}
 	return m

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/acname.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/acname.go
@@ -65,6 +65,16 @@ func NewACName(s string) (*ACName, error) {
 	return &n, nil
 }
 
+// MustACName generates a new ACName from a string, If the given string is
+// not a valid ACName, it panics.
+func MustACName(s string) *ACName {
+	n, err := NewACName(s)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
 func (n ACName) assertValid() error {
 	s := string(n)
 	if len(s) == 0 {

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/acname_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/acname_test.go
@@ -54,6 +54,29 @@ func TestNewACNameBad(t *testing.T) {
 	}
 }
 
+func TestMustACName(t *testing.T) {
+	for i, in := range goodNames {
+		l := MustACName(in)
+		if l == nil {
+			t.Errorf("#%d: got l=nil, want non-nil", i)
+		}
+	}
+}
+
+func expectPanicMustACName(i int, in string, t *testing.T) {
+	defer func() {
+		recover()
+	}()
+	_ = MustACName(in)
+	t.Errorf("#%d: panic expected", i)
+}
+
+func TestMustACNameBad(t *testing.T) {
+	for i, in := range badNames {
+		expectPanicMustACName(i, in, t)
+	}
+}
+
 func TestSanitizeACName(t *testing.T) {
 	tests := map[string]string{
 		"foo#":                                             "foo",

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/labels.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/labels.go
@@ -92,6 +92,16 @@ func (l Labels) Get(name string) (val string, ok bool) {
 	return "", false
 }
 
+// ToMap creates a map[ACName]string.
+func (l Labels) ToMap() map[ACName]string {
+	labelsMap := make(map[ACName]string)
+	for _, lbl := range l {
+		labelsMap[lbl.Name] = lbl.Value
+	}
+	return labelsMap
+}
+
+// LabelsFromMap creates Labels from a map[ACName]string
 func LabelsFromMap(labelsMap map[ACName]string) (Labels, error) {
 	labels := Labels{}
 	for n, v := range labelsMap {

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/mountpoint.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/mountpoint.go
@@ -1,7 +1,72 @@
 package types
 
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
 type MountPoint struct {
 	Name     ACName `json:"name"`
 	Path     string `json:"path"`
 	ReadOnly bool   `json:"readOnly,omitempty"`
+}
+
+func (mount MountPoint) assertValid() error {
+	if mount.Name.Empty() {
+		return errors.New("name must be set")
+	}
+	if len(mount.Path) == 0 {
+		return errors.New("path must be set")
+	}
+	return nil
+}
+
+// MountPointFromString takes a command line mountpoint parameter and returns a mountpoint
+//
+// It is useful for actool patch-manifest --mounts
+//
+// Example mountpoint parameters:
+// 	database,path=/tmp,readOnly=true
+func MountPointFromString(mp string) (*MountPoint, error) {
+	var mount MountPoint
+
+	mp = "name=" + mp
+	v, err := url.ParseQuery(strings.Replace(mp, ",", "&", -1))
+	if err != nil {
+		return nil, err
+	}
+	for key, val := range v {
+		if len(val) > 1 {
+			return nil, fmt.Errorf("label %s with multiple values %q", key, val)
+		}
+
+		// TOOD(philips): make this less hardcoded
+		switch key {
+		case "name":
+			acn, err := NewACName(val[0])
+			if err != nil {
+				return nil, err
+			}
+			mount.Name = *acn
+		case "path":
+			mount.Path = val[0]
+		case "readOnly":
+			ro, err := strconv.ParseBool(val[0])
+			if err != nil {
+				return nil, err
+			}
+			mount.ReadOnly = ro
+		default:
+			return nil, fmt.Errorf("unknown mountpoint parameter %q", key)
+		}
+	}
+	err = mount.assertValid()
+	if err != nil {
+		return nil, err
+	}
+
+	return &mount, nil
 }

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/version.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/version.go
@@ -8,7 +8,7 @@ const (
 	// version represents the canonical version of the appc spec and tooling.
 	// For now, the schema and tooling is coupled with the spec itself, so
 	// this must be kept in sync with the VERSION file in the root of the repo.
-	version string = "0.5.1"
+	version string = "0.5.1+git"
 )
 
 var (

--- a/build
+++ b/build
@@ -66,3 +66,6 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	echo "Building rootfs (stage1) using ${JOBS} CPUs..."
 	make -C stage1/rootfs -j ${JOBS}
 fi
+
+echo "Building functional tests..."
+(cd tests && ./build)

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,5 @@
+test:
+  override:
+    - ./tests/install-deps.sh
+    - RKT_STAGE1_USR_FROM=src ./build
+    - ./test

--- a/test
+++ b/test
@@ -54,4 +54,18 @@ if [ -n "${vetRes}" ]; then
 	exit 255
 fi
 
+# Functional tests are more dangerous than unit tests: they use 'sudo' and use
+# /var/lib/rkt/ directly. Only run them inside well-known Continuous
+# Integration Services.
+if [ "$CI" == true ] ; then
+	if [ "${CIRCLECI}" == true -o "${SEMAPHORE}" == true ] ; then
+		echo "Checking functional tests..."
+		(cd tests && ./test)
+	else
+		echo "Functional tests disabled."
+	fi
+else
+	echo "Functional tests disabled."
+fi
+
 echo "Success"

--- a/tests/build
+++ b/tests/build
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+if [ ! -e ./image/manifest ] ; then
+	echo "Wrong directory"
+	exit 1
+fi
+
+(cd inspect && go build)
+
+mkdir -p image/rootfs
+cp inspect/inspect image/rootfs/
+../bin/actool build          --overwrite image rkt-inspect.aci
+../bin/actool patch-manifest --overwrite --exec="/inspect --print-msg=Hello --exit-code=0"  rkt-inspect.aci rkt-inspect-success.aci
+../bin/actool patch-manifest --overwrite --exec="/inspect --print-msg=Hello --exit-code=20" rkt-inspect.aci rkt-inspect-failure.aci
+../bin/actool patch-manifest --overwrite --exec="/inspect --print-msg=Hello --print-env=MY_VARIABLE" rkt-inspect.aci rkt-inspect-env.aci
+

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -1,0 +1,39 @@
+{
+    "acKind": "ImageManifest",
+    "acVersion": "0.5.1",
+    "name": "coreos.com/rkt-inspect",
+    "labels": [
+        {
+            "name": "version",
+            "value": "1.0.0"
+        },
+        {
+            "name": "arch",
+            "value": "amd64"
+        },
+        {
+            "name": "os",
+            "value": "linux"
+        }
+    ],
+    "app": {
+        "exec": [
+            "/inspect", "--print-msg=Hello", "--exit-code=20"
+        ],
+        "user": "0",
+        "group": "0",
+        "workingDirectory": "/",
+        "environment": [
+            {
+                "name": "MY_VARIABLE",
+                "value": "manifest"
+            }
+        ],
+        "isolators": [
+        ],
+        "mountPoints": [
+        ],
+        "ports": [
+        ]
+    }
+}

--- a/tests/inspect/inspect.go
+++ b/tests/inspect/inspect.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	//"io/ioutil"
+	"os"
+	//"strings"
+)
+
+var (
+	globalFlagset = flag.NewFlagSet("inspect", flag.ExitOnError)
+	globalFlags   = struct {
+		PrintMsg string
+		PrintEnv string
+		CheckCwd string
+		ExitCode int
+	}{}
+)
+
+func init() {
+	globalFlagset.StringVar(&globalFlags.PrintMsg, "print-msg", "", "Print the message given as parameter")
+	globalFlagset.StringVar(&globalFlags.CheckCwd, "check-cwd", "", "Check if the current working directory is the one specified")
+	globalFlagset.StringVar(&globalFlags.PrintEnv, "print-env", "", "Print the specified environment variable")
+	globalFlagset.IntVar(&globalFlags.ExitCode, "exit-code", 0, "Return this exit code")
+}
+
+func main() {
+	globalFlagset.Parse(os.Args[1:])
+	args := globalFlagset.Args()
+	if len(args) > 0 {
+		fmt.Fprintln(os.Stderr, "Wrong parameters\n")
+		os.Exit(1)
+	}
+
+	if globalFlags.PrintMsg != "" {
+		fmt.Fprintf(os.Stdout, "%s\n", globalFlags.PrintMsg)
+	}
+
+	if globalFlags.PrintEnv != "" {
+		fmt.Fprintf(os.Stdout, "%s=%s\n", globalFlags.PrintEnv, os.Getenv(globalFlags.PrintEnv))
+	}
+
+	if globalFlags.CheckCwd != "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Cannot get working directory: %v\n", err)
+			os.Exit(1)
+		}
+		if wd != globalFlags.CheckCwd {
+			fmt.Fprintf(os.Stderr, "Working directory: %q. Expected: %q.\n", wd, globalFlags.CheckCwd)
+			os.Exit(1)
+		}
+	}
+
+	os.Exit(globalFlags.ExitCode)
+}

--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -eu
+
+# Helper script for Continuous Integration Services
+
+if [ "${CI-}" == true ] ; then
+	# https://semaphoreci.com/
+	if [ "${SEMAPHORE-}" == true ] ; then
+		sudo apt-get update -qq
+		sudo apt-get install -y cpio realpath squashfs-tools
+		sudo apt-get install -y strace gdb libcap-ng-utils
+		sudo apt-get install -y expect
+		sudo apt-get install -y coreutils # systemd needs a recent /bin/ln
+		sudo apt-get install -y gperf libcap-dev intltool # systemd deps
+		sudo apt-get install -y git # cloning a tag of systemd
+	fi
+
+	# https://circleci.com/
+	if [ "${CIRCLECI-}" == true ] ; then
+		sudo apt-get update -qq
+		sudo apt-get install -y cpio realpath squashfs-tools
+		sudo apt-get install -y strace gdb libcap-ng-utils
+		sudo apt-get install -y expect
+		sudo apt-get install -y coreutils # systemd needs a recent /bin/ln
+		sudo apt-get install -y gperf libcap-dev linux-headers-3.13.0-34-generic linux-libc-dev # systemd deps
+		sudo apt-get install -y git # cloning a tag of systemd
+	fi
+fi
+

--- a/tests/semaphoreci.md
+++ b/tests/semaphoreci.md
@@ -1,0 +1,29 @@
+# Semaphore
+
+[Semaphore](https://semaphoreci.com/)
+
+## Settings
+
+Use the following configuration.
+
+### Build settings
+
+Use the following build commands:
+
+```
+./tests/install-deps.sh      # Setup
+./build                      # Setup
+./test                       # Thread #1
+```
+
+### Platform
+
+Select `Ubuntu 14.04 LTS v1503 (beta with Docker support)`.
+
+### Environment variables
+
+```
+RKT_STAGE1_USR_FROM=src
+```
+
+

--- a/tests/test
+++ b/tests/test
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+red=`tput setaf 1`
+green=`tput setaf 2`
+reset=`tput sgr0`
+
+run_test() {
+	EXPECT_SCRIPT=$1
+	NAME=$2
+	LOG_FILE=${EXPECT_SCRIPT}.log
+	sudo expect -f $1 &> $LOG_FILE
+	RC=$?
+	if [ $RC == 0 ] ; then
+		echo "${green} [OK] ${reset} $NAME"
+	else
+		echo "${red} [FAIL] ${reset} $NAME"
+		echo
+		cat $LOG_FILE
+		exit $RC
+	fi
+}
+
+for i in test-*.expect ; do
+	run_test $i $i
+done

--- a/tests/test-env.expect
+++ b/tests/test-env.expect
@@ -1,0 +1,9 @@
+spawn ../bin/rkt --debug --insecure-skip-verify  run ./rkt-inspect-env.aci
+expect "Hello"
+expect "MY_VARIABLE=manifest"
+expect eof
+
+spawn ../bin/rkt --debug --insecure-skip-verify  run --set-env=MY_VARIABLE=cmdline ./rkt-inspect-env.aci
+expect "Hello"
+expect "MY_VARIABLE=cmdline"
+expect eof

--- a/tests/test-failure.expect
+++ b/tests/test-failure.expect
@@ -1,0 +1,4 @@
+spawn ../bin/rkt --debug --insecure-skip-verify  run ./rkt-inspect-failure.aci
+expect Hello
+expect "main process exited, code=exited, status=20"
+expect eof

--- a/tests/test-success.expect
+++ b/tests/test-success.expect
@@ -1,0 +1,9 @@
+spawn ../bin/rkt --debug --insecure-skip-verify  run ./rkt-inspect-success.aci
+expect "Hello"
+while {1} {
+  expect {
+    "main process exited, code=exited, status="   {exit 1}
+    "Shutting down."                              {break}
+  }
+}
+expect eof


### PR DESCRIPTION
The functional tests are not finished: this pull request is to open the discussion.

This creates several ACIs:
```
tests/rkt-inspect.aci
tests/rkt-inspect-env.aci
tests/rkt-inspect-failure.aci
tests/rkt-inspect-success.aci
```

They all contain the same binary based on `tests/inspect/inspect.go`. Its purpose is to inspect its environment and print it on stdout. The ACIs call `/inspect` with different parameters so they inspect different things (environment variables, mounts, network etc).

Then, the shell script `tests/test` runs all the ACIs and check that they print the correct environment. It uses `/usr/bin/expect`.

The functional tests don't run by default when running `./test` because it could be dangerous for existing `rkt` installations. Indeed the tests use `sudo` and it uses the system directories `/var/lib/rkt` and `/etc/rkt`.

Each commit or pull request on github can trigger the tests. I did that with CircleCI and SemaphoreCI and the results of the functional tests are available on:
- [CircleCI](https://circleci.com/gh/alban/rkt/41): it failed because of the cgroup issue mentioned above (see #600 ).
- [SemaphoreCI](https://semaphoreci.com/alban/rkt/branches/alban-tests3/builds/2): it succeeded

https://github.com/coreos/rkt/issues/600
