### PR TITLE
networking: make netns path absolute for CNI plugins

### DIFF
--- a/networking/net_plugin.go
+++ b/networking/net_plugin.go
@@ -91,6 +91,20 @@ func (e *podEnv) execNetPlugin(cmd string, n *activeNet, netns string) ([]byte, 
 		return nil, fmt.Errorf("Could not find plugin %q", n.conf.Type)
 	}
 
+	// TODO(jonboulle): This is a temporary workaround for an upstream
+	// issue in CNI: various plugins expect CNI_NETNS to be unique (e.g.
+	// veth uses it as a source of entropy, host-local uses it as an
+	// identifier), but rkt was passing a relative path which is identical
+	// for all pods. For now, let's use an absolute path, until the
+	// upstream issue is sorted. **This will break host-local removals**, but
+	// allow --private-net to work with multiple pods.
+	// (In future we will probably pass CNI_CONTAINERID and use that for
+	// uniqueness-requiring operations instead.)
+	// https://github.com/appc/cni/issues/5
+	netns, err := filepath.Abs(netns)
+	if err != nil {
+		panic(err)
+	}
 	vars := [][2]string{
 		{"CNI_COMMAND", cmd},
 		{"CNI_PODID", e.podID.String()},


### PR DESCRIPTION
As discovered in #851 - some of the CNI plugins (for example, veth) relies on
the supplied `CNI_NETNS` as a source of uniqueness for things like entropy. In
theory this is reasonable because network namespace paths should be unique
per-pod. However, in rkt, the stage1 init (which executes the plugins) was
passing a relative path from its cwd, rather than an absolute path - for
example, "netns" rather than
"/var/lib/rkt/pods/foobarbaz/netns".

As a consequence of this, every network plugin was executed with the same
value for `CNI_NETNS`. This results in conflicts when e.g. every veth plugin
attempts to create an interface by the same name, since they do a
straightforward hash of `CNI_NETNS` to generate interface names.

This should be considered an interim solution until this is definitively 
answered in the upstream CNI specification.