### PR TITLE
rkt: initial user namespace support test by doing the uidshift at extract time

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -34,9 +34,10 @@ const (
 	stage1Dir = "/stage1"
 	stage2Dir = "/opt/stage2"
 
-	EnvLockFd               = "RKT_LOCK_FD"
-	Stage1IDFilename        = "stage1ID"
-	OverlayPreparedFilename = "overlay-prepared"
+	EnvLockFd                    = "RKT_LOCK_FD"
+	Stage1IDFilename             = "stage1ID"
+	OverlayPreparedFilename      = "overlay-prepared"
+	PrivateUsersPreparedFilename = "private-users-prepared"
 
 	MetadataServicePort    = 2375
 	MetadataServiceRegSock = "/run/rkt/metadata-svc.sock"

--- a/common/common.go
+++ b/common/common.go
@@ -133,6 +133,15 @@ func SupportsOverlay() bool {
 	return false
 }
 
+// SupportsUserNS returns whether the kernel has CONFIG_USER_NS set
+func SupportsUserNS() bool {
+	if _, err := os.Stat("/proc/self/uid_map"); os.IsNotExist(err) {
+		return false
+	}
+
+	return true
+}
+
 // PrivateNetList implements the flag.Value interface to allow specification
 // of -private-net with and without values
 type PrivateNetList struct {

--- a/pkg/aci/render.go
+++ b/pkg/aci/render.go
@@ -25,32 +25,32 @@ import (
 
 // Given an imageID, start with the matching image available in the store,
 // build its dependency list and render it inside dir
-func RenderACIWithImageID(imageID types.Hash, dir string, ap acirenderer.ACIRegistry) error {
+func RenderACIWithImageID(imageID types.Hash, dir string, ap acirenderer.ACIRegistry, uidShift uint64, uidCount uint64) error {
 	renderedACI, err := acirenderer.GetRenderedACIWithImageID(imageID, ap)
 	if err != nil {
 		return err
 	}
-	return renderImage(renderedACI, dir, ap)
+	return renderImage(renderedACI, dir, ap, uidShift, uidCount)
 }
 
 // Given an image app name and optional labels, get the best matching image
 // available in the store, build its dependency list and render it inside dir
-func RenderACI(name types.ACIdentifier, labels types.Labels, dir string, ap acirenderer.ACIRegistry) error {
+func RenderACI(name types.ACIdentifier, labels types.Labels, dir string, ap acirenderer.ACIRegistry, uidShift uint64, uidCount uint64) error {
 	renderedACI, err := acirenderer.GetRenderedACI(name, labels, ap)
 	if err != nil {
 		return err
 	}
-	return renderImage(renderedACI, dir, ap)
+	return renderImage(renderedACI, dir, ap, uidShift, uidCount)
 }
 
 // Given an already populated dependency list, it will extract, under the provided
 // directory, the rendered ACI
-func RenderACIFromList(imgs acirenderer.Images, dir string, ap acirenderer.ACIProvider) error {
+func RenderACIFromList(imgs acirenderer.Images, dir string, ap acirenderer.ACIProvider, uidShift uint64, uidCount uint64) error {
 	renderedACI, err := acirenderer.GetRenderedACIFromList(imgs, ap)
 	if err != nil {
 		return err
 	}
-	return renderImage(renderedACI, dir, ap)
+	return renderImage(renderedACI, dir, ap, uidShift, uidCount)
 }
 
 // Given a RenderedACI, it will extract, under the provided directory, the
@@ -58,7 +58,7 @@ func RenderACIFromList(imgs acirenderer.Images, dir string, ap acirenderer.ACIPr
 // The manifest will be extracted from the upper ACI.
 // No file overwriting is done as it should usually be called
 // providing an empty directory.
-func renderImage(renderedACI acirenderer.RenderedACI, dir string, ap acirenderer.ACIProvider) error {
+func renderImage(renderedACI acirenderer.RenderedACI, dir string, ap acirenderer.ACIProvider, uidShift uint64, uidCount uint64) error {
 	for _, ra := range renderedACI {
 		rs, err := ap.ReadStream(ra.Key)
 		if err != nil {
@@ -66,7 +66,7 @@ func renderImage(renderedACI acirenderer.RenderedACI, dir string, ap acirenderer
 		}
 
 		// Overwrite is not needed. If a file needs to be overwritten then the renderedACI builder has a bug
-		if err := ptar.ExtractTar(rs, dir, false, ra.FileMap); err != nil {
+		if err := ptar.ExtractTar(rs, dir, false, uidShift, uidCount, ra.FileMap); err != nil {
 			rs.Close()
 			return fmt.Errorf("error extracting ACI: %v", err)
 		}

--- a/pkg/tar/chroot.go
+++ b/pkg/tar/chroot.go
@@ -41,8 +41,8 @@ func init() {
 }
 
 func extractTarCommand() error {
-	if len(os.Args) != 3 {
-		return fmt.Errorf("incorrect number of arguments. Usage: %s DIR {true|false}", multicallName)
+	if len(os.Args) != 5 {
+		return fmt.Errorf("incorrect number of arguments. Usage: %s DIR {true|false} uidShift uidCount", multicallName)
 	}
 	if !sys.HasChrootCapability() {
 		return fmt.Errorf("chroot capability not available.")
@@ -54,6 +54,15 @@ func extractTarCommand() error {
 	overwrite, err := strconv.ParseBool(os.Args[2])
 	if err != nil {
 		return fmt.Errorf("error parsing overwrite argument: %v", err)
+	}
+
+	uidShift, err := strconv.ParseUint(os.Args[3], 10, 32)
+	if err != nil {
+		return fmt.Errorf("error parsing uidShift argument: %v", err)
+	}
+	uidCount, err := strconv.ParseUint(os.Args[4], 10, 32)
+	if err != nil {
+		return fmt.Errorf("error parsing uidShift argument: %v", err)
 	}
 
 	if err := syscall.Chroot(dir); err != nil {
@@ -68,7 +77,7 @@ func extractTarCommand() error {
 	if err := json.NewDecoder(fileMapFile).Decode(&fileMap); err != nil {
 		return fmt.Errorf("error decoding fileMap: %v", err)
 	}
-	if err := extractTar(tar.NewReader(os.Stdin), overwrite, fileMap); err != nil {
+	if err := extractTar(tar.NewReader(os.Stdin), overwrite, fileMap, uidShift, uidCount); err != nil {
 		return fmt.Errorf("error extracting tar: %v", err)
 	}
 
@@ -83,14 +92,16 @@ func extractTarCommand() error {
 // If overwrite is true, existing files will be overwritten.
 // The extraction is executed by fork/exec()ing a new process. The new process
 // needs the CAP_SYS_CHROOT capability.
-func ExtractTar(rs io.Reader, dir string, overwrite bool, pwl PathWhitelistMap) error {
+func ExtractTar(rs io.Reader, dir string, overwrite bool, uidShift uint64, uidCount uint64, pwl PathWhitelistMap) error {
 	r, w, err := os.Pipe()
 	if err != nil {
 		return err
 	}
 	defer w.Close()
 	enc := json.NewEncoder(w)
-	cmd := mcEntrypoint.Cmd(dir, strconv.FormatBool(overwrite))
+	cmd := mcEntrypoint.Cmd(dir, strconv.FormatBool(overwrite),
+				strconv.FormatUint(uidShift, 10),
+				strconv.FormatUint(uidCount, 10))
 	cmd.ExtraFiles = []*os.File{r}
 
 	cmd.Stdin = rs

--- a/rkt/image_extract.go
+++ b/rkt/image_extract.go
@@ -120,7 +120,7 @@ func runImageExtract(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	if err := tar.ExtractTar(aci, extractDir, false, nil); err != nil {
+	if err := tar.ExtractTar(aci, extractDir, false, 0, 0, nil); err != nil {
 		stderr("image extract: error extracting ACI: %v", err)
 		return 1
 	}

--- a/rkt/image_extract.go
+++ b/rkt/image_extract.go
@@ -130,7 +130,7 @@ func runImageExtract(cmd *cobra.Command, args []string) (exit int) {
 		if err := os.Rename(rootfsDir, absOutputDir); err != nil {
 			if e, ok := err.(*os.LinkError); ok && e.Err == syscall.EXDEV {
 				// it's on a different device, fall back to copying
-				if err := fileutil.CopyTree(rootfsDir, absOutputDir); err != nil {
+				if err := fileutil.CopyTree(rootfsDir, absOutputDir, 0, 0); err != nil {
 					stderr("image extract: error copying ACI rootfs: %v", err)
 					return 1
 				}

--- a/rkt/image_render.go
+++ b/rkt/image_render.go
@@ -118,7 +118,7 @@ func runImageRender(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	cachedTreePath := s.GetTreeStoreRootFS(key)
-	if err := fileutil.CopyTree(cachedTreePath, rootfsOutDir); err != nil {
+	if err := fileutil.CopyTree(cachedTreePath, rootfsOutDir, 0, 0); err != nil {
 		stderr("image render: error copying ACI rootfs: %v", err)
 		return 1
 	}

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -55,6 +55,7 @@ func init() {
 	cmdPrepare.Flags().Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
 	cmdPrepare.Flags().BoolVar(&flagLocal, "local", false, "use only local images (do not discover or download from remote URLs)")
 	cmdPrepare.Flags().StringVar(&flagPodManifest, "pod-manifest", "", "the path to the pod manifest. If it's non-empty, then only '--quiet' and '--no-overlay' will have effects")
+	cmdPrepare.Flags().StringVar(&flagPrivateUsers, "private-users", "", "Run within user namespace. Can be set to [=UIDBASE[:NUIDS]]")
 
 	// Disable interspersed flags to stop parsing after the first non flag
 	// argument. This is need to permit to correctly handle
@@ -147,6 +148,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	pcfg := stage0.PrepareConfig{
 		CommonConfig: cfg,
 		UseOverlay:   !flagNoOverlay && common.SupportsOverlay(),
+		PrivateUsers: flagPrivateUsers,
 	}
 
 	if len(flagPodManifest) > 0 {

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -20,6 +20,9 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strconv"
+	"time"
+	"math/rand"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
@@ -55,7 +58,7 @@ func init() {
 	cmdPrepare.Flags().Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
 	cmdPrepare.Flags().BoolVar(&flagLocal, "local", false, "use only local images (do not discover or download from remote URLs)")
 	cmdPrepare.Flags().StringVar(&flagPodManifest, "pod-manifest", "", "the path to the pod manifest. If it's non-empty, then only '--quiet' and '--no-overlay' will have effects")
-	cmdPrepare.Flags().StringVar(&flagPrivateUsers, "private-users", "", "Run within user namespace. Can be set to [=UIDBASE[:NUIDS]]")
+	cmdPrepare.Flags().BoolVar(&flagPrivateUsers, "private-users", false, "Run within user namespaces.")
 
 	// Disable interspersed flags to stop parsing after the first non flag
 	// argument. This is need to permit to correctly handle
@@ -66,11 +69,18 @@ func init() {
 func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	var err error
 	origStdout := os.Stdout
+	var PrivateUsers string = ""
 	if flagQuiet {
 		if os.Stdout, err = os.Open("/dev/null"); err != nil {
 			stderr("prepare: unable to open /dev/null")
 			return 1
 		}
+	}
+
+	if flagPrivateUsers && common.SupportsUserNS() {
+		rand.Seed(time.Now().UnixNano())
+		uidshift := rand.Intn(0xffff)
+		PrivateUsers = strconv.Itoa(uidshift) + ":65536"
 	}
 
 	if err = parseApps(&rktApps, args, cmd.Flags(), true); err != nil {
@@ -148,7 +158,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	pcfg := stage0.PrepareConfig{
 		CommonConfig: cfg,
 		UseOverlay:   !flagNoOverlay && common.SupportsOverlay(),
-		PrivateUsers: flagPrivateUsers,
+		PrivateUsers: PrivateUsers,
 	}
 
 	if len(flagPodManifest) > 0 {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -47,17 +47,18 @@ which will instead be appended to the preceding image app's exec arguments.
 End the image arguments with a lone "---" to resume argument parsing.`,
 		Run: runWrapper(runRun),
 	}
-	flagStage1Image string
-	flagVolumes     volumeList
-	flagPorts       portList
-	flagPrivateNet  common.PrivateNetList
-	flagInheritEnv  bool
-	flagExplicitEnv envMap
-	flagInteractive bool
-	flagNoOverlay   bool
-	flagLocal       bool
-	flagPodManifest string
-	flagMDSRegister bool
+	flagStage1Image  string
+	flagVolumes      volumeList
+	flagPorts        portList
+	flagPrivateNet   common.PrivateNetList
+	flagPrivateUsers string
+	flagInheritEnv   bool
+	flagExplicitEnv  envMap
+	flagInteractive  bool
+	flagNoOverlay    bool
+	flagLocal        bool
+	flagPodManifest  string
+	flagMDSRegister  bool
 )
 
 func init() {
@@ -189,6 +190,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 	pcfg := stage0.PrepareConfig{
 		CommonConfig: cfg,
 		UseOverlay:   !flagNoOverlay && common.SupportsOverlay(),
+		PrivateUsers: flagPrivateUsers,
 	}
 
 	if len(flagPodManifest) > 0 {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -77,6 +77,7 @@ func init() {
 	cmdRun.Flags().Var(&flagPorts, "port", "ports to expose on the host (requires --private-net)")
 	cmdRun.Flags().Var(&flagPrivateNet, "private-net", "give pod a private network that defaults to the default network plus all user-configured networks. Can be limited to a comma-separated list of network names")
 	cmdRun.Flags().Lookup("private-net").NoOptDefVal = "all"
+	cmdRun.Flags().StringVar(&flagPrivateUsers, "private-users", "", "Run within user namespace. Can be set to [=UIDBASE[:NUIDS]]")
 	cmdRun.Flags().BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	cmdRun.Flags().BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
 	cmdRun.Flags().Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -379,7 +379,7 @@ func getArgsEnv(p *Pod, flavor string, debug bool) ([]string, []string, error) {
 	}
 
 	if len(PrivateUsers) > 0 {
-		args = append(args, " --private-users="+PrivateUsers)
+		args = append(args, "--private-users="+PrivateUsers)
 	}
 
 	keepUnit, err := isRunningFromUnitFile()

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -124,18 +124,20 @@ func mirrorLocalZoneInfo(root string) {
 }
 
 var (
-	debug       bool
-	privNet     common.PrivateNetList
-	interactive bool
-	mdsToken    string
-	localhostIP net.IP
-	localConfig string
+	debug        bool
+	privNet      common.PrivateNetList
+	interactive  bool
+	PrivateUsers string
+	mdsToken     string
+	localhostIP  net.IP
+	localConfig  string
 )
 
 func init() {
 	flag.BoolVar(&debug, "debug", false, "Run in debug mode")
 	flag.Var(&privNet, "private-net", "Setup private network")
 	flag.BoolVar(&interactive, "interactive", false, "The pod is interactive")
+	flag.StringVar(&PrivateUsers, "private-users", "", "Run within user namespace. Can be set to [=UIDBASE[:NUIDS]]")
 	flag.StringVar(&mdsToken, "mds-token", "", "MDS auth token")
 	flag.StringVar(&localConfig, "local-config", common.DefaultLocalConfigDir, "Local config path")
 	// this ensures that main runs only on main thread (thread group leader).
@@ -374,6 +376,10 @@ func getArgsEnv(p *Pod, flavor string, debug bool) ([]string, []string, error) {
 	if !debug {
 		args = append(args, "--quiet")             // silence most nspawn output (log_warning is currently not covered by this)
 		env = append(env, "SYSTEMD_LOG_LEVEL=err") // silence log_warning too
+	}
+
+	if len(PrivateUsers) > 0 {
+		args = append(args, " --private-users="+PrivateUsers)
 	}
 
 	keepUnit, err := isRunningFromUnitFile()

--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
@@ -333,7 +334,10 @@ func (p *Pod) writeEnvFile(env types.Environment, appName types.ACName) error {
 	for _, e := range env {
 		fmt.Fprintf(&ef, "%s=%s\000", e.Name, e.Value)
 	}
-	return ioutil.WriteFile(EnvFilePath(p.Root, appName), ef.Bytes(), 0644)
+	//TODO FIXME add a chown call here with the right uidshifts
+	syscall.Umask(0)
+	return ioutil.WriteFile(EnvFilePath(p.Root, appName), ef.Bytes(), 0666)
+	//return ioutil.WriteFile(EnvFilePath(p.Root, appName), ef.Bytes(), 0644)
 }
 
 // PodToSystemd creates the appropriate systemd service unit files for

--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -333,7 +333,7 @@ func (p *Pod) writeEnvFile(env types.Environment, appName types.ACName) error {
 	for _, e := range env {
 		fmt.Fprintf(&ef, "%s=%s\000", e.Name, e.Value)
 	}
-	return ioutil.WriteFile(EnvFilePath(p.Root, appName), ef.Bytes(), 0640)
+	return ioutil.WriteFile(EnvFilePath(p.Root, appName), ef.Bytes(), 0644)
 }
 
 // PodToSystemd creates the appropriate systemd service unit files for

--- a/store/backup.go
+++ b/store/backup.go
@@ -36,7 +36,7 @@ func createBackup(dbDir, backupsDir string, limit int) error {
 	if err := os.MkdirAll(backupsDir, defaultPathPerm); err != nil {
 		return err
 	}
-	if err := fileutil.CopyTree(dbDir, tmpBackupDir); err != nil {
+	if err := fileutil.CopyTree(dbDir, tmpBackupDir, 0, 0); err != nil {
 		return err
 	}
 	defer os.RemoveAll(tmpBackupDir)

--- a/store/store.go
+++ b/store/store.go
@@ -424,7 +424,7 @@ func (s Store) RenderTreeStore(key string, rebuild bool) error {
 	if err := s.treestore.Remove(key); err != nil {
 		return err
 	}
-	if err := s.treestore.Write(key, &s); err != nil {
+	if err := s.treestore.Write(key, &s, 0, 0); err != nil {
 		return err
 	}
 	return nil

--- a/store/tree.go
+++ b/store/tree.go
@@ -48,7 +48,7 @@ type TreeStore struct {
 // Write, to avoid having a rendered ACI with old stale files, requires that
 // the destination directory doesn't exist (usually Remove should be called
 // before Write)
-func (ts *TreeStore) Write(key string, s *Store) error {
+func (ts *TreeStore) Write(key string, s *Store, uidShift uint64, uidCount uint64) error {
 	treepath := filepath.Join(ts.path, key)
 	fi, _ := os.Stat(treepath)
 	if fi != nil {
@@ -61,7 +61,7 @@ func (ts *TreeStore) Write(key string, s *Store) error {
 	if err := os.MkdirAll(treepath, 0755); err != nil {
 		return fmt.Errorf("treestore: cannot create treestore directory %s: %v", treepath, err)
 	}
-	err = aci.RenderACIWithImageID(*imageID, treepath, s)
+	err = aci.RenderACIWithImageID(*imageID, treepath, s, uidShift, uidCount)
 	if err != nil {
 		return fmt.Errorf("treestore: cannot render aci: %v", err)
 	}


### PR DESCRIPTION
This is just a test PR to show some progress on the user namespaces feature.

The original issue can be found here "Investigating user namespaces" https://github.com/coreos/rkt/issues/986

This PR is using the uidshift at extract time method that is explained in https://github.com/coreos/rkt/issues/986.  This is only for testing so we can identify the blockers and other hidden problems, the uidbase and the uidrange are hardcoded to "10000:65536"


If you want to test it:

> $ sudo ./bin/rkt -debug -insecure-skip-verify run docker://busybox -interactive -no-overlay --private-users="10000:65536"
 
> rkt: fetching image from file:///home/tixxdz/code/endocode/rkt/bin/stage1.aci
> rkt: found image in local store, skipping fetching from docker://busybox
> 2015/06/10 15:42:04 Preparing stage1
> 2015/06/10 15:42:06 Loading image sha512-a4ddd6bfb5ebf9338b02887fa1b42d95617c678f1622ad46e14bac7ea28b7d0b
2015/06/10 15:42:06 Writing pod manifest
2015/06/10 15:42:06 Setting up stage1
2015/06/10 15:42:06 Wrote filesystem to /var/lib/rkt/pods/run/4f5c61ff-0d37-447b-af27-41d6627d4494
2015/06/10 15:42:06 Pivoting to filesystem /var/lib/rkt/pods/run/4f5c61ff-0d37-447b-af27-41d6627d4494
2015/06/10 15:42:06 Execing /init
Spawning container rkt-4f5c61ff-0d37-447b-af27-41d6627d4494 on /var/lib/rkt/pods/run/4f5c61ff-0d37-447b-af27-41d6627d4494/stage1/rootfs.
Press ^] three times within 1s to kill container.
Using user namespaces with base 10000 and range 65536.
systemd 220 running in system mode. (-PAM -AUDIT -SELINUX +IMA -APPARMOR -SMACK +SYSVINIT +UTMP -LIBCRYPTSETUP -GCRYPT -GNUTLS -ACL +XZ -LZ4 +SECCOMP -BLKID -ELFUTILS -KMOD -IDN)
Detected virtualization systemd-nspawn.
Detected architecture x86-64.
Running with unpopulated /etc.

> Welcome to Linux!

> Initializing machine ID from container UUID.
Failed to populate /etc with preset unit settings, ignoring: File exists
[  OK  ] Created slice Root Slice.
[  OK  ] Reached target rkt apps target.
[  OK  ] Created slice System Slice.
[  OK  ] Created slice system-prepare\x2dapp.slice.
         Starting Prepare minimum environment for chrooted applications...
[  OK  ] Started Graceful exit watcher.
         Starting Graceful exit watcher...
Failed to set up mount unit: Invalid argument
Failed to set up mount unit: Invalid argument
Failed to set up mount unit: Invalid argument
Failed to open directory /usr/etc/systemd/system/opt-stage2-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95-rootfs-sys-fs-cgroup-memory-machine.slice-machine\x2drkt\x2d4f5c61ff\x2d0d37\x2d447b\x2daf27\x2d41d6627d4494.scope-system.slice-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95.service-cgroup.procs.mount.wants: File name too long
Failed to open directory /usr/etc/systemd/system/opt-stage2-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95-rootfs-sys-fs-cgroup-memory-machine.slice-machine\x2drkt\x2d4f5c61ff\x2d0d37\x2d447b\x2daf27\x2d41d6627d4494.scope-system.slice-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95.service-cgroup.procs.mount.requires: File name too long
Failed to open directory /run/systemd/system/opt-stage2-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95-rootfs-sys-fs-cgroup-memory-machine.slice-machine\x2drkt\x2d4f5c61ff\x2d0d37\x2d447b\x2daf27\x2d41d6627d4494.scope-system.slice-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95.service-cgroup.procs.mount.wants: File name too long
Failed to open directory /run/systemd/system/opt-stage2-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95-rootfs-sys-fs-cgroup-memory-machine.slice-machine\x2drkt\x2d4f5c61ff\x2d0d37\x2d447b\x2daf27\x2d41d6627d4494.scope-system.slice-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95.service-cgroup.procs.mount.requires: File name too long
Failed to open directory /run/systemd/generator/opt-stage2-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95-rootfs-sys-fs-cgroup-memory-machine.slice-machine\x2drkt\x2d4f5c61ff\x2d0d37\x2d447b\x2daf27\x2d41d6627d4494.scope-system.slice-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95.service-cgroup.procs.mount.wants: File name too long
Failed to open directory /run/systemd/generator/opt-stage2-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95-rootfs-sys-fs-cgroup-memory-machine.slice-machine\x2drkt\x2d4f5c61ff\x2d0d37\x2d447b\x2daf27\x2d41d6627d4494.scope-system.slice-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95.service-cgroup.procs.mount.requires: File name too long
Failed to open directory /usr/lib/systemd/system/opt-stage2-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95-rootfs-sys-fs-cgroup-memory-machine.slice-machine\x2drkt\x2d4f5c61ff\x2d0d37\x2d447b\x2daf27\x2d41d6627d4494.scope-system.slice-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95.service-cgroup.procs.mount.wants: File name too long
Failed to open directory /usr/lib/systemd/system/opt-stage2-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95-rootfs-sys-fs-cgroup-memory-machine.slice-machine\x2drkt\x2d4f5c61ff\x2d0d37\x2d447b\x2daf27\x2d41d6627d4494.scope-system.slice-sha512\x2da4ddd6bfb5ebf9338b02887fa1b42d95.service-cgroup.procs.mount.requires: File name too long
[  OK  ] Started Prepare minimum environment for chrooted applications.

> Startup finished in 171ms.
> / #  cat /proc/self/uid_map 
         0      10000      65536
