### PR TITLE
test: add check for license header

### DIFF
--- a/pkg/tar/utimes_unsupported.go
+++ b/pkg/tar/utimes_unsupported.go
@@ -1,5 +1,3 @@
-// +build !linux
-
 // Copyright 2015 The rkt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// +build !linux
 
 // These functions are from github.com/docker/docker/pkg/system
 

--- a/test
+++ b/test
@@ -62,13 +62,6 @@ else
 	FMT="$TEST"
 fi
 
-# split TEST into an array and prepend REPO_PATH to each local package
-split=(${TEST// / })
-TEST=${split[@]/#/${REPO_PATH}/}
-
-echo "Running tests..."
-go test -timeout 60s ${COVER} $@ ${TEST} --race
-
 echo "Checking gofmt..."
 fmtRes=$(gofmt -l $FMT)
 if [ -n "${fmtRes}" ]; then
@@ -86,6 +79,24 @@ if [ -n "${vetRes}" ]; then
 	echo -e "govet checking failed:\n${vetRes}"
 	exit 255
 fi
+
+echo "Checking license header..."
+licRes=$(
+	for file in $(find . -type f -iname '*.go' ! -path './Godeps/*'); do
+		head -n1 "${file}" | grep -Eq "(Copyright|generated)" || echo -e "  ${file}"
+	done
+)
+if [ -n "${licRes}" ]; then
+	echo -e "license header checking failed:\n${licRes}"
+	exit 255
+fi
+
+# split TEST into an array and prepend REPO_PATH to each local package
+split=(${TEST// / })
+TEST=${split[@]/#/${REPO_PATH}/}
+
+echo "Running tests..."
+go test -timeout 60s ${COVER} $@ ${TEST} --race
 
 # Functional tests use 'sudo' to run as root - it's more dangerous
 # than unit tests and may require typing a password. Only run them


### PR DESCRIPTION
Dumb test looking for either a Copyright header or sign that the file was
autogenerated (e.g. by `go generate`) in all non-Godep .go files.

Also moves the actual unit/functional tests after the pre-flight checks
(gofmt, go vet, this new check)