### PR TITLE
non destructive functional tests

### DIFF
--- a/test
+++ b/test
@@ -54,13 +54,12 @@ if [ -n "${vetRes}" ]; then
 	exit 255
 fi
 
-# Functional tests are more dangerous than unit tests: they use 'sudo' and access
-# /var/lib/rkt/ directly. Only run them inside well-known CI systems.
+# Functional tests may need manual intervention to run and are more
+# dangerous than unit tests: they use 'sudo'. Only run them inside
+# well-known CI systems.
 if [ "$CI" == true ] ; then
 	if [ "${CIRCLECI}" == true -o "${SEMAPHORE}" == true ] ; then
 		echo "Checking functional tests..."
-		# Run destructive tests too
-		export RKT_ENABLE_DESTRUCTIVE_TESTS=1
 		(cd tests && ./test)
 	else
 		echo "Functional tests disabled."

--- a/test
+++ b/test
@@ -54,9 +54,9 @@ if [ -n "${vetRes}" ]; then
 	exit 255
 fi
 
-# Functional tests may need manual intervention to run and are more
-# dangerous than unit tests: they use 'sudo'. Only run them inside
-# well-known CI systems.
+# Functional tests use 'sudo' to run as root - it's more dangerous
+# than unit tests and may require typing a password. Only run them
+# inside well-known CI systems.
 if [ "$CI" == true ] ; then
 	if [ "${CIRCLECI}" == true -o "${SEMAPHORE}" == true ] ; then
 		echo "Checking functional tests..."

--- a/tests/rkt_caps_test.go
+++ b/tests/rkt_caps_test.go
@@ -125,6 +125,9 @@ func TestCaps(t *testing.T) {
 }
 
 func TestNonRootCaps(t *testing.T) {
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
+
 	for i, tt := range capsTests {
 		var fileName = "rkt-inspect-print-caps-nonroot.aci"
 		var args []string
@@ -137,7 +140,7 @@ func TestNonRootCaps(t *testing.T) {
 
 		t.Logf("Running test #%v: %v [non-root]", i, tt.testName)
 
-		cmd := fmt.Sprintf("../bin/rkt --debug --insecure-skip-verify run --set-env=CAPABILITY=%d ./%s", int(tt.capa), fileName)
+		cmd := fmt.Sprintf("%s --debug --insecure-skip-verify run --set-env=CAPABILITY=%d ./%s", ctx.cmd(), int(tt.capa), fileName)
 		t.Logf("Command: %v", cmd)
 		child, err := gexpect.Spawn(cmd)
 		if err != nil {
@@ -164,5 +167,6 @@ func TestNonRootCaps(t *testing.T) {
 		if err != nil {
 			t.Fatalf("rkt didn't terminate correctly: %v", err)
 		}
+		ctx.reset()
 	}
 }

--- a/tests/rkt_caps_test.go
+++ b/tests/rkt_caps_test.go
@@ -87,11 +87,13 @@ func TestCaps(t *testing.T) {
 		patchTestACI(stage2FileName, stage2Args...)
 		defer os.Remove(stage1FileName)
 		defer os.Remove(stage2FileName)
+		ctx := newRktRunCtx()
+		defer ctx.cleanup()
 
 		for _, stage := range []int{1, 2} {
 			t.Logf("Running test #%v: %v [stage %v]", i, tt.testName, stage)
 
-			cmd := fmt.Sprintf("../bin/rkt --debug --insecure-skip-verify run --set-env=CAPABILITY=%d ./rkt-inspect-print-caps-stage%d.aci", int(tt.capa), stage)
+			cmd := fmt.Sprintf("%s --debug --insecure-skip-verify run --set-env=CAPABILITY=%d ./rkt-inspect-print-caps-stage%d.aci", ctx.cmd(), int(tt.capa), stage)
 			t.Logf("Command: %v", cmd)
 			child, err := gexpect.Spawn(cmd)
 			if err != nil {

--- a/tests/rkt_caps_test.go
+++ b/tests/rkt_caps_test.go
@@ -74,6 +74,9 @@ var capsTests = []struct {
 }
 
 func TestCaps(t *testing.T) {
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
+
 	for i, tt := range capsTests {
 		var stage1FileName = "rkt-inspect-print-caps-stage1.aci"
 		var stage2FileName = "rkt-inspect-print-caps-stage2.aci"
@@ -87,8 +90,6 @@ func TestCaps(t *testing.T) {
 		patchTestACI(stage2FileName, stage2Args...)
 		defer os.Remove(stage1FileName)
 		defer os.Remove(stage2FileName)
-		ctx := newRktRunCtx()
-		defer ctx.cleanup()
 
 		for _, stage := range []int{1, 2} {
 			t.Logf("Running test #%v: %v [stage %v]", i, tt.testName, stage)
@@ -121,6 +122,7 @@ func TestCaps(t *testing.T) {
 				t.Fatalf("rkt didn't terminate correctly: %v", err)
 			}
 		}
+		ctx.reset()
 	}
 }
 

--- a/tests/rkt_env_test.go
+++ b/tests/rkt_env_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/ThomasRooney/gexpect"
@@ -28,40 +29,40 @@ var envTests = []struct {
 	enterCmd  string
 }{
 	{
-		`../bin/rkt --debug --insecure-skip-verify run ./rkt-inspect-print-var-from-manifest.aci`,
+		`^RKT_BIN^ --debug --insecure-skip-verify run ./rkt-inspect-print-var-from-manifest.aci`,
 		"VAR_FROM_MANIFEST=manifest",
-		`../bin/rkt --debug --insecure-skip-verify run ./rkt-inspect-sleep.aci`,
-		`/bin/sh -c "../bin/rkt --debug enter $(../bin/rkt list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_FROM_MANIFEST"`,
+		`^RKT_BIN^ --debug --insecure-skip-verify run ./rkt-inspect-sleep.aci`,
+		`/bin/sh -c "^RKT_BIN^ --debug enter $(^RKT_BIN^ list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_FROM_MANIFEST"`,
 	},
 	{
-		`../bin/rkt --debug --insecure-skip-verify run --set-env=VAR_OTHER=setenv ./rkt-inspect-print-var-other.aci`,
+		`^RKT_BIN^ --debug --insecure-skip-verify run --set-env=VAR_OTHER=setenv ./rkt-inspect-print-var-other.aci`,
 		"VAR_OTHER=setenv",
-		`../bin/rkt --debug --insecure-skip-verify run --set-env=VAR_OTHER=setenv ./rkt-inspect-sleep.aci`,
-		`/bin/sh -c "../bin/rkt --debug enter $(../bin/rkt list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_OTHER"`,
+		`^RKT_BIN^ --debug --insecure-skip-verify run --set-env=VAR_OTHER=setenv ./rkt-inspect-sleep.aci`,
+		`/bin/sh -c "^RKT_BIN^ --debug enter $(^RKT_BIN^ list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_OTHER"`,
 	},
 	{
-		`../bin/rkt --debug --insecure-skip-verify run --set-env=VAR_FROM_MANIFEST=setenv ./rkt-inspect-print-var-from-manifest.aci`,
+		`^RKT_BIN^ --debug --insecure-skip-verify run --set-env=VAR_FROM_MANIFEST=setenv ./rkt-inspect-print-var-from-manifest.aci`,
 		"VAR_FROM_MANIFEST=setenv",
-		`../bin/rkt --debug --insecure-skip-verify run --set-env=VAR_FROM_MANIFEST=setenv ./rkt-inspect-sleep.aci`,
-		`/bin/sh -c "../bin/rkt --debug enter $(../bin/rkt list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_FROM_MANIFEST"`,
+		`^RKT_BIN^ --debug --insecure-skip-verify run --set-env=VAR_FROM_MANIFEST=setenv ./rkt-inspect-sleep.aci`,
+		`/bin/sh -c "^RKT_BIN^ --debug enter $(^RKT_BIN^ list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_FROM_MANIFEST"`,
 	},
 	{
-		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-print-var-other.aci"`,
+		`/bin/sh -c "export VAR_OTHER=host ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-print-var-other.aci"`,
 		"VAR_OTHER=host",
-		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-sleep.aci"`,
-		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug enter $(../bin/rkt list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_OTHER"`,
+		`/bin/sh -c "export VAR_OTHER=host ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-sleep.aci"`,
+		`/bin/sh -c "export VAR_OTHER=host ; ^RKT_BIN^ --debug enter $(^RKT_BIN^ list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_OTHER"`,
 	},
 	{
-		`/bin/sh -c "export VAR_FROM_MANIFEST=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-print-var-from-manifest.aci"`,
+		`/bin/sh -c "export VAR_FROM_MANIFEST=host ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-print-var-from-manifest.aci"`,
 		"VAR_FROM_MANIFEST=manifest",
-		`/bin/sh -c "export VAR_FROM_MANIFEST=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-sleep.aci"`,
-		`/bin/sh -c "export VAR_FROM_MANIFEST=host ; ../bin/rkt --debug enter $(../bin/rkt list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_FROM_MANIFEST"`,
+		`/bin/sh -c "export VAR_FROM_MANIFEST=host ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true ./rkt-inspect-sleep.aci"`,
+		`/bin/sh -c "export VAR_FROM_MANIFEST=host ; ^RKT_BIN^ --debug enter $(^RKT_BIN^ list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_FROM_MANIFEST"`,
 	},
 	{
-		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true --set-env=VAR_OTHER=setenv ./rkt-inspect-print-var-other.aci"`,
+		`/bin/sh -c "export VAR_OTHER=host ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true --set-env=VAR_OTHER=setenv ./rkt-inspect-print-var-other.aci"`,
 		"VAR_OTHER=setenv",
-		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug --insecure-skip-verify run --inherit-env=true --set-env=VAR_OTHER=setenv ./rkt-inspect-sleep.aci"`,
-		`/bin/sh -c "export VAR_OTHER=host ; ../bin/rkt --debug enter $(../bin/rkt list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_OTHER"`,
+		`/bin/sh -c "export VAR_OTHER=host ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true --set-env=VAR_OTHER=setenv ./rkt-inspect-sleep.aci"`,
+		`/bin/sh -c "export VAR_OTHER=host ; ^RKT_BIN^ --debug enter $(^RKT_BIN^ list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_OTHER"`,
 	},
 }
 
@@ -72,11 +73,14 @@ func TestEnv(t *testing.T) {
 	defer os.Remove("rkt-inspect-print-var-other.aci")
 	patchTestACI("rkt-inspect-sleep.aci", "--exec=/inspect --print-msg=Hello --sleep=84000")
 	defer os.Remove("rkt-inspect-sleep.aci")
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
 
 	for i, tt := range envTests {
 		// 'run' tests
-		t.Logf("Running 'run' test #%v: %v", i, tt.runCmd)
-		child, err := gexpect.Spawn(tt.runCmd)
+		runCmd := strings.Replace(tt.runCmd, "^RKT_BIN^", ctx.cmd(), -1)
+		t.Logf("Running 'run' test #%v: %v", i, runCmd)
+		child, err := gexpect.Spawn(runCmd)
 		if err != nil {
 			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
 		}
@@ -92,8 +96,9 @@ func TestEnv(t *testing.T) {
 		}
 
 		// 'enter' tests
-		t.Logf("Running 'enter' test #%v: sleep: %v", i, tt.sleepCmd)
-		child, err = gexpect.Spawn(tt.sleepCmd)
+		sleepCmd := strings.Replace(tt.sleepCmd, "^RKT_BIN^", ctx.cmd(), -1)
+		t.Logf("Running 'enter' test #%v: sleep: %v", i, sleepCmd)
+		child, err = gexpect.Spawn(sleepCmd)
 		if err != nil {
 			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
 		}
@@ -103,8 +108,9 @@ func TestEnv(t *testing.T) {
 			t.Fatalf("Expected %q but not found", tt.runExpect)
 		}
 
-		t.Logf("Running 'enter' test #%v: enter: %v", i, tt.enterCmd)
-		enterChild, err := gexpect.Spawn(tt.enterCmd)
+		enterCmd := strings.Replace(tt.enterCmd, "^RKT_BIN^", ctx.cmd(), -1)
+		t.Logf("Running 'enter' test #%v: enter: %v", i, enterCmd)
+		enterChild, err := gexpect.Spawn(enterCmd)
 		if err != nil {
 			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
 		}
@@ -122,5 +128,6 @@ func TestEnv(t *testing.T) {
 		if err != nil {
 			t.Fatalf("rkt didn't terminate correctly: %v", err)
 		}
+		ctx.reset()
 	}
 }

--- a/tests/rkt_exit_test.go
+++ b/tests/rkt_exit_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -25,8 +26,10 @@ import (
 func TestSuccess(t *testing.T) {
 	patchTestACI("rkt-inspect-exit0.aci", "--exec=/inspect --print-msg=Hello --exit-code=0")
 	defer os.Remove("rkt-inspect-exit0.aci")
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
 
-	child, err := gexpect.Spawn("../bin/rkt --debug --insecure-skip-verify run ./rkt-inspect-exit0.aci")
+	child, err := gexpect.Spawn(fmt.Sprintf("%s --debug --insecure-skip-verify run ./rkt-inspect-exit0.aci", ctx.cmd()))
 	if err != nil {
 		t.Fatalf("Cannot exec rkt")
 	}
@@ -55,8 +58,10 @@ func TestSuccess(t *testing.T) {
 func TestFailure(t *testing.T) {
 	patchTestACI("rkt-inspect-exit20.aci", "--exec=/inspect --print-msg=Hello --exit-code=20")
 	defer os.Remove("rkt-inspect-exit20.aci")
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
 
-	child, err := gexpect.Spawn("../bin/rkt --debug --insecure-skip-verify run ./rkt-inspect-exit20.aci")
+	child, err := gexpect.Spawn(fmt.Sprintf("%s --debug --insecure-skip-verify run ./rkt-inspect-exit20.aci", ctx.cmd()))
 	if err != nil {
 		t.Fatalf("Cannot exec rkt")
 	}

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -20,20 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"testing"
 )
-
-const enableDestructiveTestsEnvVar = "RKT_ENABLE_DESTRUCTIVE_TESTS"
-
-func skipDestructive(t *testing.T) {
-	if !destructiveTestsEnabled() {
-		t.Skipf("%s envvar is not specified or has value different than 1, skipping the test", enableDestructiveTestsEnvVar)
-	}
-}
-
-func destructiveTestsEnabled() bool {
-	return os.Getenv(enableDestructiveTestsEnvVar) == "1"
-}
 
 // dirDesc structure manages one directory and provides an option for
 // rkt invocations

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -36,11 +36,11 @@ var volTests = []struct {
 	},
 	// Check that we can read files from a volume (both ro and rw)
 	{
-		`/bin/sh -c "export FILE=/dir1/file ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true --volume=dir1,kind=host,source=$TMPDIR ./rkt-inspect-vol-rw-read-file.aci"`,
+		`/bin/sh -c "export FILE=/dir1/file ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ ./rkt-inspect-vol-rw-read-file.aci"`,
 		`<<<host>>>`,
 	},
 	{
-		`/bin/sh -c "export FILE=/dir1/file ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true --volume=dir1,kind=host,source=$TMPDIR ./rkt-inspect-vol-ro-read-file.aci"`,
+		`/bin/sh -c "export FILE=/dir1/file ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ ./rkt-inspect-vol-ro-read-file.aci"`,
 		`<<<host>>>`,
 	},
 	// Check that we can write to files in the ACI
@@ -50,16 +50,16 @@ var volTests = []struct {
 	},
 	// Check that we can write files to a volume (both ro and rw)
 	{
-		`/bin/sh -c "export FILE=/dir1/file CONTENT=2 ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true --volume=dir1,kind=host,source=$TMPDIR ./rkt-inspect-vol-rw-write-file.aci"`,
+		`/bin/sh -c "export FILE=/dir1/file CONTENT=2 ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ ./rkt-inspect-vol-rw-write-file.aci"`,
 		`<<<2>>>`,
 	},
 	{
-		`/bin/sh -c "export FILE=/dir1/file CONTENT=3 ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true --volume=dir1,kind=host,source=$TMPDIR ./rkt-inspect-vol-ro-write-file.aci"`,
+		`/bin/sh -c "export FILE=/dir1/file CONTENT=3 ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ ./rkt-inspect-vol-ro-write-file.aci"`,
 		`Cannot write to file "/dir1/file": open /dir1/file: read-only file system`,
 	},
 	// Check that the volume still contain the file previously written
 	{
-		`/bin/sh -c "export FILE=/dir1/file ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true --volume=dir1,kind=host,source=$TMPDIR ./rkt-inspect-vol-ro-read-file.aci"`,
+		`/bin/sh -c "export FILE=/dir1/file ; ^RKT_BIN^ --debug --insecure-skip-verify run --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ ./rkt-inspect-vol-ro-read-file.aci"`,
 		`<<<2>>>`,
 	},
 }
@@ -93,7 +93,7 @@ func TestVolumes(t *testing.T) {
 	}
 
 	for i, tt := range volTests {
-		cmd := strings.Replace(tt.rktCmd, "$TMPDIR", tmpdir, -1)
+		cmd := strings.Replace(tt.rktCmd, "^TMPDIR^", tmpdir, -1)
 		cmd = strings.Replace(cmd, "^RKT_BIN^", ctx.cmd(), -1)
 
 		t.Logf("Running test #%v: %v", i, cmd)

--- a/tests/test
+++ b/tests/test
@@ -18,5 +18,4 @@
 # version as the system-wide installed go.
 GO=`which go`
 
-sudo GOPATH="${PWD}/../gopath" RKT_ENABLE_DESTRUCTIVE_TESTS="$RKT_ENABLE_DESTRUCTIVE_TESTS" GOROOT="$GOROOT" $GO test -v $*
-
+sudo GOPATH="${PWD}/../gopath" GOROOT="$GOROOT" $GO test -v $*


### PR DESCRIPTION
It introduces rkt run context which uses `--dir`, '--local-config` and `--system-config` flags to avoid using default values. So functional tests can be ran on local computer without worrying about messed up or deleted /var/lib/rkt or configuration.