### PR TITLE
functional tests: update string from systemd

### DIFF
--- a/tests/rkt_exit_test.go
+++ b/tests/rkt_exit_test.go
@@ -69,7 +69,7 @@ func TestFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Missing hello: %v", err)
 	}
-	err = child.Expect("main process exited, code=exited, status=20")
+	err = child.Expect("process exited, code=exited, status=20")
 	if err != nil {
 		t.Fatalf("Missing exit status: %v", err)
 	}


### PR DESCRIPTION
Since systemd commit f2341e ("core,network: major per-object logging rework"),
systemd does not log "main process exited" but "Main process exited" (notice
the uppercase).

Improve the test to accept both strings.

Fixes #891.