### PR TITLE
Docs: Remove relative links

### DIFF
--- a/Documentation/app-container.md
+++ b/Documentation/app-container.md
@@ -6,7 +6,7 @@ rkt's native [image format](#aci) and [runtime environment](#pods) are those def
 
 ## ACI
 
-The image format defined by appc and used in rkt is the [_Application Container Image_][appc-aci], or ACI. An ACI is a simple tarball bundle of a rootfs (containing all the files needed to execute an application) and an _Image Manifest_, which defines things like default execution parameters and default resource constraints. ACIs can be built with tools like [`actool`](https://github.com/appc/spec#building-acis) or [`goaci`](https://github.com/appc/goaci). Docker images can be converted to ACI using [`docker2aci`](https://github.com/appc/docker2aci), although rkt will [do this automatically](running-docker-images.md).
+The image format defined by appc and used in rkt is the [_Application Container Image_][appc-aci], or ACI. An ACI is a simple tarball bundle of a rootfs (containing all the files needed to execute an application) and an _Image Manifest_, which defines things like default execution parameters and default resource constraints. ACIs can be built with tools like [`actool`](https://github.com/appc/spec#building-acis) or [`goaci`](https://github.com/appc/goaci). Docker images can be converted to ACI using [`docker2aci`](https://github.com/appc/docker2aci), although rkt will [do this automatically](https://github.com/coreos/rkt/blob/master/Documentation/running-docker-images.md).
 
 Most parameters defined in an image can be overridden at runtime by rkt. For example, the `rkt run` command allows users to supply custom exec arguments to an image.
 

--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -306,7 +306,7 @@ sudo ./rkt run --private-net coreos.com/etcd:v2.0.0
 
 ##### Other Networking Examples
 
-Additional networking modes and more examples can be found in the [networking documentation](networking.md)
+Additional networking modes and more examples can be found in the [networking documentation](https://github.com/coreos/rkt/blob/master/Documentation/networking.md)
 
 #### Use a Custom Stage 1
 
@@ -378,7 +378,7 @@ Work in progress. Please contribute!
 
 rkt has a built-in garbage collection command that is designed to be run periodically from a timer or cron job. Stopped pods are moved to the garbage and cleaned up during a subsequent garbage collection pass. Each `gc` pass removes any pods remaining in the garbage past the grace period. [Read more about the pod lifecycle][gc-docs].
 
-[gc-docs]: devel/pod-lifecycle.md#garbage-collection
+[gc-docs]: https://github.com/coreos/rkt/blob/master/Documentation/devel/pod-lifecycle.md#garbage-collection
 
 ```
 $ rkt gc --grace-period=30m0s

--- a/Documentation/devel/pod-lifecycle.md
+++ b/Documentation/devel/pod-lifecycle.md
@@ -2,7 +2,7 @@
 
 Throughout this document `$var` is used to refer to the directory `/var/lib/rkt/pods`, and `$uuid` refers to a pod's UUID e.g. "076292e6-54c4-4cc8-9fa7-679c5f7dcfd3".
 
-Due to rkt's [architecture](architecture.md) - and specifically its lack of any management daemon process - a combination of advisory file locking and atomic directory renames (via rename(2)) is used to represent and transition the basic pod states.
+Due to rkt's [architecture](https://github.com/coreos/rkt/blob/master/Documentation/architecture.md) - and specifically its lack of any management daemon process - a combination of advisory file locking and atomic directory renames (via rename(2)) is used to represent and transition the basic pod states.
 
 At times where a state must be reliably coupled to an executing process, that process is executed with an open file descriptor possessing an exclusive advisory lock on the respective pod's directory.  Should that process exit for any reason, its open file descriptors will automatically be closed by the kernel, implicitly unlocking the pod's directory in the process.  By attempting to acquire a shared non-blocking advisory lock on a pod directory we're able to poll for these process-bound states, additionally by employing a blocking acquisition mode we may reliably synchronize indirectly with the exit of such processes, effectively providing us with a wake-up event the moment such a state transitions.  For more information on advisory locks see the flock(2) man page.
 

--- a/Documentation/getting-started-guide.md
+++ b/Documentation/getting-started-guide.md
@@ -139,7 +139,7 @@ hello-0.0.1-linux-amd64.aci: valid app container image
 $ sudo rkt -insecure-skip-verify run hello-0.0.1-linux-amd64.aci
 ```
 
-Note that `-insecure-skip-verify` is required because, by default, rkt expects our signature to be signed. See the [Signing and Verification Guide](signing-and-verification-guide.md) for more details.
+Note that `-insecure-skip-verify` is required because, by default, rkt expects our signature to be signed. See the [Signing and Verification Guide](https://github.com/coreos/rkt/blob/master/Documentation/signing-and-verification-guide.md) for more details.
 
 At this point our hello app is running on port 5000 and ready to handle HTTP
 requests.

--- a/Documentation/getting-started-ubuntu-trusty.md
+++ b/Documentation/getting-started-ubuntu-trusty.md
@@ -24,7 +24,7 @@ cd rkt-v0.5.6
 
 ## Trust the CoreOS signing key
 
-This shows how to trust the CoreOS signing key using the [`rkt trust` command](commands.md#rkt-trust). 
+This shows how to trust the CoreOS signing key using the [`rkt trust` command](https://github.com/coreos/rkt/blob/master/Documentation/commands.md#rkt-trust). 
 
 ```
 ./rkt  trust  --prefix coreos.com/etcd
@@ -54,7 +54,7 @@ rkt: signature verified:
   sha512-91e98d7f1679a097c878203c9659f2a2
 ```
 
-For more on this and other ways to retrieve ACIs, check out the `rkt fetch` section of the [commands guide](commands.md#rkt-fetch).
+For more on this and other ways to retrieve ACIs, check out the `rkt fetch` section of the [commands guide](https://github.com/coreos/rkt/blob/master/Documentation/commands.md#rkt-fetch).
 
 
 ## Run the ACI
@@ -94,4 +94,4 @@ Finally, let's run the application we just retrieved:
 ```
 
 Congratulations! You've run your first application with rkt.
-For more on how to use rkt, check out the [commands guide](commands.md).
+For more on how to use rkt, check out the [commands guide](https://github.com/coreos/rkt/blob/master/Documentation/commands.md).

--- a/Documentation/networking.md
+++ b/Documentation/networking.md
@@ -156,6 +156,7 @@ Additional configuration fields:
 
 The following shows a more complex IPv6 example in combination with the ipvlan plugin. The gateway is configured for the default
 route, allowing the pod to access external networks via the ipvlan interface.
+
 ```json
 {
     "name": "ipv6-public",

--- a/Documentation/running-docker-images.md
+++ b/Documentation/running-docker-images.md
@@ -45,7 +45,7 @@ Downloading layer: f2fb89b0a711a7178528c7785d247ba3572924353b0d5e23e9b28f0518253
 4:M 19 Apr 06:09:02.375 * The server is now ready to accept connections on port 6379
 ```
 
-This behaves similarly to the Docker client: if no specific registry is named, the Docker Hub (https://index.docker.io/v1/) is used by default.
+This behaves similarly to the Docker client: if no specific registry is named, the [Docker Hub](https://index.docker.io/v1/) is used by default.
 
 As with Docker, alternative registries can be used by specifying the registry as part of the image reference.
 For example, the following command will fetch an nginx Docker image hosted on quay.io:


### PR DESCRIPTION
Rewriting these links to be absolute instead of relative. Doesn't change anything when browsing on Github but makes it easier to manipulate via regex for display on coreos.com