### PR TITLE
Documentation: Fixup more missing paragraphs

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -65,6 +65,7 @@ Basic HTTP authentication requires two things - a user and a password. To use
 this type, define `type` as `basic` and the `credentials` field as a map
 with two keys - `user` and `password`. These fields must be specified and
 cannot be empty. For example:
+
 ```
 {
 	"rktKind": "auth",
@@ -81,6 +82,7 @@ cannot be empty. For example:
 OAuth Bearer Token authentication requires only a token. To use this type,
 define `type` as `oauth` and the `credentials` field as a map with only one
 key - `token`. This field must be specified and cannot be empty. For example:
+
 ```
 {
 	"rktKind": "auth",
@@ -100,6 +102,7 @@ authentication type and/or credentials used for each domain. As an example,
 consider this system configuration:
 
 `/usr/lib/rkt/auth.d/coreos.json`:
+
 ```
 {
 	"rktKind": "auth",
@@ -121,6 +124,7 @@ directory, this can be overridden. For example, given the above system
 configuration and the following local configurations:
 
 `/etc/rkt/auth.d/specific-coreos.json`:
+
 ```
 {
 	"rktKind": "auth",
@@ -135,6 +139,7 @@ configuration and the following local configurations:
 ```
 
 `/etc/rkt/auth.d/specific-tectonic.json`:
+
 ```
 {
 	"rktKind": "auth",
@@ -189,6 +194,7 @@ Some popular Docker registries:
 * gcr.io
 
 Example `dockerAuth` configuration:
+
 ```
 {
 	"rktKind": "dockerAuth",
@@ -207,6 +213,7 @@ Overriding is done for each registry. That means that the user can override
 credentials used for each registry. For example, given this system configuration:
 
 In `/usr/lib/rkt/auth.d/docker.json`:
+
 ```
 {
 	"rktKind": "dockerAuth",
@@ -228,6 +235,7 @@ directory, this can be overridden. For example, given the above system
 configuration and the following local configuration:
 
 `/etc/rkt/auth.d/specific-quay.json`:
+
 ```
 {
 	"rktKind": "dockerAuth",
@@ -241,6 +249,7 @@ configuration and the following local configuration:
 ```
 
 `/etc/rkt/auth.d/specific-gcr.json`:
+
 ```
 {
 	"rktKind": "dockerAuth",

--- a/Documentation/getting-started-ubuntu-trusty.md
+++ b/Documentation/getting-started-ubuntu-trusty.md
@@ -42,6 +42,7 @@ For more details on how signature verification works in rkt, see the [Signing an
 ## Fetch the ACI
 
 The simplest way to retrieve the etcd ACI is to use image discovery:
+
 ```
 ./rkt fetch coreos.com/etcd:v2.0.9 
 rkt: searching for app image coreos.com/etcd:v2.0.9

--- a/Documentation/hacking.md
+++ b/Documentation/hacking.md
@@ -64,6 +64,7 @@ $ cd $GOPATH/src/github.com/coreos/rkt
 
 If, however, you instead prefer to manage your source code in directories like `~/src/rkt`, there's a problem: `godep` doesn't like symbolic links (which is what the rkt `build` script [uses to create a self-contained GOPATH](https://github.com/coreos/rkt/blob/master/build#L8)).
 Hence, you'll need to work around this with bind mounts, with something like the following:
+
 ```
 $ export GOPATH=/tmp/foo        # or any directory you please
 $ mkdir -p $GOPATH/src/github.com/coreos/rkt
@@ -90,6 +91,7 @@ But in _all three cases_, the procedure finishes with the [same save command](#s
 
 In this case you'll first need to retrieve the dependency you're working with into `GOPATH`.
 As a simple example, assuming we're adding `github.com/fizz/buzz`:
+
 ```
 $ go get -d github.com/fizz/buzz
 ```
@@ -129,6 +131,7 @@ Now, GOTO [saving](#saving-the-set-of-dependencies)
 
 Finally, here we are, the magic command, the holy grail, the ultimate conclusion of all `godep` operations.
 Provided you have followed the preceding instructions, regardless of whether you are adding/removing/modifying dependencies, this command will cast the necessary spells to solve all of your dependency worries:
+
 ```
 $ godep save -r ./...
 ```


### PR DESCRIPTION
Add more paragraphs between code blocks and text. This fixes rendering
errors on jekyll.