### PR TITLE
functional test: TestExitCode: fix test

### DIFF
--- a/tests/rkt_exit_test.go
+++ b/tests/rkt_exit_test.go
@@ -42,6 +42,11 @@ func TestExitCode(t *testing.T) {
 			t.Fatalf("Cannot exec rkt")
 		}
 
+		err = child.Expect(fmt.Sprintf("status=%d", i))
+		if err != nil {
+			t.Fatalf("Failed to get the status")
+		}
+
 		err = child.Wait()
 		if err != nil {
 			t.Fatalf("rkt didn't terminate correctly: %v", err)


### PR DESCRIPTION
Since commit 76ed159 ("functional tests: TestFailure: don't rely on
systemd debug logs"), TestExitCode didn't test anything and always
passed.

Fortunately, there was no regression bugs introduced in rkt. So no harm
done. But let's fix the test to catch potential future regression bugs.