### PR TITLE
Refactor stage1/init to source most of options from manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tests/image/rootfs/
 tests/inspect/inspect
 tests/*.aci
 tests/*.log
+stage1/rootfs/usr_from_src/aci-manifest

--- a/stage1/rootfs/Makefile
+++ b/stage1/rootfs/Makefile
@@ -1,4 +1,5 @@
 USR=usr_from_$(subst usr-from-,,$(RKT_STAGE1_USR_FROM))
+export USR
 _SUBDIRS=$(USR) waiter shim diagexec prepare-app enter net-plugins net init gc
 SUBDIRS=$(_SUBDIRS) aggregate
 export CFLAGS=-Wall -Os

--- a/stage1/rootfs/aggregate/Makefile
+++ b/stage1/rootfs/aggregate/Makefile
@@ -1,8 +1,8 @@
 S1=stage1
 S1ACI=../../../bin/$(S1).aci
 
-$(S1ACI): aggregate.sh Makefile scripts/* units/* install.d/* aci-manifest
-	@./aggregate.sh && cp aci-manifest $(S1)/manifest && ${ACTOOL} build --overwrite $(S1) $(S1ACI)
+$(S1ACI): aggregate.sh Makefile scripts/* units/* install.d/* ../${USR}/aci-manifest
+	@./aggregate.sh && cp ../${USR}/aci-manifest $(S1)/manifest && ${ACTOOL} build --overwrite $(S1) $(S1ACI)
 
 .PHONY: clean
 clean:

--- a/stage1/rootfs/usr_from_coreos/aci-manifest
+++ b/stage1/rootfs/usr_from_coreos/aci-manifest
@@ -1,0 +1,57 @@
+{
+    "acKind": "ImageManifest",
+    "acVersion": "0.5.2",
+    "name": "coreos.com/rkt/stage1",
+    "labels": [
+        {
+            "name": "version",
+            "value": "0.0.1"
+        },
+        {
+            "name": "arch",
+            "value": "amd64"
+        },
+        {
+            "name": "os",
+            "value": "linux"
+        }
+    ],
+    "annotations": [
+        {
+            "name": "coreos.com/rkt/stage1/run",
+            "value": "/init"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/enter",
+            "value": "/enter"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/gc",
+            "value": "/gc"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/flavor",
+            "value": "coreos"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/nspawn",
+            "value": "/usr/bin/systemd-nspawn"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/systemdversion",
+            "value": "v215"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/ld.so",
+            "value": "/usr/lib/ld-linux-x86-64.so.2"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/ld-path",
+            "value": "/usr/lib"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/shim",
+            "value": "/fakesdboot.so"
+        }
+    ]
+}

--- a/stage1/rootfs/usr_from_coreos/install
+++ b/stage1/rootfs/usr_from_coreos/install
@@ -1,4 +1,2 @@
 mkdir -p "$ROOT"
 cp -a ../usr_from_coreos/rootfs/. "$ROOT"
-ln -sf "coreos" "$ROOT/flavor"
-echo "v215" > "$ROOT/systemd-version"

--- a/stage1/rootfs/usr_from_host/Makefile
+++ b/stage1/rootfs/usr_from_host/Makefile
@@ -2,7 +2,6 @@
 
 usr.done install: Makefile
 	echo mkdir -p "\$${ROOT}" > install.tmp
-	echo ln -sf usr-from-host \"\$${ROOT}/flavor\" >> install.tmp
 	mv install.tmp install
 	cp -f install ../aggregate/install.d/00usr
 	touch usr.done

--- a/stage1/rootfs/usr_from_host/aci-manifest
+++ b/stage1/rootfs/usr_from_host/aci-manifest
@@ -28,6 +28,10 @@
         {
             "name": "coreos.com/rkt/stage1/gc",
             "value": "/gc"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/flavor",
+            "value": "usr-from-host"
         }
     ]
 }

--- a/stage1/rootfs/usr_from_src/Makefile
+++ b/stage1/rootfs/usr_from_src/Makefile
@@ -3,7 +3,7 @@
 # make needs to use bash for nullglob
 SHELL := /bin/bash
 
-usr.done: Makefile install
+usr.done: Makefile aci-manifest install
 	cp -f install ../aggregate/install.d/00usr
 	touch usr.done
 
@@ -12,9 +12,11 @@ install: Makefile host_deps.txt
 	echo mkdir -p "\$${ROOT}" > install.tmp
 	echo cp -af ../usr_from_src/systemd_build/installed/. \"\$${ROOT}\" >> install.tmp
 	cat host_deps.txt | while read dep; do echo install -D \"$${dep}\" \"\$${ROOT}/$${dep}\"; done >> install.tmp
-	echo ln -sf src \"\$${ROOT}/flavor\" >> install.tmp
 	echo "echo $(RKT_STAGE1_SYSTEMD_VER) > \"\$${ROOT}/systemd-version\"" >> install.tmp
 	mv install.tmp install
+
+aci-manifest: aci-manifest.in
+	sed 's|#SYSTEMD_VERSION#|$(RKT_STAGE1_SYSTEMD_VER)|' aci-manifest.in > aci-manifest
 
 # discover host library dependencies for all the ELF executables in systemd_build/installed, note the LD_LIBRARY_PATH= to find systemd-produced libraries.
 host_deps.txt: Makefile systemd.done bash.done
@@ -109,7 +111,7 @@ systemd.src: Makefile patches/*
 
 .PHONY: clean distclean
 clean:
-	rm -Rf systemd_build systemd.done bash.done host_deps.txt rootfs usr.done install
+	rm -Rf systemd_build systemd.done bash.done host_deps.txt rootfs usr.done install aci-manifest.in
 
 distclean: clean
 	rm -Rf systemd systemd.src

--- a/stage1/rootfs/usr_from_src/aci-manifest.in
+++ b/stage1/rootfs/usr_from_src/aci-manifest.in
@@ -1,0 +1,45 @@
+{
+    "acKind": "ImageManifest",
+    "acVersion": "0.5.2",
+    "name": "coreos.com/rkt/stage1",
+    "labels": [
+        {
+            "name": "version",
+            "value": "0.0.1"
+        },
+        {
+            "name": "arch",
+            "value": "amd64"
+        },
+        {
+            "name": "os",
+            "value": "linux"
+        }
+    ],
+    "annotations": [
+        {
+            "name": "coreos.com/rkt/stage1/run",
+            "value": "/init"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/enter",
+            "value": "/enter"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/gc",
+            "value": "/gc"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/flavor",
+            "value": "src"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/nspawn",
+            "value": "/usr/bin/systemd-nspawn"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/systemdversion",
+            "value": "#SYSTEMD_VERSION#"
+        }
+    ]
+}

--- a/tests/test
+++ b/tests/test
@@ -24,7 +24,7 @@ if [ $(basename $(sudo readlink /proc/1/exe)) == systemd ] ; then
 fi
 
 STAGE1_SRC_FROM_HOST=0
-if tar tvf ../bin/stage1.aci rootfs/flavor|grep -q usr-from-host ; then
+if tar xOvf ../bin/stage1.aci manifest|grep -q usr-from-host ; then
 	STAGE1_SRC_FROM_HOST=1
 fi
 


### PR DESCRIPTION
Refactor stage1/init to source most of options from manifest rather than flavor/stampfile-based.

This refactor will make it easier to integrate lkvm support, and also
brings other benefits.

Specifically, with this refactor almost all functionality of stage1
init is flavor independent and can be fully controlled via a manifest
and uses as little hard coded paths as possible.

Thus, e.g. distribution packagers, can create package which will only
have rkt/stage1 provided binaries (gc, waiter, init, etc.) and specify
the rest of things in the manifest (path to nspawn, ld.so, LD LIBRARY
PATH, libfakesdbooted.so, etc). And create fully free-standing
stage1.aci by simply creating basic distribution chroot with
distro-native tools and supplying a matching/correct aci-manifest. By
fully free-standing, I mean similar to current coreos flavor, which is
completely independent of the host OS binaries & load paths and is
truly run everywhere.

Many of these refactors will be useful for future lkvm integration,
e.g. reusing ld.so load paths and similar.