### PR TITLE
stage1: support per-app memory and cpu isolators

### DIFF
--- a/common/cgroup_util.go
+++ b/common/cgroup_util.go
@@ -1,0 +1,183 @@
+// Copyright 2014 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+package common
+
+// adapted from systemd/src/shared/cgroup-util.c
+// TODO this should be moved to go-systemd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const (
+	unitNameMax = 256
+)
+
+var (
+	validChars = regexp.MustCompile(`[a-zA-Z0-9:\-_\.\\]+`)
+)
+
+// cgEscape implements very minimal escaping for names to be used as file names
+// in the cgroup tree: any name which might conflict with a kernel name or is
+// prefixed with '_' is prefixed with a '_'. That way, when reading cgroup
+// names it is sufficient to remove a single prefixing underscore if there is
+// one.
+func cgEscape(p string) string {
+	needPrefix := false
+
+	switch {
+	case strings.HasPrefix(p, "_"):
+		fallthrough
+	case strings.HasPrefix(p, "."):
+		fallthrough
+	case p == "notify_on_release":
+		fallthrough
+	case p == "release_agent":
+		fallthrough
+	case p == "tasks":
+		needPrefix = true
+	case strings.Contains(p, "."):
+		sp := strings.Split(p, ".")
+		if sp[0] == "cgroup" {
+			needPrefix = true
+		} else {
+			n := sp[0]
+			if checkHierarchy(n) {
+				needPrefix = true
+			}
+		}
+	}
+
+	if needPrefix {
+		return "_" + p
+	}
+
+	return p
+}
+
+func filenameIsValid(p string) bool {
+	switch {
+	case p == "", p == ".", p == "..", strings.Contains(p, "/"):
+		return false
+	default:
+		return true
+	}
+}
+
+func checkHierarchy(p string) bool {
+	if !filenameIsValid(p) {
+		return true
+	}
+
+	cc := filepath.Join("/sys/fs/cgroup", p)
+	if _, err := os.Stat(cc); os.IsNotExist(err) {
+		return false
+	}
+
+	return true
+}
+
+func cgUnescape(p string) string {
+	if p[0] == '_' {
+		return p[1:]
+	}
+
+	return p
+}
+
+func sliceNameIsValid(n string) bool {
+	if n == "" {
+		return false
+	}
+
+	if len(n) >= unitNameMax {
+		return false
+	}
+
+	if !strings.Contains(n, ".") {
+		return false
+	}
+
+	if validChars.FindString(n) != n {
+		return false
+	}
+
+	if strings.Contains(n, "@") {
+		return false
+	}
+
+	return true
+}
+
+// SliceToPath explodes a slice name to its corresponding path in the cgroup
+// hierarchy. For example, a slice named "foo-bar-baz.slice" corresponds to the
+// path "foo.slice/foo-bar.slice/foo-bar-baz.slice". See systemd.slice(5)
+func SliceToPath(unit string) (string, error) {
+	if unit == "-.slice" {
+		return "", nil
+	}
+
+	if !strings.HasSuffix(unit, ".slice") {
+		return "", fmt.Errorf("not a slice")
+	}
+
+	if !sliceNameIsValid(unit) {
+		return "", fmt.Errorf("invalid slice name")
+	}
+
+	prefix := unitnameToPrefix(unit)
+
+	// don't allow initial dashes
+	if prefix[0] == '-' {
+		return "", fmt.Errorf("initial dash")
+	}
+
+	prefixParts := strings.Split(prefix, "-")
+
+	var curSlice string
+	var slicePath string
+	for _, slicePart := range prefixParts {
+		if slicePart == "" {
+			return "", fmt.Errorf("trailing or double dash")
+		}
+
+		if curSlice != "" {
+			curSlice = curSlice + "-"
+		}
+		curSlice = curSlice + slicePart
+
+		curSliceDir := curSlice + ".slice"
+		escaped := cgEscape(curSliceDir)
+
+		slicePath = filepath.Join(slicePath, escaped)
+	}
+
+	return slicePath, nil
+}
+
+func unitnameToPrefix(unit string) string {
+	idx := strings.Index(unit, "@")
+	if idx == -1 {
+		idx = strings.LastIndex(unit, ".")
+	}
+
+	return unit[:idx]
+}

--- a/common/cgroup_util_test.go
+++ b/common/cgroup_util_test.go
@@ -1,0 +1,133 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+package common
+
+import (
+	"testing"
+)
+
+func TestCgEscape(t *testing.T) {
+	tests := []struct {
+		input  string
+		output string
+	}{
+		{
+			input:  "",
+			output: "",
+		},
+		{
+			input:  "_abc",
+			output: "__abc",
+		},
+		{
+			input:  ".abc",
+			output: "_.abc",
+		},
+		{
+			input:  "notify_on_release",
+			output: "_notify_on_release",
+		},
+		{
+			input:  "tasks",
+			output: "_tasks",
+		},
+		{
+			input:  "cgroup.abc.slice",
+			output: "_cgroup.abc.slice",
+		},
+		{
+			input:  "abc.mount",
+			output: "abc.mount",
+		},
+		{
+			input:  "a/bc.mount",
+			output: "_a/bc.mount",
+		},
+	}
+
+	for i, tt := range tests {
+		o := cgEscape(tt.input)
+		if o != tt.output {
+			t.Errorf("#%d: expected `%v` got `%v`", i, tt.output, o)
+		}
+	}
+}
+
+func TestSliceToPath(t *testing.T) {
+	tests := []struct {
+		input  string
+		output string
+		werr   bool
+	}{
+		{
+			input:  "",
+			output: "",
+			werr:   true,
+		},
+		{
+			input:  "abc.service",
+			output: "",
+			werr:   true,
+		},
+		{
+			input:  "ab/c.slice",
+			output: "",
+			werr:   true,
+		},
+		{
+			input:  "-abc.slice",
+			output: "",
+			werr:   true,
+		},
+		{
+			input:  "ab--c.slice",
+			output: "",
+			werr:   true,
+		},
+		{
+			input:  "abc-.slice",
+			output: "",
+			werr:   true,
+		},
+		{
+			input:  "abc.slice",
+			output: "abc.slice",
+			werr:   false,
+		},
+		{
+			input:  "foo-bar.slice",
+			output: "foo.slice/foo-bar.slice",
+			werr:   false,
+		},
+		{
+			input:  "foo-bar-baz.slice",
+			output: "foo.slice/foo-bar.slice/foo-bar-baz.slice",
+			werr:   false,
+		},
+	}
+
+	for i, tt := range tests {
+		o, err := SliceToPath(tt.input)
+		gerr := (err != nil)
+		if o != tt.output {
+			t.Errorf("#%d: expected `%v` got `%v`", i, tt.output, o)
+		}
+		if gerr != tt.werr {
+			t.Errorf("#%d: gerr=%t, want %t (err=%v)", i, gerr, tt.werr, err)
+		}
+	}
+}

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -17,6 +17,7 @@
 package main
 
 // #cgo LDFLAGS: -ldl
+// #include <stdlib.h>
 // #include <dlfcn.h>
 // #include <sys/types.h>
 //
@@ -29,11 +30,30 @@ package main
 //   return sd_pid_get_owner_uid(pid, uid);
 // }
 //
+// int
+// my_sd_pid_get_unit(void *f, pid_t pid, char **unit)
+// {
+//   int (*sd_pid_get_unit)(pid_t, char **);
+//
+//   sd_pid_get_unit = (int (*)(pid_t, char **))f;
+//   return sd_pid_get_unit(pid, unit);
+// }
+//
+// int
+// my_sd_pid_get_slice(void *f, pid_t pid, char **slice)
+// {
+//   int (*sd_pid_get_slice)(pid_t, char **);
+//
+//   sd_pid_get_slice = (int (*)(pid_t, char **))f;
+//   return sd_pid_get_slice(pid, slice);
+// }
+//
 import "C"
 
 // this implements /init of stage1/nspawn+systemd
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"io"
@@ -45,6 +65,7 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+	"unsafe"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/coreos/go-systemd/util"
@@ -291,6 +312,204 @@ func forwardedPorts(pod *Pod) ([]networking.ForwardedPort, error) {
 	return fps, nil
 }
 
+func parseCgroups() (map[int][]string, error) {
+	f, err := os.Open("/proc/cgroups")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+
+	// skip first line since it is a comment
+	sc.Scan()
+
+	cgroups := make(map[int][]string)
+	for sc.Scan() {
+		var controller string
+		var hierarchy int
+		var num int
+		var enabled int
+		fmt.Sscanf(sc.Text(), "%s %d %d %d", &controller, &hierarchy, &num, &enabled)
+
+		if _, ok := cgroups[hierarchy]; !ok {
+			cgroups[hierarchy] = []string{controller}
+		} else {
+			cgroups[hierarchy] = append(cgroups[hierarchy], controller)
+		}
+	}
+
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+
+	return cgroups, nil
+}
+
+func getControllers(cgroups map[int][]string) []string {
+	var controllers []string
+	for _, cs := range cgroups {
+		controllers = append(controllers, strings.Join(cs, ","))
+	}
+
+	return controllers
+}
+
+func getControllerSymlinks(cgroups map[int][]string) map[string]string {
+	symlinks := make(map[string]string)
+
+	for _, cs := range cgroups {
+		if len(cs) > 1 {
+			tgt := strings.Join(cs, ",")
+			for _, ln := range cs {
+				symlinks[ln] = tgt
+			}
+		}
+	}
+
+	return symlinks
+}
+
+// createCgroups mounts the cgroup controllers hierarchy for the container but
+// leaves the subcgroup for each app read-write so the systemd inside stage1
+// can apply isolators to them
+func createCgroups(root string, machineID string, appHashes []types.Hash) error {
+	cgroups, err := parseCgroups()
+	if err != nil {
+		return fmt.Errorf("error parsing /proc/cgroups: %v", err)
+	}
+
+	controllers := getControllers(cgroups)
+
+	var flags uintptr
+
+	// 1. Mount /sys read-only
+	sys := filepath.Join(root, "/sys")
+	if err := os.MkdirAll(sys, 0700); err != nil {
+		return err
+	}
+	flags = syscall.MS_RDONLY |
+		syscall.MS_NOSUID |
+		syscall.MS_NOEXEC |
+		syscall.MS_NODEV
+	if err := syscall.Mount("sysfs", sys, "sysfs", flags, ""); err != nil {
+		return fmt.Errorf("error mounting %q: %v", sys, err)
+	}
+
+	// 2. Mount /sys/fs/cgroup
+	cgroupTmpfs := filepath.Join(root, "/sys/fs/cgroup")
+	if err := os.MkdirAll(cgroupTmpfs, 0700); err != nil {
+		return err
+	}
+
+	flags = syscall.MS_NOSUID |
+		syscall.MS_NOEXEC |
+		syscall.MS_NODEV |
+		syscall.MS_STRICTATIME
+	if err := syscall.Mount("tmpfs", cgroupTmpfs, "tmpfs", flags, "mode=755"); err != nil {
+		return fmt.Errorf("error mounting %q: %v", cgroupTmpfs, err)
+	}
+
+	var subcgroup string
+	fromUnit, err := runningFromUnitFile()
+	if err != nil {
+		return fmt.Errorf("error determining if we're running from a unit file: %v", err)
+	}
+	if fromUnit {
+		slice, err := getSlice()
+		if err != nil {
+			return fmt.Errorf("error getting slice name: %v", err)
+		}
+		slicePath, err := common.SliceToPath(slice)
+		if err != nil {
+			return fmt.Errorf("error converting slice name to path: %v", err)
+		}
+		unit, err := getUnitFileName()
+		if err != nil {
+			return fmt.Errorf("error getting unit name: %v", err)
+		}
+		subcgroup = filepath.Join(slicePath, unit, "system.slice")
+	} else {
+		escapedmID := strings.Replace(machineID, "-", "\\x2d", -1)
+		machineDir := "machine-" + escapedmID + ".scope"
+		subcgroup = filepath.Join("machine.slice", machineDir, "system.slice")
+	}
+
+	// 3. Mount controllers
+	for _, c := range controllers {
+		// 3a. Mount controller
+		cPath := filepath.Join(root, "/sys/fs/cgroup", c)
+		if err := os.MkdirAll(cPath, 0700); err != nil {
+			return err
+		}
+
+		flags = syscall.MS_NOSUID |
+			syscall.MS_NOEXEC |
+			syscall.MS_NODEV
+		if err := syscall.Mount("cgroup", cPath, "cgroup", flags, c); err != nil {
+			return fmt.Errorf("error mounting %q: %v", cPath, err)
+		}
+
+		// 3b. Check if we're running from a unit to know which subcgroup
+		// directories to mount read-write
+		subcgroupPath := filepath.Join(cPath, subcgroup)
+
+		// 3c. Create and bind-mount app cgroup directories over themselves so
+		// they stay read-write
+		for _, a := range appHashes {
+			serviceName := ServiceUnitName(a)
+			appCgroup := filepath.Join(subcgroupPath, serviceName)
+
+			if err := os.MkdirAll(appCgroup, 0755); err != nil {
+				return err
+			}
+			if err := syscall.Mount(appCgroup, appCgroup, "", syscall.MS_BIND, ""); err != nil {
+				return fmt.Errorf("error bind mounting %q: %v", appCgroup, err)
+			}
+		}
+
+		// 3d. Re-mount controller read-only to prevent the container modifying host controllers
+		flags = syscall.MS_BIND |
+			syscall.MS_REMOUNT |
+			syscall.MS_NOSUID |
+			syscall.MS_NOEXEC |
+			syscall.MS_NODEV |
+			syscall.MS_RDONLY
+		if err := syscall.Mount(cPath, cPath, "", flags, ""); err != nil {
+			return fmt.Errorf("error remounting RO %q: %v", cPath, err)
+		}
+	}
+
+	// 4. Create symlinks for combined controllers
+	symlinks := getControllerSymlinks(cgroups)
+	for ln, tgt := range symlinks {
+		lnPath := filepath.Join(cgroupTmpfs, ln)
+		if err := os.Symlink(tgt, lnPath); err != nil {
+			return fmt.Errorf("error creating symlink: %v", err)
+		}
+	}
+
+	// 5. Create systemd cgroup directory
+	// We're letting systemd-nspawn create the systemd cgroup but later we're
+	// remounting /sys/fs/cgroup read-only so we create the directory here.
+	if err := os.MkdirAll(filepath.Join(cgroupTmpfs, "systemd"), 0700); err != nil {
+		return err
+	}
+
+	// 6. Bind-mount cgroup filesystem read-only
+	flags = syscall.MS_BIND |
+		syscall.MS_REMOUNT |
+		syscall.MS_NOSUID |
+		syscall.MS_NOEXEC |
+		syscall.MS_NODEV |
+		syscall.MS_RDONLY
+	if err := syscall.Mount(cgroupTmpfs, cgroupTmpfs, "", flags, ""); err != nil {
+		return fmt.Errorf("error remounting RO %q: %v", cgroupTmpfs, err)
+	}
+
+	return nil
+}
+
 func stage1() int {
 	uuid, err := types.NewUUID(flag.Arg(0))
 	if err != nil {
@@ -390,6 +609,19 @@ func stage1() int {
 		return 4
 	}
 
+	// The systemd version shipped with CoreOS (v215) doesn't allow the
+	// external mounting of cgroups
+	// TODO remove this check when CoreOS updates systemd to v220
+	if flavor != "coreos" {
+		appHashes := p.GetAppHashes()
+		s1Root := common.Stage1RootfsPath(p.Root)
+		machineID := p.GetMachineID()
+		if err := createCgroups(s1Root, machineID, appHashes); err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating cgroups: %v\n", err)
+			return 5
+		}
+	}
+
 	var execFn func() error
 
 	if privNet.Any() {
@@ -411,14 +643,88 @@ func stage1() int {
 	err = withClearedCloExec(lfd, execFn)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to execute nspawn: %v\n", err)
-		return 5
+		return 7
 	}
 
 	return 0
 }
 
+func getUnitFileName() (unit string, err error) {
+	libname := C.CString("libsystemd.so")
+	defer C.free(unsafe.Pointer(libname))
+	handle := C.dlopen(libname, C.RTLD_LAZY)
+	if handle == nil {
+		err = fmt.Errorf("error opening libsystemd.so")
+		return
+	}
+	defer func() {
+		if r := C.dlclose(handle); r != 0 {
+			err = fmt.Errorf("error closing libsystemd.so")
+		}
+	}()
+
+	sym := C.CString("sd_pid_get_unit")
+	defer C.free(unsafe.Pointer(sym))
+	sd_pid_get_unit := C.dlsym(handle, sym)
+	if sd_pid_get_unit == nil {
+		err = fmt.Errorf("error resolving sd_pid_get_unit function")
+		return
+	}
+
+	var s string
+	u := C.CString(s)
+	defer C.free(unsafe.Pointer(u))
+
+	ret := C.my_sd_pid_get_unit(sd_pid_get_unit, 0, &u)
+	if ret < 0 {
+		err = fmt.Errorf("error calling sd_pid_get_unit: %v", syscall.Errno(-ret))
+		return
+	}
+
+	unit = C.GoString(u)
+	return
+}
+
+func getSlice() (slice string, err error) {
+	libname := C.CString("libsystemd.so")
+	defer C.free(unsafe.Pointer(libname))
+	handle := C.dlopen(libname, C.RTLD_LAZY)
+	if handle == nil {
+		err = fmt.Errorf("error opening libsystemd.so")
+		return
+	}
+	defer func() {
+		if r := C.dlclose(handle); r != 0 {
+			err = fmt.Errorf("error closing libsystemd.so")
+		}
+	}()
+
+	sym := C.CString("sd_pid_get_slice")
+	defer C.free(unsafe.Pointer(sym))
+	sd_pid_get_slice := C.dlsym(handle, sym)
+	if sd_pid_get_slice == nil {
+		err = fmt.Errorf("error resolving sd_pid_get_slice function")
+		return
+	}
+
+	var s string
+	sl := C.CString(s)
+	defer C.free(unsafe.Pointer(sl))
+
+	ret := C.my_sd_pid_get_slice(sd_pid_get_slice, 0, &sl)
+	if ret < 0 {
+		err = fmt.Errorf("error calling sd_pid_get_slice: %v", syscall.Errno(-ret))
+		return
+	}
+
+	slice = C.GoString(sl)
+	return
+}
+
 func runningFromUnitFile() (ret bool, err error) {
-	handle := C.dlopen(C.CString("libsystemd.so"), C.RTLD_LAZY)
+	libname := C.CString("libsystemd.so")
+	defer C.free(unsafe.Pointer(libname))
+	handle := C.dlopen(libname, C.RTLD_LAZY)
 	if handle == nil {
 		// we can't open libsystemd.so so we assume systemd is not
 		// installed and we're not running from a unit file

--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -249,6 +249,14 @@ func (p *Pod) appToSystemd(ra *schema.RuntimeApp, am *schema.ImageManifest, inte
 		}
 	}
 
+	for _, i := range am.App.Isolators {
+		switch v := i.Value().(type) {
+		case *types.ResourceMemory:
+			l := v.Limit().String()
+			opts = append(opts, newUnitOption("Service", "MemoryLimit", l))
+		}
+	}
+
 	if len(saPorts) > 0 {
 		sockopts := []*unit.UnitOption{
 			newUnitOption("Unit", "Description", name+" socket-activated ports"),

--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -424,7 +424,7 @@ func (p *Pod) appToNspawnArgs(ra *schema.RuntimeApp, am *schema.ImageManifest) (
 func (p *Pod) PodToNspawnArgs() ([]string, error) {
 	args := []string{
 		"--uuid=" + p.UUID.String(),
-		"--machine=" + "rkt-" + p.UUID.String(),
+		"--machine=" + p.GetMachineID(),
 		"--directory=" + common.Stage1RootfsPath(p.Root),
 	}
 
@@ -454,4 +454,20 @@ func (p *Pod) getFlavor() (flavor string, systemdVersion string, err error) {
 	}
 	systemdVersion = strings.Trim(string(systemdVersionBytes), " \n")
 	return
+}
+
+// GetAppHashes returns a list of hashes of the apps in this pod
+func (p *Pod) GetAppHashes() []types.Hash {
+	var names []types.Hash
+	for _, a := range p.Manifest.Apps {
+		names = append(names, a.Image.ID)
+	}
+
+	return names
+}
+
+// GetMachineID returns the machine id string of the pod to be passed to
+// systemd-nspawn
+func (p *Pod) GetMachineID() string {
+	return "rkt-" + p.UUID.String()
 }

--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -254,6 +254,14 @@ func (p *Pod) appToSystemd(ra *schema.RuntimeApp, am *schema.ImageManifest, inte
 		case *types.ResourceMemory:
 			l := v.Limit().String()
 			opts = append(opts, newUnitOption("Service", "MemoryLimit", l))
+		case *types.ResourceCPU:
+			l := v.Limit().String()
+			milliCores, err := strconv.Atoi(l)
+			if err != nil {
+				return err
+			}
+			quota := strconv.Itoa(milliCores/10) + "%"
+			opts = append(opts, newUnitOption("Service", "CPUQuota", quota))
 		}
 	}
 

--- a/stage1/rootfs/usr_from_src/patches/v219/0005-nspawn-only-mount-the-cgroup-root-if-it-s-not-alread.patch
+++ b/stage1/rootfs/usr_from_src/patches/v219/0005-nspawn-only-mount-the-cgroup-root-if-it-s-not-alread.patch
@@ -1,0 +1,67 @@
+From 3e0ab7a3c7ffbb03a249f89bb5b0532deecd714d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Iago=20L=C3=B3pez=20Galeiras?= <iago@endocode.com>
+Date: Wed, 13 May 2015 15:45:48 +0200
+Subject: [PATCH 5/6] nspawn: only mount the cgroup root if it's not already
+ mounted
+
+This allows the user to set the cgroups manually before calling nspawn.
+---
+ src/nspawn/nspawn.c | 27 +++++++++++++--------------
+ 1 file changed, 13 insertions(+), 14 deletions(-)
+
+diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
+index 5a30bdd..f179dcb 100644
+--- a/src/nspawn/nspawn.c
++++ b/src/nspawn/nspawn.c
+@@ -828,18 +828,19 @@ static int mount_all(const char *dest) {
+         } MountPoint;
+ 
+         static const MountPoint mount_table[] = {
+-                { "proc",      "/proc",     "proc",  NULL,        MS_NOSUID|MS_NOEXEC|MS_NODEV,           true  },
+-                { "/proc/sys", "/proc/sys", NULL,    NULL,        MS_BIND,                                true  },   /* Bind mount first */
+-                { NULL,        "/proc/sys", NULL,    NULL,        MS_BIND|MS_RDONLY|MS_REMOUNT,           true  },   /* Then, make it r/o */
+-                { "sysfs",     "/sys",      "sysfs", NULL,        MS_RDONLY|MS_NOSUID|MS_NOEXEC|MS_NODEV, true  },
+-                { "tmpfs",     "/dev",      "tmpfs", "mode=755",  MS_NOSUID|MS_STRICTATIME,               true  },
+-                { "devpts",    "/dev/pts",  "devpts","newinstance,ptmxmode=0666,mode=620,gid=" STRINGIFY(TTY_GID), MS_NOSUID|MS_NOEXEC, true },
+-                { "tmpfs",     "/dev/shm",  "tmpfs", "mode=1777", MS_NOSUID|MS_NODEV|MS_STRICTATIME,      true  },
+-                { "tmpfs",     "/run",      "tmpfs", "mode=755",  MS_NOSUID|MS_NODEV|MS_STRICTATIME,      true  },
+-                { "tmpfs",     "/tmp",      "tmpfs", "mode=1777", MS_STRICTATIME,                         true  },
++                { "proc",      "/proc",          "proc",   NULL,        MS_NOSUID|MS_NOEXEC|MS_NODEV,                true  },
++                { "/proc/sys", "/proc/sys",      NULL,     NULL,        MS_BIND,                                     true  },   /* Bind mount first */
++                { NULL,        "/proc/sys",      NULL,     NULL,        MS_BIND|MS_RDONLY|MS_REMOUNT,                true  },   /* Then, make it r/o */
++                { "sysfs",     "/sys",           "sysfs",  NULL,        MS_RDONLY|MS_NOSUID|MS_NOEXEC|MS_NODEV,      true  },
++                { "tmpfs",     "/sys/fs/cgroup", "tmpfs",  "mode=755",  MS_NOSUID|MS_NOEXEC|MS_NODEV|MS_STRICTATIME, true  },
++                { "tmpfs",     "/dev",           "tmpfs",  "mode=755",  MS_NOSUID|MS_STRICTATIME,                    true  },
++                { "devpts",    "/dev/pts",       "devpts", "newinstance,ptmxmode=0666,mode=620,gid=" STRINGIFY(TTY_GID), MS_NOSUID|MS_NOEXEC, true },
++                { "tmpfs",     "/dev/shm",       "tmpfs",  "mode=1777", MS_NOSUID|MS_NODEV|MS_STRICTATIME,           true  },
++                { "tmpfs",     "/run",           "tmpfs",  "mode=755",  MS_NOSUID|MS_NODEV|MS_STRICTATIME,           true  },
++                { "tmpfs",     "/tmp",           "tmpfs",  "mode=1777", MS_STRICTATIME,                              true  },
+ #ifdef HAVE_SELINUX
+-                { "/sys/fs/selinux", "/sys/fs/selinux", NULL, NULL, MS_BIND,                              false },  /* Bind mount first */
+-                { NULL,              "/sys/fs/selinux", NULL, NULL, MS_BIND|MS_RDONLY|MS_REMOUNT,         false },  /* Then, make it r/o */
++                { "/sys/fs/selinux", "/sys/fs/selinux", NULL, NULL,     MS_BIND,                                     false },  /* Bind mount first */
++                { NULL,              "/sys/fs/selinux", NULL, NULL,     MS_BIND|MS_RDONLY|MS_REMOUNT,                false },  /* Then, make it r/o */
+ #endif
+         };
+ 
+@@ -1024,9 +1025,6 @@ static int mount_cgroup(const char *dest) {
+         if (r < 0)
+                 return log_error_errno(r, "Failed to determine our own cgroup path: %m");
+ 
+-        cgroup_root = strjoina(dest, "/sys/fs/cgroup");
+-        if (mount("tmpfs", cgroup_root, "tmpfs", MS_NOSUID|MS_NOEXEC|MS_NODEV|MS_STRICTATIME, "mode=755") < 0)
+-                return log_error_errno(errno, "Failed to mount tmpfs to /sys/fs/cgroup: %m");
+ 
+         for (;;) {
+                 _cleanup_free_ char *controller = NULL, *origin = NULL, *combined = NULL;
+@@ -1086,6 +1084,7 @@ static int mount_cgroup(const char *dest) {
+         if (mount(NULL, systemd_root, NULL, MS_BIND|MS_REMOUNT|MS_NOSUID|MS_NOEXEC|MS_NODEV|MS_RDONLY, NULL) < 0)
+                 return log_error_errno(errno, "Failed to mount cgroup root read-only: %m");
+ 
++        cgroup_root = strjoina(dest, "/sys/fs/cgroup");
+         if (mount(NULL, cgroup_root, NULL, MS_REMOUNT|MS_NOSUID|MS_NOEXEC|MS_NODEV|MS_STRICTATIME|MS_RDONLY, "mode=755") < 0)
+                 return log_error_errno(errno, "Failed to remount %s read-only: %m", cgroup_root);
+ 
+-- 
+2.4.1
+

--- a/stage1/rootfs/usr_from_src/patches/v219/0006-nspawn-skip-symlink-to-a-combined-cgroup-hierarchy-i.patch
+++ b/stage1/rootfs/usr_from_src/patches/v219/0006-nspawn-skip-symlink-to-a-combined-cgroup-hierarchy-i.patch
@@ -1,0 +1,92 @@
+From 4f30798831619a2ca7b56ef94d7601fe0238f04d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Iago=20L=C3=B3pez=20Galeiras?= <iago@endocode.com>
+Date: Wed, 13 May 2015 15:45:49 +0200
+Subject: [PATCH 6/6] nspawn: skip symlink to a combined cgroup hierarchy if it
+ already exists
+
+If a symlink to a combined cgroup hierarchy already exists and points to
+the right path, skip it. This avoids an error when the cgroups are set
+manually before calling nspawn.
+---
+ src/nspawn/nspawn.c | 10 +++++++---
+ src/shared/util.c   | 22 ++++++++++++++++++++++
+ src/shared/util.h   |  2 ++
+ 3 files changed, 31 insertions(+), 3 deletions(-)
+
+diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
+index f179dcb..df912a1 100644
+--- a/src/nspawn/nspawn.c
++++ b/src/nspawn/nspawn.c
+@@ -1025,7 +1025,6 @@ static int mount_cgroup(const char *dest) {
+         if (r < 0)
+                 return log_error_errno(r, "Failed to determine our own cgroup path: %m");
+ 
+-
+         for (;;) {
+                 _cleanup_free_ char *controller = NULL, *origin = NULL, *combined = NULL;
+ 
+@@ -1065,8 +1064,13 @@ static int mount_cgroup(const char *dest) {
+                         if (r < 0)
+                                 return r;
+ 
+-                        if (symlink(combined, target) < 0)
+-                                return log_error_errno(errno, "Failed to create symlink for combined hierarchy: %m");
++                        r = symlink_idempotent(combined, target);
++                        if (r == -EINVAL) {
++                                log_error("Invalid existing symlink for combined hierarchy");
++                                return r;
++                        }
++                        if (r < 0)
++                                return log_error_errno(r, "Failed to create symlink for combined hierarchy: %m");
+                 }
+         }
+ 
+diff --git a/src/shared/util.c b/src/shared/util.c
+index ba035ca..2ea9cdf 100644
+--- a/src/shared/util.c
++++ b/src/shared/util.c
+@@ -4503,6 +4503,28 @@ int symlink_atomic(const char *from, const char *to) {
+         return 0;
+ }
+ 
++int symlink_idempotent(const char *from, const char *to) {
++        _cleanup_free_ char *p = NULL;
++        int r;
++
++        assert(from);
++        assert(to);
++
++        if (symlink(from, to) < 0) {
++                if (errno != EEXIST)
++                        return -errno;
++
++                r = readlink_malloc(to, &p);
++                if (r < 0)
++                        return r;
++
++                if (!streq(p, from))
++                        return -EINVAL;
++        }
++
++        return 0;
++}
++
+ int mknod_atomic(const char *path, mode_t mode, dev_t dev) {
+         _cleanup_free_ char *t = NULL;
+         int r;
+diff --git a/src/shared/util.h b/src/shared/util.h
+index a83b588..874e2dc 100644
+--- a/src/shared/util.h
++++ b/src/shared/util.h
+@@ -564,6 +564,8 @@ int terminal_vhangup(const char *name);
+ 
+ int vt_disallocate(const char *name);
+ 
++int symlink_idempotent(const char *from, const char *to);
++
+ int symlink_atomic(const char *from, const char *to);
+ int mknod_atomic(const char *path, mode_t mode, dev_t dev);
+ int mkfifo_atomic(const char *path, mode_t mode);
+-- 
+2.4.1
+

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -30,6 +30,20 @@
             }
         ],
         "isolators": [
+            {
+                "name": "resource/memory",
+                "value": {
+                    "request": "25M",
+                    "limit": "120M"
+                }
+            },
+            {
+                "name": "resource/cpu",
+                "value": {
+                    "request": "50",
+                    "limit": "100"
+                }
+            }
         ],
         "mountPoints": [
         ],


### PR DESCRIPTION
To allow systemd inside stage1 to set resource limits for apps we mount
the cgroup controllers hierarchy in rkt. We need this because
systemd-nspawn mounts cgroup controllers as read-only.

We mimic systemd-nspawn cgroup mounts with the difference that we
bind-mount the apps' subdirectories over themselves so they stay
read-write. We leave the mounting of systemd's cgroup hierarchy to
nspawn.

Addresses (partially) #811