### PR TITLE
rkt/tests: Print out the error info on failures.

### DIFF
--- a/tests/rkt_auth_test.go
+++ b/tests/rkt_auth_test.go
@@ -176,7 +176,7 @@ func expectedRunRkt(ctx *rktRunCtx, t *testing.T, host, dir, line string) {
 	}
 	defer child.Wait()
 	if err := child.Expect(line); err != nil {
-		t.Fatalf("Didn't receive expected output %q", line)
+		t.Fatalf("Didn't receive expected output %q: %v", line, err)
 	}
 }
 

--- a/tests/rkt_caps_test.go
+++ b/tests/rkt_caps_test.go
@@ -109,12 +109,12 @@ func TestCaps(t *testing.T) {
 			}
 			err = child.Expect(expectedLine)
 			if err != nil {
-				t.Fatalf("Expected %q but not found", expectedLine)
+				t.Fatalf("Expected %q but not found: %v", expectedLine, err)
 			}
 
 			err = child.Expect("User: uid=0 euid=0 gid=0 egid=0")
 			if err != nil {
-				t.Fatalf("Expected user 0 but not found")
+				t.Fatalf("Expected user 0 but not found: %v", err)
 			}
 
 			err = child.Wait()
@@ -157,12 +157,12 @@ func TestNonRootCaps(t *testing.T) {
 		}
 		err = child.Expect(expectedLine)
 		if err != nil {
-			t.Fatalf("Expected %q but not found", expectedLine)
+			t.Fatalf("Expected %q but not found: %v", expectedLine, err)
 		}
 
 		err = child.Expect("User: uid=9000 euid=9000 gid=9000 egid=9000")
 		if err != nil {
-			t.Fatalf("Expected user 9000 but not found")
+			t.Fatalf("Expected user 9000 but not found: %v", err)
 		}
 
 		err = child.Wait()

--- a/tests/rkt_env_test.go
+++ b/tests/rkt_env_test.go
@@ -87,7 +87,7 @@ func TestEnv(t *testing.T) {
 
 		err = child.Expect(tt.runExpect)
 		if err != nil {
-			t.Fatalf("Expected %q but not found", tt.runExpect)
+			t.Fatalf("Expected %q but not found: %v", tt.runExpect, err)
 		}
 
 		err = child.Wait()
@@ -105,7 +105,7 @@ func TestEnv(t *testing.T) {
 
 		err = child.Expect("Enter text:")
 		if err != nil {
-			t.Fatalf("Waited for the prompt but not found #%v", i)
+			t.Fatalf("Waited for the prompt but not found #%v: %v", i, err)
 		}
 
 		enterCmd := strings.Replace(tt.enterCmd, "^RKT_BIN^", ctx.cmd(), -1)
@@ -117,7 +117,7 @@ func TestEnv(t *testing.T) {
 
 		err = enterChild.Expect(tt.runExpect)
 		if err != nil {
-			t.Fatalf("Expected %q but not found", tt.runExpect)
+			t.Fatalf("Expected %q but not found: %v", tt.runExpect, err)
 		}
 
 		err = enterChild.Wait()
@@ -130,7 +130,7 @@ func TestEnv(t *testing.T) {
 		}
 		err = child.Expect("Received text: Bye")
 		if err != nil {
-			t.Fatalf("Expected Bye but not found #%v", i)
+			t.Fatalf("Expected Bye but not found #%v: %v", i, err)
 		}
 
 		err = child.Wait()

--- a/tests/rkt_exit_test.go
+++ b/tests/rkt_exit_test.go
@@ -35,7 +35,7 @@ func TestSuccess(t *testing.T) {
 	}
 	err = child.Expect("Hello")
 	if err != nil {
-		t.Fatalf("Missing hello")
+		t.Fatalf("Missing hello: %v", err)
 	}
 	forbidden := "main process exited, code=exited, status="
 	_, receiver := child.AsyncInteractChannels()
@@ -67,11 +67,11 @@ func TestFailure(t *testing.T) {
 	}
 	err = child.Expect("Hello")
 	if err != nil {
-		t.Fatalf("Missing hello")
+		t.Fatalf("Missing hello: %v", err)
 	}
 	err = child.Expect("main process exited, code=exited, status=20")
 	if err != nil {
-		t.Fatalf("Missing hello")
+		t.Fatalf("Missing exit status: %v", err)
 	}
 
 	err = child.Wait()

--- a/tests/rkt_interactive_test.go
+++ b/tests/rkt_interactive_test.go
@@ -94,18 +94,18 @@ func TestInteractive(t *testing.T) {
 		if tt.say != "" {
 			err = child.ExpectTimeout("Enter text:", time.Minute)
 			if err != nil {
-				t.Fatalf("Waited for the prompt but not found #%v", i)
+				t.Fatalf("Waited for the prompt but not found #%v: %v", i, err)
 			}
 
 			err = child.SendLine(tt.say)
 			if err != nil {
-				t.Fatalf("Failed to send %q on the prompt #%v", tt.say, i)
+				t.Fatalf("Failed to send %q on the prompt #%v: %v", tt.say, i, err)
 			}
 		}
 
 		err = child.ExpectTimeout(tt.expect, time.Minute)
 		if err != nil {
-			t.Fatalf("Expected %q but not found #%v", tt.expect, i)
+			t.Fatalf("Expected %q but not found #%v: %v", tt.expect, i, err)
 		}
 
 		err = child.Wait()

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -106,7 +106,7 @@ func TestVolumes(t *testing.T) {
 		err = child.Expect(tt.expect)
 		if err != nil {
 			fmt.Printf("Command: %s\n", cmd)
-			t.Fatalf("Expected %q but not found #%v", tt.expect, i)
+			t.Fatalf("Expected %q but not found #%v: %v", tt.expect, i, err)
 		}
 
 		err = child.Wait()


### PR DESCRIPTION
This can help us to reason about the failures more easily.