### PR TITLE
script/vagrant: cp the build target to usr bin

### DIFF
--- a/scripts/vagrant/install-rkt.sh
+++ b/scripts/vagrant/install-rkt.sh
@@ -20,6 +20,7 @@ which unsquash || sudo apt-get install -y squashfs-tools
 
 pushd /vagrant
 ./build
+sudo cp -v bin/* /usr/local/bin
 
 cat << EOF | sudo tee /etc/profile.d/99rkt.sh
   export PATH=$PWD/bin:\$PATH


### PR DESCRIPTION
Before this change, when I run `sudo rkt trust` it fails. I hope
we can also install rkt under usr/local/bin by default. So our
users can have a better experience when following our rkt basic
tutorial.
This issue was introduced by a recent script rewrote (#652)