### PR TITLE
rkt: sync prepared pod file contents on disk and use syncfs also in treestore

### DIFF
--- a/pkg/sys/sys_linux.go
+++ b/pkg/sys/sys_linux.go
@@ -1,0 +1,11 @@
+package sys
+
+import "syscall"
+
+func Syncfs(fd int) error {
+	_, _, err := syscall.RawSyscall(SYS_SYNCFS, uintptr(fd), 0, 0)
+	if err != 0 {
+		return syscall.Errno(err)
+	}
+	return nil
+}

--- a/pkg/sys/sys_linux_386.go
+++ b/pkg/sys/sys_linux_386.go
@@ -1,0 +1,5 @@
+package sys
+
+const (
+	SYS_SYNCFS = 344
+)

--- a/pkg/sys/sys_linux_amd64.go
+++ b/pkg/sys/sys_linux_amd64.go
@@ -1,0 +1,5 @@
+package sys
+
+const (
+	SYS_SYNCFS = 306
+)

--- a/pkg/sys/sys_linux_arm.go
+++ b/pkg/sys/sys_linux_arm.go
@@ -1,0 +1,5 @@
+package sys
+
+const (
+	SYS_SYNCFS = 373
+)

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -146,6 +146,11 @@ func runPrepare(args []string) (exit int) {
 		return 1
 	}
 
+	if err := p.sync(); err != nil {
+		stderr("prepare: error syncing pod data: %v", err)
+		return 1
+	}
+
 	if err := p.xToPrepared(); err != nil {
 		stderr("prepare: error transitioning to prepared: %v", err)
 		return 1


### PR DESCRIPTION
This PR implement suggestions from https://github.com/coreos/rkt/issues/693#issuecomment-89003434.

`sys: add linux syncfs syscall.` adds a linux syncfs syscall. Perhaps someone should prefer the cgo way. Just let me know.

`store: use syncfs instead of syncing every file on TreeStore.Write().` converts the treestore to use the linux syncfs syscall.

`rkt: sync prepared pod file contents on disk` before returning a prepared pod uuid ensures that its contents are synced to
disk. This avoid problems running an inconsistent pod if the machine crashes
between preparing and running a pod.

This is done in two steps:

* Before calling p.xToPrepared sync all contents on disk. By now syncfs is
used as suggested in #693.
* After calling p.xToPrepared sync the PreparedDir (the parent dir of all
prepared pods) to ensure that the directory renaming is saved in its parent dir
metadata.

`rkt run` probably doesn't needs this as the pods are executed just after preparing and if the machine crashes the pod becomes garbage.

This implementation needs real world tests to verify that, under typical
workloads, no big slowdowns are introduced in the prepare phase due to the
syncfs call.