### PR TITLE
networking: podRoot -> rktRoot

### DIFF
--- a/networking/net_plugin.go
+++ b/networking/net_plugin.go
@@ -60,7 +60,7 @@ func (e *podEnv) pluginPaths() []string {
 	// try 3rd-party path first
 	return []string{
 		UserNetPluginsPath,
-		filepath.Join(common.Stage1RootfsPath(e.rktRoot), BuiltinNetPluginsPath),
+		filepath.Join(common.Stage1RootfsPath(e.podRoot), BuiltinNetPluginsPath),
 	}
 }
 

--- a/networking/podenv.go
+++ b/networking/podenv.go
@@ -45,7 +45,7 @@ const (
 // describing the environment in which the pod
 // is running in
 type podEnv struct {
-	rktRoot string
+	podRoot string
 	podID   types.UUID
 }
 
@@ -64,7 +64,7 @@ func (e *podEnv) loadNets() ([]activeNet, error) {
 	}
 
 	if !netExists(nets, "default") {
-		defPath := path.Join(common.Stage1RootfsPath(e.rktRoot), DefaultNetPath)
+		defPath := path.Join(common.Stage1RootfsPath(e.podRoot), DefaultNetPath)
 		n, err := loadNet(defPath)
 		if err != nil {
 			return nil, err
@@ -76,11 +76,11 @@ func (e *podEnv) loadNets() ([]activeNet, error) {
 }
 
 func (e *podEnv) podNSPath() string {
-	return filepath.Join(e.rktRoot, "netns")
+	return filepath.Join(e.podRoot, "netns")
 }
 
 func (e *podEnv) netDir() string {
-	return filepath.Join(e.rktRoot, "net")
+	return filepath.Join(e.podRoot, "net")
 }
 
 func (e *podEnv) setupNets(nets []activeNet) error {


### PR DESCRIPTION
rktRoot is misleading as the directory is really the root of a specific pod.
Also add a TODO note that this is currently only ever set to cwd
(i.e. "."), and hence necessitates relative paths.