### PR TITLE
stage1: dlopen libsystemd instead of libsystemd-login

### DIFF
--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -369,16 +369,16 @@ func stage1() int {
 }
 
 func runningFromUnitFile() (ret bool, err error) {
-	handle := C.dlopen(C.CString("libsystemd-login.so"), C.RTLD_LAZY)
+	handle := C.dlopen(C.CString("libsystemd.so"), C.RTLD_LAZY)
 	if handle == nil {
-		// we can't open libsystemd-login.so so we assume systemd is not
+		// we can't open libsystemd.so so we assume systemd is not
 		// installed and we're not running from a unit file
 		ret = false
 		return
 	}
 	defer func() {
 		if r := C.dlclose(handle); r != 0 {
-			err = fmt.Errorf("error closing libsystemd-login.so")
+			err = fmt.Errorf("error closing libsystemd.so")
 		}
 	}()
 


### PR DESCRIPTION
In systemd-209 libsystemd-login was merged into libsystemd and a
compatibility libsystemd-login library was created. Unfortunately,
distributions like Fedora don't ship the compatibility libraries so
runningFromUnitFile will always return false.

Fix it by dlopening libsystemd.so instead of libsystemd-login.so.