### PR TITLE
rkt/image: Add --quiet for cat-manifest.

### DIFF
--- a/rkt/image_cat_manifest.go
+++ b/rkt/image_cat_manifest.go
@@ -61,7 +61,7 @@ func runImageCatManifest(args []string) (exit int) {
 			insecureSkipVerify: true,
 			debug:              globalFlags.Debug,
 		},
-		local:    true,
+		local:    false,
 		withDeps: false,
 	}
 


### PR DESCRIPTION
Also enables to download remotely or fetch from local fs
to get the image manifest.