### PR TITLE
Introduce new build flavor: usr-from-host

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -64,6 +64,10 @@
 			"Rev": "06ed1491dee087e5a83984239e8e11577d8a6131"
 		},
 		{
+			"ImportPath": "github.com/appc/goaci/proj2aci",
+			"Rev": "f99814ac2ac967bc202afd1c923cde30a65811ed"
+		},
+		{
 			"ImportPath": "github.com/appc/spec/aci",
 			"Comment": "v0.5.2",
 			"Rev": "1d31afed77b39d52145ffd368d4c62eef675cbdf"
@@ -111,12 +115,12 @@
 			"Rev": "6fe83ccda8fb9b7549c9ab4ba47f47858bc950aa"
 		},
 		{
-			"ImportPath": "github.com/coreos/go-systemd/unit",
+			"ImportPath": "github.com/coreos/go-systemd/dbus",
 			"Comment": "v2-55-gd7b0894",
 			"Rev": "d7b08942d0d85bfcb4694864881c4af7324784d2"
 		},
 		{
-			"ImportPath": "github.com/coreos/go-systemd/dbus",
+			"ImportPath": "github.com/coreos/go-systemd/unit",
 			"Comment": "v2-55-gd7b0894",
 			"Rev": "d7b08942d0d85bfcb4694864881c4af7324784d2"
 		},
@@ -218,6 +222,10 @@
 		{
 			"ImportPath": "golang.org/x/net/html",
 			"Rev": "1dfe7915deaf3f80b962c163b918868d8a6d8974"
+		},
+		{
+			"ImportPath": "golang.org/x/tools/go/vcs",
+			"Rev": "27e692e6ec36d8f48be794f32553e1400c70dbf2"
 		},
 		{
 			"ImportPath": "speter.net/go/exp/math/dec/inf",

--- a/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/asset.go
+++ b/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/asset.go
@@ -1,0 +1,256 @@
+package proj2aci
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// GetAssetString returns a properly formatted asset string.
+func GetAssetString(aciAsset, localAsset string) string {
+	return getAssetString(aciAsset, localAsset)
+}
+
+// PrepareAssets copies given assets to ACI rootfs directory. It also
+// tries to copy required shared libraries if an asset is a
+// dynamically linked executable or library. placeholderMapping maps
+// placeholders (like "<INSTALLDIR>") to actual paths (usually
+// something inside temporary directory).
+func PrepareAssets(assets []string, rootfs string, placeholderMapping map[string]string) error {
+	newAssets := assets
+	processedAssets := make(map[string]struct{})
+	for len(newAssets) > 0 {
+		assetsToProcess := newAssets
+		newAssets = nil
+		for _, asset := range assetsToProcess {
+			Debug("Processing asset:", asset)
+			if _, ok := processedAssets[asset]; ok {
+				Debug("  skipped")
+				continue
+			}
+			processedAssets[asset] = struct{}{}
+			additionalAssets, err := processAsset(asset, rootfs, placeholderMapping)
+			if err != nil {
+				return err
+			}
+			newAssets = append(newAssets, additionalAssets...)
+		}
+	}
+	return nil
+}
+
+// processAsset validates an asset, replaces placeholders with real
+// paths and does the copying. It may return additional assets to be
+// processed when asset is an executable or a library.
+func processAsset(asset, rootfs string, placeholderMapping map[string]string) ([]string, error) {
+	splitAsset := filepath.SplitList(asset)
+	if len(splitAsset) != 2 {
+		return nil, fmt.Errorf("Malformed asset option: '%v' - expected two absolute paths separated with %v", asset, listSeparator())
+	}
+	ACIAsset := replacePlaceholders(splitAsset[0], placeholderMapping)
+	localAsset := replacePlaceholders(splitAsset[1], placeholderMapping)
+	if err := validateAsset(ACIAsset, localAsset); err != nil {
+		return nil, err
+	}
+	ACIAssetSubPath := filepath.Join(rootfs, filepath.Dir(ACIAsset))
+	err := os.MkdirAll(ACIAssetSubPath, 0755)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create directory tree for asset '%v': %v", asset, err)
+	}
+	err = copyTree(localAsset, filepath.Join(rootfs, ACIAsset))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to copy assets for %q: %v", asset, err)
+	}
+	additionalAssets, err := getSoLibs(localAsset)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get dependent assets for %q: %v", localAsset, err)
+	}
+	// HACK! if we are copying libc then try to copy libnss_* libs
+	// (glibc name service switch libs used in networking)
+	if matched, err := filepath.Match("libc.*", filepath.Base(localAsset)); err == nil && matched {
+		toGlob := filepath.Join(filepath.Dir(localAsset), "libnss_*")
+		if matches, err := filepath.Glob(toGlob); err == nil && len(matches) > 0 {
+			matchesAsAssets := make([]string, 0, len(matches))
+			for _, f := range matches {
+				matchesAsAssets = append(matchesAsAssets, getAssetString(f, f))
+			}
+			additionalAssets = append(additionalAssets, matchesAsAssets...)
+		}
+	}
+	return additionalAssets, nil
+}
+
+func replacePlaceholders(path string, placeholderMapping map[string]string) string {
+	Debug("Processing path: ", path)
+	newPath := path
+	for placeholder, replacement := range placeholderMapping {
+		newPath = strings.Replace(newPath, placeholder, replacement, -1)
+	}
+	Debug("Processed path: ", newPath)
+	return newPath
+}
+
+func validateAsset(ACIAsset, localAsset string) error {
+	if !filepath.IsAbs(ACIAsset) {
+		return fmt.Errorf("Wrong ACI asset: '%v' - ACI asset has to be absolute path", ACIAsset)
+	}
+	if !filepath.IsAbs(localAsset) {
+		return fmt.Errorf("Wrong local asset: '%v' - local asset has to be absolute path", localAsset)
+	}
+	fi, err := os.Lstat(localAsset)
+	if err != nil {
+		return fmt.Errorf("Error stating %v: %v", localAsset, err)
+	}
+	mode := fi.Mode()
+	if mode.IsDir() || mode.IsRegular() || isSymlink(mode) {
+		return nil
+	}
+	return fmt.Errorf("Can't handle local asset %v - not a file, not a dir, not a symlink", fi.Name())
+}
+
+func copyTree(src, dest string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rootLess := path[len(src):]
+		target := filepath.Join(dest, rootLess)
+		mode := info.Mode()
+		switch {
+		case mode.IsDir():
+			err := os.Mkdir(target, mode.Perm())
+			if err != nil {
+				return err
+			}
+		case mode.IsRegular():
+			if err := copyRegularFile(path, target); err != nil {
+				return err
+			}
+		case isSymlink(mode):
+			if err := copySymlink(path, target); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("Unsupported node %q in assets, only regular files, directories and symlinks are supported.", path, mode.String())
+		}
+		return nil
+	})
+}
+
+func copyRegularFile(src, dest string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+	destFile, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+	if _, err := io.Copy(destFile, srcFile); err != nil {
+		return err
+	}
+	fi, err := srcFile.Stat()
+	if err != nil {
+		return err
+	}
+	if err := destFile.Chmod(fi.Mode().Perm()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func copySymlink(src, dest string) error {
+	symTarget, err := os.Readlink(src)
+	if err != nil {
+		return err
+	}
+	if err := os.Symlink(symTarget, dest); err != nil {
+		return err
+	}
+	return nil
+}
+
+// getSoLibs tries to run ldd on given path and to process its output
+// to get a list of shared libraries to copy. This list is returned as
+// an array of assets.
+//
+// man ldd says that running ldd on untrusted executables is dangerous
+// (it might run an executable to get the libraries), so possibly this
+// should be replaced with objdump. Problem with objdump is that it
+// just gives library names, while ldd gives absolute paths to those
+// libraries - to use objdump we need to know the $libdir.
+func getSoLibs(path string) ([]string, error) {
+	assets := []string{}
+	buf := new(bytes.Buffer)
+	args := []string{
+		"ldd",
+		path,
+	}
+	if err := RunCmdFull("", args, nil, "", buf, nil); err != nil {
+		if _, ok := err.(CmdFailedError); !ok {
+			return nil, err
+		}
+	} else {
+		re := regexp.MustCompile(`(?m)^\t(?:\S+\s+=>\s+)?(\/\S+)\s+\([0-9a-fA-Fx]+\)$`)
+		for _, matches := range re.FindAllStringSubmatch(string(buf.Bytes()), -1) {
+			lib := matches[1]
+			if lib == "" {
+				continue
+			}
+			symlinkedAssets, err := getSymlinkedAssets(lib)
+			if err != nil {
+				return nil, err
+			}
+			assets = append(assets, symlinkedAssets...)
+		}
+	}
+	return assets, nil
+}
+
+// getSymlinkedAssets returns an array of many assets if given path is
+// a symlink - useful for getting shared libraries, which are often
+// surrounded with a bunch of symlinks.
+func getSymlinkedAssets(path string) ([]string, error) {
+	assets := []string{}
+	maxLevels := 100
+	levels := maxLevels
+	for {
+		if levels < 1 {
+			return nil, fmt.Errorf("Too many levels of symlinks (>$d)", maxLevels)
+		}
+		fi, err := os.Lstat(path)
+		if err != nil {
+			return nil, err
+		}
+		asset := getAssetString(path, path)
+		assets = append(assets, asset)
+		if !isSymlink(fi.Mode()) {
+			break
+		}
+		symTarget, err := os.Readlink(path)
+		if err != nil {
+			return nil, err
+		}
+		if filepath.IsAbs(symTarget) {
+			path = symTarget
+		} else {
+			path = filepath.Join(filepath.Dir(path), symTarget)
+		}
+		levels--
+	}
+	return assets, nil
+}
+
+func getAssetString(aciAsset, localAsset string) string {
+	return fmt.Sprintf("%s%s%s", aciAsset, listSeparator(), localAsset)
+}
+
+func isSymlink(mode os.FileMode) bool {
+	return mode&os.ModeSymlink == os.ModeSymlink
+}

--- a/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/binary.go
+++ b/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/binary.go
@@ -1,0 +1,44 @@
+package proj2aci
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+// GetBinaryName checks if useBinary is in binDir and returns it. If
+// useBinary is empty it returns a binary name if there is only one
+// such in binDir. Otherwise it returns an error.
+func GetBinaryName(binDir, useBinary string) (string, error) {
+	fi, err := ioutil.ReadDir(binDir)
+	if err != nil {
+		return "", err
+	}
+
+	switch {
+	case len(fi) < 1:
+		return "", fmt.Errorf("No binaries found in %q", binDir)
+	case len(fi) == 1:
+		name := fi[0].Name()
+		if useBinary != "" && name != useBinary {
+			return "", fmt.Errorf("No such binary found in %q: %q. There is only %q", binDir, useBinary, name)
+		}
+		Debug("found binary: ", name)
+		return name, nil
+	case len(fi) > 1:
+		names := []string{}
+		for _, v := range fi {
+			names = append(names, v.Name())
+		}
+		if useBinary == "" {
+			return "", fmt.Errorf("Found multiple binaries in %q, but no specific binary is preferred. Please specify which binary to pick up. Following binaries are available: %q", binDir, strings.Join(names, `", "`))
+		}
+		for _, v := range names {
+			if v == useBinary {
+				return v, nil
+			}
+		}
+		return "", fmt.Errorf("No such binary found in %q: %q. There are following binaries available: %q", binDir, useBinary, strings.Join(names, `", "`))
+	}
+	panic("Reaching this point shouldn't be possible.")
+}

--- a/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/builder.go
+++ b/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/builder.go
@@ -1,0 +1,365 @@
+package proj2aci
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/aci"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+// CommonConfiguration keeps configuration items common for all the
+// builders. Users of a Builder are supposed to create a
+// BuilderCustomizations instance, get a CommonConfiguration instance
+// via GetCommonConfiguration function and modify it before running
+// Builder.Run().
+type CommonConfiguration struct {
+	Exec        []string
+	UseBinary   string
+	Assets      []string
+	KeepTmpDir  bool
+	TmpDir      string
+	ReuseTmpDir string
+	Project     string
+}
+
+// CommonPaths keeps some paths common for all builders. Implementers
+// of new BuilderCustomizations can read those after they are set up.
+type CommonPaths struct {
+	TmpDir string
+	AciDir string
+	RootFS string
+}
+
+// BuilderCustomizations is an interface for customizing a build
+// process. The order of function roughly describe the build process.
+type BuilderCustomizations interface {
+	Name() string
+	GetCommonConfiguration() *CommonConfiguration
+	ValidateConfiguration() error
+	GetCommonPaths() *CommonPaths
+	SetupPaths() error
+	GetDirectoriesToMake() []string
+	PrepareProject() error
+	GetPlaceholderMapping() map[string]string
+	GetAssets(aciBinDir string) ([]string, error)
+	GetImageACName() (*types.ACName, error)
+	GetBinaryName() (string, error)
+	GetRepoPath() (string, error)
+	GetImageFileName() (string, error)
+}
+
+type Builder struct {
+	manifest  *schema.ImageManifest
+	aciBinDir string
+	custom    BuilderCustomizations
+}
+
+func NewBuilder(custom BuilderCustomizations) *Builder {
+	return &Builder{
+		manifest:  nil,
+		aciBinDir: "/",
+		custom:    custom,
+	}
+}
+
+func (cmd *Builder) Name() string {
+	return cmd.custom.Name()
+}
+
+func (cmd *Builder) Run() error {
+	Info("Validating builder configuration")
+	if err := cmd.validateConfiguration(); err != nil {
+		return err
+	}
+
+	Info("Setting up paths")
+	if err := cmd.setupPaths(); err != nil {
+		return err
+	}
+
+	config := cmd.custom.GetCommonConfiguration()
+	paths := cmd.custom.GetCommonPaths()
+	if config.KeepTmpDir {
+		Info(fmt.Sprintf("Preserving temporary directory %q", paths.TmpDir))
+	} else {
+		defer os.RemoveAll(paths.TmpDir)
+	}
+
+	if config.ReuseTmpDir != "" {
+		Info("Reusing temporary directory")
+		Info("Deleting old ACI contents")
+		if err := os.RemoveAll(paths.AciDir); err != nil {
+			return err
+		}
+
+		Info("Creating directories")
+		if err := cmd.makeDirectories(); err != nil {
+			return err
+		}
+	} else {
+		Info("Creating directories")
+		if err := cmd.makeDirectories(); err != nil {
+			return err
+		}
+
+		Info("Preparing a project")
+		if err := cmd.prepareProject(); err != nil {
+			return err
+		}
+	}
+
+	Info("Copying assets to ACI directory")
+	if err := cmd.copyAssets(); err != nil {
+		return err
+	}
+
+	Info("Preparing manifest")
+	if err := cmd.prepareManifest(); err != nil {
+		return err
+	}
+
+	Info("Writing ACI")
+	if name, err := cmd.writeACI(); err != nil {
+		return err
+	} else {
+		Info(fmt.Sprintf("Done, wrote %q", name))
+	}
+	return nil
+}
+
+func (cmd *Builder) validateConfiguration() error {
+	config := cmd.custom.GetCommonConfiguration()
+	if config == nil {
+		panic("common configuration is nil")
+	}
+	if config.Project == "" {
+		fmt.Errorf("Got no project to build")
+	}
+
+	if config.TmpDir != "" && config.ReuseTmpDir != "" && config.TmpDir != config.ReuseTmpDir {
+		return fmt.Errorf("Specified both tmp dir to reuse and a tmp dir and they are different. ")
+	}
+	if !DirExists(config.ReuseTmpDir) {
+		return fmt.Errorf("Invalid tmp dir to reuse")
+	}
+
+	return cmd.custom.ValidateConfiguration()
+}
+
+func (cmd *Builder) setupPaths() error {
+	config := cmd.custom.GetCommonConfiguration()
+	paths := cmd.custom.GetCommonPaths()
+	tmpDir := ""
+	if config.TmpDir != "" {
+		tmpDir = config.TmpDir
+	} else if config.ReuseTmpDir != "" {
+		tmpDir = config.ReuseTmpDir
+	} else {
+		tmpName := fmt.Sprintf("proj2aci-%s-", cmd.custom.Name())
+		aTmpDir, err := ioutil.TempDir("", tmpName)
+		if err != nil {
+			return fmt.Errorf("Failed to set up temporary directory: %v", err)
+		}
+		tmpDir = aTmpDir
+	}
+	paths.TmpDir = tmpDir
+	paths.AciDir = filepath.Join(paths.TmpDir, "aci")
+	paths.RootFS = filepath.Join(paths.AciDir, "rootfs")
+	return cmd.custom.SetupPaths()
+}
+
+func (cmd *Builder) makeDirectories() error {
+	paths := cmd.custom.GetCommonPaths()
+	config := cmd.custom.GetCommonConfiguration()
+
+	toMake := []string{}
+	if config.ReuseTmpDir == "" && config.TmpDir != "" {
+		tmpDirs, err := tmpDirList(paths.TmpDir)
+		if err != nil {
+			return err
+		}
+		toMake = append(toMake, tmpDirs...)
+	}
+	toMake = append(toMake, paths.AciDir, paths.RootFS)
+	if config.ReuseTmpDir == "" {
+		toMake = append(toMake, cmd.custom.GetDirectoriesToMake()...)
+	}
+
+	for _, dir := range toMake {
+		Debug("mkdir ", dir)
+		if err := os.Mkdir(dir, 0755); err != nil {
+			return fmt.Errorf("Failed to make directory %q: %v", dir, err)
+		}
+	}
+	return nil
+}
+
+func tmpDirList(path string) ([]string, error) {
+	list := []string{}
+	test := path
+	for {
+		if _, err := os.Stat(test); err != nil {
+			if !os.IsNotExist(err) {
+				return nil, err
+			}
+			// prepend
+			list = append([]string{test}, list...)
+			test = filepath.Dir(test)
+		} else {
+			break
+		}
+	}
+	return list, nil
+}
+
+func (cmd *Builder) prepareProject() error {
+	return cmd.custom.PrepareProject()
+}
+
+func (cmd *Builder) copyAssets() error {
+	paths := cmd.custom.GetCommonPaths()
+	config := cmd.custom.GetCommonConfiguration()
+	mapping := cmd.custom.GetPlaceholderMapping()
+	customAssets, err := cmd.custom.GetAssets(cmd.aciBinDir)
+	if err != nil {
+		return err
+	}
+	assets := append(config.Assets, customAssets...)
+	if err := PrepareAssets(assets, paths.RootFS, mapping); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *Builder) prepareManifest() error {
+	name, err := cmd.custom.GetImageACName()
+	if err != nil {
+		return err
+	}
+	labels, err := cmd.getLabels()
+	if err != nil {
+		return err
+	}
+	app, err := cmd.getApp()
+	if err != nil {
+		return err
+	}
+
+	cmd.manifest = schema.BlankImageManifest()
+	cmd.manifest.Name = *name
+	cmd.manifest.App = app
+	cmd.manifest.Labels = labels
+	return nil
+}
+
+func (cmd *Builder) getApp() (*types.App, error) {
+	binaryName, err := cmd.custom.GetBinaryName()
+	if err != nil {
+		return nil, err
+	}
+	exec := []string{filepath.Join(cmd.aciBinDir, binaryName)}
+	config := cmd.custom.GetCommonConfiguration()
+
+	return &types.App{
+		Exec:  append(exec, config.Exec...),
+		User:  "0",
+		Group: "0",
+	}, nil
+}
+
+func (cmd *Builder) getLabels() (types.Labels, error) {
+	arch, err := newLabel("arch", runtime.GOARCH)
+	if err != nil {
+		return nil, err
+	}
+	os, err := newLabel("os", runtime.GOOS)
+	if err != nil {
+		return nil, err
+	}
+
+	labels := types.Labels{
+		*arch,
+		*os,
+	}
+
+	vcsLabel, err := cmd.getVCSLabel()
+	if err != nil {
+		return nil, err
+	} else if vcsLabel != nil {
+		labels = append(labels, *vcsLabel)
+	}
+
+	return labels, nil
+}
+
+func newLabel(name, value string) (*types.Label, error) {
+	acName, err := types.NewACName(name)
+	if err != nil {
+		return nil, err
+	}
+	return &types.Label{
+		Name:  *acName,
+		Value: value,
+	}, nil
+}
+
+func (cmd *Builder) getVCSLabel() (*types.Label, error) {
+	repoPath, err := cmd.custom.GetRepoPath()
+	if err != nil {
+		return nil, err
+	}
+	if repoPath == "" {
+		return nil, nil
+	}
+	name, value, err := GetVCSInfo(repoPath)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get VCS info: %v", err)
+	}
+	acname, err := types.NewACName(name)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid VCS label: %v", err)
+	}
+	return &types.Label{
+		Name:  *acname,
+		Value: value,
+	}, nil
+}
+
+func (cmd *Builder) writeACI() (string, error) {
+	mode := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+	filename, err := cmd.custom.GetImageFileName()
+	if err != nil {
+		return "", err
+	}
+	of, err := os.OpenFile(filename, mode, 0644)
+	if err != nil {
+		return "", fmt.Errorf("Error opening output file: %v", err)
+	}
+	defer of.Close()
+
+	gw := gzip.NewWriter(of)
+	defer gw.Close()
+
+	tr := tar.NewWriter(gw)
+	defer tr.Close()
+
+	// FIXME: the files in the tar archive are added with the
+	// wrong uid/gid. The uid/gid of the aci builder leaks in the
+	// tar archive. See: https://github.com/appc/goaci/issues/16
+	iw := aci.NewImageWriter(*cmd.manifest, tr)
+	paths := cmd.custom.GetCommonPaths()
+	if err := filepath.Walk(paths.AciDir, aci.BuildWalker(paths.AciDir, iw)); err != nil {
+		return "", err
+	}
+	if err := iw.Close(); err != nil {
+		return "", err
+	}
+	return of.Name(), nil
+}

--- a/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/cmake.go
+++ b/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/cmake.go
@@ -1,0 +1,233 @@
+package proj2aci
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+	"github.com/coreos/rkt/Godeps/_workspace/src/golang.org/x/tools/go/vcs"
+)
+
+type CmakeConfiguration struct {
+	CommonConfiguration
+	BinDir      string
+	ReuseSrcDir string
+	CmakeParams []string
+}
+
+type CmakePaths struct {
+	CommonPaths
+	src     string
+	build   string
+	install string
+	binDir  string
+}
+
+type CmakeCustomizations struct {
+	Configuration CmakeConfiguration
+
+	paths       CmakePaths
+	fullBinPath string
+}
+
+func (custom *CmakeCustomizations) Name() string {
+	return "cmake"
+}
+
+func (custom *CmakeCustomizations) GetCommonConfiguration() *CommonConfiguration {
+	return &custom.Configuration.CommonConfiguration
+}
+
+func (custom *CmakeCustomizations) ValidateConfiguration() error {
+	if !DirExists(custom.Configuration.ReuseSrcDir) {
+		return fmt.Errorf("Invalid src dir to reuse")
+	}
+	return nil
+}
+
+func (custom *CmakeCustomizations) GetCommonPaths() *CommonPaths {
+	return &custom.paths.CommonPaths
+}
+
+func (custom *CmakeCustomizations) SetupPaths() error {
+	setupReusableDir(&custom.paths.src, custom.Configuration.ReuseSrcDir, filepath.Join(custom.paths.TmpDir, "src"))
+	custom.paths.build = filepath.Join(custom.paths.TmpDir, "build")
+	custom.paths.install = filepath.Join(custom.paths.TmpDir, "install")
+	return nil
+}
+
+func setupReusableDir(path *string, reusePath, stockPath string) {
+	if path == nil {
+		panic("path in setupReusableDir cannot be nil")
+	}
+	if reusePath != "" {
+		*path = reusePath
+	} else {
+		*path = stockPath
+	}
+}
+
+func (custom *CmakeCustomizations) GetDirectoriesToMake() []string {
+	dirs := []string{
+		custom.paths.build,
+		custom.paths.install,
+	}
+	// not creating custom.paths.src, because go.vcs requires the
+	// src directory to be nonexistent
+	return dirs
+}
+
+func (custom *CmakeCustomizations) PrepareProject() error {
+	if custom.Configuration.ReuseSrcDir == "" {
+		if err := custom.createRepo(); err != nil {
+			return err
+		}
+	}
+
+	Info("Running cmake")
+	if err := custom.runCmake(); err != nil {
+		return err
+	}
+
+	Info("Running make")
+	if err := custom.runMake(); err != nil {
+		return err
+	}
+
+	Info("Running make install")
+	if err := custom.runMakeInstall(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (custom *CmakeCustomizations) createRepo() error {
+	Info(fmt.Sprintf("Downloading %s", custom.Configuration.Project))
+	repo, err := vcs.RepoRootForImportPath(custom.Configuration.Project, false)
+	if err != nil {
+		return err
+	}
+	return repo.VCS.Create(custom.paths.src, repo.Repo)
+}
+
+func (custom *CmakeCustomizations) runCmake() error {
+	args := []string{"cmake"}
+	args = append(args, custom.Configuration.CmakeParams...)
+	args = append(args, custom.paths.src)
+	return RunCmd(args, nil, custom.paths.build)
+}
+
+func (custom *CmakeCustomizations) runMake() error {
+	args := []string{
+		"make",
+		fmt.Sprintf("-j%d", runtime.NumCPU()),
+	}
+	return RunCmd(args, nil, custom.paths.build)
+}
+
+func (custom *CmakeCustomizations) runMakeInstall() error {
+	args := []string{
+		"make",
+		"install",
+	}
+	env := append(os.Environ(), "DESTDIR="+custom.paths.install)
+	return RunCmd(args, env, custom.paths.build)
+}
+
+func (custom *CmakeCustomizations) GetPlaceholderMapping() map[string]string {
+	return map[string]string{
+		"<SRCPATH>":     custom.paths.src,
+		"<BUILDPATH>":   custom.paths.build,
+		"<INSTALLPATH>": custom.paths.install,
+	}
+}
+
+func (custom *CmakeCustomizations) GetAssets(aciBinDir string) ([]string, error) {
+	binaryName, err := custom.GetBinaryName()
+	if err != nil {
+		return nil, err
+	}
+	rootBinary := filepath.Join(aciBinDir, binaryName)
+	return []string{GetAssetString(rootBinary, custom.fullBinPath)}, nil
+}
+
+func (custom *CmakeCustomizations) getBinDir() (string, error) {
+	if custom.Configuration.BinDir != "" {
+		return filepath.Join(custom.paths.install, custom.Configuration.BinDir), nil
+	}
+	dirs := []string{
+		"/usr/local/sbin",
+		"/usr/local/bin",
+		"/usr/sbin",
+		"/usr/bin",
+		"/sbin",
+		"/bin",
+	}
+	for _, dir := range dirs {
+		path := filepath.Join(custom.paths.install, dir)
+		_, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", err
+		}
+		return path, nil
+	}
+	return "", fmt.Errorf("Could not find any bin directory")
+}
+
+func (custom *CmakeCustomizations) GetImageACName() (*types.ACName, error) {
+	imageACName := custom.Configuration.Project
+	if filepath.Base(imageACName) == "..." {
+		imageACName = filepath.Dir(imageACName)
+		if custom.Configuration.UseBinary != "" {
+			imageACName += "-" + custom.Configuration.UseBinary
+		}
+	}
+	return types.NewACName(strings.ToLower(imageACName))
+}
+
+func (custom *CmakeCustomizations) GetBinaryName() (string, error) {
+	if err := custom.findFullBinPath(); err != nil {
+		return "", err
+	}
+
+	return filepath.Base(custom.fullBinPath), nil
+}
+
+func (custom *CmakeCustomizations) findFullBinPath() error {
+	if custom.fullBinPath != "" {
+		return nil
+	}
+	binDir, err := custom.getBinDir()
+	if err != nil {
+		return err
+	}
+	binary, err := GetBinaryName(binDir, custom.Configuration.UseBinary)
+	if err != nil {
+		return err
+	}
+	custom.fullBinPath = filepath.Join(binDir, binary)
+	return nil
+}
+
+func (custom *CmakeCustomizations) GetRepoPath() (string, error) {
+	return custom.paths.src, nil
+}
+
+func (custom *CmakeCustomizations) GetImageFileName() (string, error) {
+	base := filepath.Base(custom.Configuration.Project)
+	if base == "..." {
+		base = filepath.Base(filepath.Dir(custom.Configuration.Project))
+		if custom.Configuration.UseBinary != "" {
+			base += "-" + custom.Configuration.UseBinary
+		}
+	}
+	return base + schema.ACIExtension, nil
+}

--- a/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/go.go
+++ b/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/go.go
@@ -1,0 +1,195 @@
+package proj2aci
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+type GoConfiguration struct {
+	CommonConfiguration
+	GoBinary string
+	GoPath   string
+}
+
+type GoPaths struct {
+	CommonPaths
+	project string
+	realGo  string
+	fakeGo  string
+	goRoot  string
+	goBin   string
+}
+
+type GoCustomizations struct {
+	Configuration GoConfiguration
+
+	paths GoPaths
+	app   string
+}
+
+func (custom *GoCustomizations) Name() string {
+	return "go"
+}
+
+func (custom *GoCustomizations) GetCommonConfiguration() *CommonConfiguration {
+	return &custom.Configuration.CommonConfiguration
+}
+
+func (custom *GoCustomizations) GetCommonPaths() *CommonPaths {
+	return &custom.paths.CommonPaths
+}
+
+func (custom *GoCustomizations) ValidateConfiguration() error {
+	if custom.Configuration.GoBinary == "" {
+		return fmt.Errorf("Go binary not found")
+	}
+	return nil
+}
+
+func (custom *GoCustomizations) SetupPaths() error {
+	custom.paths.realGo, custom.paths.fakeGo = custom.getGoPath()
+
+	if os.Getenv("GOPATH") != "" {
+		Warn("GOPATH env var is ignored, use --go-path=\"$GOPATH\" option instead")
+	}
+	custom.paths.goRoot = os.Getenv("GOROOT")
+	if custom.paths.goRoot != "" {
+		Warn("Overriding GOROOT env var to ", custom.paths.goRoot)
+	}
+
+	projectName := getProjectName(custom.Configuration.Project)
+	// Project name is path-like string with slashes, but slash is
+	// not a file separator on every OS.
+	custom.paths.project = filepath.Join(custom.paths.realGo, "src", filepath.Join(strings.Split(projectName, "/")...))
+	custom.paths.goBin = filepath.Join(custom.paths.fakeGo, "bin")
+	return nil
+}
+
+// getGoPath returns go path and fake go path. The former is either in
+// /tmp (which is a default) or some other path as specified by
+// --go-path parameter. The latter is always in /tmp.
+func (custom *GoCustomizations) getGoPath() (string, string) {
+	fakeGoPath := filepath.Join(custom.paths.TmpDir, "gopath")
+	if custom.Configuration.GoPath == "" {
+		return fakeGoPath, fakeGoPath
+	}
+	return custom.Configuration.GoPath, fakeGoPath
+}
+
+func getProjectName(project string) string {
+	if filepath.Base(project) != "..." {
+		return project
+	}
+	return filepath.Dir(project)
+}
+
+func (custom *GoCustomizations) GetDirectoriesToMake() []string {
+	return []string{
+		custom.paths.fakeGo,
+		custom.paths.goBin,
+	}
+}
+
+func (custom *GoCustomizations) PrepareProject() error {
+	Info("Running go get")
+	// Construct args for a go get that does a static build
+	args := []string{
+		"go",
+		"get",
+		"-a",
+		custom.Configuration.Project,
+	}
+
+	env := []string{
+		"GOPATH=" + custom.paths.realGo,
+		"GOBIN=" + custom.paths.goBin,
+		"PATH=" + os.Getenv("PATH"),
+	}
+	if custom.paths.goRoot != "" {
+		env = append(env, "GOROOT="+custom.paths.goRoot)
+	}
+
+	cmd := exec.Cmd{
+		Env:    env,
+		Path:   custom.Configuration.GoBinary,
+		Args:   args,
+		Stderr: os.Stderr,
+		Stdout: os.Stdout,
+	}
+	Debug("env: ", cmd.Env)
+	Debug("running command: ", strings.Join(cmd.Args, " "))
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (custom *GoCustomizations) GetPlaceholderMapping() map[string]string {
+	return map[string]string{
+		"<PROJPATH>": custom.paths.project,
+		"<GOPATH>":   custom.paths.realGo,
+	}
+}
+
+func (custom *GoCustomizations) GetAssets(aciBinDir string) ([]string, error) {
+	name, err := custom.GetBinaryName()
+	if err != nil {
+		return nil, err
+	}
+	aciAsset := filepath.Join(aciBinDir, name)
+	localAsset := filepath.Join(custom.paths.goBin, name)
+
+	return []string{GetAssetString(aciAsset, localAsset)}, nil
+}
+
+func (custom *GoCustomizations) GetImageACName() (*types.ACName, error) {
+	imageACName := custom.Configuration.Project
+	if filepath.Base(imageACName) == "..." {
+		imageACName = filepath.Dir(imageACName)
+		if custom.Configuration.UseBinary != "" {
+			imageACName += "-" + custom.Configuration.UseBinary
+		}
+	}
+	return types.NewACName(strings.ToLower(imageACName))
+}
+
+func (custom *GoCustomizations) GetBinaryName() (string, error) {
+	if err := custom.findBinaryName(); err != nil {
+		return "", err
+	}
+
+	return custom.app, nil
+}
+
+func (custom *GoCustomizations) findBinaryName() error {
+	if custom.app != "" {
+		return nil
+	}
+	binaryName, err := GetBinaryName(custom.paths.goBin, custom.Configuration.UseBinary)
+	if err != nil {
+		return err
+	}
+	custom.app = binaryName
+	return nil
+}
+
+func (custom *GoCustomizations) GetRepoPath() (string, error) {
+	return custom.paths.project, nil
+}
+
+func (custom *GoCustomizations) GetImageFileName() (string, error) {
+	base := filepath.Base(custom.Configuration.Project)
+	if base == "..." {
+		base = filepath.Base(filepath.Dir(custom.Configuration.Project))
+		if custom.Configuration.UseBinary != "" {
+			base += "-" + custom.Configuration.UseBinary
+		}
+	}
+	return base + schema.ACIExtension, nil
+}

--- a/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/run.go
+++ b/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/run.go
@@ -1,0 +1,65 @@
+package proj2aci
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type CmdFailedError struct {
+	Err error
+}
+
+func (e CmdFailedError) Error() string {
+	return fmt.Sprintf("CmdFailedError: %s", e.Err.Error())
+}
+
+type CmdNotFoundError struct {
+	Err error
+}
+
+func (e CmdNotFoundError) Error() string {
+	return fmt.Sprintf("CmdNotFoundError: %s", e.Err.Error())
+}
+
+// RunCmdFull runs given execProg. execProg should be an absolute path
+// to a program or it can be an empty string. In the latter case first
+// string in args is taken and searched for in $PATH.
+//
+// If execution fails then CmdFailedError is returned. This can be
+// useful if we don't care if execution fails or not. CmdNotFoundError
+// is returned if executable is not found.
+func RunCmdFull(execProg string, args, env []string, cwd string, stdout, stderr io.Writer) error {
+	if len(args) < 1 {
+		return fmt.Errorf("No args to execute passed")
+	}
+	prog := execProg
+	if prog == "" {
+		pathProg, err := exec.LookPath(args[0])
+		if err != nil {
+			return CmdNotFoundError{err}
+		}
+		prog = pathProg
+	} else if _, err := os.Stat(prog); err != nil {
+		return CmdNotFoundError{err}
+	}
+	cmd := exec.Cmd{
+		Path:   prog,
+		Args:   args,
+		Env:    env,
+		Dir:    cwd,
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+	Debug(`running command: "`, strings.Join(args, `" "`), `"`)
+	if err := cmd.Run(); err != nil {
+		return CmdFailedError{err}
+	}
+	return nil
+}
+
+func RunCmd(args, env []string, cwd string) error {
+	return RunCmdFull("", args, env, cwd, os.Stdout, os.Stderr)
+}

--- a/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/util.go
+++ b/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/util.go
@@ -1,0 +1,68 @@
+package proj2aci
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+)
+
+var debugEnabled bool
+var pathListSep string
+
+// DirExists checks if directory exists if given path is not empty.
+//
+// This function is rather specific as it is mostly used for checking
+// overrides validity (like overriding temporary directory, where
+// empty string means "do not override").
+func DirExists(path string) bool {
+	if path != "" {
+		fi, err := os.Stat(path)
+		if err != nil || !fi.IsDir() {
+			return false
+		}
+	}
+	return true
+}
+
+func printTo(w io.Writer, i ...interface{}) {
+	s := fmt.Sprint(i...)
+	fmt.Fprintln(w, strings.TrimSuffix(s, "\n"))
+}
+
+func Warn(i ...interface{}) {
+	printTo(os.Stderr, i...)
+}
+
+func Info(i ...interface{}) {
+	printTo(os.Stdout, i...)
+}
+
+func Debug(i ...interface{}) {
+	if debugEnabled {
+		printTo(os.Stdout, i...)
+	}
+}
+
+func InitDebug() {
+	if os.Getenv("GOACI_DEBUG") != "" {
+		debugEnabled = true
+	}
+}
+
+// listSeparator returns filepath.ListSeparator rune as a string.
+func listSeparator() string {
+	if pathListSep == "" {
+		len := utf8.RuneLen(filepath.ListSeparator)
+		if len < 0 {
+			panic("filepath.ListSeparator is not valid utf8?!")
+		}
+		buf := make([]byte, len)
+		len = utf8.EncodeRune(buf, filepath.ListSeparator)
+		pathListSep = string(buf[:len])
+	}
+
+	return pathListSep
+}

--- a/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/vcs.go
+++ b/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/vcs.go
@@ -1,0 +1,118 @@
+package proj2aci
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func repoDirExists(projPath, repoDir string) bool {
+	path := filepath.Join(projPath, repoDir)
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+
+// getId gets first line of commands output which should hold some VCS
+// specific id of current code checkout.
+func getId(dir, cmd string, params []string) (string, error) {
+	args := []string{cmd}
+	args = append(args, params...)
+	buffer := new(bytes.Buffer)
+	cmdPath, err := exec.LookPath(cmd)
+	if err != nil {
+		return "", nil
+	}
+	process := &exec.Cmd{
+		Path: cmdPath,
+		Args: args,
+		Env: []string{
+			"PATH=" + os.Getenv("PATH"),
+		},
+		Dir:    dir,
+		Stdout: buffer,
+	}
+	if err := process.Run(); err != nil {
+		return "", err
+	}
+	output := string(buffer.Bytes())
+	if newline := strings.Index(output, "\n"); newline < 0 {
+		return output, nil
+	} else {
+		return output[:newline], nil
+	}
+}
+
+func getLabelAndId(label, path, cmd string, params []string) (string, string, error) {
+	if info, err := getId(path, cmd, params); err != nil {
+		return "", "", err
+	} else {
+		return label, info, nil
+	}
+}
+
+type VCSInfo interface {
+	IsValid(path string) bool
+	GetLabelAndId(path string) (string, string, error)
+}
+
+type GitInfo struct{}
+
+func (info GitInfo) IsValid(path string) bool {
+	return repoDirExists(path, ".git")
+}
+
+func (info GitInfo) GetLabelAndId(path string) (string, string, error) {
+	return getLabelAndId("git", path, "git", []string{"rev-parse", "HEAD"})
+}
+
+type HgInfo struct{}
+
+func (info HgInfo) IsValid(path string) bool {
+	return repoDirExists(path, ".hg")
+}
+
+func (info HgInfo) GetLabelAndId(path string) (string, string, error) {
+	return getLabelAndId("hg", path, "hg", []string{"id", "-i"})
+}
+
+type SvnInfo struct{}
+
+func (info SvnInfo) IsValid(path string) bool {
+	return repoDirExists(path, ".svn")
+}
+
+func (info SvnInfo) GetLabelAndId(path string) (string, string, error) {
+	return getLabelAndId("svn", path, "svnversion", []string{})
+}
+
+type BzrInfo struct{}
+
+func (info BzrInfo) IsValid(path string) bool {
+	return repoDirExists(path, ".bzr")
+}
+
+func (info BzrInfo) GetLabelAndId(path string) (string, string, error) {
+	return getLabelAndId("bzr", path, "bzr", []string{"revno"})
+}
+
+func GetVCSInfo(projPath string) (string, string, error) {
+	vcses := []VCSInfo{
+		GitInfo{},
+		HgInfo{},
+		SvnInfo{},
+		BzrInfo{},
+	}
+
+	for _, vcs := range vcses {
+		if vcs.IsValid(projPath) {
+			return vcs.GetLabelAndId(projPath)
+		}
+	}
+	return "", "", fmt.Errorf("Unknown code repository in %q", projPath)
+}

--- a/Godeps/_workspace/src/golang.org/x/tools/go/vcs/discovery.go
+++ b/Godeps/_workspace/src/golang.org/x/tools/go/vcs/discovery.go
@@ -1,0 +1,76 @@
+// Copyright 2012 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// charsetReader returns a reader for the given charset. Currently
+// it only supports UTF-8 and ASCII. Otherwise, it returns a meaningful
+// error which is printed by go get, so the user can find why the package
+// wasn't downloaded if the encoding is not supported. Note that, in
+// order to reduce potential errors, ASCII is treated as UTF-8 (i.e. characters
+// greater than 0x7f are not rejected).
+func charsetReader(charset string, input io.Reader) (io.Reader, error) {
+	switch strings.ToLower(charset) {
+	case "ascii":
+		return input, nil
+	default:
+		return nil, fmt.Errorf("can't decode XML document using charset %q", charset)
+	}
+}
+
+// parseMetaGoImports returns meta imports from the HTML in r.
+// Parsing ends at the end of the <head> section or the beginning of the <body>.
+func parseMetaGoImports(r io.Reader) (imports []metaImport, err error) {
+	d := xml.NewDecoder(r)
+	d.CharsetReader = charsetReader
+	d.Strict = false
+	var t xml.Token
+	for {
+		t, err = d.Token()
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			return
+		}
+		if e, ok := t.(xml.StartElement); ok && strings.EqualFold(e.Name.Local, "body") {
+			return
+		}
+		if e, ok := t.(xml.EndElement); ok && strings.EqualFold(e.Name.Local, "head") {
+			return
+		}
+		e, ok := t.(xml.StartElement)
+		if !ok || !strings.EqualFold(e.Name.Local, "meta") {
+			continue
+		}
+		if attrValue(e.Attr, "name") != "go-import" {
+			continue
+		}
+		if f := strings.Fields(attrValue(e.Attr, "content")); len(f) == 3 {
+			imports = append(imports, metaImport{
+				Prefix:   f[0],
+				VCS:      f[1],
+				RepoRoot: f[2],
+			})
+		}
+	}
+}
+
+// attrValue returns the attribute value for the case-insensitive key
+// `name', or the empty string if nothing is found.
+func attrValue(attrs []xml.Attr, name string) string {
+	for _, a := range attrs {
+		if strings.EqualFold(a.Name.Local, name) {
+			return a.Value
+		}
+	}
+	return ""
+}

--- a/Godeps/_workspace/src/golang.org/x/tools/go/vcs/env.go
+++ b/Godeps/_workspace/src/golang.org/x/tools/go/vcs/env.go
@@ -1,0 +1,39 @@
+// Copyright 2013 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"os"
+	"strings"
+)
+
+// envForDir returns a copy of the environment
+// suitable for running in the given directory.
+// The environment is the current process's environment
+// but with an updated $PWD, so that an os.Getwd in the
+// child will be faster.
+func envForDir(dir string) []string {
+	env := os.Environ()
+	// Internally we only use rooted paths, so dir is rooted.
+	// Even if dir is not rooted, no harm done.
+	return mergeEnvLists([]string{"PWD=" + dir}, env)
+}
+
+// mergeEnvLists merges the two environment lists such that
+// variables with the same name in "in" replace those in "out".
+func mergeEnvLists(in, out []string) []string {
+NextVar:
+	for _, inkv := range in {
+		k := strings.SplitAfterN(inkv, "=", 2)[0]
+		for i, outkv := range out {
+			if strings.HasPrefix(outkv, k) {
+				out[i] = inkv
+				continue NextVar
+			}
+		}
+		out = append(out, inkv)
+	}
+	return out
+}

--- a/Godeps/_workspace/src/golang.org/x/tools/go/vcs/http.go
+++ b/Godeps/_workspace/src/golang.org/x/tools/go/vcs/http.go
@@ -1,0 +1,80 @@
+// Copyright 2012 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+// httpClient is the default HTTP client, but a variable so it can be
+// changed by tests, without modifying http.DefaultClient.
+var httpClient = http.DefaultClient
+
+// httpGET returns the data from an HTTP GET request for the given URL.
+func httpGET(url string) ([]byte, error) {
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("%s: %s", url, resp.Status)
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %v", url, err)
+	}
+	return b, nil
+}
+
+// httpsOrHTTP returns the body of either the importPath's
+// https resource or, if unavailable, the http resource.
+func httpsOrHTTP(importPath string) (urlStr string, body io.ReadCloser, err error) {
+	fetch := func(scheme string) (urlStr string, res *http.Response, err error) {
+		u, err := url.Parse(scheme + "://" + importPath)
+		if err != nil {
+			return "", nil, err
+		}
+		u.RawQuery = "go-get=1"
+		urlStr = u.String()
+		if Verbose {
+			log.Printf("Fetching %s", urlStr)
+		}
+		res, err = httpClient.Get(urlStr)
+		return
+	}
+	closeBody := func(res *http.Response) {
+		if res != nil {
+			res.Body.Close()
+		}
+	}
+	urlStr, res, err := fetch("https")
+	if err != nil || res.StatusCode != 200 {
+		if Verbose {
+			if err != nil {
+				log.Printf("https fetch failed.")
+			} else {
+				log.Printf("ignoring https fetch with status code %d", res.StatusCode)
+			}
+		}
+		closeBody(res)
+		urlStr, res, err = fetch("http")
+	}
+	if err != nil {
+		closeBody(res)
+		return "", nil, err
+	}
+	// Note: accepting a non-200 OK here, so people can serve a
+	// meta import in their http 404 page.
+	if Verbose {
+		log.Printf("Parsing meta tags from %s (status code %d)", urlStr, res.StatusCode)
+	}
+	return urlStr, res.Body, nil
+}

--- a/Godeps/_workspace/src/golang.org/x/tools/go/vcs/vcs.go
+++ b/Godeps/_workspace/src/golang.org/x/tools/go/vcs/vcs.go
@@ -1,0 +1,754 @@
+// Copyright 2012 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Verbose enables verbose operation logging.
+var Verbose bool
+
+// ShowCmd controls whether VCS commands are printed.
+var ShowCmd bool
+
+// A Cmd describes how to use a version control system
+// like Mercurial, Git, or Subversion.
+type Cmd struct {
+	Name string
+	Cmd  string // name of binary to invoke command
+
+	CreateCmd   string // command to download a fresh copy of a repository
+	DownloadCmd string // command to download updates into an existing repository
+
+	TagCmd         []TagCmd // commands to list tags
+	TagLookupCmd   []TagCmd // commands to lookup tags before running tagSyncCmd
+	TagSyncCmd     string   // command to sync to specific tag
+	TagSyncDefault string   // command to sync to default tag
+
+	LogCmd string // command to list repository changelogs in an XML format
+
+	Scheme  []string
+	PingCmd string
+}
+
+// A TagCmd describes a command to list available tags
+// that can be passed to Cmd.TagSyncCmd.
+type TagCmd struct {
+	Cmd     string // command to list tags
+	Pattern string // regexp to extract tags from list
+}
+
+// vcsList lists the known version control systems
+var vcsList = []*Cmd{
+	vcsHg,
+	vcsGit,
+	vcsSvn,
+	vcsBzr,
+}
+
+// ByCmd returns the version control system for the given
+// command name (hg, git, svn, bzr).
+func ByCmd(cmd string) *Cmd {
+	for _, vcs := range vcsList {
+		if vcs.Cmd == cmd {
+			return vcs
+		}
+	}
+	return nil
+}
+
+// vcsHg describes how to use Mercurial.
+var vcsHg = &Cmd{
+	Name: "Mercurial",
+	Cmd:  "hg",
+
+	CreateCmd:   "clone -U {repo} {dir}",
+	DownloadCmd: "pull",
+
+	// We allow both tag and branch names as 'tags'
+	// for selecting a version.  This lets people have
+	// a go.release.r60 branch and a go1 branch
+	// and make changes in both, without constantly
+	// editing .hgtags.
+	TagCmd: []TagCmd{
+		{"tags", `^(\S+)`},
+		{"branches", `^(\S+)`},
+	},
+	TagSyncCmd:     "update -r {tag}",
+	TagSyncDefault: "update default",
+
+	LogCmd: "log --encoding=utf-8 --limit={limit} --template={template}",
+
+	Scheme:  []string{"https", "http", "ssh"},
+	PingCmd: "identify {scheme}://{repo}",
+}
+
+// vcsGit describes how to use Git.
+var vcsGit = &Cmd{
+	Name: "Git",
+	Cmd:  "git",
+
+	CreateCmd:   "clone {repo} {dir}",
+	DownloadCmd: "pull --ff-only",
+
+	TagCmd: []TagCmd{
+		// tags/xxx matches a git tag named xxx
+		// origin/xxx matches a git branch named xxx on the default remote repository
+		{"show-ref", `(?:tags|origin)/(\S+)$`},
+	},
+	TagLookupCmd: []TagCmd{
+		{"show-ref tags/{tag} origin/{tag}", `((?:tags|origin)/\S+)$`},
+	},
+	TagSyncCmd:     "checkout {tag}",
+	TagSyncDefault: "checkout master",
+
+	Scheme:  []string{"git", "https", "http", "git+ssh"},
+	PingCmd: "ls-remote {scheme}://{repo}",
+}
+
+// vcsBzr describes how to use Bazaar.
+var vcsBzr = &Cmd{
+	Name: "Bazaar",
+	Cmd:  "bzr",
+
+	CreateCmd: "branch {repo} {dir}",
+
+	// Without --overwrite bzr will not pull tags that changed.
+	// Replace by --overwrite-tags after http://pad.lv/681792 goes in.
+	DownloadCmd: "pull --overwrite",
+
+	TagCmd:         []TagCmd{{"tags", `^(\S+)`}},
+	TagSyncCmd:     "update -r {tag}",
+	TagSyncDefault: "update -r revno:-1",
+
+	Scheme:  []string{"https", "http", "bzr", "bzr+ssh"},
+	PingCmd: "info {scheme}://{repo}",
+}
+
+// vcsSvn describes how to use Subversion.
+var vcsSvn = &Cmd{
+	Name: "Subversion",
+	Cmd:  "svn",
+
+	CreateCmd:   "checkout {repo} {dir}",
+	DownloadCmd: "update",
+
+	// There is no tag command in subversion.
+	// The branch information is all in the path names.
+
+	LogCmd: "log --xml --limit={limit}",
+
+	Scheme:  []string{"https", "http", "svn", "svn+ssh"},
+	PingCmd: "info {scheme}://{repo}",
+}
+
+func (v *Cmd) String() string {
+	return v.Name
+}
+
+// run runs the command line cmd in the given directory.
+// keyval is a list of key, value pairs.  run expands
+// instances of {key} in cmd into value, but only after
+// splitting cmd into individual arguments.
+// If an error occurs, run prints the command line and the
+// command's combined stdout+stderr to standard error.
+// Otherwise run discards the command's output.
+func (v *Cmd) run(dir string, cmd string, keyval ...string) error {
+	_, err := v.run1(dir, cmd, keyval, true)
+	return err
+}
+
+// runVerboseOnly is like run but only generates error output to standard error in verbose mode.
+func (v *Cmd) runVerboseOnly(dir string, cmd string, keyval ...string) error {
+	_, err := v.run1(dir, cmd, keyval, false)
+	return err
+}
+
+// runOutput is like run but returns the output of the command.
+func (v *Cmd) runOutput(dir string, cmd string, keyval ...string) ([]byte, error) {
+	return v.run1(dir, cmd, keyval, true)
+}
+
+// run1 is the generalized implementation of run and runOutput.
+func (v *Cmd) run1(dir string, cmdline string, keyval []string, verbose bool) ([]byte, error) {
+	m := make(map[string]string)
+	for i := 0; i < len(keyval); i += 2 {
+		m[keyval[i]] = keyval[i+1]
+	}
+	args := strings.Fields(cmdline)
+	for i, arg := range args {
+		args[i] = expand(m, arg)
+	}
+
+	_, err := exec.LookPath(v.Cmd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"go: missing %s command. See http://golang.org/s/gogetcmd\n",
+			v.Name)
+		return nil, err
+	}
+
+	cmd := exec.Command(v.Cmd, args...)
+	cmd.Dir = dir
+	cmd.Env = envForDir(cmd.Dir)
+	if ShowCmd {
+		fmt.Printf("cd %s\n", dir)
+		fmt.Printf("%s %s\n", v.Cmd, strings.Join(args, " "))
+	}
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err = cmd.Run()
+	out := buf.Bytes()
+	if err != nil {
+		if verbose || Verbose {
+			fmt.Fprintf(os.Stderr, "# cd %s; %s %s\n", dir, v.Cmd, strings.Join(args, " "))
+			os.Stderr.Write(out)
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+// Ping pings the repo to determine if scheme used is valid.
+// This repo must be pingable with this scheme and VCS.
+func (v *Cmd) Ping(scheme, repo string) error {
+	return v.runVerboseOnly(".", v.PingCmd, "scheme", scheme, "repo", repo)
+}
+
+// Create creates a new copy of repo in dir.
+// The parent of dir must exist; dir must not.
+func (v *Cmd) Create(dir, repo string) error {
+	return v.run(".", v.CreateCmd, "dir", dir, "repo", repo)
+}
+
+// CreateAtRev creates a new copy of repo in dir at revision rev.
+// The parent of dir must exist; dir must not.
+// rev must be a valid revision in repo.
+func (v *Cmd) CreateAtRev(dir, repo, rev string) error {
+	if err := v.Create(dir, repo); err != nil {
+		return err
+	}
+	return v.run(dir, v.TagSyncCmd, "tag", rev)
+}
+
+// Download downloads any new changes for the repo in dir.
+// dir must be a valid VCS repo compatible with v.
+func (v *Cmd) Download(dir string) error {
+	return v.run(dir, v.DownloadCmd)
+}
+
+// Tags returns the list of available tags for the repo in dir.
+// dir must be a valid VCS repo compatible with v.
+func (v *Cmd) Tags(dir string) ([]string, error) {
+	var tags []string
+	for _, tc := range v.TagCmd {
+		out, err := v.runOutput(dir, tc.Cmd)
+		if err != nil {
+			return nil, err
+		}
+		re := regexp.MustCompile(`(?m-s)` + tc.Pattern)
+		for _, m := range re.FindAllStringSubmatch(string(out), -1) {
+			tags = append(tags, m[1])
+		}
+	}
+	return tags, nil
+}
+
+// TagSync syncs the repo in dir to the named tag,
+// which either is a tag returned by tags or is v.TagDefault.
+// dir must be a valid VCS repo compatible with v and the tag must exist.
+func (v *Cmd) TagSync(dir, tag string) error {
+	if v.TagSyncCmd == "" {
+		return nil
+	}
+	if tag != "" {
+		for _, tc := range v.TagLookupCmd {
+			out, err := v.runOutput(dir, tc.Cmd, "tag", tag)
+			if err != nil {
+				return err
+			}
+			re := regexp.MustCompile(`(?m-s)` + tc.Pattern)
+			m := re.FindStringSubmatch(string(out))
+			if len(m) > 1 {
+				tag = m[1]
+				break
+			}
+		}
+	}
+	if tag == "" && v.TagSyncDefault != "" {
+		return v.run(dir, v.TagSyncDefault)
+	}
+	return v.run(dir, v.TagSyncCmd, "tag", tag)
+}
+
+// Log logs the changes for the repo in dir.
+// dir must be a valid VCS repo compatible with v.
+func (v *Cmd) Log(dir, logTemplate string) ([]byte, error) {
+	if err := v.Download(dir); err != nil {
+		return []byte{}, err
+	}
+
+	const N = 50 // how many revisions to grab
+	return v.runOutput(dir, v.LogCmd, "limit", strconv.Itoa(N), "template", logTemplate)
+}
+
+// LogAtRev logs the change for repo in dir at the rev revision.
+// dir must be a valid VCS repo compatible with v.
+// rev must be a valid revision for the repo in dir.
+func (v *Cmd) LogAtRev(dir, rev, logTemplate string) ([]byte, error) {
+	if err := v.Download(dir); err != nil {
+		return []byte{}, err
+	}
+
+	// Append revision flag to LogCmd.
+	logAtRevCmd := v.LogCmd + " --rev=" + rev
+	return v.runOutput(dir, logAtRevCmd, "limit", strconv.Itoa(1), "template", logTemplate)
+}
+
+// A vcsPath describes how to convert an import path into a
+// version control system and repository name.
+type vcsPath struct {
+	prefix string                              // prefix this description applies to
+	re     string                              // pattern for import path
+	repo   string                              // repository to use (expand with match of re)
+	vcs    string                              // version control system to use (expand with match of re)
+	check  func(match map[string]string) error // additional checks
+	ping   bool                                // ping for scheme to use to download repo
+
+	regexp *regexp.Regexp // cached compiled form of re
+}
+
+// FromDir inspects dir and its parents to determine the
+// version control system and code repository to use.
+// On return, root is the import path
+// corresponding to the root of the repository
+// (thus root is a prefix of importPath).
+func FromDir(dir, srcRoot string) (vcs *Cmd, root string, err error) {
+	// Clean and double-check that dir is in (a subdirectory of) srcRoot.
+	dir = filepath.Clean(dir)
+	srcRoot = filepath.Clean(srcRoot)
+	if len(dir) <= len(srcRoot) || dir[len(srcRoot)] != filepath.Separator {
+		return nil, "", fmt.Errorf("directory %q is outside source root %q", dir, srcRoot)
+	}
+
+	for len(dir) > len(srcRoot) {
+		for _, vcs := range vcsList {
+			if fi, err := os.Stat(filepath.Join(dir, "."+vcs.Cmd)); err == nil && fi.IsDir() {
+				return vcs, dir[len(srcRoot)+1:], nil
+			}
+		}
+
+		// Move to parent.
+		ndir := filepath.Dir(dir)
+		if len(ndir) >= len(dir) {
+			// Shouldn't happen, but just in case, stop.
+			break
+		}
+		dir = ndir
+	}
+
+	return nil, "", fmt.Errorf("directory %q is not using a known version control system", dir)
+}
+
+// RepoRoot represents a version control system, a repo, and a root of
+// where to put it on disk.
+type RepoRoot struct {
+	VCS *Cmd
+
+	// repo is the repository URL, including scheme
+	Repo string
+
+	// root is the import path corresponding to the root of the
+	// repository
+	Root string
+}
+
+// RepoRootForImportPath analyzes importPath to determine the
+// version control system, and code repository to use.
+func RepoRootForImportPath(importPath string, verbose bool) (*RepoRoot, error) {
+	rr, err := RepoRootForImportPathStatic(importPath, "")
+	if err == errUnknownSite {
+		rr, err = RepoRootForImportDynamic(importPath, verbose)
+
+		// RepoRootForImportDynamic returns error detail
+		// that is irrelevant if the user didn't intend to use a
+		// dynamic import in the first place.
+		// Squelch it.
+		if err != nil {
+			if Verbose {
+				log.Printf("import %q: %v", importPath, err)
+			}
+			err = fmt.Errorf("unrecognized import path %q", importPath)
+		}
+	}
+
+	if err == nil && strings.Contains(importPath, "...") && strings.Contains(rr.Root, "...") {
+		// Do not allow wildcards in the repo root.
+		rr = nil
+		err = fmt.Errorf("cannot expand ... in %q", importPath)
+	}
+	return rr, err
+}
+
+var errUnknownSite = errors.New("dynamic lookup required to find mapping")
+
+// RepoRootForImportPathStatic attempts to map importPath to a
+// RepoRoot using the commonly-used VCS hosting sites in vcsPaths
+// (github.com/user/dir), or from a fully-qualified importPath already
+// containing its VCS type (foo.com/repo.git/dir)
+//
+// If scheme is non-empty, that scheme is forced.
+func RepoRootForImportPathStatic(importPath, scheme string) (*RepoRoot, error) {
+	if strings.Contains(importPath, "://") {
+		return nil, fmt.Errorf("invalid import path %q", importPath)
+	}
+	for _, srv := range vcsPaths {
+		if !strings.HasPrefix(importPath, srv.prefix) {
+			continue
+		}
+		m := srv.regexp.FindStringSubmatch(importPath)
+		if m == nil {
+			if srv.prefix != "" {
+				return nil, fmt.Errorf("invalid %s import path %q", srv.prefix, importPath)
+			}
+			continue
+		}
+
+		// Build map of named subexpression matches for expand.
+		match := map[string]string{
+			"prefix": srv.prefix,
+			"import": importPath,
+		}
+		for i, name := range srv.regexp.SubexpNames() {
+			if name != "" && match[name] == "" {
+				match[name] = m[i]
+			}
+		}
+		if srv.vcs != "" {
+			match["vcs"] = expand(match, srv.vcs)
+		}
+		if srv.repo != "" {
+			match["repo"] = expand(match, srv.repo)
+		}
+		if srv.check != nil {
+			if err := srv.check(match); err != nil {
+				return nil, err
+			}
+		}
+		vcs := ByCmd(match["vcs"])
+		if vcs == nil {
+			return nil, fmt.Errorf("unknown version control system %q", match["vcs"])
+		}
+		if srv.ping {
+			if scheme != "" {
+				match["repo"] = scheme + "://" + match["repo"]
+			} else {
+				for _, scheme := range vcs.Scheme {
+					if vcs.Ping(scheme, match["repo"]) == nil {
+						match["repo"] = scheme + "://" + match["repo"]
+						break
+					}
+				}
+			}
+		}
+		rr := &RepoRoot{
+			VCS:  vcs,
+			Repo: match["repo"],
+			Root: match["root"],
+		}
+		return rr, nil
+	}
+	return nil, errUnknownSite
+}
+
+// RepoRootForImportDynamic finds a *RepoRoot for a custom domain that's not
+// statically known by RepoRootForImportPathStatic.
+//
+// This handles "vanity import paths" like "name.tld/pkg/foo".
+func RepoRootForImportDynamic(importPath string, verbose bool) (*RepoRoot, error) {
+	slash := strings.Index(importPath, "/")
+	if slash < 0 {
+		return nil, errors.New("import path doesn't contain a slash")
+	}
+	host := importPath[:slash]
+	if !strings.Contains(host, ".") {
+		return nil, errors.New("import path doesn't contain a hostname")
+	}
+	urlStr, body, err := httpsOrHTTP(importPath)
+	if err != nil {
+		return nil, fmt.Errorf("http/https fetch: %v", err)
+	}
+	defer body.Close()
+	imports, err := parseMetaGoImports(body)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %v", importPath, err)
+	}
+	metaImport, err := matchGoImport(imports, importPath)
+	if err != nil {
+		if err != errNoMatch {
+			return nil, fmt.Errorf("parse %s: %v", urlStr, err)
+		}
+		return nil, fmt.Errorf("parse %s: no go-import meta tags", urlStr)
+	}
+	if verbose {
+		log.Printf("get %q: found meta tag %#v at %s", importPath, metaImport, urlStr)
+	}
+	// If the import was "uni.edu/bob/project", which said the
+	// prefix was "uni.edu" and the RepoRoot was "evilroot.com",
+	// make sure we don't trust Bob and check out evilroot.com to
+	// "uni.edu" yet (possibly overwriting/preempting another
+	// non-evil student).  Instead, first verify the root and see
+	// if it matches Bob's claim.
+	if metaImport.Prefix != importPath {
+		if verbose {
+			log.Printf("get %q: verifying non-authoritative meta tag", importPath)
+		}
+		urlStr0 := urlStr
+		urlStr, body, err = httpsOrHTTP(metaImport.Prefix)
+		if err != nil {
+			return nil, fmt.Errorf("fetch %s: %v", urlStr, err)
+		}
+		imports, err := parseMetaGoImports(body)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %v", importPath, err)
+		}
+		if len(imports) == 0 {
+			return nil, fmt.Errorf("fetch %s: no go-import meta tag", urlStr)
+		}
+		metaImport2, err := matchGoImport(imports, importPath)
+		if err != nil || metaImport != metaImport2 {
+			return nil, fmt.Errorf("%s and %s disagree about go-import for %s", urlStr0, urlStr, metaImport.Prefix)
+		}
+	}
+
+	if !strings.Contains(metaImport.RepoRoot, "://") {
+		return nil, fmt.Errorf("%s: invalid repo root %q; no scheme", urlStr, metaImport.RepoRoot)
+	}
+	rr := &RepoRoot{
+		VCS:  ByCmd(metaImport.VCS),
+		Repo: metaImport.RepoRoot,
+		Root: metaImport.Prefix,
+	}
+	if rr.VCS == nil {
+		return nil, fmt.Errorf("%s: unknown vcs %q", urlStr, metaImport.VCS)
+	}
+	return rr, nil
+}
+
+// metaImport represents the parsed <meta name="go-import"
+// content="prefix vcs reporoot" /> tags from HTML files.
+type metaImport struct {
+	Prefix, VCS, RepoRoot string
+}
+
+// errNoMatch is returned from matchGoImport when there's no applicable match.
+var errNoMatch = errors.New("no import match")
+
+// matchGoImport returns the metaImport from imports matching importPath.
+// An error is returned if there are multiple matches.
+// errNoMatch is returned if none match.
+func matchGoImport(imports []metaImport, importPath string) (_ metaImport, err error) {
+	match := -1
+	for i, im := range imports {
+		if !strings.HasPrefix(importPath, im.Prefix) {
+			continue
+		}
+		if match != -1 {
+			err = fmt.Errorf("multiple meta tags match import path %q", importPath)
+			return
+		}
+		match = i
+	}
+	if match == -1 {
+		err = errNoMatch
+		return
+	}
+	return imports[match], nil
+}
+
+// expand rewrites s to replace {k} with match[k] for each key k in match.
+func expand(match map[string]string, s string) string {
+	for k, v := range match {
+		s = strings.Replace(s, "{"+k+"}", v, -1)
+	}
+	return s
+}
+
+// vcsPaths lists the known vcs paths.
+var vcsPaths = []*vcsPath{
+	// go.googlesource.com
+	{
+		prefix: "go.googlesource.com",
+		re:     `^(?P<root>go\.googlesource\.com/[A-Za-z0-9_.\-]+/?)$`,
+		vcs:    "git",
+		repo:   "https://{root}",
+		check:  noVCSSuffix,
+	},
+
+	// Google Code - new syntax
+	{
+		prefix: "code.google.com/",
+		re:     `^(?P<root>code\.google\.com/[pr]/(?P<project>[a-z0-9\-]+)(\.(?P<subrepo>[a-z0-9\-]+))?)(/[A-Za-z0-9_.\-]+)*$`,
+		repo:   "https://{root}",
+		check:  googleCodeVCS,
+	},
+
+	// Google Code - old syntax
+	{
+		re:    `^(?P<project>[a-z0-9_\-.]+)\.googlecode\.com/(git|hg|svn)(?P<path>/.*)?$`,
+		check: oldGoogleCode,
+	},
+
+	// Github
+	{
+		prefix: "github.com/",
+		re:     `^(?P<root>github\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(/[A-Za-z0-9_.\-]+)*$`,
+		vcs:    "git",
+		repo:   "https://{root}",
+		check:  noVCSSuffix,
+	},
+
+	// Bitbucket
+	{
+		prefix: "bitbucket.org/",
+		re:     `^(?P<root>bitbucket\.org/(?P<bitname>[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+))(/[A-Za-z0-9_.\-]+)*$`,
+		repo:   "https://{root}",
+		check:  bitbucketVCS,
+	},
+
+	// Launchpad
+	{
+		prefix: "launchpad.net/",
+		re:     `^(?P<root>launchpad\.net/((?P<project>[A-Za-z0-9_.\-]+)(?P<series>/[A-Za-z0-9_.\-]+)?|~[A-Za-z0-9_.\-]+/(\+junk|[A-Za-z0-9_.\-]+)/[A-Za-z0-9_.\-]+))(/[A-Za-z0-9_.\-]+)*$`,
+		vcs:    "bzr",
+		repo:   "https://{root}",
+		check:  launchpadVCS,
+	},
+
+	// General syntax for any server.
+	{
+		re:   `^(?P<root>(?P<repo>([a-z0-9.\-]+\.)+[a-z0-9.\-]+(:[0-9]+)?/[A-Za-z0-9_.\-/]*?)\.(?P<vcs>bzr|git|hg|svn))(/[A-Za-z0-9_.\-]+)*$`,
+		ping: true,
+	},
+}
+
+func init() {
+	// fill in cached regexps.
+	// Doing this eagerly discovers invalid regexp syntax
+	// without having to run a command that needs that regexp.
+	for _, srv := range vcsPaths {
+		srv.regexp = regexp.MustCompile(srv.re)
+	}
+}
+
+// noVCSSuffix checks that the repository name does not
+// end in .foo for any version control system foo.
+// The usual culprit is ".git".
+func noVCSSuffix(match map[string]string) error {
+	repo := match["repo"]
+	for _, vcs := range vcsList {
+		if strings.HasSuffix(repo, "."+vcs.Cmd) {
+			return fmt.Errorf("invalid version control suffix in %s path", match["prefix"])
+		}
+	}
+	return nil
+}
+
+var googleCheckout = regexp.MustCompile(`id="checkoutcmd">(hg|git|svn)`)
+
+// googleCodeVCS determines the version control system for
+// a code.google.com repository, by scraping the project's
+// /source/checkout page.
+func googleCodeVCS(match map[string]string) error {
+	if err := noVCSSuffix(match); err != nil {
+		return err
+	}
+	data, err := httpGET(expand(match, "https://code.google.com/p/{project}/source/checkout?repo={subrepo}"))
+	if err != nil {
+		return err
+	}
+
+	if m := googleCheckout.FindSubmatch(data); m != nil {
+		if vcs := ByCmd(string(m[1])); vcs != nil {
+			// Subversion requires the old URLs.
+			// TODO: Test.
+			if vcs == vcsSvn {
+				if match["subrepo"] != "" {
+					return fmt.Errorf("sub-repositories not supported in Google Code Subversion projects")
+				}
+				match["repo"] = expand(match, "https://{project}.googlecode.com/svn")
+			}
+			match["vcs"] = vcs.Cmd
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unable to detect version control system for code.google.com/ path")
+}
+
+// oldGoogleCode is invoked for old-style foo.googlecode.com paths.
+// It prints an error giving the equivalent new path.
+func oldGoogleCode(match map[string]string) error {
+	return fmt.Errorf("invalid Google Code import path: use %s instead",
+		expand(match, "code.google.com/p/{project}{path}"))
+}
+
+// bitbucketVCS determines the version control system for a
+// Bitbucket repository, by using the Bitbucket API.
+func bitbucketVCS(match map[string]string) error {
+	if err := noVCSSuffix(match); err != nil {
+		return err
+	}
+
+	var resp struct {
+		SCM string `json:"scm"`
+	}
+	url := expand(match, "https://api.bitbucket.org/1.0/repositories/{bitname}")
+	data, err := httpGET(url)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("decoding %s: %v", url, err)
+	}
+
+	if ByCmd(resp.SCM) != nil {
+		match["vcs"] = resp.SCM
+		if resp.SCM == "git" {
+			match["repo"] += ".git"
+		}
+		return nil
+	}
+
+	return fmt.Errorf("unable to detect version control system for bitbucket.org/ path")
+}
+
+// launchpadVCS solves the ambiguity for "lp.net/project/foo". In this case,
+// "foo" could be a series name registered in Launchpad with its own branch,
+// and it could also be the name of a directory within the main project
+// branch one level up.
+func launchpadVCS(match map[string]string) error {
+	if match["project"] == "" || match["series"] == "" {
+		return nil
+	}
+	_, err := httpGET(expand(match, "https://code.launchpad.net/{project}{series}/.bzr/branch-format"))
+	if err != nil {
+		match["root"] = expand(match, "launchpad.net/{project}")
+		match["repo"] = expand(match, "https://{root}")
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/golang.org/x/tools/go/vcs/vcs_test.go
+++ b/Godeps/_workspace/src/golang.org/x/tools/go/vcs/vcs_test.go
@@ -1,0 +1,130 @@
+// Copyright 2013 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Test that RepoRootForImportPath creates the correct RepoRoot for a given importPath.
+// TODO(cmang): Add tests for SVN and BZR.
+func TestRepoRootForImportPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want *RepoRoot
+	}{
+		{
+			"code.google.com/p/go",
+			&RepoRoot{
+				VCS:  vcsHg,
+				Repo: "https://code.google.com/p/go",
+			},
+		},
+		{
+			"code.google.com/r/go",
+			&RepoRoot{
+				VCS:  vcsHg,
+				Repo: "https://code.google.com/r/go",
+			},
+		},
+		{
+			"github.com/golang/groupcache",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://github.com/golang/groupcache",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		got, err := RepoRootForImportPath(test.path, false)
+		if err != nil {
+			t.Errorf("RepoRootForImport(%q): %v", test.path, err)
+			continue
+		}
+		want := test.want
+		if got.VCS.Name != want.VCS.Name || got.Repo != want.Repo {
+			t.Errorf("RepoRootForImport(%q) = VCS(%s) Repo(%s), want VCS(%s) Repo(%s)", test.path, got.VCS, got.Repo, want.VCS, want.Repo)
+		}
+	}
+}
+
+// Test that FromDir correctly inspects a given directory and returns the right VCS.
+func TestFromDir(t *testing.T) {
+	type testStruct struct {
+		path string
+		want *Cmd
+	}
+
+	tests := make([]testStruct, len(vcsList))
+	tempDir, err := ioutil.TempDir("", "vcstest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	for i, vcs := range vcsList {
+		tests[i] = testStruct{
+			filepath.Join(tempDir, vcs.Name, "."+vcs.Cmd),
+			vcs,
+		}
+	}
+
+	for _, test := range tests {
+		os.MkdirAll(test.path, 0755)
+		got, _, _ := FromDir(test.path, tempDir)
+		if got.Name != test.want.Name {
+			t.Errorf("FromDir(%q, %q) = %s, want %s", test.path, tempDir, got, test.want)
+		}
+		os.RemoveAll(test.path)
+	}
+}
+
+var parseMetaGoImportsTests = []struct {
+	in  string
+	out []metaImport
+}{
+	{
+		`<meta name="go-import" content="foo/bar git https://github.com/rsc/foo/bar">`,
+		[]metaImport{{"foo/bar", "git", "https://github.com/rsc/foo/bar"}},
+	},
+	{
+		`<meta name="go-import" content="foo/bar git https://github.com/rsc/foo/bar">
+		<meta name="go-import" content="baz/quux git http://github.com/rsc/baz/quux">`,
+		[]metaImport{
+			{"foo/bar", "git", "https://github.com/rsc/foo/bar"},
+			{"baz/quux", "git", "http://github.com/rsc/baz/quux"},
+		},
+	},
+	{
+		`<head>
+		<meta name="go-import" content="foo/bar git https://github.com/rsc/foo/bar">
+		</head>`,
+		[]metaImport{{"foo/bar", "git", "https://github.com/rsc/foo/bar"}},
+	},
+	{
+		`<meta name="go-import" content="foo/bar git https://github.com/rsc/foo/bar">
+		<body>`,
+		[]metaImport{{"foo/bar", "git", "https://github.com/rsc/foo/bar"}},
+	},
+}
+
+func TestParseMetaGoImports(t *testing.T) {
+	for i, tt := range parseMetaGoImportsTests {
+		out, err := parseMetaGoImports(strings.NewReader(tt.in))
+		if err != nil {
+			t.Errorf("test#%d: %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(out, tt.out) {
+			t.Errorf("test#%d:\n\thave %q\n\twant %q", i, out, tt.out)
+		}
+	}
+}

--- a/build
+++ b/build
@@ -19,6 +19,9 @@ case "${RKT_STAGE1_USR_FROM}" in
 	none)
 		echo "stage1 build disabled"
 		;;
+	usr-from-host)
+		echo "stage1 will pick binaries from the host at run-time"
+		;;
 	coreos)
 		echo "stage1 will reuse coreos image"
 		;;

--- a/stage1/dummy.go
+++ b/stage1/dummy.go
@@ -28,5 +28,4 @@ import (
 	_ "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/cni/plugins/main/ipvlan"
 	_ "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/cni/plugins/main/macvlan"
 	_ "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/cni/plugins/main/veth"
-	_ "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/goaci/proj2aci"
 )

--- a/stage1/dummy.go
+++ b/stage1/dummy.go
@@ -28,4 +28,5 @@ import (
 	_ "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/cni/plugins/main/ipvlan"
 	_ "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/cni/plugins/main/macvlan"
 	_ "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/cni/plugins/main/veth"
+	_ "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/goaci/proj2aci"
 )

--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -464,12 +464,18 @@ func (p *Pod) getFlavor() (flavor string, systemdVersion string, err error) {
 	if err != nil {
 		return "", "", fmt.Errorf("unable to determine stage1 flavor: %v", err)
 	}
+
+	if flavor == "usr-from-host" {
+		// This flavor does not contain systemd, so don't return systemdVersion
+		return flavor, "", nil
+	}
+
 	systemdVersionBytes, err := ioutil.ReadFile(filepath.Join(common.Stage1RootfsPath(p.Root), "systemd-version"))
 	if err != nil {
 		return "", "", fmt.Errorf("unable to determine stage1's systemd version: %v", err)
 	}
 	systemdVersion = strings.Trim(string(systemdVersionBytes), " \n")
-	return
+	return flavor, systemdVersion, nil
 }
 
 // GetAppHashes returns a list of hashes of the apps in this pod

--- a/stage1/rootfs/Makefile
+++ b/stage1/rootfs/Makefile
@@ -1,4 +1,4 @@
-USR=usr_from_$(RKT_STAGE1_USR_FROM)
+USR=usr_from_$(subst usr-from-,,$(RKT_STAGE1_USR_FROM))
 _SUBDIRS=$(USR) waiter shim diagexec prepare-app enter net-plugins net init gc
 SUBDIRS=$(_SUBDIRS) aggregate
 export CFLAGS=-Wall -Os

--- a/stage1/rootfs/aggregate/aggregate.sh
+++ b/stage1/rootfs/aggregate/aggregate.sh
@@ -6,8 +6,10 @@ ROOT=stage1/rootfs
 
 # always start over
 [ -e "$ROOT" ] && rm -Rf "$ROOT"
+mkdir -p "$ROOT"
 
 # run everything in install.d/*
 for i in install.d/*; do
+	echo "Sourcing $i"
 	source "$i"
 done

--- a/stage1/rootfs/usr_from_host/Makefile
+++ b/stage1/rootfs/usr_from_host/Makefile
@@ -1,0 +1,18 @@
+# do not include systemd in stage1, let's find it at run-time
+
+usr.done install: Makefile
+	echo mkdir -p "\$${ROOT}" > install.tmp
+	echo ln -sf usr-from-host \"\$${ROOT}/flavor\" >> install.tmp
+	mv install.tmp install
+	cp -f install ../aggregate/install.d/00usr
+	touch usr.done
+
+.PHONY: clean distclean
+
+distclean: clean
+
+clean:
+	rm -Rf rootfs usr.done install
+
+test:
+	echo TODO

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,12 +14,13 @@ The credentials for `rktbot` are currently managed by CoreOS.
 Use the following build commands:
 
 ```
-./tests/install-deps.sh         # Setup
-./tests/run-build.sh none       # Thread 1
-./tests/run-build.sh coreos     # Thread 2
-./tests/run-build.sh src v220   # Thread 1
-./tests/run-build.sh src master # Thread 2
-git clean -ffdx                 # Post Thread
+./tests/install-deps.sh            # Setup
+./tests/run-build.sh none          # Thread 1
+./tests/run-build.sh usr-from-host # Thread 1
+./tests/run-build.sh coreos        # Thread 1
+./tests/run-build.sh src v220      # Thread 2
+./tests/run-build.sh src master    # Thread 2
+git clean -ffdx                    # Post Thread
 ```
 
 ### Platform

--- a/tests/test
+++ b/tests/test
@@ -18,4 +18,20 @@
 # version as the system-wide installed go.
 GO=`which go`
 
+HOST_RUNNING_SYSTEMD=0
+if [ $(basename $(sudo readlink /proc/1/exe)) == systemd ] ; then
+	HOST_RUNNING_SYSTEMD=1
+fi
+
+STAGE1_SRC_FROM_HOST=0
+if tar tvf ../bin/stage1.aci rootfs/flavor|grep -q usr-from-host ; then
+	STAGE1_SRC_FROM_HOST=1
+fi
+
+if [ $HOST_RUNNING_SYSTEMD -eq 0 -a $STAGE1_SRC_FROM_HOST -eq 1 ] ; then
+	echo "Cannot use stage1 compiled with usr-from-host because systemd is not installed."
+	echo "Functional tests disabled."
+	exit 0
+fi
+
 sudo GOPATH="${PWD}/../gopath" GOROOT="$GOROOT" $GO test -v $*


### PR DESCRIPTION
As mentioned on https://github.com/coreos/rkt/issues/686#issuecomment-101305256, I would like to have a new build flavor:
```
RKT_STAGE1_USR_FROM=host ./build
```
to build `stage1.aci` without `systemd` or `systemd-nspawn`. `systemd` or `systemd-nspawn` would be taken from the host at run-time. It would just fail if the host does not have those. This would be useful for Linux distributions packagers who have policies restricting "convenience copies of code" and access to internet.

This is proof-of-concept code based on top of #910 to work on a non-patched systemd-v220. I have tested it on Debian-sid with systemd-v220.

My stage1.aci contains the following:
```
$ tar tvf  bin/stage1.aci
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs
-rwxr-xr-x 1000/1000    750992 2015-06-02 16:16 rootfs/diagexec
-rwxr-xr-x 1000/1000    746896 2015-06-02 16:16 rootfs/enter
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/etc
-rw-r--r-- 1000/1000         4 2015-06-02 16:16 rootfs/etc/os-release
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/etc/rkt
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/etc/rkt/net.d
-rwxr-xr-x 1000/1000       130 2015-06-02 16:16 rootfs/etc/rkt/net.d/99-default-restricted.conf
-rwxr-xr-x 1000/1000       174 2015-06-02 16:16 rootfs/etc/rkt/net.d/99-default.conf
lrwxrwxrwx 1000/1000         0 2015-06-02 16:16 rootfs/fakesdboot.so -> shim.so
lrwxrwxrwx 1000/1000         0 2015-06-02 16:16 rootfs/flavor -> host
-rwxr-xr-x 1000/1000   7787104 2015-06-02 16:16 rootfs/gc
-rwxr-xr-x 1000/1000   9504600 2015-06-02 16:16 rootfs/init
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/opt
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/opt/stage2
-rwxr-xr-x 1000/1000    746896 2015-06-02 16:16 rootfs/prepare-app
-rwxr-xr-x 1000/1000       248 2015-06-02 16:16 rootfs/reaper.sh
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/rkt
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/rkt/env
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/rkt/status
-rwxr-xr-x 1000/1000      7368 2015-06-02 16:16 rootfs/shim.so
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/usr
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/usr/lib
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/usr/lib/rkt
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/usr/lib/rkt/plugins
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/usr/lib/rkt/plugins/net
-rwxr-xr-x 1000/1000   4159552 2015-06-02 16:16 rootfs/usr/lib/rkt/plugins/net/bridge
-rwxr-xr-x 1000/1000   3302640 2015-06-02 16:16 rootfs/usr/lib/rkt/plugins/net/host-local
lrwxrwxrwx 1000/1000         0 2015-06-02 16:16 rootfs/usr/lib/rkt/plugins/net/host-local-ptp -> host-local
-rwxr-xr-x 1000/1000   4137000 2015-06-02 16:16 rootfs/usr/lib/rkt/plugins/net/ipvlan
-rwxr-xr-x 1000/1000   4137048 2015-06-02 16:16 rootfs/usr/lib/rkt/plugins/net/macvlan
-rwxr-xr-x 1000/1000   4189608 2015-06-02 16:16 rootfs/usr/lib/rkt/plugins/net/veth
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/usr/lib/systemd
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/usr/lib/systemd/system
-rw-r--r-- 1000/1000        61 2015-06-02 16:16 rootfs/usr/lib/systemd/system/default.target
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/usr/lib/systemd/system/default.target.wants
-rw-r--r-- 1000/1000       173 2015-06-02 16:16 rootfs/usr/lib/systemd/system/exit-watcher.service
-rw-r--r-- 1000/1000       132 2015-06-02 16:16 rootfs/usr/lib/systemd/system/local-fs.target
-rw-r--r-- 1000/1000       111 2015-06-02 16:16 rootfs/usr/lib/systemd/system/reaper.service
-rw-r--r-- 1000/1000        53 2015-06-02 16:16 rootfs/usr/lib/systemd/system/sockets.target
drwxr-xr-x 1000/1000         0 2015-06-02 16:16 rootfs/usr/lib/systemd/system/sockets.target.wants
-rwxr-xr-x 1000/1000    746896 2015-06-02 16:16 rootfs/waiter
-rw-r--r-- root/root       360 2015-06-02 16:16 manifest
```

It vendors @krnowak's work on goaci / proj2aci: https://github.com/appc/goaci/pull/17 + a fix.

And I can successfully start 
```
$ sudo bin/rkt --debug --insecure-skip-verify run -interactive docker://busybox
...
/ # ls -l  /proc/1/root/flavor 
lrwxrwxrwx    1 default  default          4 Jun  2 14:16 /proc/1/root/flavor -> host

```