### PR TITLE
aci: extract tar in chroot

### DIFF
--- a/pkg/aci/render.go
+++ b/pkg/aci/render.go
@@ -1,12 +1,12 @@
 package aci
 
 import (
-	"archive/tar"
 	"fmt"
+
+	ptar "github.com/coreos/rkt/pkg/tar"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/pkg/acirenderer"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
-	ptar "github.com/coreos/rkt/pkg/tar"
 )
 
 // Given an imageID, start with the matching image available in the store,
@@ -50,11 +50,13 @@ func renderImage(renderedACI acirenderer.RenderedACI, dir string, ap acirenderer
 		if err != nil {
 			return err
 		}
-		defer rs.Close()
+
 		// Overwrite is not needed. If a file needs to be overwritten then the renderedACI builder has a bug
-		if err := ptar.ExtractTar(tar.NewReader(rs), dir, false, ra.FileMap); err != nil {
+		if err := ptar.ExtractTar(rs, dir, false, ra.FileMap); err != nil {
+			rs.Close()
 			return fmt.Errorf("error extracting ACI: %v", err)
 		}
+		rs.Close()
 	}
 
 	return nil

--- a/pkg/multicall/multicall.go
+++ b/pkg/multicall/multicall.go
@@ -1,0 +1,87 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// inspired by github.com/docker/docker/pkg/reexec
+
+//+build linux
+
+package multicall
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+var exePath string
+
+func init() {
+	// save the program path
+	var err error
+	exePath, err = os.Readlink("/proc/self/exe")
+	if err != nil {
+		panic("cannot get current executable")
+	}
+}
+
+type commandFn func() error
+
+var commands = make(map[string]commandFn)
+
+// Entrypoint provides the access to a multicall command.
+type Entrypoint string
+
+// Add adds a new multicall command. name is the command name and fn is the
+// function that will be executed for the specified command. It returns the
+// related Entrypoint.
+// Packages adding new multicall commands should call Add in their init
+// function.
+func Add(name string, fn commandFn) Entrypoint {
+	if _, ok := commands[name]; ok {
+		panic(fmt.Errorf("command with name %q already exists", name))
+	}
+	commands[name] = fn
+	return Entrypoint(name)
+}
+
+// MaybeExec should be called at the start of the program, if the process argv[0] is
+// a name registered with multicall, the related function will be executed.
+// If the functions returns an error, it will be printed to stderr and will
+// exit with an exit status of 1, otherwise it will exit with a 0 exit
+// status.
+func MaybeExec() {
+	name := os.Args[0]
+	if fn, ok := commands[name]; ok {
+		if err := fn(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+}
+
+// Cmd will prepare the *exec.Cmd for the given entrypoint, configured with the
+// provided args.
+func (e Entrypoint) Cmd(args ...string) *exec.Cmd {
+	// append the Entrypoint as argv[0]
+	args = append([]string{string(e)}, args...)
+	return &exec.Cmd{
+		Path: exePath,
+		Args: args,
+		SysProcAttr: &syscall.SysProcAttr{
+			Pdeathsig: syscall.SIGTERM,
+		},
+	}
+}

--- a/pkg/sys/capability.go
+++ b/pkg/sys/capability.go
@@ -1,0 +1,21 @@
+package sys
+
+import (
+	"os"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/syndtr/gocapability/capability"
+)
+
+// HasChrootCapability checks if the current process has the CAP_SYS_CHROOT
+// capability
+func HasChrootCapability() bool {
+	// Checking the capabilities should be enough, but in case there're
+	// problem retrieving them, fallback checking for the effective uid
+	// (hoping it hasn't dropped its CAP_SYS_CHROOT).
+	caps, err := capability.NewPid(0)
+	if err == nil {
+		return caps.Get(capability.EFFECTIVE, capability.CAP_SYS_CHROOT)
+	} else {
+		return os.Geteuid() == 0
+	}
+}

--- a/pkg/tar/chroot.go
+++ b/pkg/tar/chroot.go
@@ -1,0 +1,113 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tar
+
+import (
+	"archive/tar"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"github.com/coreos/rkt/pkg/multicall"
+	"github.com/coreos/rkt/pkg/sys"
+)
+
+const (
+	multicallName = "extracttar"
+	fileMapFdNum  = 3
+)
+
+var mcEntrypoint multicall.Entrypoint
+
+func init() {
+	mcEntrypoint = multicall.Add(multicallName, extractTarCommand)
+}
+
+func extractTarCommand() error {
+	if len(os.Args) != 3 {
+		return fmt.Errorf("incorrect number of arguments. Usage: %s DIR {true|false}", multicallName)
+	}
+	if !sys.HasChrootCapability() {
+		return fmt.Errorf("chroot capability not available.")
+	}
+	dir := os.Args[1]
+	if !filepath.IsAbs(dir) {
+		return fmt.Errorf("dir %s must be an absolute path", dir)
+	}
+	overwrite, err := strconv.ParseBool(os.Args[2])
+	if err != nil {
+		return fmt.Errorf("error parsing overwrite argument: %v", err)
+	}
+
+	if err := syscall.Chroot(dir); err != nil {
+		return fmt.Errorf("failed to chroot in %s: %v", dir, err)
+	}
+	if err := syscall.Chdir("/"); err != nil {
+		return fmt.Errorf("failed to chdir: %v", err)
+	}
+	fileMapFile := os.NewFile(uintptr(fileMapFdNum), "fileMap")
+
+	fileMap := map[string]struct{}{}
+	if err := json.NewDecoder(fileMapFile).Decode(&fileMap); err != nil {
+		return fmt.Errorf("error decoding fileMap: %v", err)
+	}
+	if err := extractTar(tar.NewReader(os.Stdin), overwrite, fileMap); err != nil {
+		return fmt.Errorf("error extracting tar: %v", err)
+	}
+
+	// flush remaining bytes
+	io.Copy(ioutil.Discard, os.Stdin)
+
+	return nil
+}
+
+// ExtractTar extracts a tarball (from a io.Reader) into the given directory
+// if pwl is not nil, only the paths in the map are extracted.
+// If overwrite is true, existing files will be overwritten.
+// The extraction is executed by fork/exec()ing a new process. The new process
+// needs the CAP_SYS_CHROOT capability.
+func ExtractTar(rs io.Reader, dir string, overwrite bool, pwl PathWhitelistMap) error {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+	enc := json.NewEncoder(w)
+	cmd := mcEntrypoint.Cmd(dir, strconv.FormatBool(overwrite))
+	cmd.ExtraFiles = []*os.File{r}
+
+	cmd.Stdin = rs
+	encodeCh := make(chan error)
+	go func() {
+		encodeCh <- enc.Encode(pwl)
+	}()
+
+	out, err := cmd.CombinedOutput()
+
+	// read from blocking encodeCh to release the goroutine
+	encodeErr := <-encodeCh
+	if err != nil {
+		return fmt.Errorf("extracttar error: %v, output: %s", err, out)
+	}
+	if encodeErr != nil {
+		return fmt.Errorf("extracttar failed to json encode filemap: %v", encodeErr)
+	}
+	return nil
+}

--- a/rkt/rkt.go
+++ b/rkt/rkt.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/pkg/keystore"
+	"github.com/coreos/rkt/pkg/multicall"
 	"github.com/coreos/rkt/rkt/config"
 )
 
@@ -78,6 +79,9 @@ func init() {
 }
 
 func main() {
+	// check if rkt is executed with a multicall command
+	multicall.MaybeExec()
+
 	// parse global arguments
 	globalFlagset.Parse(os.Args[1:])
 	args := globalFlagset.Args()

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -25,11 +25,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/pkg/aci"
+	"github.com/coreos/rkt/pkg/multicall"
+	"github.com/coreos/rkt/pkg/sys"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
 const tstprefix = "store-test"
+
+func init() {
+	multicall.MaybeExec()
+}
 
 func TestBlobStore(t *testing.T) {
 	dir, err := ioutil.TempDir("", tstprefix)
@@ -334,6 +341,10 @@ func TestGetAci(t *testing.T) {
 }
 
 func TestTreeStore(t *testing.T) {
+	if !sys.HasChrootCapability() {
+		t.Skipf("chroot capability not available. Disabling test.")
+	}
+
 	dir, err := ioutil.TempDir("", tstprefix)
 	if err != nil {
 		t.Fatalf("error creating tempdir: %v", err)

--- a/store/tree.go
+++ b/store/tree.go
@@ -44,6 +44,9 @@ func (ts *TreeStore) Write(key string, s *Store) error {
 	if err != nil {
 		return fmt.Errorf("treestore: cannot convert key to imageID: %v", err)
 	}
+	if err := os.MkdirAll(treepath, 0755); err != nil {
+		return fmt.Errorf("treestore: cannot create treestore directory %s: %v", treepath, err)
+	}
 	err = aci.RenderACIWithImageID(*imageID, treepath, s)
 	if err != nil {
 		return fmt.Errorf("treestore: cannot render aci: %v", err)

--- a/store/tree_test.go
+++ b/store/tree_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/coreos/rkt/pkg/aci"
+	"github.com/coreos/rkt/pkg/sys"
 )
 
 func treeStoreWriteACI(dir string, s *Store) (string, error) {
@@ -75,6 +76,10 @@ func treeStoreWriteACI(dir string, s *Store) (string, error) {
 }
 
 func TestTreeStoreWrite(t *testing.T) {
+	if !sys.HasChrootCapability() {
+		t.Skipf("chroot capability not available. Disabling test.")
+	}
+
 	dir, err := ioutil.TempDir("", tstprefix)
 	if err != nil {
 		t.Fatalf("error creating tempdir: %v", err)
@@ -104,6 +109,10 @@ func TestTreeStoreWrite(t *testing.T) {
 }
 
 func TestTreeStoreRemove(t *testing.T) {
+	if !sys.HasChrootCapability() {
+		t.Skipf("chroot capability not available. Disabling test.")
+	}
+
 	dir, err := ioutil.TempDir("", tstprefix)
 	if err != nil {
 		t.Fatalf("error creating tempdir: %v", err)

--- a/tests/run-build.sh
+++ b/tests/run-build.sh
@@ -11,16 +11,16 @@ mkdir -p builds
 cd builds
 
 # Semaphore does not clean git subtrees between each build.
-rm -rf $BUILD_DIR
+sudo rm -rf $BUILD_DIR
 
 git clone --depth 1 ../ $BUILD_DIR
 
 cd $BUILD_DIR
 
-./test
+sudo -E PATH="$PATH" ./test
 
 cd ..
 
 # Make sure there is enough disk space for the next build
-rm -rf $BUILD_DIR
+sudo rm -rf $BUILD_DIR
 


### PR DESCRIPTION
this introduces tar extraction inside a chroot. This is done spawning a
new process. Instead of creating a new executable (difficult to find,
package etc...) it adds the concept of a multicall process (like busybox).

Now a new multicall command "extracttar" is added.
tar.ExtractTar executes this new command passing a pipe to send the
filesMap and the tar contents to stdin.

The incomplete "insecure link" checks are removed from the the tar
functions.  Additionally these functions are now not exported and the
extraction directory is always the root directory.