### PR TITLE
rkt/enter: use pod.getPID() to get container's pid race-free

### DIFF
--- a/rkt/enter.go
+++ b/rkt/enter.go
@@ -76,6 +76,12 @@ func runEnter(args []string) (exit int) {
 		return 1
 	}
 
+	podPID, err := p.getPID()
+	if err != nil {
+		stderr("Unable to determine pid for pod %q: %v", pid, err)
+		return 1
+	}
+
 	imageID, err := getAppImageID(p)
 	if err != nil {
 		stderr("Unable to determine image id: %v", err)
@@ -102,7 +108,7 @@ func runEnter(args []string) (exit int) {
 
 	stage1RootFS := s.GetTreeStoreRootFS(stage1ID.String())
 
-	if err = stage0.Enter(p.path(), imageID, stage1RootFS, argv); err != nil {
+	if err = stage0.Enter(p.path(), podPID, imageID, stage1RootFS, argv); err != nil {
 		stderr("Enter failed: %v", err)
 		return 1
 	}

--- a/stage0/enter.go
+++ b/stage0/enter.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"syscall"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
@@ -29,7 +30,7 @@ import (
 // /enter can expect to have its CWD set to the app root.
 // imageID and command are supplied to /enter on argv followed by any arguments.
 // stage1Path is the path of the stage1 rootfs
-func Enter(cdir string, imageID *types.Hash, stage1Path string, cmdline []string) error {
+func Enter(cdir string, podPID int, imageID *types.Hash, stage1Path string, cmdline []string) error {
 	if err := os.Chdir(cdir); err != nil {
 		return fmt.Errorf("error changing to dir: %v", err)
 	}
@@ -42,6 +43,7 @@ func Enter(cdir string, imageID *types.Hash, stage1Path string, cmdline []string
 	}
 
 	argv := []string{filepath.Join(stage1Path, ep)}
+	argv = append(argv, strconv.Itoa(podPID))
 	argv = append(argv, id)
 	argv = append(argv, cmdline...)
 	if err := syscall.Exec(argv[0], argv, os.Environ()); err != nil {


### PR DESCRIPTION
- Fixup pod.getPID() to cover race between xToRun() and stage1 getting
  around to writing the pid file.

- Rework `rkt enter` to retrieve the pid in rkt/stage0 and supply it to
  stage1 enter.

- Rework stage1 enter to consume pid from argv instead of opening it
  itself, so as to not have to duplicate the same race coverage.

- Some stage1 enter code cleanups thrown in for good measure, particularly
  around the argv forwarding copy which started simple had become unwieldy.