### PR TITLE
stage1: use --link-journal=try-host in systemd-nspawn

### DIFF
--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -321,7 +321,7 @@ func getArgsEnv(p *Pod, flavor string, systemdStage1Version string, debug bool) 
 			log.Fatalf("error writing /etc/machine-id: %v\n", err)
 		}
 
-		args = append(args, "--link-journal=host")
+		args = append(args, "--link-journal=try-host")
 	}
 
 	if !debug {


### PR DESCRIPTION
--link-journal=host fails if the host system doesn't have persistent
journaling enabled. Fix that by using "try-host"; if the system has
persistent journaling enabled it links the journal, otherwise it skips
the linking without exiting with a failure.

In 969a57c6 (stage1: use --link-journal=host instead of try-host) we
switched from "try-host" to "host" to support journal linking in systemd
versions <219 but now we don't support it on them anymore.

Fixes #1000