### PR TITLE
networking: populate AC_METADATA_URL correctly

### DIFF
--- a/networking/netinfo/netinfo.go
+++ b/networking/netinfo/netinfo.go
@@ -30,6 +30,7 @@ type NetInfo struct {
 	IfName   string `json:"ifName"`
 	IP       net.IP `json:"ip"`
 	Args     string `json:"args"`
+	HostIP   net.IP
 }
 
 func LoadAt(cdirfd int) ([]NetInfo, error) {

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -155,11 +155,11 @@ func (n *Networking) GetDefaultIP() net.IP {
 	return n.nets[len(n.nets)-1].runtime.IP
 }
 
-func (n *Networking) GetDefaultHostIP() net.IP {
+func (n *Networking) GetDefaultHostIP() (net.IP, error) {
 	if len(n.nets) == 0 {
-		return nil
+		return nil, fmt.Errorf("no networks found")
 	}
-	return n.nets[len(n.nets)-1].hostIP
+	return n.nets[len(n.nets)-1].runtime.HostIP, nil
 }
 
 // Teardown cleans up a produced Networking object.

--- a/networking/podenv.go
+++ b/networking/podenv.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -54,7 +53,6 @@ type activeNet struct {
 	confBytes []byte
 	conf      *plugin.NetConf
 	runtime   *netinfo.NetInfo
-	hostIP    net.IP // kludge for default network
 }
 
 // Loads nets specified by user and default one from stage1
@@ -108,12 +106,11 @@ func (e *podEnv) setupNets(nets []activeNet) error {
 			return fmt.Errorf("error copying %q to %q: %v", n.runtime.ConfPath, e.netDir(), err)
 		}
 
-		n.runtime.IP, n.hostIP, err = e.netPluginAdd(&n, nspath)
+		n.runtime.IP, n.runtime.HostIP, err = e.netPluginAdd(&n, nspath)
 		if err != nil {
 			return fmt.Errorf("error adding network %q: %v", n.conf.Name, err)
 		}
 	}
-
 	return nil
 }
 

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -345,7 +345,12 @@ func stage1() int {
 			return 6
 		}
 
-		p.MetadataServiceURL = common.MetadataServicePublicURL(n.GetDefaultHostIP())
+		hostIP, err := n.GetDefaultHostIP()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to get default Host IP: %v\n", err)
+			return 6
+		}
+		p.MetadataServiceURL = common.MetadataServicePublicURL(hostIP)
 
 		if err = registerPod(p, n.GetDefaultIP()); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to register pod: %v\n", err)


### PR DESCRIPTION
This commit allows the mentioned environment var to be populated correctly.
On the way some error handling for involved code was added.

Fixes #962
Fixes #875