### PR TITLE
rkt: added gc hooks support

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -62,6 +62,11 @@ func PodManifestPath(root string) string {
 	return filepath.Join(root, "pod")
 }
 
+// GCHooksPath returns the path of the directory with installed gc hooks
+func GCHooksPath(root string) string {
+	return filepath.Join(root, "gchooks")
+}
+
 // AppImagesPath returns the path where the app images live
 func AppImagesPath(root string) string {
 	return filepath.Join(Stage1RootfsPath(root), stage2Dir)

--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -168,6 +168,13 @@ func newPod() (*pod, error) {
 		return nil, err
 	}
 
+	// p.FileLock was just opened so it can't be in closed state
+	fd, _ := p.Fd()
+	err = syscall.Mkdirat(fd, common.GCHooksPath("."), 0700)
+	if err != nil {
+		return nil, err
+	}
+
 	err = p.xToPreparing()
 	if err != nil {
 		return nil, err
@@ -799,4 +806,9 @@ func (p *pod) getExitStatuses() (map[string]int, error) {
 		stats[name] = s
 	}
 	return stats, nil
+}
+
+// getGCHooks returns the registered gc hooks found in gchooks dir
+func (p *pod) getGCHooks() ([]string, error) {
+	return p.getDirNames(common.GCHooksPath("."))
 }


### PR DESCRIPTION
gc hooks are executables (or symlinks to such) in gchooks
subdirectory of the pod root. "rkt gc" will execute those
hooks for exited-garbage pods.