### PR TITLE
stage0: copy stage1 image from tree cache instead of extracting it

### DIFF
--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -1,0 +1,191 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/pkg/device"
+)
+
+func copyRegularFile(src, dest string) (err error) {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+	destFile, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		e := destFile.Close()
+		if err == nil {
+			err = e
+		}
+	}()
+	if _, err := io.Copy(destFile, srcFile); err != nil {
+		return err
+	}
+	return nil
+}
+
+func copySymlink(src, dest string) error {
+	symTarget, err := os.Readlink(src)
+	if err != nil {
+		return err
+	}
+	if err := os.Symlink(symTarget, dest); err != nil {
+		return err
+	}
+	return nil
+}
+
+func CopyTree(src, dest string) error {
+	dirs := make(map[string][]syscall.Timespec)
+	copyWalker := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rootLess := path[len(src):]
+		target := filepath.Join(dest, rootLess)
+		mode := info.Mode()
+		switch {
+		case mode.IsDir():
+			err := os.Mkdir(target, mode.Perm())
+			if err != nil {
+				return err
+			}
+
+			dir, err := os.Open(target)
+			if err != nil {
+				return err
+			}
+			if err := dir.Chmod(mode); err != nil {
+				dir.Close()
+				return err
+			}
+			dir.Close()
+		case mode.IsRegular():
+			if err := copyRegularFile(path, target); err != nil {
+				return err
+			}
+		case mode&os.ModeSymlink == os.ModeSymlink:
+			if err := copySymlink(path, target); err != nil {
+				return err
+			}
+		case mode&os.ModeCharDevice == os.ModeCharDevice:
+			stat := syscall.Stat_t{}
+			if err := syscall.Stat(path, &stat); err != nil {
+				return err
+			}
+
+			dev := device.Makedev(device.Major(stat.Rdev), device.Minor(stat.Rdev))
+			mode := uint32(mode) | syscall.S_IFCHR
+			if err := syscall.Mknod(target, mode, int(dev)); err != nil {
+				return err
+			}
+		case mode&os.ModeDevice == os.ModeDevice:
+			stat := syscall.Stat_t{}
+			if err := syscall.Stat(path, &stat); err != nil {
+				return err
+			}
+
+			dev := device.Makedev(device.Major(stat.Rdev), device.Minor(stat.Rdev))
+			mode := uint32(mode) | syscall.S_IFBLK
+			if err := syscall.Mknod(target, mode, int(dev)); err != nil {
+				return err
+			}
+		case mode&os.ModeNamedPipe == os.ModeNamedPipe:
+			if err := syscall.Mkfifo(target, uint32(mode)); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported mode: %v", mode)
+		}
+
+		if err := os.Lchown(target, int(info.Sys().(*syscall.Stat_t).Uid), int(info.Sys().(*syscall.Stat_t).Gid)); err != nil {
+			return err
+		}
+
+		// lchown(2) says that, depending on the linux kernel version, it
+		// can change the file's mode also if executed as root. So call
+		// os.Chmod after it.
+		if mode&os.ModeSymlink != os.ModeSymlink {
+			if err := os.Chmod(target, mode); err != nil {
+				return err
+			}
+		}
+
+		ts, err := pathToTimespec(path)
+		if err != nil {
+			return err
+		}
+
+		if mode.IsDir() {
+			dirs[target] = ts
+		}
+		if mode&os.ModeSymlink != os.ModeSymlink {
+			if err := syscall.UtimesNano(target, ts); err != nil {
+				return err
+			}
+		} else {
+			if err := LUtimesNano(target, ts); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	if err := filepath.Walk(src, copyWalker); err != nil {
+		return err
+	}
+
+	// Restore dirs atime and mtime. This has to be done after copying
+	// as a file copying will change its parent directory's times.
+	for dirPath, ts := range dirs {
+		if err := syscall.UtimesNano(dirPath, ts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func pathToTimespec(name string) ([]syscall.Timespec, error) {
+	fi, err := os.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	mtime := fi.ModTime()
+	stat := fi.Sys().(*syscall.Stat_t)
+	atime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+	return []syscall.Timespec{TimeToTimespec(atime), TimeToTimespec(mtime)}, nil
+}
+
+// TODO(sgotti) use UTIMES_OMIT on linux if Time.IsZero ?
+func TimeToTimespec(time time.Time) (ts syscall.Timespec) {
+	nsec := int64(0)
+	if !time.IsZero() {
+		nsec = time.UnixNano()
+	}
+	return syscall.NsecToTimespec(nsec)
+}

--- a/pkg/fileutil/utimes_linux.go
+++ b/pkg/fileutil/utimes_linux.go
@@ -17,7 +17,7 @@
 // TODO(sgotti) waiting for a utimensat functions accepting flags and a
 // LUtimesNano using it in https://github.com/golang/sys/
 
-package tar
+package fileutil
 
 import (
 	"syscall"

--- a/pkg/fileutil/utimes_unsupported.go
+++ b/pkg/fileutil/utimes_unsupported.go
@@ -16,7 +16,7 @@
 
 // These functions are from github.com/docker/docker/pkg/system
 
-package tar
+package fileutil
 
 import "syscall"
 

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -26,6 +26,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/pkg/device"
 	"github.com/coreos/rkt/pkg/fileutil"
 )
 
@@ -145,15 +146,15 @@ func extractFile(tr *tar.Reader, hdr *tar.Header, overwrite bool) error {
 			return err
 		}
 	case typ == tar.TypeChar:
-		dev := makedev(int(hdr.Devmajor), int(hdr.Devminor))
+		dev := device.Makedev(uint(hdr.Devmajor), uint(hdr.Devminor))
 		mode := uint32(fi.Mode()) | syscall.S_IFCHR
-		if err := syscall.Mknod(p, mode, dev); err != nil {
+		if err := syscall.Mknod(p, mode, int(dev)); err != nil {
 			return err
 		}
 	case typ == tar.TypeBlock:
-		dev := makedev(int(hdr.Devmajor), int(hdr.Devminor))
+		dev := device.Makedev(uint(hdr.Devmajor), uint(hdr.Devminor))
 		mode := uint32(fi.Mode()) | syscall.S_IFBLK
-		if err := syscall.Mknod(p, mode, dev); err != nil {
+		if err := syscall.Mknod(p, mode, int(dev)); err != nil {
 			return err
 		}
 	case typ == tar.TypeFifo:
@@ -222,11 +223,6 @@ func extractFileFromTar(tr *tar.Reader, file string) ([]byte, error) {
 			return nil, fmt.Errorf("error extracting tarball: %v", err)
 		}
 	}
-}
-
-// makedev mimics glib's gnu_dev_makedev
-func makedev(major, minor int) int {
-	return (minor & 0xff) | (major & 0xfff << 8) | int((uint64(minor & ^0xff) << 12)) | int(uint64(major & ^0xfff)<<32)
 }
 
 func HdrToTimespec(hdr *tar.Header) []syscall.Timespec {

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/pkg/device"
 	"github.com/coreos/rkt/pkg/fileutil"
@@ -226,14 +225,5 @@ func extractFileFromTar(tr *tar.Reader, file string) ([]byte, error) {
 }
 
 func HdrToTimespec(hdr *tar.Header) []syscall.Timespec {
-	return []syscall.Timespec{timeToTimespec(hdr.AccessTime), timeToTimespec(hdr.ModTime)}
-}
-
-// TODO(sgotti) use UTIMES_OMIT on linux if Time.IsZero ?
-func timeToTimespec(time time.Time) (ts syscall.Timespec) {
-	nsec := int64(0)
-	if !time.IsZero() {
-		nsec = time.UnixNano()
-	}
-	return syscall.NsecToTimespec(nsec)
+	return []syscall.Timespec{fileutil.TimeToTimespec(hdr.AccessTime), fileutil.TimeToTimespec(hdr.ModTime)}
 }

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -25,6 +25,8 @@ import (
 	"path/filepath"
 	"syscall"
 	"time"
+
+	"github.com/coreos/rkt/pkg/fileutil"
 )
 
 const DEFAULT_DIR_MODE os.FileMode = 0755
@@ -185,7 +187,7 @@ func extractFile(tr *tar.Reader, hdr *tar.Header, overwrite bool) error {
 			return err
 		}
 	} else {
-		if err := LUtimesNano(p, ts); err != nil && err != ErrNotSupportedPlatform {
+		if err := fileutil.LUtimesNano(p, ts); err != nil && err != ErrNotSupportedPlatform {
 			return err
 		}
 	}


### PR DESCRIPTION
Since we render the stage1 image anyway, if we don't use overlay fs, we
copy its rootfs from the tree cache instead of extracting it every
single time.

Addresses #693 