### PR TITLE
stage1: fix metadata service registration errors

### DIFF
--- a/rkt/metadata_service.go
+++ b/rkt/metadata_service.go
@@ -238,7 +238,7 @@ func handleRegisterApp(w http.ResponseWriter, r *http.Request) {
 	uuid, err := types.NewUUID(mux.Vars(r)["uuid"])
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, "UUID is missing or mulformed: %v", err)
+		fmt.Fprintf(w, "UUID is missing or malformed: %v", err)
 		return
 	}
 


### PR DESCRIPTION
When registering a pod to the metadata service, if individual app 
registrations failed then an error object was being instantiated but not 
actually returned. This fixes it to return the error and also to make a 
best-effort attempt to unregister the pod in this scenario.

Also tweaks the file operations to close manifests more immediately after
they've been used.

Also fixes minor typo in rkt/metadata_service error message.

/cc @eyakubovich