### PR TITLE
stage1: fix parseCgroups function

### DIFF
--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -332,10 +332,12 @@ func parseCgroups() (map[int][]string, error) {
 		var enabled int
 		fmt.Sscanf(sc.Text(), "%s %d %d %d", &controller, &hierarchy, &num, &enabled)
 
-		if _, ok := cgroups[hierarchy]; !ok {
-			cgroups[hierarchy] = []string{controller}
-		} else {
-			cgroups[hierarchy] = append(cgroups[hierarchy], controller)
+		if enabled == 1 {
+			if _, ok := cgroups[hierarchy]; !ok {
+				cgroups[hierarchy] = []string{controller}
+			} else {
+				cgroups[hierarchy] = append(cgroups[hierarchy], controller)
+			}
 		}
 	}
 


### PR DESCRIPTION
It wasn't taking into account if the cgroup controller was enabled or
not.