### PR TITLE
Documentation: fixup formatting on getting-started

### DIFF
--- a/Documentation/getting-started-guide.md
+++ b/Documentation/getting-started-guide.md
@@ -28,16 +28,19 @@ Next we need to build our application. We are going to statically link our app
 so we can ship an App Container Image with no external dependencies.
 
 With Go 1.3:
+
 ```
 $ CGO_ENABLED=0 GOOS=linux go build -o hello -a -tags netgo -ldflags '-w' .
 ```
 
 or, on [Go 1.4](https://github.com/golang/go/issues/9344#issuecomment-69944514):
+
 ```
 $ CGO_ENABLED=0 GOOS=linux go build -o hello -a -installsuffix cgo .
 ```
 
 Before proceeding, verify that the produced binary is statically linked:
+
 ```
 $ file hello
 hello: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, not stripped
@@ -75,18 +78,18 @@ Edit: manifest.json
             "/bin/hello"
         ],
         "ports": [
-        {
-            "name": "www",
-            "protocol": "tcp",
-            "port": 5000
-        }
+            {
+                "name": "www",
+                "protocol": "tcp",
+                "port": 5000
+            }
         ]
     },
     "annotations": [
         {
-	    "name": "authors",
-	    "value": "Kelsey Hightower <kelsey.hightower@gmail.com>"
-	}
+            "name": "authors",
+            "value": "Kelsey Hightower <kelsey.hightower@gmail.com>"
+        }
     ]
 }
 ```


### PR DESCRIPTION
- Be consistent with tabs/spaces in json
- Always put a newline between a code section and previous paragraph