### PR TITLE
functional tests: improve scripts

### DIFF
--- a/tests/build
+++ b/tests/build
@@ -5,7 +5,8 @@ if [ ! -e ./image/manifest ] ; then
 	exit 1
 fi
 
-# Fail if "rootfs" already exists. We delete it at the end.
+# Fail if "rootfs" already contains something. We delete it at the end.
+[ -d image/rootfs ] && rmdir image/rootfs
 mkdir image/rootfs
 
 # Populate rootfs

--- a/tests/test
+++ b/tests/test
@@ -1,4 +1,17 @@
 #!/bin/bash
 
-sudo GOPATH=$GOPATH go test -v
+# This script is normally executed by ./test in the topdir source directory.
+# In this case, $GOPATH is already set.
+#
+# However, when developing a new functional test, it is useful to run the
+# tests manually without recompiling rkt. GOPATH is set to the same directory
+# as ./build in the topdir source directory does.
+#
+# To run all tests:
+#     $ cd tests && ./test
+#
+# To run only one test:
+#     $ cd tests && ./test -run=TestEnv
+
+sudo GOPATH="${PWD}/../gopath" go test -v $*
 


### PR DESCRIPTION
It is now possible to run only one functional test, see the instructions
in tests/test.

The build script is also more reliable.