### PR TITLE
install: fix rkt install again

### DIFF
--- a/store/db.go
+++ b/store/db.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	dbfilename = "ql.db"
+	DbFilename = "ql.db"
 )
 
 type DB struct {
@@ -53,7 +53,7 @@ func (db *DB) Open() error {
 	}
 	db.lock = dl
 
-	sqldb, err := sql.Open("ql", filepath.Join(db.dbdir, dbfilename))
+	sqldb, err := sql.Open("ql", filepath.Join(db.dbdir, DbFilename))
 	if err != nil {
 		dl.Close()
 		return err


### PR DESCRIPTION
Create all cas directories explicitly and create qldb files with the
right permissions.

If we don't create them and the first fetch is made by root, the
files/directories will be created with root permissions and following
fetches as a user belonging to the rkt group will fail.