### PR TITLE
stage1: fixes compilation on systemd-v220 (flavor=src)

### DIFF
--- a/stage1/rootfs/usr_from_src/patches/v220/0001-nspawn-add-pid-file.patch
+++ b/stage1/rootfs/usr_from_src/patches/v220/0001-nspawn-add-pid-file.patch
@@ -1,0 +1,96 @@
+From a7bfa4b16a833ff5e2b25e28b406c300a8d3e318 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Iago=20L=C3=B3pez=20Galeiras?= <iago@endocode.com>
+Date: Thu, 21 May 2015 16:52:48 +0200
+Subject: [PATCH] nspawn: add --pid-file
+
+Simple mechanism for recording the container's pid independent of any
+external daemons/systemd services.
+
+[patch ported to v219 -alban]
+[patch ported to git master 2015-05-20 -alban]
+[patch ported to git master 2015-05-21 -iaguis]
+[patch ported to v220 2015-05-26 -alban]
+---
+ src/nspawn/nspawn.c | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
+index 5009363..41c034c 100644
+--- a/src/nspawn/nspawn.c
++++ b/src/nspawn/nspawn.c
+@@ -190,6 +190,7 @@ static bool arg_quiet = false;
+ static bool arg_share_system = false;
+ static bool arg_register = true;
+ static bool arg_keep_unit = false;
++static const char *arg_pid_file = NULL;
+ static char **arg_network_interfaces = NULL;
+ static char **arg_network_macvlan = NULL;
+ static char **arg_network_ipvlan = NULL;
+@@ -271,6 +272,7 @@ static void help(void) {
+                "     --keep-unit            Do not register a scope for the machine, reuse\n"
+                "                            the service unit nspawn is running in\n"
+                "     --volatile[=MODE]      Run the system in volatile mode\n"
++               "     --pid-file=FILE        Write child pid to FILE\n"
+                , program_invocation_short_name);
+ }
+ 
+@@ -397,6 +399,7 @@ static int parse_argv(int argc, char *argv[]) {
+                 ARG_SHARE_SYSTEM,
+                 ARG_REGISTER,
+                 ARG_KEEP_UNIT,
++                ARG_PID_FILE,
+                 ARG_NETWORK_INTERFACE,
+                 ARG_NETWORK_MACVLAN,
+                 ARG_NETWORK_IPVLAN,
+@@ -437,6 +440,7 @@ static int parse_argv(int argc, char *argv[]) {
+                 { "share-system",          no_argument,       NULL, ARG_SHARE_SYSTEM      },
+                 { "register",              required_argument, NULL, ARG_REGISTER          },
+                 { "keep-unit",             no_argument,       NULL, ARG_KEEP_UNIT         },
++                { "pid-file",              required_argument, NULL, ARG_PID_FILE          },
+                 { "network-interface",     required_argument, NULL, ARG_NETWORK_INTERFACE },
+                 { "network-macvlan",       required_argument, NULL, ARG_NETWORK_MACVLAN   },
+                 { "network-ipvlan",        required_argument, NULL, ARG_NETWORK_IPVLAN    },
+@@ -820,6 +824,10 @@ static int parse_argv(int argc, char *argv[]) {
+                         arg_keep_unit = true;
+                         break;
+ 
++                case ARG_PID_FILE:
++                        arg_pid_file = optarg;
++                        break;
++
+                 case ARG_PERSONALITY:
+ 
+                         arg_personality = personality_from_string(optarg);
+@@ -3921,6 +3929,14 @@ static int wait_for_container(pid_t pid, ContainerStatus *container) {
+         return r;
+ }
+ 
++static int write_pid(const char *f, int pid) {
++        char pid_str[13]; /* -2147483646\n\0 */
++
++        snprintf(pid_str, sizeof(pid_str), "%i\n", pid);
++        return write_string_file_atomic(f, pid_str);
++}
++
++
+ static void nop_handler(int sig) {}
+ 
+ static int on_orderly_shutdown(sd_event_source *s, const struct signalfd_siginfo *si, void *userdata) {
+@@ -4876,6 +4892,14 @@ int main(int argc, char *argv[]) {
+                         goto finish;
+                 }
+ 
++                if (arg_pid_file) {
++                        r = write_pid(arg_pid_file, pid);
++                        if (r < 0) {
++                                log_error_errno(r, "Failed to write pid file: %m");
++                                goto finish;
++                        }
++                }
++
+                 sd_notifyf(false,
+                            "READY=1\n"
+                            "STATUS=Container running.\n"
+-- 
+2.1.4
+


### PR DESCRIPTION
This fixes the compilation for:
  RKT_STAGE1_USR_FROM=src RKT_STAGE1_SYSTEMD_VER=v220

By copying the patch from:
stage1/rootfs/usr_from_src/patches/master/0001-nspawn-add-pid-file.patch
to:
stage1/rootfs/usr_from_src/patches/v220/0001-nspawn-add-pid-file.patch

There is ongoing work to build stage1 without patches on systemd but
it's not ready yet.

The ./build script still use v219 by default.