### PR TITLE
update appc/spec and docker2aci for tmpdir #839

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -57,11 +57,11 @@
 		},
 		{
 			"ImportPath": "github.com/appc/docker2aci/lib",
-			"Rev": "4e4333c116ee15c74ea06ec036c1bc4fad651628"
+			"Rev": "52b5a4e299eb92c51c7b0e9596543b52e7540010"
 		},
 		{
 			"ImportPath": "github.com/appc/docker2aci/tarball",
-			"Rev": "4e4333c116ee15c74ea06ec036c1bc4fad651628"
+			"Rev": "52b5a4e299eb92c51c7b0e9596543b52e7540010"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/aci",

--- a/Godeps/_workspace/src/github.com/appc/docker2aci/lib/backend/file/file.go
+++ b/Godeps/_workspace/src/github.com/appc/docker2aci/lib/backend/file/file.go
@@ -44,8 +44,8 @@ func (lb *FileBackend) GetImageInfo(dockerURL string) ([]string, *types.ParsedDo
 	return ancestry, parsedDockerURL, nil
 }
 
-func (lb *FileBackend) BuildACI(layerID string, dockerURL *types.ParsedDockerURL, outputDir string, curPwl []string, compress bool) (string, *schema.ImageManifest, error) {
-	tmpDir, err := ioutil.TempDir("", "docker2aci-")
+func (lb *FileBackend) BuildACI(layerID string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, curPwl []string, compress bool) (string, *schema.ImageManifest, error) {
+	tmpDir, err := ioutil.TempDir(tmpBaseDir, "docker2aci-")
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating dir: %v", err)
 	}
@@ -204,7 +204,7 @@ func getTarFileBytes(file *os.File, path string) ([]byte, error) {
 }
 
 func extractEmbeddedLayer(file *os.File, layerID string, outputPath string) (*os.File, error) {
-	util.Info("Extracting layer: ", layerID, "\n")
+	util.Info("Extracting ", layerID[:12], "\n")
 
 	_, err := file.Seek(0, 0)
 	if err != nil {

--- a/Godeps/_workspace/src/github.com/appc/docker2aci/lib/util/util.go
+++ b/Godeps/_workspace/src/github.com/appc/docker2aci/lib/util/util.go
@@ -67,12 +67,12 @@ func Warn(i ...interface{}) {
 }
 
 func Info(i ...interface{}) {
-	printTo(os.Stdout, i...)
+	printTo(os.Stderr, i...)
 }
 
 func Debug(i ...interface{}) {
 	if debugEnabled {
-		printTo(os.Stdout, i...)
+		printTo(os.Stderr, i...)
 	}
 }
 

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -356,7 +356,7 @@ func (f *fetcher) fetch(aciURL, ascURL string, ascFile *os.File) (*openpgp.Entit
 			user = creds.User
 			password = creds.Password
 		}
-		acis, err := docker2aci.Convert(registryURL, true, tmpDir, user, password)
+		acis, err := docker2aci.Convert(registryURL, true, tmpDir, tmpDir, user, password)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error converting docker image to ACI: %v", err)
 		}

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -365,7 +365,7 @@ func stage1() int {
 
 	args, env, err := getArgsEnv(p, flavor, systemdVersion, debug)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to get execution parameters: %v\n", err)
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		return 3
 	}
 


### PR DESCRIPTION
fetch: docker2aci: use the correct tmpDir

This requires a new version of docker2aci in Godeps. And the new version of docker2aci requires a new version of appc/spec. Update both accordingly.

Fixes: https://github.com/coreos/rkt/issues/839