### PR TITLE
rkt: make warning map to `insecure-skip-verify` usage

### DIFF
--- a/Documentation/running-docker-images.md
+++ b/Documentation/running-docker-images.md
@@ -13,7 +13,7 @@ As a simple example, let's run the latest `redis` container image from the defau
 ```
 $ rkt --insecure-skip-verify run docker://redis
 rkt: fetching image from docker://redis
-rkt: warning: signature verification has been disabled
+rkt: warning: TLS verification and signature verification has been disabled
 Downloading layer: 511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158
 ...
 Downloading layer: f2fb89b0a711a7178528c7785d247ba3572924353b0d5e23e9b28f0518253b22
@@ -53,7 +53,7 @@ For example, the following command will fetch an nginx Docker image hosted on qu
 ```
 $ rkt --insecure-skip-verify fetch docker://quay.io/zanui/nginx
 rkt: fetching image from docker://quay.io/zanui/nginx
-rkt: warning: signature verification has been disabled
+rkt: warning: TLS verification and signature verification has been disabled
 Downloading layer: 511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158
 ...
 Downloading layer: 340951f1240f3dc1189ae32cfa5af35df2dc640e0c92f2397b7a72e174c1a158

--- a/Documentation/signing-and-verification-guide.md
+++ b/Documentation/signing-and-verification-guide.md
@@ -310,13 +310,13 @@ rkt: example.com/hello:0.0.1 verified signed by:
 ^]^]Container stage1 terminated by signal KILL.
 ```
 
-Use the `-insecure-skip-verify` flag to disable image verification for a single run:
+Use the `-insecure-skip-verify` flag to disable all verification for a single run:
 
 ```
 $ sudo rkt -insecure-skip-verify run example.com/hello:0.0.1
 rkt: starting to discover app img example.com/hello:0.0.1
 rkt: starting to fetch img from http://example.com/images/example.com/hello-0.0.1-linux-amd64.aci
-rkt: warning: signature verification has been disabled
+rkt: warning: TLS verification and signature verification has been disabled
 Downloading aci: [=                                            ] 32.8 KB/1.26 MB
 /etc/localtime is not a symlink, not updating container timezone.
 ^]^]Container stage1 terminated by signal KILL.
@@ -325,7 +325,7 @@ Downloading aci: [=                                            ] 32.8 KB/1.26 MB
 Notice when the `-insecure-skip-verify` flag is used, rkt will print the following warning:
 
 ```
-rkt: warning: signature verification has been disabled
+rkt: warning: TLS verification and signature verification has been disabled
 ```
 
 #### Download and verify an ACI
@@ -343,13 +343,13 @@ rkt: example.com/hello:0.0.1 verified signed by:
 sha512-b3f138e10482d4b5f334294d69ae5c40
 ```
 
-As before, use the `-insecure-skip-verify` flag to disable image verification:
+As before, use the `-insecure-skip-verify` flag to disable tls and image verification:
 
 ```
 $ sudo rkt -insecure-skip-verify fetch example.com/hello:0.0.1
 rkt: starting to discover app img example.com/hello:0.0.1
 rkt: starting to fetch img from http://example.com/images/example.com/hello-0.0.1-linux-amd64.aci
-rkt: warning: signature verification has been disabled
+rkt: warning: TLS verification and signature verification has been disabled
 Downloading aci: [                                             ] 4.34 KB/1.26 MB
 sha512-b3f138e10482d4b5f334294d69ae5c40
 ```

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -274,7 +274,7 @@ func (f *fetcher) fetchImageFromURL(imgurl string, scheme string, ascFile *os.Fi
 func (f *fetcher) fetchImageFrom(aciURL, ascURL, scheme string, ascFile *os.File, latest bool) (string, error) {
 	if f.insecureSkipVerify {
 		if f.ks != nil {
-			stdout("rkt: warning: signature verification has been disabled")
+			stdout("rkt: warning: TLS verification and signature verification has been disabled")
 		}
 	} else if scheme == "docker" {
 		return "", fmt.Errorf("signature verification for docker images is not supported (try --insecure-skip-verify)")

--- a/rkt/rkt.go
+++ b/rkt/rkt.go
@@ -57,7 +57,7 @@ func init() {
 	globalFlagset.StringVar(&globalFlags.Dir, "dir", defaultDataDir, "rkt data directory")
 	globalFlagset.StringVar(&globalFlags.SystemConfigDir, "system-config", common.DefaultSystemConfigDir, "system configuration directory")
 	globalFlagset.StringVar(&globalFlags.LocalConfigDir, "local-config", common.DefaultLocalConfigDir, "local configuration directory")
-	globalFlagset.BoolVar(&globalFlags.InsecureSkipVerify, "insecure-skip-verify", false, "skip image or key verification")
+	globalFlagset.BoolVar(&globalFlags.InsecureSkipVerify, "insecure-skip-verify", false, "skip all TLS, image or fingerprint verification")
 }
 
 type Command struct {

--- a/rkt/trust.go
+++ b/rkt/trust.go
@@ -293,6 +293,8 @@ func reviewKey(prefix string, location string, key *os.File, forceAccept bool) (
 				stdout("Please enter 'yes' or 'no'")
 			}
 		}
+	} else {
+		stdout("rkt: warning: trust fingerprint verification has been disabled")
 	}
 	return true, nil
 }


### PR DESCRIPTION
- insecure-skip-verify is used in image fetch and trust for skipping
  verification, document this in the flags usage
- make the docs more explicit about what insecure-skip-verify does

We will split this sledgehammer flag into multiple flags via #912