### PR TITLE
networking: allow network selection with private-net

### DIFF
--- a/Documentation/networking.md
+++ b/Documentation/networking.md
@@ -16,11 +16,19 @@ For all of the private networking options the metadata service, launched via `rk
 The service will listen on 0.0.0.0:2375 by default and provides the private networking containers the metadata services described in the App Container Spec.
 Ideally this metadata service is launched via your systems init system.
 
-If `rkt run` is started with `--private-net`, the pod will be executed with its own network stack.
-By default, rkt will create a loopback device and a veth device. The veth pair creates a point-to-point link between the pod and the host.
+If `rkt run` is started with the `--private-net` flag, the pod will be executed with its own network stack, with the default network plus all configured networks.
+Passing a list of comma separated network names as in `--private-net=net1,net2,net3,...` restricts the network stack to the specified networks.
+This can be useful for grouping certain pods together while separating others.
+If the list of network names contains no known networks the pod will end up with loop networking only.
+
+### The default network
+The default network consists of a loopback device and a veth device.
+The veth pair creates a point-to-point link between the pod and the host.
 rkt will allocate an IPv4 /31 (2 IP addresses) out of 172.16.28.0/24 and assign one IP to each end of the veth pair.
 It will additionally set a route for metadata service (169.254.169.255/32) and default route in the pod namespace.
 Finally, it will enable IP masquerading on the host to NAT the egress traffic.
+
+**Note**: The default network must be explicitly listed in order to be loaded when `-private-net=...` is specified with a list of network names.
 
 ### Setting up additional networks
 

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -43,7 +43,7 @@ var (
 
 func init() {
 	commands = append(commands, cmdRunPrepared)
-	runPreparedFlags.BoolVar(&flagPrivateNet, "private-net", false, "give pod a private network")
+	runPreparedFlags.Var(&flagPrivateNet, "private-net", "give pod a private network")
 	runPreparedFlags.BoolVar(&flagInteractive, "interactive", false, "the pod is interactive")
 }
 
@@ -128,7 +128,7 @@ func runRunPrepared(args []string) (exit int) {
 			UUID:        p.uuid,
 			Debug:       globalFlags.Debug,
 		},
-		PrivateNet:  flagPrivateNet,
+		PrivateNet:  flagPrivateNet.String(),
 		LockFd:      lfd,
 		Interactive: flagInteractive,
 		Images:      imgs,

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -62,7 +62,7 @@ type PrepareConfig struct {
 // configuration parameters needed by Run
 type RunConfig struct {
 	CommonConfig
-	PrivateNet  bool         // pod should have its own network stack
+	PrivateNet  string       // pod should have its own network stack
 	LockFd      int          // lock file descriptor
 	Interactive bool         // whether the pod is interactive or not
 	Images      []types.Hash // application images (prepare gets them via Apps)
@@ -319,8 +319,8 @@ func Run(cfg RunConfig, dir string) {
 	if cfg.Debug {
 		args = append(args, "--debug")
 	}
-	if cfg.PrivateNet {
-		args = append(args, "--private-net")
+	if cfg.PrivateNet != "" {
+		args = append(args, "--private-net="+cfg.PrivateNet)
 	}
 	if cfg.Interactive {
 		args = append(args, "--interactive")

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -100,13 +100,13 @@ func mirrorLocalZoneInfo(root string) {
 
 var (
 	debug       bool
-	privNet     bool
+	privNet     string
 	interactive bool
 )
 
 func init() {
 	flag.BoolVar(&debug, "debug", false, "Run in debug mode")
-	flag.BoolVar(&privNet, "private-net", false, "Setup private network")
+	flag.StringVar(&privNet, "private-net", "", "Setup private network")
 	flag.BoolVar(&interactive, "interactive", false, "The pod is interactive")
 
 	// this ensures that main runs only on main thread (thread group leader).
@@ -324,14 +324,14 @@ func stage1() int {
 
 	mirrorLocalZoneInfo(p.Root)
 
-	if privNet {
+	if privNet != "" {
 		fps, err := forwardedPorts(p)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())
 			return 6
 		}
 
-		n, err := networking.Setup(root, p.UUID, fps)
+		n, err := networking.Setup(root, p.UUID, fps, privNet)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to setup network: %v\n", err)
 			return 6
@@ -371,7 +371,7 @@ func stage1() int {
 
 	var execFn func() error
 
-	if privNet {
+	if privNet != "" {
 		cmd := exec.Cmd{
 			Path:   args[0],
 			Args:   args,


### PR DESCRIPTION
This commit adds the possiblity of passing a comma separated list of network
names to the '-private-net' argument. Only networks with their names specified
are loaded in the pods network stack.

The network documentation has been updated accordingly.

Fixes #874.