### PR TITLE
rkt: Allow overriding configuration directory paths

### DIFF
--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/common/apps"
-	"github.com/coreos/rkt/rkt/config"
 	"github.com/coreos/rkt/store"
 )
 
@@ -66,7 +65,7 @@ func runFetch(args []string) (exit int) {
 		return 1
 	}
 	ks := getKeystore()
-	config, err := config.GetConfig()
+	config, err := getConfig()
 	if err != nil {
 		stderr("fetch: cannot get configuration: %v", err)
 		return 1

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/common"
-	"github.com/coreos/rkt/rkt/config"
 	"github.com/coreos/rkt/stage0"
 	"github.com/coreos/rkt/store"
 )
@@ -94,7 +93,7 @@ func runPrepare(args []string) (exit int) {
 		return 1
 	}
 
-	config, err := config.GetConfig()
+	config, err := getConfig()
 	if err != nil {
 		stderr("prepare: cannot get configuration: %v", err)
 		return 1

--- a/rkt/rkt.go
+++ b/rkt/rkt.go
@@ -25,6 +25,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/coreos/rkt/pkg/keystore"
+	"github.com/coreos/rkt/rkt/config"
 )
 
 const (
@@ -40,6 +41,8 @@ var (
 	commands      []*Command // Commands should register themselves by appending
 	globalFlags   = struct {
 		Dir                string
+		VendorConfigDir    string
+		CustomConfigDir    string
 		Debug              bool
 		Help               bool
 		InsecureSkipVerify bool
@@ -50,6 +53,8 @@ func init() {
 	globalFlagset.BoolVar(&globalFlags.Help, "help", false, "Print usage information and exit")
 	globalFlagset.BoolVar(&globalFlags.Debug, "debug", false, "Print out more debug information to stderr")
 	globalFlagset.StringVar(&globalFlags.Dir, "dir", defaultDataDir, "rkt data directory")
+	globalFlagset.StringVar(&globalFlags.VendorConfigDir, "vendor-config", config.DefaultVendorPath, "vendor configuration directory")
+	globalFlagset.StringVar(&globalFlags.CustomConfigDir, "custom-config", config.DefaultCustomPath, "custom configuration directory")
 	globalFlagset.BoolVar(&globalFlags.InsecureSkipVerify, "insecure-skip-verify", false, "skip image or key verification")
 }
 
@@ -170,4 +175,8 @@ func getKeystore() *keystore.Keystore {
 		return nil
 	}
 	return keystore.New(nil)
+}
+
+func getConfig() (*config.Config, error) {
+	return config.GetConfigFrom(globalFlags.VendorConfigDir, globalFlags.CustomConfigDir)
 }

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/common"
-	"github.com/coreos/rkt/rkt/config"
 	"github.com/coreos/rkt/stage0"
 	"github.com/coreos/rkt/store"
 )
@@ -125,7 +124,7 @@ func runRun(args []string) (exit int) {
 		return 1
 	}
 
-	config, err := config.GetConfig()
+	config, err := getConfig()
 	if err != nil {
 		stderr("run: cannot get configuration: %v", err)
 		return 1


### PR DESCRIPTION
In the same way as we allow overriding rkt data directory. Can be
useful for some functional tests that need clean state. With those
parameters these tests could set their own data and configuration
directories.