### PR TITLE
Allow setting keystore paths from cmdline

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -1,8 +1,8 @@
 # rkt configuration
 
-`rkt` reads configuration from two directories - vendor one and custom
-one. Vendor directory is by default `/usr/lib/rkt` and custom
-directory - `/etc/rkt`. `rkt` looks for configuration files inside
+`rkt` reads configuration from two directories - system one and local
+one. System directory is by default `/usr/lib/rkt` and local directory
+- `/etc/rkt`. `rkt` looks for configuration files inside
 subdirectories of those two. Inside them, it ignores everything but
 regular files with `.json` extension. This means - `rkt` does _not_
 search for the files by recursively going down the directory
@@ -26,8 +26,8 @@ file. That way older version of `rkt` can work with
 newer-but-compatible version of configuration files and newer versions
 of `rkt` can still work with older versions of configuration files.
 
-The configuration in vendor directory can be overridden by a
-configuration in custom directory. Semantics of configuration override
+The configuration in system directory can be overridden by a
+configuration in local directory. Semantics of configuration override
 are specific to the kind and the version of configuration file and are
 described below. Filenames are not playing any role in overriding.
 
@@ -100,7 +100,7 @@ be empty. Example:
 
 Overriding is done for each domain. That means that the user can
 override authentication type and/or credentials used for each
-domain. Example of vendor configuration:
+domain. Example of system configuration:
 
 In `/usr/lib/rkt/auth.d/coreos.json`:
 ```
@@ -121,7 +121,7 @@ downloading data from either `coreos.com`, `tectonic.com` or
 Bearer common-token`.
 
 But with additional configuration like follows situation
-changes. Example of custom configuration:
+changes. Example of local configuration:
 
 In `/etc/rkt/auth.d/specific-coreos.json`:
 ```
@@ -203,7 +203,7 @@ Example of dockerAuth config:
 ##### Overriding semantics
 
 Overriding is done for each registry. That means that the user can
-override credentials used for each registry. Example of vendor
+override credentials used for each registry. Example of system
 configuration:
 
 In `/usr/lib/rkt/auth.d/docker.json`:
@@ -224,7 +224,7 @@ downloading images from either `index.docker.io`, `gcr.io` or
 `quay.io`, `rkt` would use user `foo` and password `bar`.
 
 But with additional configuration like follows situation
-changes. Example of custom configuration:
+changes. Example of local configuration:
 
 In `/etc/rkt/auth.d/specific-quay.json`:
 ```

--- a/common/common.go
+++ b/common/common.go
@@ -39,6 +39,9 @@ const (
 
 	MetadataServicePort    = 2375
 	MetadataServiceRegSock = "/run/rkt/metadata-svc.sock"
+
+	DefaultCustomConfigDir = "/etc/rkt"
+	DefaultSystemConfigDir = "/usr/lib/rkt"
 )
 
 // Stage1ImagePath returns the path where the stage1 app image (unpacked ACI) is rooted,

--- a/common/common.go
+++ b/common/common.go
@@ -40,7 +40,7 @@ const (
 	MetadataServicePort    = 2375
 	MetadataServiceRegSock = "/run/rkt/metadata-svc.sock"
 
-	DefaultCustomConfigDir = "/etc/rkt"
+	DefaultLocalConfigDir  = "/etc/rkt"
 	DefaultSystemConfigDir = "/usr/lib/rkt"
 )
 

--- a/pkg/keystore/keystore.go
+++ b/pkg/keystore/keystore.go
@@ -33,8 +33,8 @@ import (
 
 // A Config structure is used to configure a Keystore.
 type Config struct {
-	RootPath         string
-	PrefixPath       string
+	LocalRootPath    string
+	LocalPrefixPath  string
 	SystemRootPath   string
 	SystemPrefixPath string
 }
@@ -53,16 +53,16 @@ func New(config *Config) *Keystore {
 	return &Keystore{config}
 }
 
-func NewConfig(systemPath, customPath string) *Config {
+func NewConfig(systemPath, localPath string) *Config {
 	return &Config{
-		RootPath:         filepath.Join(customPath, "trustedkeys", "root.d"),
-		PrefixPath:       filepath.Join(customPath, "trustedkeys", "prefix.d"),
+		LocalRootPath:    filepath.Join(localPath, "trustedkeys", "root.d"),
+		LocalPrefixPath:  filepath.Join(localPath, "trustedkeys", "prefix.d"),
 		SystemRootPath:   filepath.Join(systemPath, "trustedkeys", "root.d"),
 		SystemPrefixPath: filepath.Join(systemPath, "trustedkeys", "prefix.d"),
 	}
 }
 
-var defaultConfig = NewConfig(common.DefaultSystemConfigDir, common.DefaultCustomConfigDir)
+var defaultConfig = NewConfig(common.DefaultSystemConfigDir, common.DefaultLocalConfigDir)
 
 // CheckSignature is a convenience method for creating a Keystore with a default
 // configuration and invoking CheckSignature.
@@ -101,7 +101,7 @@ func (ks *Keystore) DeleteTrustedKeyPrefix(prefix, fingerprint string) error {
 	if err != nil {
 		return err
 	}
-	return os.Remove(path.Join(ks.PrefixPath, acname.String(), fingerprint))
+	return os.Remove(path.Join(ks.LocalPrefixPath, acname.String(), fingerprint))
 }
 
 // MaskTrustedKeySystemPrefix masks the system prefix trusted key identified by fingerprint.
@@ -110,18 +110,18 @@ func (ks *Keystore) MaskTrustedKeySystemPrefix(prefix, fingerprint string) (stri
 	if err != nil {
 		return "", err
 	}
-	dst := path.Join(ks.PrefixPath, acname.String(), fingerprint)
+	dst := path.Join(ks.LocalPrefixPath, acname.String(), fingerprint)
 	return dst, ioutil.WriteFile(dst, []byte(""), 0644)
 }
 
 // DeleteTrustedKeyRoot deletes the root trusted key identified by fingerprint.
 func (ks *Keystore) DeleteTrustedKeyRoot(fingerprint string) error {
-	return os.Remove(path.Join(ks.RootPath, fingerprint))
+	return os.Remove(path.Join(ks.LocalRootPath, fingerprint))
 }
 
 // MaskTrustedKeySystemRoot masks the system root trusted key identified by fingerprint.
 func (ks *Keystore) MaskTrustedKeySystemRoot(fingerprint string) (string, error) {
-	dst := path.Join(ks.RootPath, fingerprint)
+	dst := path.Join(ks.LocalRootPath, fingerprint)
 	return dst, ioutil.WriteFile(dst, []byte(""), 0644)
 }
 
@@ -131,12 +131,12 @@ func (ks *Keystore) StoreTrustedKeyPrefix(prefix string, r io.Reader) (string, e
 	if err != nil {
 		return "", err
 	}
-	return storeTrustedKey(path.Join(ks.PrefixPath, acname.String()), r)
+	return storeTrustedKey(path.Join(ks.LocalPrefixPath, acname.String()), r)
 }
 
 // StoreTrustedKeyRoot stores the contents of public key r as a root trusted key.
 func (ks *Keystore) StoreTrustedKeyRoot(r io.Reader) (string, error) {
-	return storeTrustedKey(ks.RootPath, r)
+	return storeTrustedKey(ks.LocalRootPath, r)
 }
 
 func storeTrustedKey(dir string, r io.Reader) (string, error) {
@@ -194,9 +194,9 @@ func (ks *Keystore) loadKeyring(prefix string) (openpgp.KeyRing, error) {
 		fullPath string
 	}{
 		{ks.SystemRootPath, ks.SystemRootPath},
-		{ks.RootPath, ks.RootPath},
+		{ks.LocalRootPath, ks.LocalRootPath},
 		{path.Join(ks.SystemPrefixPath, prefixRoot), path.Join(ks.SystemPrefixPath, acname.String())},
-		{path.Join(ks.PrefixPath, prefixRoot), path.Join(ks.PrefixPath, acname.String())},
+		{path.Join(ks.LocalPrefixPath, prefixRoot), path.Join(ks.LocalPrefixPath, acname.String())},
 	}
 	for _, p := range paths {
 		err := filepath.Walk(p.root, func(path string, info os.FileInfo, err error) error {
@@ -250,9 +250,9 @@ func NewTestKeystore() (*Keystore, string, error) {
 		return nil, "", err
 	}
 	systemDir := filepath.Join(dir, common.DefaultSystemConfigDir)
-	customDir := filepath.Join(dir, common.DefaultCustomConfigDir)
-	c := NewConfig(systemDir, customDir)
-	for _, path := range []string{c.RootPath, c.SystemRootPath, c.PrefixPath, c.SystemPrefixPath} {
+	localDir := filepath.Join(dir, common.DefaultLocalConfigDir)
+	c := NewConfig(systemDir, localDir)
+	for _, path := range []string{c.LocalRootPath, c.SystemRootPath, c.LocalPrefixPath, c.SystemPrefixPath} {
 		if err := os.MkdirAll(path, 0755); err != nil {
 			return nil, "", err
 		}

--- a/pkg/keystore/keystore.go
+++ b/pkg/keystore/keystore.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/Godeps/_workspace/src/golang.org/x/crypto/openpgp"
+	"github.com/coreos/rkt/common"
 )
 
 // A Config structure is used to configure a Keystore.
@@ -52,12 +53,16 @@ func New(config *Config) *Keystore {
 	return &Keystore{config}
 }
 
-var defaultConfig = &Config{
-	RootPath:         "/etc/rkt/trustedkeys/root.d",
-	PrefixPath:       "/etc/rkt/trustedkeys/prefix.d",
-	SystemRootPath:   "/usr/lib/rkt/trustedkeys/root.d",
-	SystemPrefixPath: "/usr/lib/rkt/trustedkeys/prefix.d",
+func NewConfig(systemPath, customPath string) *Config {
+	return &Config{
+		RootPath:         filepath.Join(customPath, "trustedkeys", "root.d"),
+		PrefixPath:       filepath.Join(customPath, "trustedkeys", "prefix.d"),
+		SystemRootPath:   filepath.Join(systemPath, "trustedkeys", "root.d"),
+		SystemPrefixPath: filepath.Join(systemPath, "trustedkeys", "prefix.d"),
+	}
 }
+
+var defaultConfig = NewConfig(common.DefaultSystemConfigDir, common.DefaultCustomConfigDir)
 
 // CheckSignature is a convenience method for creating a Keystore with a default
 // configuration and invoking CheckSignature.
@@ -244,12 +249,9 @@ func NewTestKeystore() (*Keystore, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	c := &Config{
-		RootPath:         path.Join(dir, "/etc/rkt/trustedkeys/root.d"),
-		SystemRootPath:   path.Join(dir, "/usr/lib/rkt/trustedkeys/root.d"),
-		PrefixPath:       path.Join(dir, "/etc/rkt/trustedkeys/prefix.d"),
-		SystemPrefixPath: path.Join(dir, "/usr/lib/rkt/trustedkeys/prefix.d"),
-	}
+	systemDir := filepath.Join(dir, common.DefaultSystemConfigDir)
+	customDir := filepath.Join(dir, common.DefaultCustomConfigDir)
+	c := NewConfig(systemDir, customDir)
 	for _, path := range []string{c.RootPath, c.SystemRootPath, c.PrefixPath, c.SystemPrefixPath} {
 		if err := os.MkdirAll(path, 0755); err != nil {
 			return nil, "", err

--- a/rkt/config/config.go
+++ b/rkt/config/config.go
@@ -104,19 +104,19 @@ func toArray(s map[string]struct{}) []string {
 }
 
 // GetConfig gets the Config instance with configuration taken from
-// default vendor path (see common.DefaultSystemConfigDir) overridden
-// with configuration from default custom path (see
-// common.DefaultSystemConfigDir).
+// default system path (see common.DefaultSystemConfigDir) overridden
+// with configuration from default local path (see
+// common.DefaultLocalConfigDir).
 func GetConfig() (*Config, error) {
-	return GetConfigFrom(common.DefaultSystemConfigDir, common.DefaultCustomConfigDir)
+	return GetConfigFrom(common.DefaultSystemConfigDir, common.DefaultLocalConfigDir)
 }
 
-// GetConfigFrom gets the Config instance with configuration taken from
-// given vendor path overridden with configuration from given custom
-// path.
-func GetConfigFrom(vendor, custom string) (*Config, error) {
+// GetConfigFrom gets the Config instance with configuration taken
+// from given system path overridden with configuration from given
+// local path.
+func GetConfigFrom(system, local string) (*Config, error) {
 	cfg := newConfig()
-	for _, cd := range []string{vendor, custom} {
+	for _, cd := range []string{system, local} {
 		subcfg, err := GetConfigFromDir(cd)
 		if err != nil {
 			return nil, err

--- a/rkt/config/config.go
+++ b/rkt/config/config.go
@@ -56,12 +56,6 @@ var (
 	parsersForKind = make(map[string]map[string]configParser)
 )
 
-// Default paths for vendor and custom configuration
-const (
-	DefaultVendorPath = common.DefaultSystemConfigDir
-	DefaultCustomPath = common.DefaultCustomConfigDir
-)
-
 func addParser(kind, version string, parser configParser) {
 	if len(kind) == 0 {
 		panic("empty kind string when registering a config parser")
@@ -110,10 +104,11 @@ func toArray(s map[string]struct{}) []string {
 }
 
 // GetConfig gets the Config instance with configuration taken from
-// default vendor path (see DefaultVendorPath) overridden with
-// configuration from default custom path (see DefaultCustomPath).
+// default vendor path (see common.DefaultSystemConfigDir) overridden
+// with configuration from default custom path (see
+// common.DefaultSystemConfigDir).
 func GetConfig() (*Config, error) {
-	return GetConfigFrom(DefaultVendorPath, DefaultCustomPath)
+	return GetConfigFrom(common.DefaultSystemConfigDir, common.DefaultCustomConfigDir)
 }
 
 // GetConfigFrom gets the Config instance with configuration taken from

--- a/rkt/config/config.go
+++ b/rkt/config/config.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/coreos/rkt/common"
 )
 
 // Headerer is an interface for getting additional HTTP headers to use
@@ -56,8 +58,8 @@ var (
 
 // Default paths for vendor and custom configuration
 const (
-	DefaultVendorPath = "/usr/lib/rkt"
-	DefaultCustomPath = "/etc/rkt"
+	DefaultVendorPath = common.DefaultSystemConfigDir
+	DefaultCustomPath = common.DefaultCustomConfigDir
 )
 
 func addParser(kind, version string, parser configParser) {

--- a/rkt/config/config_test.go
+++ b/rkt/config/config_test.go
@@ -156,17 +156,17 @@ func TestConfigLoading(t *testing.T) {
 		panic(fmt.Sprintf("Failed to create temporary directory: %v", err))
 	}
 	defer os.RemoveAll(dir)
-	vendorAuth := filepath.Join("vendor", "auth.d")
-	vendorIgnored := filepath.Join(vendorAuth, "ignoreddir")
-	customAuth := filepath.Join("custom", "auth.d")
-	customIgnored := filepath.Join(customAuth, "ignoreddir")
+	systemAuth := filepath.Join("system", "auth.d")
+	systemIgnored := filepath.Join(systemAuth, "ignoreddir")
+	localAuth := filepath.Join("local", "auth.d")
+	localIgnored := filepath.Join(localAuth, "ignoreddir")
 	dirs := []string{
-		"vendor",
-		vendorAuth,
-		vendorIgnored,
-		"custom",
-		customAuth,
-		customIgnored,
+		"system",
+		systemAuth,
+		systemIgnored,
+		"local",
+		localAuth,
+		localIgnored,
 	}
 	for _, d := range dirs {
 		cd := filepath.Join(dir, d)
@@ -180,23 +180,23 @@ func TestConfigLoading(t *testing.T) {
 		user   string
 		pass   string
 	}{
-		{filepath.Join(dir, vendorAuth, "endocode.json"), "endocode.com", "vendor_user1", "vendor_password1"},
-		{filepath.Join(dir, vendorAuth, "coreos.json"), "coreos.com", "vendor_user2", "vendor_password2"},
-		{filepath.Join(dir, vendorAuth, "ignoredfile"), "example1.com", "ignored_user1", "ignored_password1"},
-		{filepath.Join(dir, vendorIgnored, "ignoredfile"), "example2.com", "ignored_user2", "ignored_password2"},
-		{filepath.Join(dir, vendorIgnored, "ignoredanyway.json"), "example3.com", "ignored_user3", "ignored_password3"},
-		{filepath.Join(dir, customAuth, "endocode.json"), "endocode.com", "custom_user1", "custom_password1"},
-		{filepath.Join(dir, customAuth, "tectonic.json"), "tectonic.com", "custom_user2", "custom_password2"},
-		{filepath.Join(dir, customAuth, "ignoredfile"), "example4.com", "ignored_user4", "ignored_password4"},
-		{filepath.Join(dir, customIgnored, "ignoredfile"), "example5.com", "ignored_user5", "ignored_password5"},
-		{filepath.Join(dir, customIgnored, "ignoredanyway.json"), "example6.com", "ignored_user6", "ignored_password6"},
+		{filepath.Join(dir, systemAuth, "endocode.json"), "endocode.com", "system_user1", "system_password1"},
+		{filepath.Join(dir, systemAuth, "coreos.json"), "coreos.com", "system_user2", "system_password2"},
+		{filepath.Join(dir, systemAuth, "ignoredfile"), "example1.com", "ignored_user1", "ignored_password1"},
+		{filepath.Join(dir, systemIgnored, "ignoredfile"), "example2.com", "ignored_user2", "ignored_password2"},
+		{filepath.Join(dir, systemIgnored, "ignoredanyway.json"), "example3.com", "ignored_user3", "ignored_password3"},
+		{filepath.Join(dir, localAuth, "endocode.json"), "endocode.com", "local_user1", "local_password1"},
+		{filepath.Join(dir, localAuth, "tectonic.json"), "tectonic.com", "local_user2", "local_password2"},
+		{filepath.Join(dir, localAuth, "ignoredfile"), "example4.com", "ignored_user4", "ignored_password4"},
+		{filepath.Join(dir, localIgnored, "ignoredfile"), "example5.com", "ignored_user5", "ignored_password5"},
+		{filepath.Join(dir, localIgnored, "ignoredanyway.json"), "example6.com", "ignored_user6", "ignored_password6"},
 	}
 	for _, f := range files {
 		if err := writeBasicConfig(f.path, f.domain, f.user, f.pass); err != nil {
 			panic(fmt.Sprintf("Failed to write configuration file: %v", err))
 		}
 	}
-	cfg, err := GetConfigFrom(filepath.Join(dir, "vendor"), filepath.Join(dir, "custom"))
+	cfg, err := GetConfigFrom(filepath.Join(dir, "system"), filepath.Join(dir, "local"))
 	if err != nil {
 		panic(fmt.Sprintf("Failed to get configuration: %v", err))
 	}
@@ -206,16 +206,16 @@ func TestConfigLoading(t *testing.T) {
 	}
 	expected := map[string]http.Header{
 		"endocode.com": http.Header{
-			// custom_user1:custom_password1
-			authHeader: []string{"Basic Y3VzdG9tX3VzZXIxOmN1c3RvbV9wYXNzd29yZDE="},
+			// local_user1:local_password1
+			authHeader: []string{"Basic bG9jYWxfdXNlcjE6bG9jYWxfcGFzc3dvcmQx"},
 		},
 		"coreos.com": http.Header{
-			// vendor_user2:vendor_password2
-			authHeader: []string{"Basic dmVuZG9yX3VzZXIyOnZlbmRvcl9wYXNzd29yZDI="},
+			// system_user2:system_password2
+			authHeader: []string{"Basic c3lzdGVtX3VzZXIyOnN5c3RlbV9wYXNzd29yZDI="},
 		},
 		"tectonic.com": http.Header{
-			// custom_user2:custom_password2
-			authHeader: []string{"Basic Y3VzdG9tX3VzZXIyOmN1c3RvbV9wYXNzd29yZDI="},
+			// local_user2:local_password2
+			authHeader: []string{"Basic bG9jYWxfdXNlcjI6bG9jYWxfcGFzc3dvcmQy"},
 		},
 	}
 	if !reflect.DeepEqual(result, expected) {

--- a/rkt/rkt.go
+++ b/rkt/rkt.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/pkg/keystore"
 	"github.com/coreos/rkt/rkt/config"
 )
@@ -53,8 +54,8 @@ func init() {
 	globalFlagset.BoolVar(&globalFlags.Help, "help", false, "Print usage information and exit")
 	globalFlagset.BoolVar(&globalFlags.Debug, "debug", false, "Print out more debug information to stderr")
 	globalFlagset.StringVar(&globalFlags.Dir, "dir", defaultDataDir, "rkt data directory")
-	globalFlagset.StringVar(&globalFlags.VendorConfigDir, "vendor-config", config.DefaultVendorPath, "vendor configuration directory")
-	globalFlagset.StringVar(&globalFlags.CustomConfigDir, "custom-config", config.DefaultCustomPath, "custom configuration directory")
+	globalFlagset.StringVar(&globalFlags.VendorConfigDir, "vendor-config", common.DefaultSystemConfigDir, "vendor configuration directory")
+	globalFlagset.StringVar(&globalFlags.CustomConfigDir, "custom-config", common.DefaultCustomConfigDir, "custom configuration directory")
 	globalFlagset.BoolVar(&globalFlags.InsecureSkipVerify, "insecure-skip-verify", false, "skip image or key verification")
 }
 

--- a/rkt/rkt.go
+++ b/rkt/rkt.go
@@ -42,8 +42,8 @@ var (
 	commands      []*Command // Commands should register themselves by appending
 	globalFlags   = struct {
 		Dir                string
-		VendorConfigDir    string
-		CustomConfigDir    string
+		SystemConfigDir    string
+		LocalConfigDir     string
 		Debug              bool
 		Help               bool
 		InsecureSkipVerify bool
@@ -54,8 +54,8 @@ func init() {
 	globalFlagset.BoolVar(&globalFlags.Help, "help", false, "Print usage information and exit")
 	globalFlagset.BoolVar(&globalFlags.Debug, "debug", false, "Print out more debug information to stderr")
 	globalFlagset.StringVar(&globalFlags.Dir, "dir", defaultDataDir, "rkt data directory")
-	globalFlagset.StringVar(&globalFlags.VendorConfigDir, "vendor-config", common.DefaultSystemConfigDir, "vendor configuration directory")
-	globalFlagset.StringVar(&globalFlags.CustomConfigDir, "custom-config", common.DefaultCustomConfigDir, "custom configuration directory")
+	globalFlagset.StringVar(&globalFlags.SystemConfigDir, "system-config", common.DefaultSystemConfigDir, "system configuration directory")
+	globalFlagset.StringVar(&globalFlags.LocalConfigDir, "local-config", common.DefaultLocalConfigDir, "local configuration directory")
 	globalFlagset.BoolVar(&globalFlags.InsecureSkipVerify, "insecure-skip-verify", false, "skip image or key verification")
 }
 
@@ -175,10 +175,10 @@ func getKeystore() *keystore.Keystore {
 	if globalFlags.InsecureSkipVerify {
 		return nil
 	}
-	config := keystore.NewConfig(globalFlags.VendorConfigDir, globalFlags.CustomConfigDir)
+	config := keystore.NewConfig(globalFlags.SystemConfigDir, globalFlags.LocalConfigDir)
 	return keystore.New(config)
 }
 
 func getConfig() (*config.Config, error) {
-	return config.GetConfigFrom(globalFlags.VendorConfigDir, globalFlags.CustomConfigDir)
+	return config.GetConfigFrom(globalFlags.SystemConfigDir, globalFlags.LocalConfigDir)
 }

--- a/rkt/rkt.go
+++ b/rkt/rkt.go
@@ -174,7 +174,8 @@ func getKeystore() *keystore.Keystore {
 	if globalFlags.InsecureSkipVerify {
 		return nil
 	}
-	return keystore.New(nil)
+	config := keystore.NewConfig(globalFlags.VendorConfigDir, globalFlags.CustomConfigDir)
+	return keystore.New(config)
 }
 
 func getConfig() (*config.Config, error) {

--- a/tests/rkt_auth_test.go
+++ b/tests/rkt_auth_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/ThomasRooney/gexpect"
-	"github.com/coreos/rkt/rkt/config"
+	"github.com/coreos/rkt/common"
 	taas "github.com/coreos/rkt/tests/test-auth-server/aci"
 )
 
@@ -50,8 +50,8 @@ type genericAuthTest struct {
 func TestAuthBasic(t *testing.T) {
 	tests := []genericAuthTest{
 		{"basic-no-config", false, "", authFailedDownload},
-		{"basic-custom-config", true, config.DefaultCustomPath, authSuccessfulDownload},
-		{"basic-vendor-config", true, config.DefaultVendorPath, authSuccessfulDownload},
+		{"basic-custom-config", true, common.DefaultCustomConfigDir, authSuccessfulDownload},
+		{"basic-vendor-config", true, common.DefaultSystemConfigDir, authSuccessfulDownload},
 	}
 	testAuthGeneric(t, taas.Basic, tests)
 }
@@ -59,8 +59,8 @@ func TestAuthBasic(t *testing.T) {
 func TestAuthOauth(t *testing.T) {
 	tests := []genericAuthTest{
 		{"oauth-no-config", false, "", authFailedDownload},
-		{"oauth-custom-config", true, config.DefaultCustomPath, authSuccessfulDownload},
-		{"oauth-vendor-config", true, config.DefaultVendorPath, authSuccessfulDownload},
+		{"oauth-custom-config", true, common.DefaultCustomConfigDir, authSuccessfulDownload},
+		{"oauth-vendor-config", true, common.DefaultSystemConfigDir, authSuccessfulDownload},
 	}
 	testAuthGeneric(t, taas.Oauth, tests)
 }
@@ -126,8 +126,8 @@ func testAuthIgnoreBogusFiles(t *testing.T, server *taas.Server) {
 
 func testAuthIgnoreSubdirectories(t *testing.T, server *taas.Server) {
 	removeAllConfig(t)
-	customSubdir := filepath.Join(config.DefaultCustomPath, "subdir")
-	vendorSubdir := filepath.Join(config.DefaultVendorPath, "subdir")
+	customSubdir := filepath.Join(common.DefaultCustomConfigDir, "subdir")
+	vendorSubdir := filepath.Join(common.DefaultSystemConfigDir, "subdir")
 	writeConfig(t, customSubdir, "test.json", server.Conf)
 	writeConfig(t, vendorSubdir, "test.json", server.Conf)
 	failedRunRkt(t, server.URL, "oauth-subdirectories")
@@ -189,8 +189,8 @@ func runRkt(t *testing.T, host, dir string) *gexpect.ExpectSubprocess {
 
 func removeAllConfig(t *testing.T) {
 	dirs := []string{
-		authDir(config.DefaultCustomPath),
-		authDir(config.DefaultVendorPath),
+		authDir(common.DefaultCustomConfigDir),
+		authDir(common.DefaultSystemConfigDir),
 	}
 	for _, p := range dirs {
 		if err := os.RemoveAll(p); err != nil {
@@ -203,11 +203,11 @@ func removeAllConfig(t *testing.T) {
 }
 
 func writeCustomConfig(t *testing.T, filename, contents string) {
-	writeConfig(t, config.DefaultCustomPath, filename, contents)
+	writeConfig(t, common.DefaultCustomConfigDir, filename, contents)
 }
 
 func writeVendorConfig(t *testing.T, filename, contents string) {
-	writeConfig(t, config.DefaultVendorPath, filename, contents)
+	writeConfig(t, common.DefaultSystemConfigDir, filename, contents)
 }
 
 func writeConfig(t *testing.T, baseDir, filename, contents string) {

--- a/tests/rkt_auth_test.go
+++ b/tests/rkt_auth_test.go
@@ -50,8 +50,8 @@ type genericAuthTest struct {
 func TestAuthBasic(t *testing.T) {
 	tests := []genericAuthTest{
 		{"basic-no-config", false, "", authFailedDownload},
-		{"basic-custom-config", true, common.DefaultCustomConfigDir, authSuccessfulDownload},
-		{"basic-vendor-config", true, common.DefaultSystemConfigDir, authSuccessfulDownload},
+		{"basic-local-config", true, common.DefaultLocalConfigDir, authSuccessfulDownload},
+		{"basic-system-config", true, common.DefaultSystemConfigDir, authSuccessfulDownload},
 	}
 	testAuthGeneric(t, taas.Basic, tests)
 }
@@ -59,8 +59,8 @@ func TestAuthBasic(t *testing.T) {
 func TestAuthOauth(t *testing.T) {
 	tests := []genericAuthTest{
 		{"oauth-no-config", false, "", authFailedDownload},
-		{"oauth-custom-config", true, common.DefaultCustomConfigDir, authSuccessfulDownload},
-		{"oauth-vendor-config", true, common.DefaultSystemConfigDir, authSuccessfulDownload},
+		{"oauth-local-config", true, common.DefaultLocalConfigDir, authSuccessfulDownload},
+		{"oauth-system-config", true, common.DefaultSystemConfigDir, authSuccessfulDownload},
 	}
 	testAuthGeneric(t, taas.Oauth, tests)
 }
@@ -87,20 +87,20 @@ func TestAuthOverride(t *testing.T) {
 	server := runServer(t, taas.Oauth)
 	defer server.Close()
 	tests := []struct {
-		vendorConfig         string
-		customConfig         string
+		systemConfig         string
+		localConfig          string
 		name                 string
 		resultBeforeOverride string
 		resultAfterOverride  string
 	}{
-		{server.Conf, getInvalidOAuthConfig(server.Conf), "valid-vendor-invalid-custom", authSuccessfulDownload, authFailedDownload},
-		{getInvalidOAuthConfig(server.Conf), server.Conf, "invalid-vendor-valid-custom", authFailedDownload, authSuccessfulDownload},
+		{server.Conf, getInvalidOAuthConfig(server.Conf), "valid-system-invalid-local", authSuccessfulDownload, authFailedDownload},
+		{getInvalidOAuthConfig(server.Conf), server.Conf, "invalid-system-valid-local", authFailedDownload, authSuccessfulDownload},
 	}
 	for _, tt := range tests {
 		removeAllConfig(t)
-		writeVendorConfig(t, "test.json", tt.vendorConfig)
+		writeSystemConfig(t, "test.json", tt.systemConfig)
 		expectedRunRkt(t, server.URL, tt.name+"-1", tt.resultBeforeOverride)
-		writeCustomConfig(t, "test.json", tt.customConfig)
+		writeLocalConfig(t, "test.json", tt.localConfig)
 		expectedRunRkt(t, server.URL, tt.name+"-2", tt.resultAfterOverride)
 	}
 }
@@ -117,19 +117,19 @@ func TestAuthIgnore(t *testing.T) {
 
 func testAuthIgnoreBogusFiles(t *testing.T, server *taas.Server) {
 	removeAllConfig(t)
-	writeVendorConfig(t, "README", "This is vendor config")
-	writeCustomConfig(t, "README", "This is custom config")
-	writeVendorConfig(t, "test.notjson", server.Conf)
-	writeCustomConfig(t, "test.notjson", server.Conf)
+	writeSystemConfig(t, "README", "This is system config")
+	writeLocalConfig(t, "README", "This is local config")
+	writeSystemConfig(t, "test.notjson", server.Conf)
+	writeLocalConfig(t, "test.notjson", server.Conf)
 	failedRunRkt(t, server.URL, "oauth-bogus-files")
 }
 
 func testAuthIgnoreSubdirectories(t *testing.T, server *taas.Server) {
 	removeAllConfig(t)
-	customSubdir := filepath.Join(common.DefaultCustomConfigDir, "subdir")
-	vendorSubdir := filepath.Join(common.DefaultSystemConfigDir, "subdir")
-	writeConfig(t, customSubdir, "test.json", server.Conf)
-	writeConfig(t, vendorSubdir, "test.json", server.Conf)
+	localSubdir := filepath.Join(common.DefaultLocalConfigDir, "subdir")
+	systemSubdir := filepath.Join(common.DefaultSystemConfigDir, "subdir")
+	writeConfig(t, localSubdir, "test.json", server.Conf)
+	writeConfig(t, systemSubdir, "test.json", server.Conf)
 	failedRunRkt(t, server.URL, "oauth-subdirectories")
 }
 
@@ -170,7 +170,7 @@ func expectedRunRkt(t *testing.T, host, dir, line string) {
 }
 
 // TODO (krnowak): Use --dir option when we also add
-// --vendor-config-dir and --custom-config-dir options. Then we can
+// --system-config-dir and --local-config-dir options. Then we can
 // remove destructive tests checks.
 
 // runRkt tries to fetch and run a prog.aci from host within given
@@ -189,7 +189,7 @@ func runRkt(t *testing.T, host, dir string) *gexpect.ExpectSubprocess {
 
 func removeAllConfig(t *testing.T) {
 	dirs := []string{
-		authDir(common.DefaultCustomConfigDir),
+		authDir(common.DefaultLocalConfigDir),
 		authDir(common.DefaultSystemConfigDir),
 	}
 	for _, p := range dirs {
@@ -202,11 +202,11 @@ func removeAllConfig(t *testing.T) {
 	}
 }
 
-func writeCustomConfig(t *testing.T, filename, contents string) {
-	writeConfig(t, common.DefaultCustomConfigDir, filename, contents)
+func writeLocalConfig(t *testing.T, filename, contents string) {
+	writeConfig(t, common.DefaultLocalConfigDir, filename, contents)
 }
 
-func writeVendorConfig(t *testing.T, filename, contents string) {
+func writeSystemConfig(t *testing.T, filename, contents string) {
 	writeConfig(t, common.DefaultSystemConfigDir, filename, contents)
 }
 


### PR DESCRIPTION
This is a continuation of #778. It reuses --vendor-config and --custom-config to set up keystore parameters.

This somewhat conflicts for now with #760 - that PR uses constants from rkt/config package which were moved to common package in this PR.