### PR TITLE
Check more packages with gofmt and go vet

### DIFF
--- a/test
+++ b/test
@@ -14,8 +14,37 @@ COVER=${COVER:-"-cover"}
 
 source ./build
 
-TESTABLE_AND_FORMATTABLE="pkg/keystore pkg/lock pkg/tar rkt rkt/config stage1/init store"
-FORMATTABLE="$TESTABLE_AND_FORMATTABLE common common/apps networking networking/netinfo pkg/aci pkg/keystore/keystoretest pkg/sys stage0 stage1 stage1/gc tests tests/inspect tests/test-auth-server tests/test-auth-server/aci version"
+function find_dirs_with_suffixed_files
+{
+    # File suffix, can contain dots, asterisks and question marks -
+    # they will be escaped. Use of other metacharacters is at your own
+    # risk.
+    local suffix="$1"
+    # Escape question mark and asterisk metacharacters from suffix, so
+    # they are matched literally in find command.
+    local find_escaped_suffix=$(echo "${suffix}" | sed -e 's/\([?*]\)/\\\1/g')
+    # Escape dot and asterisk metacharacters from suffix, so they are
+    # matched literally in sed 's' command.
+    local sed_escaped_suffix=$(echo "${suffix}" | sed -e 's/\([.*]\)/\\\1/g')
+    # Variable 'exclude' is an POSIX ERE fragment to be put between
+    # '^(' and ')$'.
+    local exclude="$2"
+    # Find all files ending with given suffix, ...
+    find . -name '*'"${find_escaped_suffix}" |
+	# ... remove files with given suffix together with preceding slash, ...
+	sed -e 's/\/[[:alnum:]_]\+'"${sed_escaped_suffix}"'//g' |
+	# ... remove leading './', ...
+	sed -e 's/^\.\///g' |
+	# ... sort alphabetically, ...
+	sort |
+	# ... remove repeated directories, ...
+	uniq |
+	# ... and filter out given directories.
+	grep -vEe '^('"${exclude}"')$'
+}
+
+TESTABLE_AND_FORMATTABLE=$(find_dirs_with_suffixed_files '_test.go' 'Godeps/.*|tests')
+FORMATTABLE=$(find_dirs_with_suffixed_files '.go' 'Godeps/.*')
 
 # user has not provided PKG override
 if [ -z "$PKG" ]; then

--- a/test
+++ b/test
@@ -15,7 +15,7 @@ COVER=${COVER:-"-cover"}
 source ./build
 
 TESTABLE_AND_FORMATTABLE="pkg/keystore pkg/lock pkg/tar rkt rkt/config stage1/init store"
-FORMATTABLE="$TESTABLE_AND_FORMATTABLE common networking stage0/run.go version"
+FORMATTABLE="$TESTABLE_AND_FORMATTABLE common common/apps networking networking/netinfo pkg/aci pkg/keystore/keystoretest pkg/sys stage0 stage1 stage1/gc tests tests/inspect tests/test-auth-server tests/test-auth-server/aci version"
 
 # user has not provided PKG override
 if [ -z "$PKG" ]; then
@@ -47,8 +47,12 @@ if [ -n "${fmtRes}" ]; then
 	exit 255
 fi
 
+# split FMT into an array and prepend REPO_PATH to each local package for go vet
+split_vet=(${FMT// / })
+VET_TEST=${split_vet[@]/#/${REPO_PATH}/}
+
 echo "Checking govet..."
-vetRes=$(go vet $TEST)
+vetRes=$(go vet $VET_TEST)
 if [ -n "${vetRes}" ]; then
 	echo -e "govet checking failed:\n${vetRes}"
 	exit 255

--- a/tests/inspect/inspect.go
+++ b/tests/inspect/inspect.go
@@ -63,7 +63,7 @@ func main() {
 	globalFlagset.Parse(os.Args[1:])
 	args := globalFlagset.Args()
 	if len(args) > 0 {
-		fmt.Fprintln(os.Stderr, "Wrong parameters\n")
+		fmt.Fprintln(os.Stderr, "Wrong parameters")
 		os.Exit(1)
 	}
 

--- a/tests/rkt_auth_test.go
+++ b/tests/rkt_auth_test.go
@@ -48,9 +48,9 @@ const (
 )
 
 type genericAuthTest struct {
-	name          string
-	confDir       authConfDir
-	expectedLine  string
+	name         string
+	confDir      authConfDir
+	expectedLine string
 }
 
 func TestAuthBasic(t *testing.T) {

--- a/tests/test-auth-server/aci/server.go
+++ b/tests/test-auth-server/aci/server.go
@@ -229,7 +229,7 @@ func NewServerWithPaths(auth Type, msgCapacity int, acTool, goTool string) (*Ser
 func getTool(tool string) (string, error) {
 	toolPath, err := exec.LookPath(tool)
 	if err != nil {
-		return "", fmt.Errorf("failed to find %s in $PATH: $v", tool, err)
+		return "", fmt.Errorf("failed to find %s in $PATH: %v", tool, err)
 	}
 	absToolPath, err := filepath.Abs(toolPath)
 	if err != nil {


### PR DESCRIPTION
Commits in this PR do:
1. Run `go vet` against packages mentioned in `FORMATTABLE` instead of `TESTABLE_AND_FORMATTABLE` and extend the list of packages in `FORMATTABLE`.
3. Fix issues in inspect and networking.
4. Replace the hardcoded list of packages with inexplicable magic.
5. Remove dead unit test file from networking - outdated, does not build, never executed.

cc @alban @eyakubovich for `go vet` fixes.