### PR TITLE
Godeps: bump ioprogress dependency

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -125,7 +125,7 @@
 		},
 		{
 			"ImportPath": "github.com/mitchellh/ioprogress",
-			"Rev": "b0a0b6773359ef5016d5ecc4522150e43a189a53"
+			"Rev": "c2b2845d63abaf335647a8b9c7437e6c11a2a613"
 		},
 		{
 			"ImportPath": "github.com/petar/GoLLRB/llrb",

--- a/Godeps/_workspace/src/github.com/mitchellh/ioprogress/reader.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/ioprogress/reader.go
@@ -83,6 +83,7 @@ func (r *Reader) finishProgress() {
 	// Only output the final draw if we drawed prior
 	if !r.lastDraw.IsZero() {
 		f := r.drawFunc()
+		f(r.progress, r.Size)
 		f(-1, -1)
 
 		// Reset lastDraw so we don't finish again


### PR DESCRIPTION
It fixes a bug that caused the progress bar never to reach the end.