### PR TITLE
Semaphore: reduce dependencies for faster functional tests

### DIFF
--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -5,13 +5,14 @@
 if [ "${CI-}" == true ] ; then
 	# https://semaphoreci.com/
 	if [ "${SEMAPHORE-}" == true ] ; then
-		sudo apt-get update -qq
-		sudo apt-get install -y cpio realpath squashfs-tools
-		sudo apt-get install -y strace gdb libcap-ng-utils
-		sudo apt-get install -y coreutils # systemd needs a recent /bin/ln
-		sudo apt-get install -y gperf libcap-dev intltool # systemd deps
-		sudo apt-get install -y git # cloning a tag of systemd
-		sudo apt-get install -y gawk # used by TestEnv
+		# Most dependencies are already installed on Semaphore.
+		# Here we can install any missing dependencies. Whenever
+		# Semaphore installs more dependencies on their platform,
+		# they should be removed from here to save time.
+
+		#sudo apt-get update -qq
+		#sudo apt-get install -y packagename
+		:
 	fi
 
 	# https://circleci.com/

--- a/tests/rkt_env_test.go
+++ b/tests/rkt_env_test.go
@@ -31,37 +31,37 @@ var envTests = []struct {
 		`../bin/rkt --debug --insecure-skip-verify run ./rkt-inspect-print-var-from-manifest.aci`,
 		"VAR_FROM_MANIFEST=manifest",
 		`../bin/rkt --debug --insecure-skip-verify run ./rkt-inspect-sleep.aci`,
-		`/bin/sh -c "../bin/rkt --debug enter $(../bin/rkt list --full|grep running|gawk '{print $1}') /inspect --print-env=VAR_FROM_MANIFEST"`,
+		`/bin/sh -c "../bin/rkt --debug enter $(../bin/rkt list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_FROM_MANIFEST"`,
 	},
 	{
 		`../bin/rkt --debug --insecure-skip-verify run --set-env=VAR_OTHER=setenv ./rkt-inspect-print-var-other.aci`,
 		"VAR_OTHER=setenv",
 		`../bin/rkt --debug --insecure-skip-verify run --set-env=VAR_OTHER=setenv ./rkt-inspect-sleep.aci`,
-		`/bin/sh -c "../bin/rkt --debug enter $(../bin/rkt list --full|grep running|gawk '{print $1}') /inspect --print-env=VAR_OTHER"`,
+		`/bin/sh -c "../bin/rkt --debug enter $(../bin/rkt list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_OTHER"`,
 	},
 	{
 		`../bin/rkt --debug --insecure-skip-verify run --set-env=VAR_FROM_MANIFEST=setenv ./rkt-inspect-print-var-from-manifest.aci`,
 		"VAR_FROM_MANIFEST=setenv",
 		`../bin/rkt --debug --insecure-skip-verify run --set-env=VAR_FROM_MANIFEST=setenv ./rkt-inspect-sleep.aci`,
-		`/bin/sh -c "../bin/rkt --debug enter $(../bin/rkt list --full|grep running|gawk '{print $1}') /inspect --print-env=VAR_FROM_MANIFEST"`,
+		`/bin/sh -c "../bin/rkt --debug enter $(../bin/rkt list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_FROM_MANIFEST"`,
 	},
 	{
 		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-print-var-other.aci"`,
 		"VAR_OTHER=host",
 		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-sleep.aci"`,
-		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug enter $(../bin/rkt list --full|grep running|gawk '{print $1}') /inspect --print-env=VAR_OTHER"`,
+		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug enter $(../bin/rkt list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_OTHER"`,
 	},
 	{
 		`/bin/sh -c "export VAR_FROM_MANIFEST=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-print-var-from-manifest.aci"`,
 		"VAR_FROM_MANIFEST=manifest",
 		`/bin/sh -c "export VAR_FROM_MANIFEST=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-sleep.aci"`,
-		`/bin/sh -c "export VAR_FROM_MANIFEST=host ; ../bin/rkt --debug enter $(../bin/rkt list --full|grep running|gawk '{print $1}') /inspect --print-env=VAR_FROM_MANIFEST"`,
+		`/bin/sh -c "export VAR_FROM_MANIFEST=host ; ../bin/rkt --debug enter $(../bin/rkt list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_FROM_MANIFEST"`,
 	},
 	{
 		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true --set-env=VAR_OTHER=setenv ./rkt-inspect-print-var-other.aci"`,
 		"VAR_OTHER=setenv",
 		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true --set-env=VAR_OTHER=setenv ./rkt-inspect-sleep.aci"`,
-		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug enter $(../bin/rkt list --full|grep running|gawk '{print $1}') /inspect --print-env=VAR_OTHER"`,
+		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug enter $(../bin/rkt list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_OTHER"`,
 	},
 }
 


### PR DESCRIPTION
The new Semaphore platform has most packages already installed.

Use awk instead of gawk in functional tests: awk is more commonly installed than gawk.