### PR TITLE
networking: allow network selection with private-net (2nd impl.)

### DIFF
--- a/Documentation/networking.md
+++ b/Documentation/networking.md
@@ -16,11 +16,21 @@ For all of the private networking options the metadata service, launched via `rk
 The service will listen on 0.0.0.0:2375 by default and provides the private networking containers the metadata services described in the App Container Spec.
 Ideally this metadata service is launched via your systems init system.
 
-If `rkt run` is started with `--private-net`, the pod will be executed with its own network stack.
-By default, rkt will create a loopback device and a veth device. The veth pair creates a point-to-point link between the pod and the host.
+If `rkt run` is started with the `--private-net` flag, the pod will be executed with its own network stack, with the default network plus all configured networks.
+Passing a list of comma separated network names as in `--private-net=net1,net2,net3,...` restricts the network stack to the specified networks.
+This can be useful for grouping certain pods together while separating others.
+If the list of network names contains no known networks the pod will end up with loop networking only.
+
+### The default network
+The default network consists of a loopback device and a veth device.
+The veth pair creates a point-to-point link between the pod and the host.
 rkt will allocate an IPv4 /31 (2 IP addresses) out of 172.16.28.0/24 and assign one IP to each end of the veth pair.
-It will additionally set a route for metadata service (169.254.169.255/32) and default route in the pod namespace.
+It will additionally set the default route in the pod namespace.
 Finally, it will enable IP masquerading on the host to NAT the egress traffic.
+
+**Note**: The default network must be explicitly listed in order to be loaded when `-private-net=...` is specified with a list of network names. 
+In case it's not specified, a restricted default network will be created to allow communication with the metadata service. 
+In this case the default route and IP masquerading will not be setup.
 
 ### Setting up additional networks
 

--- a/common/common.go
+++ b/common/common.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/aci"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
@@ -134,4 +135,46 @@ func SupportsOverlay() bool {
 		}
 	}
 	return false
+}
+
+// PrivateNetList implements the flag.Value interface to allow specification
+// of -private-net with and without values
+type PrivateNetList struct {
+	mapping map[string]bool
+}
+
+func (i *PrivateNetList) IsBoolFlag() bool { return true }
+
+func (l *PrivateNetList) String() string {
+	return strings.Join(l.Strings(), ",")
+}
+
+func (l *PrivateNetList) Set(value string) error {
+	if l.mapping == nil {
+		l.mapping = make(map[string]bool)
+	}
+	for _, s := range strings.Split(value, ",") {
+		l.mapping[s] = true
+	}
+	return nil
+}
+
+func (l *PrivateNetList) Strings() []string {
+	var list []string
+	for k, _ := range l.mapping {
+		list = append(list, k)
+	}
+	return list
+}
+
+func (l *PrivateNetList) Any() bool {
+	return len(l.mapping) > 0
+}
+
+func (l *PrivateNetList) All() bool {
+	return l.mapping["true"]
+}
+
+func (l *PrivateNetList) Specific(net string) bool {
+	return l.mapping[net]
 }

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/vishvananda/netlink"
 
+	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/networking/netinfo"
 )
 
@@ -51,13 +52,14 @@ type Networking struct {
 
 // Setup creates a new networking namespace and executes network plugins to
 // setup private networking. It returns in the new pod namespace
-func Setup(podRoot string, podID types.UUID, fps []ForwardedPort) (*Networking, error) {
+func Setup(podRoot string, podID types.UUID, fps []ForwardedPort, privateNetList common.PrivateNetList) (*Networking, error) {
 	// TODO(jonboulle): currently podRoot is _always_ ".", and behaviour in other
 	// circumstances is untested. This should be cleaned up.
 	n := Networking{
 		podEnv: podEnv{
-			podRoot: podRoot,
-			podID:   podID,
+			podRoot:      podRoot,
+			podID:        podID,
+			netsLoadList: privateNetList,
 		},
 	}
 

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -53,7 +53,7 @@ End the image arguments with a lone "---" to resume argument parsing.`,
 	flagStage1Image string
 	flagVolumes     volumeList
 	flagPorts       portList
-	flagPrivateNet  bool
+	flagPrivateNet  common.PrivateNetList
 	flagInheritEnv  bool
 	flagExplicitEnv envMap
 	flagInteractive bool
@@ -76,7 +76,7 @@ func init() {
 	runFlags.StringVar(&flagStage1Image, "stage1-image", defaultStage1Image, `image to use as stage1. Local paths and http/https URLs are supported. If empty, rkt will look for a file called "stage1.aci" in the same directory as rkt itself`)
 	runFlags.Var(&flagVolumes, "volume", "volumes to mount into the pod")
 	runFlags.Var(&flagPorts, "port", "ports to expose on the host (requires --private-net)")
-	runFlags.BoolVar(&flagPrivateNet, "private-net", false, "give pod a private network")
+	runFlags.Var(&flagPrivateNet, "private-net", "give pod a private network that defaults to the default network plus all user networks. Can be limited to a a comma separated list of network names")
 	runFlags.BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	runFlags.BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
 	runFlags.Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
@@ -89,7 +89,7 @@ func init() {
 }
 
 func runRun(args []string) (exit int) {
-	if len(flagPorts) > 0 && !flagPrivateNet {
+	if len(flagPorts) > 0 && !flagPrivateNet.Any() {
 		stderr("--port flag requires --private-net")
 		return 1
 	}

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -43,7 +43,7 @@ var (
 
 func init() {
 	commands = append(commands, cmdRunPrepared)
-	runPreparedFlags.BoolVar(&flagPrivateNet, "private-net", false, "give pod a private network")
+	runPreparedFlags.Var(&flagPrivateNet, "private-net", "give pod a private network")
 	runPreparedFlags.BoolVar(&flagInteractive, "interactive", false, "the pod is interactive")
 }
 

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -62,10 +62,10 @@ type PrepareConfig struct {
 // configuration parameters needed by Run
 type RunConfig struct {
 	CommonConfig
-	PrivateNet  bool         // pod should have its own network stack
-	LockFd      int          // lock file descriptor
-	Interactive bool         // whether the pod is interactive or not
-	Images      []types.Hash // application images (prepare gets them via Apps)
+	PrivateNet  common.PrivateNetList // pod should have its own network stack
+	LockFd      int                   // lock file descriptor
+	Interactive bool                  // whether the pod is interactive or not
+	Images      []types.Hash          // application images (prepare gets them via Apps)
 }
 
 // configuration shared by both Run and Prepare
@@ -319,8 +319,8 @@ func Run(cfg RunConfig, dir string) {
 	if cfg.Debug {
 		args = append(args, "--debug")
 	}
-	if cfg.PrivateNet {
-		args = append(args, "--private-net")
+	if cfg.PrivateNet.Any() {
+		args = append(args, "--private-net="+cfg.PrivateNet.String())
 	}
 	if cfg.Interactive {
 		args = append(args, "--interactive")

--- a/stage1/rootfs/net/99-default-restricted.conf
+++ b/stage1/rootfs/net/99-default-restricted.conf
@@ -1,0 +1,9 @@
+{
+	"name": "default",
+	"type": "veth",
+	"ipMasq": false,
+	"ipam": {
+		"type": "host-local-ptp",
+		"subnet": "172.16.28.0/24"
+	}
+}

--- a/stage1/rootfs/net/Makefile
+++ b/stage1/rootfs/net/Makefile
@@ -1,4 +1,4 @@
-../aggregate/install.d/30net: Makefile install 99-default.conf
+../aggregate/install.d/30net: Makefile install 99-default.conf 99-default-restricted.conf
 	@cp install ../aggregate/install.d/30net
 
 .PHONY: clean


### PR DESCRIPTION
Alternative implementation of #954 that uses a common type for the argument handling in stage0 and stage1.

Fixes #874. Closes #954.