### PR TITLE
stage1: add halt.target

### DIFF
--- a/stage1/rootfs/aggregate/install.d/99misc
+++ b/stage1/rootfs/aggregate/install.d/99misc
@@ -7,6 +7,7 @@ install -m 0644 units/exit-watcher.service "$ROOT/usr/lib/systemd/system"
 install -m 0644 units/local-fs.target "$ROOT/usr/lib/systemd/system"
 install -m 0644 units/reaper.service "$ROOT/usr/lib/systemd/system"
 install -m 0644 units/sockets.target "$ROOT/usr/lib/systemd/system"
+install -m 0644 units/halt.target "$ROOT/usr/lib/systemd/system"
 install -m 0755 scripts/reaper.sh "$ROOT"
 
 install -d "$ROOT/etc"

--- a/stage1/rootfs/aggregate/units/halt.target
+++ b/stage1/rootfs/aggregate/units/halt.target
@@ -1,0 +1,6 @@
+[Unit]
+Description=Halt
+DefaultDependencies=no
+Requires=reaper.service
+After=reaper.service
+AllowIsolate=yes


### PR DESCRIPTION
When systemd-nspawn receives a TERM signal it will send it to systemd in
stage1 which will try to run the halt.target. This target was not
present in the current stage1 so the container was not being shut down.

Fix this by adding halt.target which calls reaper.service to shut down
the container cleanly.

Fixes #1008 