### PR TITLE
lock: add missing closes in keylock.

### DIFF
--- a/pkg/lock/keylock.go
+++ b/pkg/lock/keylock.go
@@ -144,6 +144,7 @@ func createAndLock(lockDir string, key string, mode keyLockMode) (*KeyLock, erro
 	}
 	err = keyLock.lock(mode, defaultLockRetries)
 	if err != nil {
+		keyLock.Close()
 		return nil, err
 	}
 	return keyLock, nil
@@ -206,10 +207,11 @@ func (l *KeyLock) lock(mode keyLockMode, maxRetries int) error {
 		if err != nil {
 			return err
 		}
-		err = syscall.Fstat(fd, &curStat)
-		if err != nil {
+		if err := syscall.Fstat(fd, &curStat); err != nil {
+			syscall.Close(fd)
 			return err
 		}
+		syscall.Close(fd)
 		if lockStat.Ino == curStat.Ino && lockStat.Dev == curStat.Dev {
 			return nil
 		}


### PR DESCRIPTION
* the keylock FileLock wasn't closed on error in createAndLock
* fd for changed file detection wasn't closed.