### PR TITLE
functional tests: cpu isolator test

### DIFF
--- a/stage1/init/cgroup.go
+++ b/stage1/init/cgroup.go
@@ -166,8 +166,11 @@ func getOwnCgroupPath(controller string) (string, error) {
 		if len(parts) < 3 {
 			return "", fmt.Errorf("error parsing /proc/self/cgroup")
 		}
-		if parts[1] == controller {
-			return parts[2], nil
+		controllerParts := strings.Split(parts[1], ",")
+		for _, c := range controllerParts {
+			if c == controller {
+				return parts[2], nil
+			}
 		}
 	}
 

--- a/tests/inspect/inspect.go
+++ b/tests/inspect/inspect.go
@@ -213,8 +213,11 @@ func getOwnCgroupPath(controller string) (string, error) {
 		if len(parts) < 3 {
 			return "", fmt.Errorf("error parsing /proc/self/cgroup")
 		}
-		if parts[1] == controller {
-			return parts[2], nil
+		controllerParts := strings.Split(parts[1], ",")
+		for _, c := range controllerParts {
+			if c == controller {
+				return parts[2], nil
+			}
 		}
 	}
 

--- a/tests/rkt_app_isolator_test.go
+++ b/tests/rkt_app_isolator_test.go
@@ -28,6 +28,7 @@ import (
 const (
 	// if you change this you need to change tests/image/manifest accordingly
 	maxMemoryUsage = 25 * 1024 * 1024 // 25MB
+	CPUQuota       = 100              // milli-cores
 )
 
 var memoryTest = struct {
@@ -37,6 +38,16 @@ var memoryTest = struct {
 }{
 	`Check memory isolator`,
 	[]string{"--exec=/inspect --print-memorylimit"},
+	`--insecure-skip-verify run rkt-inspect-isolators.aci`,
+}
+
+var cpuTest = struct {
+	testName     string
+	aciBuildArgs []string
+	rktArgs      string
+}{
+	`Check CPU quota`,
+	[]string{"--exec=/inspect --print-cpuquota"},
 	`--insecure-skip-verify run rkt-inspect-isolators.aci`,
 }
 
@@ -97,4 +108,40 @@ func TestAppIsolatorMemory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("rkt didn't terminate correctly: %v", err)
 	}
+}
+
+func TestAppIsolatorCPU(t *testing.T) {
+	ok, err := isControllerEnabled("cpu")
+	if err != nil {
+		t.Fatalf("Error checking if the cpu cgroup controller is enabled: %v", err)
+	}
+	if !ok {
+		t.Skip("CPU cgroup controller disabled.")
+	}
+
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
+
+	t.Logf("Running test: %v", cpuTest.testName)
+
+	aciFileName := "rkt-inspect-isolators.aci"
+	patchTestACI(aciFileName, cpuTest.aciBuildArgs...)
+	defer os.Remove(aciFileName)
+
+	rktCmd := fmt.Sprintf("%s %s", ctx.cmd(), cpuTest.rktArgs)
+	t.Logf("Command: %v", rktCmd)
+	child, err := gexpect.Spawn(rktCmd)
+	if err != nil {
+		t.Fatalf("Cannot exec rkt: %v", err)
+	}
+	expectedLine := "CPU Quota: " + strconv.Itoa(CPUQuota)
+	if err := expectWithOutput(child, expectedLine); err != nil {
+		t.Fatalf("Didn't receive expected output %q: %v", expectedLine, err)
+	}
+
+	err = child.Wait()
+	if err != nil {
+		t.Fatalf("rkt didn't terminate correctly: %v", err)
+	}
+
 }

--- a/tests/rkt_app_isolator_test.go
+++ b/tests/rkt_app_isolator_test.go
@@ -53,8 +53,11 @@ func isControllerEnabled(controller string) (bool, error) {
 		if len(parts) < 2 {
 			return false, fmt.Errorf("error parsing /proc/1/cgroup")
 		}
-		if parts[1] == controller {
-			return true, nil
+		controllerParts := strings.Split(parts[1], ",")
+		for _, c := range controllerParts {
+			if c == controller {
+				return true, nil
+			}
 		}
 	}
 

--- a/tests/rkt_app_isolator_test.go
+++ b/tests/rkt_app_isolator_test.go
@@ -35,7 +35,7 @@ var memoryTest = struct {
 	aciBuildArgs []string
 	rktArgs      string
 }{
-	`Check memory isolator 25MB`,
+	`Check memory isolator`,
 	[]string{"--exec=/inspect --print-memorylimit"},
 	`--insecure-skip-verify run rkt-inspect-isolators.aci`,
 }


### PR DESCRIPTION
This test checks that the cpu isolator is applied by reading the values
cpu.cfs_period_us and cpu.cfs_quota_us of the process cgroup knob and
converting them to milli-cores.