### PR TITLE
vagrantfile: fix slow VM DNS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,9 +2,10 @@ Vagrant.configure('2') do |config|
     # grab Ubuntu 14.04 official image
     config.vm.box = "ubuntu/trusty64" # Ubuntu 14.04
 
-    # fix issues with slow dns https://www.virtualbox.org/ticket/13002
+    # fix issues with slow dns http://serverfault.com/a/595010
     config.vm.provider :virtualbox do |vb, override|
-        vb.customize ["modifyvm", :id, "--natdnsproxy1", "off"]
+        vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+        vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
     end
 
     # install Build Dependencies (GOLANG)


### PR DESCRIPTION
I had to do this last Sunday to get `rkt trust --prefix quay.io` working.

See the thread at ServerFault for more info http://serverfault.com/a/595010