### PR TITLE
Alban/functests enter

### DIFF
--- a/tests/inspect/inspect.go
+++ b/tests/inspect/inspect.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strconv"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/syndtr/gocapability/capability"
@@ -39,6 +40,7 @@ var (
 		ExitCode     int
 		ReadFile     bool
 		WriteFile    bool
+		Sleep        int
 	}{}
 )
 
@@ -52,6 +54,7 @@ func init() {
 	globalFlagset.IntVar(&globalFlags.ExitCode, "exit-code", 0, "Return this exit code")
 	globalFlagset.BoolVar(&globalFlags.ReadFile, "read-file", false, "Print the content of the file $FILE")
 	globalFlagset.BoolVar(&globalFlags.WriteFile, "write-file", false, "Write $CONTENT in the file $FILE")
+	globalFlagset.IntVar(&globalFlags.Sleep, "sleep", -1, "Sleep before exiting (in seconds)")
 }
 
 func main() {
@@ -149,6 +152,10 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Working directory: %q. Expected: %q.\n", wd, globalFlags.CheckCwd)
 			os.Exit(1)
 		}
+	}
+
+	if globalFlags.Sleep >= 0 {
+		time.Sleep(time.Duration(globalFlags.Sleep) * time.Second)
 	}
 
 	os.Exit(globalFlags.ExitCode)

--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -11,6 +11,7 @@ if [ "${CI-}" == true ] ; then
 		sudo apt-get install -y coreutils # systemd needs a recent /bin/ln
 		sudo apt-get install -y gperf libcap-dev intltool # systemd deps
 		sudo apt-get install -y git # cloning a tag of systemd
+		sudo apt-get install -y gawk # used by TestEnv
 	fi
 
 	# https://circleci.com/

--- a/tests/rkt_env_test.go
+++ b/tests/rkt_env_test.go
@@ -22,32 +22,46 @@ import (
 )
 
 var envTests = []struct {
-	rktCmd string
-	expect string
+	runCmd    string
+	runExpect string
+	sleepCmd  string
+	enterCmd  string
 }{
 	{
 		`../bin/rkt --debug --insecure-skip-verify run ./rkt-inspect-print-var-from-manifest.aci`,
 		"VAR_FROM_MANIFEST=manifest",
+		`../bin/rkt --debug --insecure-skip-verify run ./rkt-inspect-sleep.aci`,
+		`/bin/sh -c "../bin/rkt --debug enter $(../bin/rkt list --full|grep running|gawk '{print $1}') /inspect --print-env=VAR_FROM_MANIFEST"`,
 	},
 	{
 		`../bin/rkt --debug --insecure-skip-verify run --set-env=VAR_OTHER=setenv ./rkt-inspect-print-var-other.aci`,
 		"VAR_OTHER=setenv",
+		`../bin/rkt --debug --insecure-skip-verify run --set-env=VAR_OTHER=setenv ./rkt-inspect-sleep.aci`,
+		`/bin/sh -c "../bin/rkt --debug enter $(../bin/rkt list --full|grep running|gawk '{print $1}') /inspect --print-env=VAR_OTHER"`,
 	},
 	{
 		`../bin/rkt --debug --insecure-skip-verify run --set-env=VAR_FROM_MANIFEST=setenv ./rkt-inspect-print-var-from-manifest.aci`,
 		"VAR_FROM_MANIFEST=setenv",
+		`../bin/rkt --debug --insecure-skip-verify run --set-env=VAR_FROM_MANIFEST=setenv ./rkt-inspect-sleep.aci`,
+		`/bin/sh -c "../bin/rkt --debug enter $(../bin/rkt list --full|grep running|gawk '{print $1}') /inspect --print-env=VAR_FROM_MANIFEST"`,
 	},
 	{
 		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-print-var-other.aci"`,
 		"VAR_OTHER=host",
+		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-sleep.aci"`,
+		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug enter $(../bin/rkt list --full|grep running|gawk '{print $1}') /inspect --print-env=VAR_OTHER"`,
 	},
 	{
 		`/bin/sh -c "export VAR_FROM_MANIFEST=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-print-var-from-manifest.aci"`,
 		"VAR_FROM_MANIFEST=manifest",
+		`/bin/sh -c "export VAR_FROM_MANIFEST=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-sleep.aci"`,
+		`/bin/sh -c "export VAR_FROM_MANIFEST=host ; ../bin/rkt --debug enter $(../bin/rkt list --full|grep running|gawk '{print $1}') /inspect --print-env=VAR_FROM_MANIFEST"`,
 	},
 	{
 		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true --set-env=VAR_OTHER=setenv ./rkt-inspect-print-var-other.aci"`,
 		"VAR_OTHER=setenv",
+		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true --set-env=VAR_OTHER=setenv ./rkt-inspect-sleep.aci"`,
+		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug enter $(../bin/rkt list --full|grep running|gawk '{print $1}') /inspect --print-env=VAR_OTHER"`,
 	},
 }
 
@@ -56,21 +70,55 @@ func TestEnv(t *testing.T) {
 	defer os.Remove("rkt-inspect-print-var-from-manifest.aci")
 	patchTestACI("rkt-inspect-print-var-other.aci", "--exec=/inspect --print-env=VAR_OTHER")
 	defer os.Remove("rkt-inspect-print-var-other.aci")
+	patchTestACI("rkt-inspect-sleep.aci", "--exec=/inspect --print-msg=Hello --sleep=84000")
+	defer os.Remove("rkt-inspect-sleep.aci")
 
 	for i, tt := range envTests {
-		t.Logf("Running test #%v: %v", i, tt.rktCmd)
-
-		child, err := gexpect.Spawn(tt.rktCmd)
+		// 'run' tests
+		t.Logf("Running 'run' test #%v: %v", i, tt.runCmd)
+		child, err := gexpect.Spawn(tt.runCmd)
 		if err != nil {
 			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
 		}
 
-		err = child.Expect(tt.expect)
+		err = child.Expect(tt.runExpect)
 		if err != nil {
-			t.Fatalf("Expected %q but not found", tt.expect)
+			t.Fatalf("Expected %q but not found", tt.runExpect)
 		}
 
 		err = child.Wait()
+		if err != nil {
+			t.Fatalf("rkt didn't terminate correctly: %v", err)
+		}
+
+		// 'enter' tests
+		t.Logf("Running 'enter' test #%v: sleep: %v", i, tt.sleepCmd)
+		child, err = gexpect.Spawn(tt.sleepCmd)
+		if err != nil {
+			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
+		}
+
+		err = child.Expect("Hello")
+		if err != nil {
+			t.Fatalf("Expected %q but not found", tt.runExpect)
+		}
+
+		t.Logf("Running 'enter' test #%v: enter: %v", i, tt.enterCmd)
+		enterChild, err := gexpect.Spawn(tt.enterCmd)
+		if err != nil {
+			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
+		}
+
+		err = enterChild.Expect(tt.runExpect)
+		if err != nil {
+			t.Fatalf("Expected %q but not found", tt.runExpect)
+		}
+
+		err = enterChild.Wait()
+		if err != nil {
+			t.Fatalf("rkt didn't terminate correctly: %v", err)
+		}
+		err = child.Close()
 		if err != nil {
 			t.Fatalf("rkt didn't terminate correctly: %v", err)
 		}


### PR DESCRIPTION
functional tests: rkt-enter: check environment variables

This tests that the "rkt enter" command get the environment variables set in various ways:
- from the manifest
- from -set-env
- from -inherit-env

This is a regression test for https://github.com/coreos/rkt/issues/433

I would like this test merged before we start implementing the support for starting non-root apps in https://github.com/coreos/rkt/issues/539

This PR is based on #775 and #765 to avoid multiple PR conflicting with each other