### PR TITLE
functional tests: test v220

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -17,9 +17,8 @@ Use the following build commands:
 ./tests/install-deps.sh         # Setup
 ./tests/run-build.sh none       # Thread 1
 ./tests/run-build.sh coreos     # Thread 2
-./tests/run-build.sh src v215   # Thread 1
-./tests/run-build.sh src v219   # Thread 2
-./tests/run-build.sh src master # Thread 1
+./tests/run-build.sh src v220   # Thread 1
+./tests/run-build.sh src master # Thread 2
 git clean -ffdx                 # Post Thread
 ```
 


### PR DESCRIPTION
This is following-up the bump to v220: https://github.com/coreos/rkt/pull/952

I checked the other occurrences of v219 (`git grep "v219"`) and they don't require other changes.

@jonboulle : this requires some changes in the Semaphore configuration.

/cc @steveeJ 