### PR TITLE
Functional tests: do not restrict to Semaphore

### DIFF
--- a/test
+++ b/test
@@ -100,14 +100,10 @@ go test -timeout 60s ${COVER} $@ ${TEST} --race
 
 # Functional tests use 'sudo' to run as root - it's more dangerous
 # than unit tests and may require typing a password. Only run them
-# inside well-known CI systems.
-if [ "$CI" == true -a -e bin/stage1.aci ] ; then
-	if [ "${CIRCLECI}" == true -o "${SEMAPHORE}" == true ] ; then
-		echo "Checking functional tests..."
-		(cd tests && ./test)
-	else
-		echo "Functional tests disabled."
-	fi
+# inside CI systems that opts-in with $RKT_ENABLE_FUNCTIONAL_TESTS=true.
+if [ "$CI" == true -a "${RKT_ENABLE_FUNCTIONAL_TESTS}" == true -a -e bin/stage1.aci ] ; then
+	echo "Checking functional tests..."
+	(cd tests && ./test)
 else
 	echo "Functional tests disabled."
 fi

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,7 +30,7 @@ Select `Ubuntu 14.04 LTS v1503 (beta with Docker support)`.
 ### Environment variables
 
 ```
-RKT_STAGE1_USR_FROM=src
+RKT_ENABLE_FUNCTIONAL_TESTS=true
 ```
 
 ## CircleCI


### PR DESCRIPTION
The functional tests are already guarded by $CI, no need to restrict to
SemaphoreCI and CircleCI. I will need this change for Jenkins.