### PR TITLE
common: move cgroup.go from stage1/init to common/cgroup

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -116,18 +116,18 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/go-systemd/dbus",
-			"Comment": "v2-55-gd7b0894",
-			"Rev": "d7b08942d0d85bfcb4694864881c4af7324784d2"
+			"Comment": "v2-57-gbe94bc7",
+			"Rev": "be94bc700879ae8217780e9d141789a2defa302b"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-systemd/unit",
-			"Comment": "v2-55-gd7b0894",
-			"Rev": "d7b08942d0d85bfcb4694864881c4af7324784d2"
+			"Comment": "v2-57-gbe94bc7",
+			"Rev": "be94bc700879ae8217780e9d141789a2defa302b"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-systemd/util",
-			"Comment": "v2-55-gd7b0894",
-			"Rev": "d7b08942d0d85bfcb4694864881c4af7324784d2"
+			"Comment": "v2-57-gbe94bc7",
+			"Rev": "be94bc700879ae8217780e9d141789a2defa302b"
 		},
 		{
 			"ImportPath": "github.com/coreos/ioprogress",

--- a/Godeps/_workspace/src/github.com/coreos/go-systemd/unit/option.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-systemd/unit/option.go
@@ -24,6 +24,10 @@ type UnitOption struct {
 	Value   string
 }
 
+func NewUnitOption(section, name, value string) *UnitOption {
+	return &UnitOption{Section: section, Name: name, Value: value}
+}
+
 func (uo *UnitOption) String() string {
 	return fmt.Sprintf("{Section: %q, Name: %q, Value: %q}", uo.Section, uo.Name, uo.Value)
 }

--- a/common/cgroup/cgroup.go
+++ b/common/cgroup/cgroup.go
@@ -60,7 +60,7 @@ func addMemoryLimit(opts []*unit.UnitOption, limit string) ([]*unit.UnitOption, 
 
 func MaybeAddIsolator(opts []*unit.UnitOption, isolator string, limit string) ([]*unit.UnitOption, error) {
 	var err error
-	if isIsolatorSupported(isolator) {
+	if IsIsolatorSupported(isolator) {
 		opts, err = isolatorFuncs[isolator](opts, limit)
 		if err != nil {
 			return nil, err
@@ -71,7 +71,8 @@ func MaybeAddIsolator(opts []*unit.UnitOption, isolator string, limit string) ([
 	return opts, nil
 }
 
-func isIsolatorSupported(isolator string) bool {
+// IsIsolatorSupported returns whether an isolator is supported in the kernel
+func IsIsolatorSupported(isolator string) bool {
 	if files, ok := cgroupControllerRWFiles[isolator]; ok {
 		for _, f := range files {
 			isolatorPath := filepath.Join("/sys/fs/cgroup/", isolator, f)

--- a/common/cgroup/cgroup.go
+++ b/common/cgroup/cgroup.go
@@ -14,7 +14,7 @@
 
 //+build linux
 
-package main
+package cgroup
 
 import (
 	"bufio"
@@ -49,16 +49,16 @@ func addCpuLimit(opts []*unit.UnitOption, limit string) ([]*unit.UnitOption, err
 		return nil, err
 	}
 	quota := strconv.Itoa(milliCores/10) + "%"
-	opts = append(opts, newUnitOption("Service", "CPUQuota", quota))
+	opts = append(opts, unit.NewUnitOption("Service", "CPUQuota", quota))
 	return opts, nil
 }
 
 func addMemoryLimit(opts []*unit.UnitOption, limit string) ([]*unit.UnitOption, error) {
-	opts = append(opts, newUnitOption("Service", "MemoryLimit", limit))
+	opts = append(opts, unit.NewUnitOption("Service", "MemoryLimit", limit))
 	return opts, nil
 }
 
-func maybeAddIsolator(opts []*unit.UnitOption, isolator string, limit string) ([]*unit.UnitOption, error) {
+func MaybeAddIsolator(opts []*unit.UnitOption, isolator string, limit string) ([]*unit.UnitOption, error) {
 	var err error
 	if isIsolatorSupported(isolator) {
 		opts, err = isolatorFuncs[isolator](opts, limit)
@@ -152,11 +152,11 @@ func getControllerRWFiles(controller string) []string {
 	return nil
 }
 
-func getOwnCgroupPath(controller string) (string, error) {
-	selfCgroupPath := "/proc/self/cgroup"
-	cg, err := os.Open(selfCgroupPath)
+func parseOwnCgroupController(controller string) ([]string, error) {
+	cgroupPath := "/proc/self/cgroup"
+	cg, err := os.Open(cgroupPath)
 	if err != nil {
-		return "", fmt.Errorf("error opening /proc/self/cgroup: %v", err)
+		return nil, fmt.Errorf("error opening /proc/self/cgroup: %v", err)
 	}
 	defer cg.Close()
 
@@ -164,23 +164,33 @@ func getOwnCgroupPath(controller string) (string, error) {
 	for s.Scan() {
 		parts := strings.SplitN(s.Text(), ":", 3)
 		if len(parts) < 3 {
-			return "", fmt.Errorf("error parsing /proc/self/cgroup")
+			return nil, fmt.Errorf("error parsing /proc/self/cgroup")
 		}
 		controllerParts := strings.Split(parts[1], ",")
 		for _, c := range controllerParts {
 			if c == controller {
-				return parts[2], nil
+				return parts, nil
 			}
 		}
 	}
 
-	return "", fmt.Errorf("controller %q not found", controller)
+	return nil, fmt.Errorf("controller %q not found", controller)
 }
 
-// createCgroups mounts the cgroup controllers hierarchy for the container but
+// GetOwnCgroupPath returns the cgroup path of this process in controller
+// hierarchy
+func GetOwnCgroupPath(controller string) (string, error) {
+	parts, err := parseOwnCgroupController(controller)
+	if err != nil {
+		return "", err
+	}
+	return parts[2], nil
+}
+
+// CreateCgroups mounts the cgroup controllers hierarchy for the container but
 // leaves the subcgroup for each app read-write so the systemd inside stage1
 // can apply isolators to them
-func createCgroups(root string, subcgroup string, appHashes []types.Hash) error {
+func CreateCgroups(root string, subcgroup string, appHashes []types.Hash) error {
 	cgroupsFile, err := os.Open("/proc/cgroups")
 	if err != nil {
 		return err
@@ -245,7 +255,8 @@ func createCgroups(root string, subcgroup string, appHashes []types.Hash) error 
 		// 3c. Create cgroup directories and mount the files we need over
 		// themselves so they stay read-write
 		for _, a := range appHashes {
-			serviceName := ServiceUnitName(a)
+			serviceName := types.ShortHash(a.String()) + ".service"
+
 			appCgroup := filepath.Join(subcgroupPath, serviceName)
 			if err := os.MkdirAll(appCgroup, 0755); err != nil {
 				return err

--- a/common/cgroup/cgroup_test.go
+++ b/common/cgroup/cgroup_test.go
@@ -14,7 +14,7 @@
 
 //+build linux
 
-package main
+package cgroup
 
 import (
 	"io"

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -73,6 +73,7 @@ import (
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/godbus/dbus/introspect"
 
 	"github.com/coreos/rkt/common"
+	"github.com/coreos/rkt/common/cgroup"
 	"github.com/coreos/rkt/networking"
 	"github.com/coreos/rkt/pkg/sys"
 )
@@ -485,7 +486,7 @@ func stage1() int {
 	machineID := p.GetMachineID()
 	subcgroup, err := getContainerSubCgroup(machineID)
 	if err == nil {
-		if err := createCgroups(s1Root, subcgroup, appHashes); err != nil {
+		if err := cgroup.CreateCgroups(s1Root, subcgroup, appHashes); err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating cgroups: %v\n", err)
 			return 5
 		}
@@ -564,7 +565,7 @@ func getContainerSubCgroup(machineID string) (string, error) {
 		} else {
 			// when registration is disabled the container will be directly
 			// under rkt's cgroup so we can look it up in /proc/self/cgroup
-			ownCgroupPath, err := getOwnCgroupPath("name=systemd")
+			ownCgroupPath, err := cgroup.GetOwnCgroupPath("name=systemd")
 			if err != nil {
 				return "", fmt.Errorf("error getting own cgroup path: %v", err)
 			}

--- a/tests/build
+++ b/tests/build
@@ -10,7 +10,7 @@ fi
 mkdir image/rootfs
 
 # Populate rootfs
-(cd inspect && go build)
+(cd inspect && CGO_ENABLED=0 go build -a -installsuffix cgo)
 cp inspect/inspect image/rootfs/
 mkdir image/rootfs/dir{1,2}
 echo -n dir1 > image/rootfs/dir1/file

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -41,7 +41,7 @@
                 "name": "resource/cpu",
                 "value": {
                     "request": "50",
-                    "limit": "100"
+                    "limit": "800"
                 }
             }
         ],

--- a/tests/rkt_app_isolator_test.go
+++ b/tests/rkt_app_isolator_test.go
@@ -27,7 +27,7 @@ import (
 const (
 	// if you change this you need to change tests/image/manifest accordingly
 	maxMemoryUsage = 25 * 1024 * 1024 // 25MB
-	CPUQuota       = 100              // milli-cores
+	CPUQuota       = 800              // milli-cores
 )
 
 var memoryTest = struct {


### PR DESCRIPTION
This allows sharing functions between stage1 and the functional tests.

Depends on coreos/go-systemd#91 and #1036 