### PR TITLE
stage0: add ability to inject arbitrary volumes, refs coreos/rkt#761

### DIFF
--- a/stage0/ivolume.go
+++ b/stage0/ivolume.go
@@ -2,7 +2,6 @@ package stage0
 
 import (
 	"fmt"
-	"net/url"
 	"strconv"
 	"strings"
 
@@ -21,9 +20,15 @@ type InjectedVolume struct {
 func InjectedVolumeFromString(s string) (*InjectedVolume, error) {
 	var vol InjectedVolume
 
-	v, err := url.ParseQuery(strings.Replace(s, ",", "&", -1))
-	if err != nil {
-		return nil, err
+	v := make(map[string][]string)
+	pairs := strings.Split(s, ",")
+	for _, p := range pairs {
+		sp := strings.Split(p, "=")
+		if len(sp) != 2 {
+			return nil, fmt.Errorf(
+				"expected comma separated list of key=val pairs")
+		}
+		v[sp[0]] = append(v[sp[0]], sp[1])
 	}
 
 	for key, val := range v {

--- a/stage0/ivolume.go
+++ b/stage0/ivolume.go
@@ -1,0 +1,140 @@
+package stage0
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+// InjectedVolume is an arbitrary volume that is injected into pod when the container
+// starts and is not defined in the manifest
+type InjectedVolume struct {
+	types.Volume
+	Dest string
+}
+
+func InjectedVolumeFromString(s string) (*InjectedVolume, error) {
+	var vol InjectedVolume
+
+	v, err := url.ParseQuery(strings.Replace(s, ",", "&", -1))
+	if err != nil {
+		return nil, err
+	}
+
+	for key, val := range v {
+		if len(val) > 1 {
+			return nil, fmt.Errorf("label %s with multiple values %q", key, val)
+		}
+		// TOOD(philips): make this less hardcoded
+		switch key {
+		case "kind":
+			vol.Kind = val[0]
+		case "source":
+			vol.Source = val[0]
+		case "readOnly":
+			ro, err := strconv.ParseBool(val[0])
+			if err != nil {
+				return nil, err
+			}
+			vol.ReadOnly = &ro
+		case "dest":
+			vol.Dest = val[0]
+		default:
+			return nil, fmt.Errorf("unknown volume parameter %q", key)
+		}
+	}
+	vol.Name = types.ACName(uuid.New())
+	return &vol, nil
+}
+
+func (iv *InjectedVolume) toMountPoint() types.MountPoint {
+	ro := false
+	if iv.ReadOnly != nil {
+		ro = *iv.ReadOnly
+	}
+	return types.MountPoint{
+		Name:     iv.Name,
+		Path:     iv.Dest,
+		ReadOnly: ro,
+	}
+}
+
+type InjectedVolumes []InjectedVolume
+
+func (ivs InjectedVolumes) toMountPoints() []types.MountPoint {
+	out := make([]types.MountPoint, len(ivs))
+	for i := range ivs {
+		out[i] = ivs[i].toMountPoint()
+	}
+	return out
+}
+
+func (ivs InjectedVolumes) toVolumes() []types.Volume {
+	out := make([]types.Volume, len(ivs))
+	for i := range ivs {
+		out[i] = ivs[i].Volume
+	}
+	return out
+}
+
+// before injecting the volumes, make sure injected volumes do not conflict
+// with any of the app mount points and volumes and each other
+func (ivs InjectedVolumes) checkPodConflicts(pm schema.PodManifest) error {
+
+	// check that volumes do not conflict with each other first
+	ivexist := make(map[string]InjectedVolume)
+	for _, v := range ivs {
+		if iv, ok := ivexist[v.Dest]; ok {
+			return fmt.Errorf(
+				"injected volume destination %v conflicts with the injected volume %v", v, iv)
+		}
+		ivexist[v.Dest] = v
+	}
+
+	// next, check if injected volumes conflict with the mount points defined in the spec
+	if len(pm.Apps) == 0 {
+		return nil
+	}
+	mpexist := make(map[string]types.MountPoint)
+	for _, app := range pm.Apps {
+		if app.App == nil || len(app.App.MountPoints) == 0 {
+			continue
+		}
+		for _, mp := range app.App.MountPoints {
+			mpexist[mp.Path] = mp
+		}
+	}
+
+	for _, iv := range ivs {
+		if mp, ok := mpexist[iv.Dest]; ok {
+			return fmt.Errorf(
+				"injected volume destination %v conflicts with the existing mount point %v", iv.Dest, mp)
+		}
+	}
+	return nil
+}
+
+func (ivs InjectedVolumes) inject(pm schema.PodManifest) (*schema.PodManifest, error) {
+	if len(ivs) == 0 {
+		return &pm, nil
+	}
+
+	if err := ivs.checkPodConflicts(pm); err != nil {
+		return nil, err
+	}
+
+	// inject a volume and a mount point for every app
+	pm.Volumes = append(pm.Volumes, ivs.toVolumes()...)
+	for i := range pm.Apps {
+		if pm.Apps[i].App == nil {
+			continue
+		}
+		pm.Apps[i].App.MountPoints = append(pm.Apps[i].App.MountPoints, ivs.toMountPoints()...)
+	}
+	return &pm, nil
+}


### PR DESCRIPTION
This is an implementation proposal for adding an ability to mount arbitrary volumes into a running Pod.

Injected volumes is a runtime flag added to rkt tool with the ability to
mount arbitrary volumes in the container.

To inject an arbitrary volume when starting pod, do this:

rkt run app.aci --inject-volume=kind=host,source=/source/path,dest=/dest/path

Implementation details
-----------------------------

1. Implement it as a part of stage0 without changing spec or other stages.
2. Make sure the injected volume does not conflict with the volume defined in the Pod
to avoid errors.
3. Generate and inject mount points into the pod spec during the prepare phase.
4. Move the logic of overriding pod app during stage1 in case if image app is missing
to the prepare stage0 instead of stage1 phase to be able to specify the mount points

Open questions
---------------------
* Does the approach of injecting the mount points into the Pod spec looks ok?
* What to do in case if the injected volume destination conflicts with the Pod mount point? The alternative may be to override the mount point. This implementation chooses to back off with error to avoid ambiguity
* Duplicating types.VolumeFromString()  logic does not look cool, I'm thinking of making it more generic library and using it for both cases, your ideas are appreciated
* Is moving logic of merging image app and pod app to stage0 looks good to you?

I'd be glad to address the comments on the design and if the overall approach looks ok, I will cover it by tests and send for the final review.


