### PR TITLE
trust: expand message for invalid command

### DIFF
--- a/rkt/trust.go
+++ b/rkt/trust.go
@@ -66,7 +66,13 @@ func init() {
 func runTrust(args []string) (exit int) {
 	if flagPrefix == "" && !flagRoot {
 		if len(args) != 0 {
-			stderr("--root required for non-prefixed (root) keys")
+			rootKeyName := args[0]
+			stderr(`Prevented potentially dangerous unbounded trust of all containers signed by keys from "%s"
+To continue trusting this root domain:
+  rkt %s --root "%s"
+Or, establish a smaller scope with a prefix:
+  rkt %s --prefix "example.com/hello" "%s"
+  rkt $s --prefix "example.com/foo/*" "%s"`, rootKeyName, cmdTrustName, rootKeyName, cmdTrustName, rootKeyName, cmdTrustName, rootKeyName)
 		} else {
 			printCommandUsageByName(cmdTrustName)
 		}


### PR DESCRIPTION
This PR implements the friendly error message as suggested. I would have specified it, but the possibilities for the meaning of `args[0]` were a bit too broad: either a URL without URL schema (as in `rkt trust --prefix coreos.com/etcd`), a URL with schema (`rkt trust --root https://coreos.com/dist/pubkeys/aci-pubkeys.gpg`), a file on disk (`rkt trust --root aci-pubkeys.gpg`)

Therefor I thought it would be better to keep the instruction as broad as possible.