### PR TITLE
stage1: add ipvlan network plugin

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -21,35 +21,39 @@
 		},
 		{
 			"ImportPath": "github.com/appc/cni/pkg/ip",
-			"Rev": "88377fa3466eea30817b038c69ac06686e7655b7"
+			"Rev": "49a018fa85ac216fdc76c835371807bdcf3b8ead"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/pkg/ns",
-			"Rev": "88377fa3466eea30817b038c69ac06686e7655b7"
+			"Rev": "49a018fa85ac216fdc76c835371807bdcf3b8ead"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/pkg/plugin",
-			"Rev": "88377fa3466eea30817b038c69ac06686e7655b7"
+			"Rev": "49a018fa85ac216fdc76c835371807bdcf3b8ead"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/pkg/skel",
-			"Rev": "88377fa3466eea30817b038c69ac06686e7655b7"
+			"Rev": "49a018fa85ac216fdc76c835371807bdcf3b8ead"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/plugins/ipam/host-local",
-			"Rev": "88377fa3466eea30817b038c69ac06686e7655b7"
+			"Rev": "49a018fa85ac216fdc76c835371807bdcf3b8ead"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/plugins/main/bridge",
-			"Rev": "88377fa3466eea30817b038c69ac06686e7655b7"
+			"Rev": "49a018fa85ac216fdc76c835371807bdcf3b8ead"
+		},
+		{
+			"ImportPath": "github.com/appc/cni/plugins/main/ipvlan",
+			"Rev": "49a018fa85ac216fdc76c835371807bdcf3b8ead"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/plugins/main/macvlan",
-			"Rev": "88377fa3466eea30817b038c69ac06686e7655b7"
+			"Rev": "49a018fa85ac216fdc76c835371807bdcf3b8ead"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/plugins/main/veth",
-			"Rev": "88377fa3466eea30817b038c69ac06686e7655b7"
+			"Rev": "49a018fa85ac216fdc76c835371807bdcf3b8ead"
 		},
 		{
 			"ImportPath": "github.com/appc/docker2aci/lib",

--- a/Godeps/_workspace/src/github.com/appc/cni/pkg/plugin/ipam.go
+++ b/Godeps/_workspace/src/github.com/appc/cni/pkg/plugin/ipam.go
@@ -124,9 +124,18 @@ func ConfigureIface(ifName string, res *Result) error {
 	return nil
 }
 
-// PrintResult writes out prettified Result to stdout
+// PrintResult writes out prettified Result JSON to stdout
 func PrintResult(res *Result) error {
-	data, err := json.MarshalIndent(res, "", "    ")
+	return prettyPrint(res)
+}
+
+// PrintError writes out prettified Error JSON to stdout
+func PrintError(err *Error) error {
+	return prettyPrint(err)
+}
+
+func prettyPrint(obj interface{}) error {
+	data, err := json.MarshalIndent(obj, "", "    ")
 	if err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/github.com/appc/cni/pkg/plugin/types.go
+++ b/Godeps/_workspace/src/github.com/appc/cni/pkg/plugin/types.go
@@ -48,6 +48,12 @@ type Route struct {
 	GW  net.IP
 }
 
+type Error struct {
+	Code    uint   `json:"code"`
+	Msg     string `json:"msg"`
+	Details string `json:"details,omitempty"`
+}
+
 // net.IPNet is not JSON (un)marshallable so this duality is needed
 // for our custom ip.IPNet type
 

--- a/Godeps/_workspace/src/github.com/appc/cni/plugins/ipam/host-local/main.go
+++ b/Godeps/_workspace/src/github.com/appc/cni/plugins/ipam/host-local/main.go
@@ -47,9 +47,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	switch ipamConf.Type {
 	case "host-local":
-		ipConf, err = allocator.Get(args.Netns)
+		ipConf, err = allocator.Get(args.ContainerID)
 	case "host-local-ptp":
-		ipConf, err = allocator.GetPtP(args.Netns)
+		ipConf, err = allocator.GetPtP(args.ContainerID)
 	default:
 		return errors.New("Unsupported IPAM plugin type")
 	}
@@ -80,5 +80,5 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
-	return allocator.Release(args.Netns)
+	return allocator.Release(args.ContainerID)
 }

--- a/Godeps/_workspace/src/github.com/appc/cni/plugins/main/bridge/bridge.go
+++ b/Godeps/_workspace/src/github.com/appc/cni/plugins/main/bridge/bridge.go
@@ -130,7 +130,7 @@ func setupVeth(netns string, br *netlink.Bridge, ifName string, mtu int, pr *plu
 
 	err := ns.WithNetNSPath(netns, func(hostNS *os.File) error {
 		// create the veth pair in the container and move host end into host netns
-		hostVeth, _, err := ip.SetupVeth(netns, ifName, mtu, hostNS)
+		hostVeth, _, err := ip.SetupVeth(ifName, mtu, hostNS)
 		if err != nil {
 			return err
 		}

--- a/Godeps/_workspace/src/github.com/appc/cni/plugins/main/veth/veth.go
+++ b/Godeps/_workspace/src/github.com/appc/cni/plugins/main/veth/veth.go
@@ -46,9 +46,7 @@ type NetConf struct {
 func setupContainerVeth(netns, ifName string, mtu int, pr *plugin.Result) (string, error) {
 	var hostVethName string
 	err := ns.WithNetNSPath(netns, func(hostNS *os.File) error {
-		entropy := netns + ifName
-
-		hostVeth, _, err := ip.SetupVeth(entropy, ifName, mtu, hostNS)
+		hostVeth, _, err := ip.SetupVeth(ifName, mtu, hostNS)
 		if err != nil {
 			return err
 		}
@@ -115,7 +113,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	if conf.IPMasq {
-		h := sha512.Sum512([]byte(args.Netns))
+		h := sha512.Sum512([]byte(args.ContainerID))
 		chain := fmt.Sprintf("CNI-%s-%x", conf.Name, h[:8])
 		if err = ip.SetupIPMasq(&result.IP4.IP, chain); err != nil {
 			return err
@@ -142,7 +140,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	}
 
 	if conf.IPMasq {
-		h := sha512.Sum512([]byte(args.Netns))
+		h := sha512.Sum512([]byte(args.ContainerID))
 		chain := fmt.Sprintf("CNI-%s-%x", conf.Name, h[:8])
 		if err = ip.TeardownIPMasq(ipn, chain); err != nil {
 			return err

--- a/stage1/dummy.go
+++ b/stage1/dummy.go
@@ -11,6 +11,7 @@ import (
 import (
 	_ "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/cni/plugins/ipam/host-local"
 	_ "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/cni/plugins/main/bridge"
+	_ "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/cni/plugins/main/ipvlan"
 	_ "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/cni/plugins/main/macvlan"
 	_ "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/cni/plugins/main/veth"
 )


### PR DESCRIPTION
This plugin is very similar to macvlan but let's the secondary interfaces use
the primary interface's MAC address instead of generating their own one.

Fixes #479 