### PR TITLE
networking: load only *.conf files

### DIFF
--- a/networking/podenv.go
+++ b/networking/podenv.go
@@ -25,6 +25,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/cni/pkg/plugin"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
@@ -218,6 +219,11 @@ func loadUserNets() ([]activeNet, error) {
 
 	for _, filename := range files {
 		filepath := path.Join(UserNetPath, filename)
+
+		if !strings.HasSuffix(filepath, ".conf") {
+			continue
+		}
+
 		n, err := loadNet(filepath)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
All files found in UserNetPath that don't match the suffix '.conf' will be
ignored as a network configuration file.

Fixes #859.