### PR TITLE
*.*: bump appc/spec to v0.6.0

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -65,7 +65,7 @@
 		},
 		{
 			"ImportPath": "github.com/appc/goaci/proj2aci",
-			"Rev": "f99814ac2ac967bc202afd1c923cde30a65811ed"
+			"Rev": "333820b419dc7930374b38e40660a45156a7b4c8"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/aci",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -57,11 +57,11 @@
 		},
 		{
 			"ImportPath": "github.com/appc/docker2aci/lib",
-			"Rev": "06ed1491dee087e5a83984239e8e11577d8a6131"
+			"Rev": "7261e05a82af26ad9f1f6bdcd9f2ae67d52cd986"
 		},
 		{
 			"ImportPath": "github.com/appc/docker2aci/tarball",
-			"Rev": "06ed1491dee087e5a83984239e8e11577d8a6131"
+			"Rev": "7261e05a82af26ad9f1f6bdcd9f2ae67d52cd986"
 		},
 		{
 			"ImportPath": "github.com/appc/goaci/proj2aci",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -69,38 +69,38 @@
 		},
 		{
 			"ImportPath": "github.com/appc/spec/aci",
-			"Comment": "v0.5.2",
-			"Rev": "1d31afed77b39d52145ffd368d4c62eef675cbdf"
+			"Comment": "v0.6.0",
+			"Rev": "d427c5c1c3c40eacb71605b389dfab941437a809"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/actool",
-			"Comment": "v0.5.2",
-			"Rev": "1d31afed77b39d52145ffd368d4c62eef675cbdf"
+			"Comment": "v0.6.0",
+			"Rev": "d427c5c1c3c40eacb71605b389dfab941437a809"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/discovery",
-			"Comment": "v0.5.2",
-			"Rev": "1d31afed77b39d52145ffd368d4c62eef675cbdf"
+			"Comment": "v0.6.0",
+			"Rev": "d427c5c1c3c40eacb71605b389dfab941437a809"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/acirenderer",
-			"Comment": "v0.5.2",
-			"Rev": "1d31afed77b39d52145ffd368d4c62eef675cbdf"
+			"Comment": "v0.6.0",
+			"Rev": "d427c5c1c3c40eacb71605b389dfab941437a809"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/device",
-			"Comment": "v0.5.2",
-			"Rev": "1d31afed77b39d52145ffd368d4c62eef675cbdf"
+			"Comment": "v0.6.0",
+			"Rev": "d427c5c1c3c40eacb71605b389dfab941437a809"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/tarheader",
-			"Comment": "v0.5.2",
-			"Rev": "1d31afed77b39d52145ffd368d4c62eef675cbdf"
+			"Comment": "v0.6.0",
+			"Rev": "d427c5c1c3c40eacb71605b389dfab941437a809"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/schema",
-			"Comment": "v0.5.2",
-			"Rev": "1d31afed77b39d52145ffd368d4c62eef675cbdf"
+			"Comment": "v0.6.0",
+			"Rev": "d427c5c1c3c40eacb71605b389dfab941437a809"
 		},
 		{
 			"ImportPath": "github.com/camlistore/lock",

--- a/Godeps/_workspace/src/github.com/appc/docker2aci/lib/common/common.go
+++ b/Godeps/_workspace/src/github.com/appc/docker2aci/lib/common/common.go
@@ -105,11 +105,11 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 		appURL = dockerURL.IndexURL + "/"
 	}
 	appURL += dockerURL.ImageName + "-" + layerData.ID
-	appURL, err := appctypes.SanitizeACName(appURL)
+	appURL, err := appctypes.SanitizeACIdentifier(appURL)
 	if err != nil {
 		return nil, err
 	}
-	name := appctypes.MustACName(appURL)
+	name := appctypes.MustACIdentifier(appURL)
 	genManifest.Name = *name
 
 	acVersion, err := appctypes.NewSemVer(schemaVersion)
@@ -126,20 +126,20 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 		annotations  appctypes.Annotations
 	)
 
-	layer := appctypes.MustACName("layer")
+	layer := appctypes.MustACIdentifier("layer")
 	labels = append(labels, appctypes.Label{Name: *layer, Value: layerData.ID})
 
 	tag := dockerURL.Tag
-	version := appctypes.MustACName("version")
+	version := appctypes.MustACIdentifier("version")
 	labels = append(labels, appctypes.Label{Name: *version, Value: tag})
 
 	if layerData.OS != "" {
-		os := appctypes.MustACName("os")
+		os := appctypes.MustACIdentifier("os")
 		labels = append(labels, appctypes.Label{Name: *os, Value: layerData.OS})
 		parentLabels = append(parentLabels, appctypes.Label{Name: *os, Value: layerData.OS})
 
 		if layerData.Architecture != "" {
-			arch := appctypes.MustACName("arch")
+			arch := appctypes.MustACIdentifier("arch")
 			parentLabels = append(parentLabels, appctypes.Label{Name: *arch, Value: layerData.Architecture})
 		}
 	}
@@ -154,7 +154,7 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 		annotations = append(annotations, appctypes.Annotation{Name: *createdKey, Value: layerData.Created.Format(time.RFC3339)})
 	}
 	if layerData.Comment != "" {
-		commentKey := appctypes.MustACName("docker/comment")
+		commentKey := appctypes.MustACName("docker-comment")
 		annotations = append(annotations, appctypes.Annotation{Name: *commentKey, Value: layerData.Comment})
 	}
 
@@ -193,14 +193,14 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 	}
 
 	if layerData.Parent != "" {
-		parentAppNameString := dockerURL.IndexURL + "/" + dockerURL.ImageName + "-" + layerData.Parent
-		parentAppNameString, err := appctypes.SanitizeACName(parentAppNameString)
+		parentImageNameString := dockerURL.IndexURL + "/" + dockerURL.ImageName + "-" + layerData.Parent
+		parentImageNameString, err := appctypes.SanitizeACIdentifier(parentImageNameString)
 		if err != nil {
 			return nil, err
 		}
-		parentAppName := appctypes.MustACName(parentAppNameString)
+		parentImageName := appctypes.MustACIdentifier(parentImageNameString)
 
-		genManifest.Dependencies = append(genManifest.Dependencies, appctypes.Dependency{App: *parentAppName, Labels: parentLabels})
+		genManifest.Dependencies = append(genManifest.Dependencies, appctypes.Dependency{ImageName: *parentImageName, Labels: parentLabels})
 	}
 
 	return genManifest, nil
@@ -247,8 +247,13 @@ func parseDockerPort(dockerPort string) (*appctypes.Port, error) {
 		return nil, fmt.Errorf("error parsing port %q: %v", portString, err)
 	}
 
+	sn, err := appctypes.SanitizeACName(dockerPort)
+	if err != nil {
+		return nil, err
+	}
+
 	appcPort := &appctypes.Port{
-		Name:     *appctypes.MustACName(dockerPort),
+		Name:     *appctypes.MustACName(sn),
 		Protocol: proto,
 		Port:     uint(port),
 	}
@@ -261,7 +266,7 @@ func convertVolumesToMPs(dockerVolumes map[string]struct{}) ([]appctypes.MountPo
 	dup := make(map[string]int)
 
 	for p := range dockerVolumes {
-		n := filepath.Join("volume-", p)
+		n := filepath.Join("volume", p)
 		sn, err := appctypes.SanitizeACName(n)
 		if err != nil {
 			return nil, err

--- a/Godeps/_workspace/src/github.com/appc/docker2aci/lib/conversion_store.go
+++ b/Godeps/_workspace/src/github.com/appc/docker2aci/lib/conversion_store.go
@@ -72,7 +72,7 @@ func (ms *ConversionStore) GetImageManifest(key string) (*schema.ImageManifest, 
 	return aci.ImageManifest, nil
 }
 
-func (ms *ConversionStore) GetACI(name types.ACName, labels types.Labels) (string, error) {
+func (ms *ConversionStore) GetACI(name types.ACIdentifier, labels types.Labels) (string, error) {
 	for _, aci := range ms.acis {
 		// we implement this function to comply with the interface so don't
 		// bother implementing a proper label check

--- a/Godeps/_workspace/src/github.com/appc/docker2aci/lib/docker2aci.go
+++ b/Godeps/_workspace/src/github.com/appc/docker2aci/lib/docker2aci.go
@@ -280,8 +280,7 @@ func mergeManifests(manifests []schema.ImageManifest) schema.ImageManifest {
 		manifest.Labels = append(manifest.Labels[:layerIndex], manifest.Labels[layerIndex+1:]...)
 	}
 
-	// this can't fail because the old name is legal
-	nameWithoutLayerID, _ := appctypes.NewACName(stripLayerID(manifest.Name.String()))
+	nameWithoutLayerID := appctypes.MustACIdentifier(stripLayerID(manifest.Name.String()))
 
 	manifest.Name = *nameWithoutLayerID
 

--- a/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/builder.go
+++ b/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/builder.go
@@ -49,7 +49,7 @@ type BuilderCustomizations interface {
 	PrepareProject() error
 	GetPlaceholderMapping() map[string]string
 	GetAssets(aciBinDir string) ([]string, error)
-	GetImageACName() (*types.ACName, error)
+	GetImageName() (*types.ACIdentifier, error)
 	GetBinaryName() (string, error)
 	GetRepoPath() (string, error)
 	GetImageFileName() (string, error)
@@ -239,7 +239,7 @@ func (cmd *Builder) copyAssets() error {
 }
 
 func (cmd *Builder) prepareManifest() error {
-	name, err := cmd.custom.GetImageACName()
+	name, err := cmd.custom.GetImageName()
 	if err != nil {
 		return err
 	}
@@ -300,7 +300,7 @@ func (cmd *Builder) getLabels() (types.Labels, error) {
 }
 
 func newLabel(name, value string) (*types.Label, error) {
-	acName, err := types.NewACName(name)
+	acName, err := types.NewACIdentifier(name)
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +322,7 @@ func (cmd *Builder) getVCSLabel() (*types.Label, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get VCS info: %v", err)
 	}
-	acname, err := types.NewACName(name)
+	acname, err := types.NewACIdentifier(name)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid VCS label: %v", err)
 	}

--- a/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/cmake.go
+++ b/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/cmake.go
@@ -182,15 +182,15 @@ func (custom *CmakeCustomizations) getBinDir() (string, error) {
 	return "", fmt.Errorf("Could not find any bin directory")
 }
 
-func (custom *CmakeCustomizations) GetImageACName() (*types.ACName, error) {
-	imageACName := custom.Configuration.Project
-	if filepath.Base(imageACName) == "..." {
-		imageACName = filepath.Dir(imageACName)
+func (custom *CmakeCustomizations) GetImageName() (*types.ACIdentifier, error) {
+	imageName := custom.Configuration.Project
+	if filepath.Base(imageName) == "..." {
+		imageName = filepath.Dir(imageName)
 		if custom.Configuration.UseBinary != "" {
-			imageACName += "-" + custom.Configuration.UseBinary
+			imageName += "-" + custom.Configuration.UseBinary
 		}
 	}
-	return types.NewACName(strings.ToLower(imageACName))
+	return types.NewACIdentifier(strings.ToLower(imageName))
 }
 
 func (custom *CmakeCustomizations) GetBinaryName() (string, error) {

--- a/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/go.go
+++ b/Godeps/_workspace/src/github.com/appc/goaci/proj2aci/go.go
@@ -148,15 +148,15 @@ func (custom *GoCustomizations) GetAssets(aciBinDir string) ([]string, error) {
 	return []string{GetAssetString(aciAsset, localAsset)}, nil
 }
 
-func (custom *GoCustomizations) GetImageACName() (*types.ACName, error) {
-	imageACName := custom.Configuration.Project
-	if filepath.Base(imageACName) == "..." {
-		imageACName = filepath.Dir(imageACName)
+func (custom *GoCustomizations) GetImageName() (*types.ACIdentifier, error) {
+	imageName := custom.Configuration.Project
+	if filepath.Base(imageName) == "..." {
+		imageName = filepath.Dir(imageName)
 		if custom.Configuration.UseBinary != "" {
-			imageACName += "-" + custom.Configuration.UseBinary
+			imageName += "-" + custom.Configuration.UseBinary
 		}
 	}
-	return types.NewACName(strings.ToLower(imageACName))
+	return types.NewACIdentifier(strings.ToLower(imageName))
 }
 
 func (custom *GoCustomizations) GetBinaryName() (string, error) {

--- a/Godeps/_workspace/src/github.com/appc/spec/aci/file_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/aci/file_test.go
@@ -14,7 +14,7 @@ func newTestACI(usedotslash bool) (*os.File, error) {
 		return nil, err
 	}
 
-	manifestBody := `{"acKind":"ImageManifest","acVersion":"0.5.2","name":"example.com/app"}`
+	manifestBody := `{"acKind":"ImageManifest","acVersion":"0.6.0","name":"example.com/app"}`
 
 	gw := gzip.NewWriter(tf)
 	tw := tar.NewWriter(gw)

--- a/Godeps/_workspace/src/github.com/appc/spec/actool/manifest.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/actool/manifest.go
@@ -86,7 +86,7 @@ func getIsolatorStr(name, value string) string {
 func patchManifest(im *schema.ImageManifest) error {
 
 	if patchName != "" {
-		name, err := types.NewACName(patchName)
+		name, err := types.NewACIdentifier(patchName)
 		if err != nil {
 			return err
 		}

--- a/Godeps/_workspace/src/github.com/appc/spec/discovery/discovery.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/discovery/discovery.go
@@ -110,6 +110,7 @@ func createTemplateVars(app App) []string {
 }
 
 func doDiscover(pre string, app App, insecure bool) (*Endpoints, error) {
+	app = *app.Copy()
 	if app.Labels["version"] == "" {
 		app.Labels["version"] = defaultVersion
 	}

--- a/Godeps/_workspace/src/github.com/appc/spec/discovery/discovery_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/discovery/discovery_test.go
@@ -67,7 +67,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			true,
 			App{
 				Name: "example.com/myapp",
-				Labels: map[types.ACName]string{
+				Labels: map[types.ACIdentifier]string{
 					"version": "1.0.0",
 					"os":      "linux",
 					"arch":    "amd64",
@@ -90,7 +90,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			true,
 			App{
 				Name: "example.com/myapp/foobar",
-				Labels: map[types.ACName]string{
+				Labels: map[types.ACIdentifier]string{
 					"version": "1.0.0",
 					"os":      "linux",
 					"arch":    "amd64",
@@ -113,7 +113,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			false,
 			App{
 				Name: "example.com/myapp/foobar/bazzer",
-				Labels: map[types.ACName]string{
+				Labels: map[types.ACIdentifier]string{
 					"version": "1.0.0",
 					"os":      "linux",
 					"arch":    "amd64",
@@ -130,7 +130,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			true,
 			App{
 				Name: "example.com/myapp",
-				Labels: map[types.ACName]string{
+				Labels: map[types.ACIdentifier]string{
 					"version": "1.0.0",
 				},
 			},
@@ -149,7 +149,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			false,
 			App{
 				Name:   "example.com/myapp",
-				Labels: map[types.ACName]string{},
+				Labels: map[types.ACIdentifier]string{},
 			},
 			[]ACIEndpoint{
 				ACIEndpoint{
@@ -165,7 +165,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 			false,
 			App{
 				Name: "example.com/myapp",
-				Labels: map[types.ACName]string{
+				Labels: map[types.ACIdentifier]string{
 					"name":    "labelcalledname",
 					"version": "1.0.0",
 				},
@@ -181,7 +181,7 @@ func TestDiscoverEndpoints(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		httpGet = tt.get
+		httpGet = &mockHttpGetter{getter: tt.get}
 		de, _, err := DiscoverEndpoints(tt.app, true)
 		if err != nil && !tt.expectDiscoverySuccess {
 			continue

--- a/Godeps/_workspace/src/github.com/appc/spec/discovery/http.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/discovery/http.go
@@ -14,10 +14,19 @@ const (
 )
 
 var (
-	// httpGet is the function used by discovery to retrieve URLs; it is
+	// Client is the default http.Client used for discovery requests.
+	Client *http.Client
+
+	// httpGet is the internal object used by discovery to retrieve URLs; it is
 	// defined here so it can be overridden for testing
-	httpGet func(url string) (resp *http.Response, err error)
+	httpGet httpGetter
 )
+
+// httpGetter is an interface used to wrap http.Client for real requests and
+// allow easy mocking in local tests.
+type httpGetter interface {
+	Get(url string) (resp *http.Response, err error)
+}
 
 func init() {
 	t := &http.Transport{
@@ -26,10 +35,10 @@ func init() {
 			return net.DialTimeout(n, a, defaultDialTimeout)
 		},
 	}
-	c := &http.Client{
+	Client = &http.Client{
 		Transport: t,
 	}
-	httpGet = c.Get
+	httpGet = Client
 }
 
 func httpsOrHTTP(name string, insecure bool) (urlStr string, body io.ReadCloser, err error) {
@@ -40,7 +49,7 @@ func httpsOrHTTP(name string, insecure bool) (urlStr string, body io.ReadCloser,
 		}
 		u.RawQuery = "ac-discovery=1"
 		urlStr = u.String()
-		res, err = httpGet(urlStr)
+		res, err = httpGet.Get(urlStr)
 		return
 	}
 	closeBody := func(res *http.Response) {

--- a/Godeps/_workspace/src/github.com/appc/spec/discovery/http_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/discovery/http_test.go
@@ -10,6 +10,15 @@ import (
 	"testing"
 )
 
+// mockHttpGetter defines a wrapper that allows returning a mocked response.
+type mockHttpGetter struct {
+	getter func(url string) (resp *http.Response, err error)
+}
+
+func (m *mockHttpGetter) Get(url string) (resp *http.Response, err error) {
+	return m.getter(url)
+}
+
 func fakeHttpOrHttpsGet(filename string, httpSuccess bool, httpsSuccess bool, httpErrorCode int) func(uri string) (*http.Response, error) {
 	return func(uri string) (*http.Response, error) {
 		f, err := os.Open(filename)
@@ -108,7 +117,7 @@ func TestHttpsOrHTTP(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		httpGet = tt.get
+		httpGet = &mockHttpGetter{getter: tt.get}
 		urlStr, body, err := httpsOrHTTP(tt.name, tt.insecure)
 		if tt.expectSuccess {
 			if err != nil {

--- a/Godeps/_workspace/src/github.com/appc/spec/discovery/parse.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/discovery/parse.go
@@ -9,15 +9,15 @@ import (
 )
 
 type App struct {
-	Name   types.ACName
-	Labels map[types.ACName]string
+	Name   types.ACIdentifier
+	Labels map[types.ACIdentifier]string
 }
 
-func NewApp(name string, labels map[types.ACName]string) (*App, error) {
+func NewApp(name string, labels map[types.ACIdentifier]string) (*App, error) {
 	if labels == nil {
-		labels = make(map[types.ACName]string, 0)
+		labels = make(map[types.ACIdentifier]string, 0)
 	}
-	acn, err := types.NewACName(name)
+	acn, err := types.NewACIdentifier(name)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func NewApp(name string, labels map[types.ACName]string) (*App, error) {
 func NewAppFromString(app string) (*App, error) {
 	var (
 		name   string
-		labels map[types.ACName]string
+		labels map[types.ACIdentifier]string
 	)
 
 	app = strings.Replace(app, ":", ",version=", -1)
@@ -44,7 +44,7 @@ func NewAppFromString(app string) (*App, error) {
 	if err != nil {
 		return nil, err
 	}
-	labels = make(map[types.ACName]string, 0)
+	labels = make(map[types.ACIdentifier]string, 0)
 	for key, val := range v {
 		if len(val) > 1 {
 			return nil, fmt.Errorf("label %s with multiple values %q", key, val)
@@ -53,7 +53,7 @@ func NewAppFromString(app string) (*App, error) {
 			name = val[0]
 			continue
 		}
-		labelName, err := types.NewACName(key)
+		labelName, err := types.NewACIdentifier(key)
 		if err != nil {
 			return nil, err
 		}
@@ -64,6 +64,17 @@ func NewAppFromString(app string) (*App, error) {
 		return nil, err
 	}
 	return a, nil
+}
+
+func (a *App) Copy() *App {
+	ac := &App{
+		Name:   a.Name,
+		Labels: make(map[types.ACIdentifier]string, 0),
+	}
+	for k, v := range a.Labels {
+		ac.Labels[k] = v
+	}
+	return ac
 }
 
 // String returns the URL-like image name

--- a/Godeps/_workspace/src/github.com/appc/spec/discovery/parse_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/discovery/parse_test.go
@@ -19,7 +19,7 @@ func TestNewAppFromString(t *testing.T) {
 
 			&App{
 				Name: "example.com/reduce-worker",
-				Labels: map[types.ACName]string{
+				Labels: map[types.ACIdentifier]string{
 					"version": "1.0.0",
 				},
 			},
@@ -30,7 +30,7 @@ func TestNewAppFromString(t *testing.T) {
 
 			&App{
 				Name: "example.com/reduce-worker",
-				Labels: map[types.ACName]string{
+				Labels: map[types.ACIdentifier]string{
 					"channel": "alpha",
 					"label":   "value",
 				},
@@ -83,14 +83,14 @@ func TestAppString(t *testing.T) {
 		{
 			&App{
 				Name:   "example.com/reduce-worker",
-				Labels: map[types.ACName]string{},
+				Labels: map[types.ACIdentifier]string{},
 			},
 			"example.com/reduce-worker",
 		},
 		{
 			&App{
 				Name: "example.com/reduce-worker",
-				Labels: map[types.ACName]string{
+				Labels: map[types.ACIdentifier]string{
 					"version": "1.0.0",
 				},
 			},
@@ -99,7 +99,7 @@ func TestAppString(t *testing.T) {
 		{
 			&App{
 				Name: "example.com/reduce-worker",
-				Labels: map[types.ACName]string{
+				Labels: map[types.ACIdentifier]string{
 					"channel": "alpha",
 					"label":   "value",
 				},
@@ -116,6 +116,46 @@ func TestAppString(t *testing.T) {
 		}
 		if !reflect.DeepEqual(g, tt.a) {
 			t.Errorf("#%d: got %#v, want %#v", i, g, tt.a)
+		}
+	}
+}
+
+func TestAppCopy(t *testing.T) {
+	tests := []struct {
+		a   *App
+		out string
+	}{
+		{
+			&App{
+				Name:   "example.com/reduce-worker",
+				Labels: map[types.ACIdentifier]string{},
+			},
+			"example.com/reduce-worker",
+		},
+		{
+			&App{
+				Name: "example.com/reduce-worker",
+				Labels: map[types.ACIdentifier]string{
+					"version": "1.0.0",
+				},
+			},
+			"example.com/reduce-worker:1.0.0",
+		},
+		{
+			&App{
+				Name: "example.com/reduce-worker",
+				Labels: map[types.ACIdentifier]string{
+					"channel": "alpha",
+					"label":   "value",
+				},
+			},
+			"example.com/reduce-worker,channel=alpha,label=value",
+		},
+	}
+	for i, tt := range tests {
+		appCopy := tt.a.Copy()
+		if !reflect.DeepEqual(appCopy, tt.a) {
+			t.Errorf("#%d: got %#v, want %#v", i, appCopy, tt.a)
 		}
 	}
 }

--- a/Godeps/_workspace/src/github.com/appc/spec/pkg/acirenderer/acirenderer.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/pkg/acirenderer/acirenderer.go
@@ -19,17 +19,17 @@ import (
 type ACIRegistry interface {
 	ACIProvider
 	GetImageManifest(key string) (*schema.ImageManifest, error)
-	GetACI(name types.ACName, labels types.Labels) (string, error)
+	GetACI(name types.ACIdentifier, labels types.Labels) (string, error)
 }
 
 // An ACIProvider provides functions to get an ACI contents, to convert an
 // ACI hash to the key under which the ACI is known to the provider and to resolve an
-// ImageID to the key under which it's known to the provider.
+// image ID to the key under which it's known to the provider.
 type ACIProvider interface {
 	// Read the ACI contents stream given the key. Use ResolveKey to
-	// convert an ImageID to the relative provider's key.
+	// convert an image ID to the relative provider's key.
 	ReadStream(key string) (io.ReadCloser, error)
-	// Converts an ImageID to the, if existent, key under which the
+	// Converts an image ID to the, if existent, key under which the
 	// ACI is known to the provider
 	ResolveKey(key string) (string, error)
 	// Converts a Hash to the provider's key
@@ -75,7 +75,7 @@ func GetRenderedACIWithImageID(imageID types.Hash, ap ACIRegistry) (RenderedACI,
 // GetRenderedACI, given an image app name and optional labels, starts with the
 // best matching image available in the store, creates the dependencies list
 // and returns the RenderedACI list.
-func GetRenderedACI(name types.ACName, labels types.Labels, ap ACIRegistry) (RenderedACI, error) {
+func GetRenderedACI(name types.ACIdentifier, labels types.Labels, ap ACIRegistry) (RenderedACI, error) {
 	imgs, err := CreateDepListFromNameLabels(name, labels, ap)
 	if err != nil {
 		return nil, err

--- a/Godeps/_workspace/src/github.com/appc/spec/pkg/acirenderer/acirenderer_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/pkg/acirenderer/acirenderer_test.go
@@ -264,8 +264,8 @@ func TestDirFromParent(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -359,8 +359,8 @@ func TestNewDir(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -453,8 +453,8 @@ func TestDirOverride(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -556,8 +556,8 @@ func TestFileFromParent(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -644,8 +644,8 @@ func TestNewFile(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -746,8 +746,8 @@ func TestFileOverride(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -863,8 +863,8 @@ func TestFileOvverideDir(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -1030,8 +1030,8 @@ func TestPWLOnlyParent(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -1211,8 +1211,8 @@ func TestPWLOnlyImage(t *testing.T) {
 	k1, _ := types.NewHash(key1)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 	)
 
 	entries = []*testTarEntry{
@@ -1412,11 +1412,11 @@ func Test2Deps1(t *testing.T) {
 	k2, _ := types.NewHash(key2)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 		types.Dependency{
-			App:     "example.com/test02",
-			ImageID: k2},
+			ImageName: "example.com/test02",
+			ImageID:   k2},
 	)
 
 	entries = []*testTarEntry{
@@ -1625,11 +1625,11 @@ func Test2Deps2(t *testing.T) {
 	k2, _ := types.NewHash(key2)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 		types.Dependency{
-			App:     "example.com/test02",
-			ImageID: k2},
+			ImageName: "example.com/test02",
+			ImageID:   k2},
 	)
 
 	entries = []*testTarEntry{
@@ -1845,8 +1845,8 @@ func Test3Deps(t *testing.T) {
 	k2, _ := types.NewHash(key2)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test03",
-			ImageID: k2},
+			ImageName: "example.com/test03",
+			ImageID:   k2},
 	)
 
 	entries = []*testTarEntry{
@@ -1905,11 +1905,11 @@ func Test3Deps(t *testing.T) {
 	k3, _ := types.NewHash(key3)
 	imj, err = addDependencies(imj,
 		types.Dependency{
-			App:     "example.com/test01",
-			ImageID: k1},
+			ImageName: "example.com/test01",
+			ImageID:   k1},
 		types.Dependency{
-			App:     "example.com/test02",
-			ImageID: k3},
+			ImageName: "example.com/test02",
+			ImageID:   k3},
 	)
 
 	entries = []*testTarEntry{
@@ -1978,7 +1978,7 @@ func Test3Deps(t *testing.T) {
 
 // Given an image app name and optional labels, get the best matching image
 // available in the store, build its dependency list and render it inside dir
-func RenderACI(name types.ACName, labels types.Labels, ap ACIRegistry) (map[string]*fileInfo, error) {
+func RenderACI(name types.ACIdentifier, labels types.Labels, ap ACIRegistry) (map[string]*fileInfo, error) {
 	renderedACI, err := GetRenderedACI(name, labels, ap)
 	if err != nil {
 		return nil, err
@@ -2039,7 +2039,7 @@ func renderImage(renderedACI RenderedACI, ap ACIProvider) (map[string]*fileInfo,
 	return files, nil
 }
 
-func checkRenderACI(app types.ACName, expectedFiles []*fileInfo, ds *TestStore) error {
+func checkRenderACI(app types.ACIdentifier, expectedFiles []*fileInfo, ds *TestStore) error {
 	files, err := RenderACI(app, nil, ds)
 	if err != nil {
 		return err

--- a/Godeps/_workspace/src/github.com/appc/spec/pkg/acirenderer/resolve.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/pkg/acirenderer/resolve.go
@@ -18,7 +18,7 @@ func CreateDepListFromImageID(imageID types.Hash, ap ACIRegistry) (Images, error
 
 // CreateDepListFromNameLabels returns the flat dependency tree of the image
 // with the provided app name and optional labels.
-func CreateDepListFromNameLabels(name types.ACName, labels types.Labels, ap ACIRegistry) (Images, error) {
+func CreateDepListFromNameLabels(name types.ACIdentifier, labels types.Labels, ap ACIRegistry) (Images, error) {
 	key, err := ap.GetACI(name, labels)
 	if err != nil {
 		return nil, err
@@ -52,7 +52,7 @@ func createDepList(key string, ap ACIRegistry) (Images, error) {
 				}
 			} else {
 				var err error
-				depKey, err = ap.GetACI(d.App, d.Labels)
+				depKey, err = ap.GetACI(d.ImageName, d.Labels)
 				if err != nil {
 					return nil, err
 				}

--- a/Godeps/_workspace/src/github.com/appc/spec/pkg/acirenderer/store_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/pkg/acirenderer/store_test.go
@@ -61,7 +61,7 @@ func (ts *TestStore) GetImageManifest(key string) (*schema.ImageManifest, error)
 	return aci.ImageManifest, nil
 
 }
-func (ts *TestStore) GetACI(name types.ACName, labels types.Labels) (string, error) {
+func (ts *TestStore) GetACI(name types.ACIdentifier, labels types.Labels) (string, error) {
 	for _, aci := range ts.acis {
 		if aci.ImageManifest.Name.String() == name.String() {
 			return aci.key, nil

--- a/Godeps/_workspace/src/github.com/appc/spec/pkg/tarheader/pop_posix.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/pkg/tarheader/pop_posix.go
@@ -22,8 +22,8 @@ func populateHeaderUnix(h *tar.Header, fi os.FileInfo, seen map[uint64]string) {
 	h.Uid = int(st.Uid)
 	h.Gid = int(st.Gid)
 	if st.Mode&syscall.S_IFMT == syscall.S_IFBLK || st.Mode&syscall.S_IFMT == syscall.S_IFCHR {
-		h.Devminor = int64(device.Minor(st.Rdev))
-		h.Devmajor = int64(device.Major(st.Rdev))
+		h.Devminor = int64(device.Minor(uint64(st.Rdev)))
+		h.Devmajor = int64(device.Major(uint64(st.Rdev)))
 	}
 	// If we have already seen this inode, generate a hardlink
 	p, ok := seen[uint64(st.Ino)]

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/image.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/image.go
@@ -15,7 +15,7 @@ const (
 type ImageManifest struct {
 	ACKind        types.ACKind       `json:"acKind"`
 	ACVersion     types.SemVer       `json:"acVersion"`
-	Name          types.ACName       `json:"name"`
+	Name          types.ACIdentifier `json:"name"`
 	Labels        types.Labels       `json:"labels,omitempty"`
 	App           *types.App         `json:"app,omitempty"`
 	Annotations   types.Annotations  `json:"annotations,omitempty"`

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/image_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/image_test.go
@@ -6,7 +6,7 @@ func TestEmptyApp(t *testing.T) {
 	imj := `
 		{
 		    "acKind": "ImageManifest",
-		    "acVersion": "0.5.2",
+		    "acVersion": "0.6.0",
 		    "name": "example.com/test"
 		}
 		`

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/pod.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/pod.go
@@ -140,7 +140,7 @@ type RuntimeApp struct {
 
 // RuntimeImage describes an image referenced in a RuntimeApp
 type RuntimeImage struct {
-	Name   *types.ACName `json:"name,omitempty"`
-	ID     types.Hash    `json:"id"`
-	Labels types.Labels  `json:"labels,omitempty"`
+	Name   *types.ACIdentifier `json:"name,omitempty"`
+	ID     types.Hash          `json:"id"`
+	Labels types.Labels        `json:"labels,omitempty"`
 }

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/acidentifier.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/acidentifier.go
@@ -1,0 +1,131 @@
+package types
+
+import (
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strings"
+)
+
+var (
+	// ValidACIdentifier is a regular expression that defines a valid ACIdentifier
+	ValidACIdentifier = regexp.MustCompile("^[a-z0-9]+([-._~/][a-z0-9]+)*$")
+
+	invalidACIdentifierChars = regexp.MustCompile("[^a-z0-9-._~/]")
+	invalidACIdentifierEdges = regexp.MustCompile("(^[-._~/]+)|([-._~/]+$)")
+
+	ErrEmptyACIdentifier         = ACIdentifierError("ACIdentifier cannot be empty")
+	ErrInvalidEdgeInACIdentifier = ACIdentifierError("ACIdentifier must start and end with only lower case " +
+		"alphanumeric characters")
+	ErrInvalidCharInACIdentifier = ACIdentifierError("ACIdentifier must contain only lower case " +
+		`alphanumeric characters plus "-._~/"`)
+)
+
+// ACIdentifier (an App-Container Identifier) is a format used by keys in image names
+// and image labels of the App Container Standard. An ACIdentifier is restricted to numeric
+// and lowercase URI unreserved characters defined in URI RFC[1]; all alphabetical characters
+// must be lowercase only. Furthermore, the first and last character ("edges") must be
+// alphanumeric, and an ACIdentifier cannot be empty. Programmatically, an ACIdentifier must
+// conform to the regular expression ValidACIdentifier.
+//
+// [1] http://tools.ietf.org/html/rfc3986#section-2.3
+type ACIdentifier string
+
+func (n ACIdentifier) String() string {
+	return string(n)
+}
+
+// Set sets the ACIdentifier to the given value, if it is valid; if not,
+// an error is returned.
+func (n *ACIdentifier) Set(s string) error {
+	nn, err := NewACIdentifier(s)
+	if err == nil {
+		*n = *nn
+	}
+	return err
+}
+
+// Equals checks whether a given ACIdentifier is equal to this one.
+func (n ACIdentifier) Equals(o ACIdentifier) bool {
+	return strings.ToLower(string(n)) == strings.ToLower(string(o))
+}
+
+// Empty returns a boolean indicating whether this ACIdentifier is empty.
+func (n ACIdentifier) Empty() bool {
+	return n.String() == ""
+}
+
+// NewACIdentifier generates a new ACIdentifier from a string. If the given string is
+// not a valid ACIdentifier, nil and an error are returned.
+func NewACIdentifier(s string) (*ACIdentifier, error) {
+	n := ACIdentifier(s)
+	if err := n.assertValid(); err != nil {
+		return nil, err
+	}
+	return &n, nil
+}
+
+// MustACIdentifier generates a new ACIdentifier from a string, If the given string is
+// not a valid ACIdentifier, it panics.
+func MustACIdentifier(s string) *ACIdentifier {
+	n, err := NewACIdentifier(s)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+func (n ACIdentifier) assertValid() error {
+	s := string(n)
+	if len(s) == 0 {
+		return ErrEmptyACIdentifier
+	}
+	if invalidACIdentifierChars.MatchString(s) {
+		return ErrInvalidCharInACIdentifier
+	}
+	if invalidACIdentifierEdges.MatchString(s) {
+		return ErrInvalidEdgeInACIdentifier
+	}
+	return nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (n *ACIdentifier) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	nn, err := NewACIdentifier(s)
+	if err != nil {
+		return err
+	}
+	*n = *nn
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface
+func (n ACIdentifier) MarshalJSON() ([]byte, error) {
+	if err := n.assertValid(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(n.String())
+}
+
+// SanitizeACIdentifier replaces every invalid ACIdentifier character in s with an underscore
+// making it a legal ACIdentifier string. If the character is an upper case letter it
+// replaces it with its lower case. It also removes illegal edge characters
+// (hyphens, period, underscore, tilde and slash).
+//
+// This is a helper function and its algorithm is not part of the spec. It
+// should not be called without the user explicitly asking for a suggestion.
+func SanitizeACIdentifier(s string) (string, error) {
+	s = strings.ToLower(s)
+	s = invalidACIdentifierChars.ReplaceAllString(s, "_")
+	s = invalidACIdentifierEdges.ReplaceAllString(s, "")
+
+	if s == "" {
+		return "", errors.New("must contain at least one valid character")
+	}
+
+	return s, nil
+}

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/acidentifier_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/acidentifier_test.go
@@ -1,0 +1,265 @@
+package types
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+var (
+	goodIdentifiers = []string{
+		"asdf",
+		"foo-bar-baz",
+		"zab_rab_oof",
+		"database",
+		"my~database",
+		"example.com/database",
+		"example.com/~bob/database",
+		"example.com/ourapp-1.0.0",
+		"sub-domain.example.com/org/product/release-1.0.0",
+		"sub-domain.example.com/org/product/~alice/release-1.0.0",
+	}
+	badIdentifiers = []string{
+		"",
+		"BAR",
+		"foo#",
+		"EXAMPLE.com",
+		"foo.com/BAR",
+		"/app",
+		"app/",
+		"-app",
+		"app-",
+		".app",
+		"app.",
+		"_app",
+		"app_",
+		"~app",
+		"app~",
+	}
+)
+
+func TestNewACIdentifier(t *testing.T) {
+	for i, in := range goodIdentifiers {
+		l, err := NewACIdentifier(in)
+		if err != nil {
+			t.Errorf("#%d: got err=%v, want nil", i, err)
+		}
+		if l == nil {
+			t.Errorf("#%d: got l=nil, want non-nil", i)
+		}
+	}
+}
+
+func TestNewACIdentifierBad(t *testing.T) {
+	for i, in := range badIdentifiers {
+		l, err := NewACIdentifier(in)
+		if l != nil {
+			t.Errorf("#%d: got l=%v, want nil", i, l)
+		}
+		if err == nil {
+			t.Errorf("#%d: got err=nil, want non-nil", i)
+		}
+	}
+}
+
+func TestMustACIdentifier(t *testing.T) {
+	for i, in := range goodIdentifiers {
+		l := MustACIdentifier(in)
+		if l == nil {
+			t.Errorf("#%d: got l=nil, want non-nil", i)
+		}
+	}
+}
+
+func expectPanicMustACIdentifier(i int, in string, t *testing.T) {
+	defer func() {
+		recover()
+	}()
+	_ = MustACIdentifier(in)
+	t.Errorf("#%d: panic expected", i)
+}
+
+func TestMustACIdentifierBad(t *testing.T) {
+	for i, in := range badIdentifiers {
+		expectPanicMustACIdentifier(i, in, t)
+	}
+}
+
+func TestSanitizeACIdentifier(t *testing.T) {
+	tests := map[string]string{
+		"foo#":                                                    "foo",
+		"FOO":                                                     "foo",
+		"EXAMPLE.com":                                             "example.com",
+		"foo.com/BAR":                                             "foo.com/bar",
+		"/app":                                                    "app",
+		"app/":                                                    "app",
+		"-app":                                                    "app",
+		"app-":                                                    "app",
+		".app":                                                    "app",
+		"app.":                                                    "app",
+		"_app":                                                    "app",
+		"app_":                                                    "app",
+		"~app":                                                    "app",
+		"app~":                                                    "app",
+		"app///":                                                  "app",
+		"-/.app..":                                                "app",
+		"-/app.name-test/-/":                                      "app.name-test",
+		"sub-domain.example.com/org/product/~alice/release-1.0.0": "sub-domain.example.com/org/product/~alice/release-1.0.0",
+	}
+	for in, ex := range tests {
+		o, err := SanitizeACIdentifier(in)
+		if err != nil {
+			t.Errorf("got err=%v, want nil", err)
+		}
+		if o != ex {
+			t.Errorf("got l=%s, want %s", o, ex)
+		}
+	}
+}
+
+func TestACIdentifierSetGood(t *testing.T) {
+	tests := map[string]ACIdentifier{
+		"blargh":               ACIdentifier("blargh"),
+		"example-ourapp-1-0-0": ACIdentifier("example-ourapp-1-0-0"),
+	}
+	for in, w := range tests {
+		// Ensure an empty name is set appropriately
+		var a ACIdentifier
+		err := a.Set(in)
+		if err != nil {
+			t.Errorf("%v: got err=%v, want nil", in, err)
+			continue
+		}
+		if !reflect.DeepEqual(a, w) {
+			t.Errorf("%v: a=%v, want %v", in, a, w)
+		}
+
+		// Ensure an existing name is overwritten
+		var b ACIdentifier = ACIdentifier("orig")
+		err = b.Set(in)
+		if err != nil {
+			t.Errorf("%v: got err=%v, want nil", in, err)
+			continue
+		}
+		if !reflect.DeepEqual(b, w) {
+			t.Errorf("%v: b=%v, want %v", in, b, w)
+		}
+	}
+}
+
+func TestACIdentifierSetBad(t *testing.T) {
+	for i, in := range badIdentifiers {
+		// Ensure an empty name stays empty
+		var a ACIdentifier
+		err := a.Set(in)
+		if err == nil {
+			t.Errorf("#%d: err=%v, want nil", i, err)
+			continue
+		}
+		if w := ACIdentifier(""); !reflect.DeepEqual(a, w) {
+			t.Errorf("%d: a=%v, want %v", i, a, w)
+		}
+
+		// Ensure an existing name is not overwritten
+		var b ACIdentifier = ACIdentifier("orig")
+		err = b.Set(in)
+		if err == nil {
+			t.Errorf("#%d: err=%v, want nil", i, err)
+			continue
+		}
+		if w := ACIdentifier("orig"); !reflect.DeepEqual(b, w) {
+			t.Errorf("%d: b=%v, want %v", i, b, w)
+		}
+	}
+}
+
+func TestSanitizeACIdentifierBad(t *testing.T) {
+	tests := []string{
+		"__",
+		"..",
+		"//",
+		"",
+		".//-"}
+	for i, in := range tests {
+		l, err := SanitizeACIdentifier(in)
+		if l != "" {
+			t.Errorf("#%d: got l=%v, want nil", i, l)
+		}
+		if err == nil {
+			t.Errorf("#%d: got err=nil, want non-nil", i)
+		}
+	}
+}
+
+func TestACIdentifierUnmarshalBad(t *testing.T) {
+	tests := []string{
+		"",
+		"garbage",
+		`""`,
+		`"EXAMPLE"`,
+		`"example.com/app#1"`,
+		`"~example.com/app1"`,
+	}
+	for i, in := range tests {
+		var a, b ACIdentifier
+		err := a.UnmarshalJSON([]byte(in))
+		if err == nil {
+			t.Errorf("#%d: err=nil, want non-nil", i)
+		} else if !reflect.DeepEqual(a, b) {
+			t.Errorf("#%d: a=%v, want empty", i, a)
+		}
+	}
+}
+
+func TestACIdentifierUnmarshalGood(t *testing.T) {
+	tests := map[string]ACIdentifier{
+		`"example"`: ACIdentifier("example"),
+		`"foo-bar"`: ACIdentifier("foo-bar"),
+	}
+	for in, w := range tests {
+		var a ACIdentifier
+		err := json.Unmarshal([]byte(in), &a)
+		if err != nil {
+			t.Errorf("%v: err=%v, want nil", in, err)
+		} else if !reflect.DeepEqual(a, w) {
+			t.Errorf("%v: a=%v, want %v", in, a, w)
+		}
+	}
+}
+
+func TestACIdentifierMarshalBad(t *testing.T) {
+	tests := map[string]error{
+		"Foo":      ErrInvalidCharInACIdentifier,
+		"foo#":     ErrInvalidCharInACIdentifier,
+		"-foo":     ErrInvalidEdgeInACIdentifier,
+		"example-": ErrInvalidEdgeInACIdentifier,
+		"":         ErrEmptyACIdentifier,
+	}
+	for in, werr := range tests {
+		a := ACIdentifier(in)
+		b, gerr := json.Marshal(a)
+		if b != nil {
+			t.Errorf("ACIdentifier(%q): want b=nil, got %v", in, b)
+		}
+		if jerr, ok := gerr.(*json.MarshalerError); !ok {
+			t.Errorf("expected JSONMarshalerError")
+		} else {
+			if e := jerr.Err; e != werr {
+				t.Errorf("err=%#v, want %#v", e, werr)
+			}
+		}
+	}
+}
+
+func TestACIdentifierMarshalGood(t *testing.T) {
+	for i, in := range goodIdentifiers {
+		a := ACIdentifier(in)
+		b, err := json.Marshal(a)
+		if !reflect.DeepEqual(b, []byte(`"`+in+`"`)) {
+			t.Errorf("#%d: marshalled=%v, want %v", i, b, []byte(in))
+		}
+		if err != nil {
+			t.Errorf("#%d: err=%v, want nil", i, err)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/acname.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/acname.go
@@ -9,24 +9,24 @@ import (
 
 var (
 	// ValidACName is a regular expression that defines a valid ACName
-	ValidACName = regexp.MustCompile("^[a-z0-9]+([-./][a-z0-9]+)*$")
+	ValidACName = regexp.MustCompile("^[a-z0-9]+([-][a-z0-9]+)*$")
 
-	invalidChars = regexp.MustCompile("[^a-z0-9./-]")
-	invalidEdges = regexp.MustCompile("(^[./-]+)|([./-]+$)")
+	invalidACNameChars = regexp.MustCompile("[^a-z0-9-]")
+	invalidACNameEdges = regexp.MustCompile("(^[-]+)|([-]+$)")
 
-	ErrEmptyACName = ACNameError("ACName cannot be empty")
-	ErrInvalidEdge = ACNameError("ACName must start and end with only lower case " +
+	ErrEmptyACName         = ACNameError("ACName cannot be empty")
+	ErrInvalidEdgeInACName = ACNameError("ACName must start and end with only lower case " +
 		"alphanumeric characters")
-	ErrInvalidChar = ACNameError("ACName must contain only lower case " +
-		`alphanumeric characters plus ".", "-", "/"`)
+	ErrInvalidCharInACName = ACNameError("ACName must contain only lower case " +
+		`alphanumeric characters plus "-"`)
 )
 
 // ACName (an App-Container Name) is a format used by keys in different formats
-// of the App Container Standard. An ACName is restricted to characters
-// accepted by the DNS RFC[1] and "/"; all alphabetical characters must be
-// lowercase only. Furthermore, the first and last character ("edges") must be
-// alphanumeric, and an ACName cannot be empty. Programmatically, an ACName
-// must conform to the regular expression ValidACName.
+// of the App Container Standard. An ACName is restricted to numeric and lowercase
+// characters accepted by the DNS RFC[1] plus "-"; all alphabetical characters must
+// be lowercase only. Furthermore, the first and last character ("edges") must be
+// alphanumeric, and an ACName cannot be empty. Programmatically, an ACName must
+// conform to the regular expression ValidACName.
 //
 // [1] http://tools.ietf.org/html/rfc1123#page-13
 type ACName string
@@ -80,11 +80,11 @@ func (n ACName) assertValid() error {
 	if len(s) == 0 {
 		return ErrEmptyACName
 	}
-	if invalidChars.MatchString(s) {
-		return ErrInvalidChar
+	if invalidACNameChars.MatchString(s) {
+		return ErrInvalidCharInACName
 	}
-	if invalidEdges.MatchString(s) {
-		return ErrInvalidEdge
+	if invalidACNameEdges.MatchString(s) {
+		return ErrInvalidEdgeInACName
 	}
 	return nil
 }
@@ -114,14 +114,14 @@ func (n ACName) MarshalJSON() ([]byte, error) {
 // SanitizeACName replaces every invalid ACName character in s with a dash
 // making it a legal ACName string. If the character is an upper case letter it
 // replaces it with its lower case. It also removes illegal edge characters
-// (hyphens, periods and slashes).
+// (hyphens).
 //
 // This is a helper function and its algorithm is not part of the spec. It
 // should not be called without the user explicitly asking for a suggestion.
 func SanitizeACName(s string) (string, error) {
 	s = strings.ToLower(s)
-	s = invalidChars.ReplaceAllString(s, "-")
-	s = invalidEdges.ReplaceAllString(s, "")
+	s = invalidACNameChars.ReplaceAllString(s, "-")
+	s = invalidACNameEdges.ReplaceAllString(s, "")
 
 	if s == "" {
 		return "", errors.New("must contain at least one valid character")

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/acname_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/acname_test.go
@@ -11,14 +11,14 @@ var (
 		"asdf",
 		"foo-bar-baz",
 		"database",
-		"example.com/database",
-		"example.com/ourapp-1.0.0",
-		"sub-domain.example.com/org/product/release-1.0.0",
 	}
 	badNames = []string{
 		"",
 		"foo#",
+		"example.com",
 		"EXAMPLE.com",
+		"example/database",
+		"example/database-1.0.0",
 		"foo.com/BAR",
 		"example.com/app_1",
 		"/app",
@@ -80,9 +80,9 @@ func TestMustACNameBad(t *testing.T) {
 func TestSanitizeACName(t *testing.T) {
 	tests := map[string]string{
 		"foo#":                                             "foo",
-		"EXAMPLE.com":                                      "example.com",
-		"foo.com/BAR":                                      "foo.com/bar",
-		"example.com/app_1":                                "example.com/app-1",
+		"EXAMPLE.com":                                      "example-com",
+		"foo.com/BAR":                                      "foo-com-bar",
+		"example.com/app_1":                                "example-com-app-1",
 		"/app":                                             "app",
 		"app/":                                             "app",
 		"-app":                                             "app",
@@ -91,8 +91,8 @@ func TestSanitizeACName(t *testing.T) {
 		"app.":                                             "app",
 		"app///":                                           "app",
 		"-/.app..":                                         "app",
-		"-/app.name-test/-/":                               "app.name-test",
-		"sub-domain.example.com/org/product/release-1.0.0": "sub-domain.example.com/org/product/release-1.0.0",
+		"-/app.name-test/-/":                               "app-name-test",
+		"sub-domain.example.com/org/product/release-1.0.0": "sub-domain-example-com-org-product-release-1-0-0",
 	}
 	for in, ex := range tests {
 		o, err := SanitizeACName(in)
@@ -107,8 +107,8 @@ func TestSanitizeACName(t *testing.T) {
 
 func TestACNameSetGood(t *testing.T) {
 	tests := map[string]ACName{
-		"blargh":                   ACName("blargh"),
-		"example.com/ourapp-1.0.0": ACName("example.com/ourapp-1.0.0"),
+		"blargh":               ACName("blargh"),
+		"example-ourapp-1-0-0": ACName("example-ourapp-1-0-0"),
 	}
 	for in, w := range tests {
 		// Ensure an empty name is set appropriately
@@ -200,8 +200,8 @@ func TestACNameUnmarshalBad(t *testing.T) {
 
 func TestACNameUnmarshalGood(t *testing.T) {
 	tests := map[string]ACName{
-		`"example"`:     ACName("example"),
-		`"foo.com/bar"`: ACName("foo.com/bar"),
+		`"example"`: ACName("example"),
+		`"foo-bar"`: ACName("foo-bar"),
 	}
 	for in, w := range tests {
 		var a ACName
@@ -216,11 +216,11 @@ func TestACNameUnmarshalGood(t *testing.T) {
 
 func TestACNameMarshalBad(t *testing.T) {
 	tests := map[string]error{
-		"Foo":          ErrInvalidChar,
-		"foo#":         ErrInvalidChar,
-		"/foo":         ErrInvalidEdge,
-		"example.com/": ErrInvalidEdge,
-		"":             ErrEmptyACName,
+		"Foo":      ErrInvalidCharInACName,
+		"foo#":     ErrInvalidCharInACName,
+		"-foo":     ErrInvalidEdgeInACName,
+		"example-": ErrInvalidEdgeInACName,
+		"":         ErrEmptyACName,
 	}
 	for in, werr := range tests {
 		a := ACName(in)

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/dependencies.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/dependencies.go
@@ -8,16 +8,17 @@ import (
 type Dependencies []Dependency
 
 type Dependency struct {
-	App     ACName `json:"app"`
-	ImageID *Hash  `json:"imageID,omitempty"`
-	Labels  Labels `json:"labels,omitempty"`
+	ImageName ACIdentifier `json:"imageName"`
+	ImageID   *Hash        `json:"imageID,omitempty"`
+	Labels    Labels       `json:"labels,omitempty"`
+	Size      uint         `json:"size,omitempty"`
 }
 
 type dependency Dependency
 
 func (d Dependency) assertValid() error {
-	if len(d.App) < 1 {
-		return errors.New(`App cannot be empty`)
+	if len(d.ImageName) < 1 {
+		return errors.New(`imageName cannot be empty`)
 	}
 	return nil
 }

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/dependencies_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/dependencies_test.go
@@ -3,7 +3,7 @@ package types
 import "testing"
 
 func TestEmptyHash(t *testing.T) {
-	dj := `{"app": "example.com/reduce-worker-base"}`
+	dj := `{"imageName": "example.com/reduce-worker-base"}`
 
 	var d Dependency
 

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/errors.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/errors.go
@@ -20,6 +20,13 @@ func (e ACVersionError) Error() string {
 	return string(e)
 }
 
+// An ACIdentifierError is returned when a bad value is used for an ACIdentifier
+type ACIdentifierError string
+
+func (e ACIdentifierError) Error() string {
+	return string(e)
+}
+
 // An ACNameError is returned when a bad value is used for an ACName
 type ACNameError string
 

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator.go
@@ -5,23 +5,23 @@ import (
 )
 
 var (
-	isolatorMap map[ACName]IsolatorValueConstructor
+	isolatorMap map[ACIdentifier]IsolatorValueConstructor
 )
 
 func init() {
-	isolatorMap = make(map[ACName]IsolatorValueConstructor)
+	isolatorMap = make(map[ACIdentifier]IsolatorValueConstructor)
 }
 
 type IsolatorValueConstructor func() IsolatorValue
 
-func AddIsolatorValueConstructor(n ACName, i IsolatorValueConstructor) {
+func AddIsolatorValueConstructor(n ACIdentifier, i IsolatorValueConstructor) {
 	isolatorMap[n] = i
 }
 
 type Isolators []Isolator
 
 // GetByName returns the last isolator in the list by the given name.
-func (is *Isolators) GetByName(name ACName) *Isolator {
+func (is *Isolators) GetByName(name ACIdentifier) *Isolator {
 	var i Isolator
 	for j := len(*is) - 1; j >= 0; j-- {
 		i = []Isolator(*is)[j]
@@ -50,7 +50,7 @@ type IsolatorValue interface {
 	AssertValid() error
 }
 type Isolator struct {
-	Name     ACName           `json:"name"`
+	Name     ACIdentifier     `json:"name"`
 	ValueRaw *json.RawMessage `json:"value"`
 	value    IsolatorValue
 }

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_test.go
@@ -157,7 +157,7 @@ func TestIsolatorsGetByName(t *testing.T) {
 	`
 
 	tests := []struct {
-		name     ACName
+		name     ACIdentifier
 		wlimit   int64
 		wrequest int64
 		wset     []LinuxCapability

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/labels.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/labels.go
@@ -7,7 +7,7 @@ import (
 )
 
 var ValidOSArch = map[string][]string{
-	"linux":   {"amd64", "i386", "aarch64", "armv7l", "armv7b"},
+	"linux":   {"amd64", "i386", "aarch64", "aarch64_be", "armv7l", "armv7b"},
 	"freebsd": {"amd64", "i386", "arm"},
 	"darwin":  {"x86_64", "i386"},
 }
@@ -17,12 +17,12 @@ type Labels []Label
 type labels Labels
 
 type Label struct {
-	Name  ACName `json:"name"`
-	Value string `json:"value"`
+	Name  ACIdentifier `json:"name"`
+	Value string       `json:"value"`
 }
 
 func (l Labels) assertValid() error {
-	seen := map[ACName]string{}
+	seen := map[ACIdentifier]string{}
 	for _, lbl := range l {
 		if lbl.Name == "name" {
 			return fmt.Errorf(`invalid label name: "name"`)
@@ -92,17 +92,17 @@ func (l Labels) Get(name string) (val string, ok bool) {
 	return "", false
 }
 
-// ToMap creates a map[ACName]string.
-func (l Labels) ToMap() map[ACName]string {
-	labelsMap := make(map[ACName]string)
+// ToMap creates a map[ACIdentifier]string.
+func (l Labels) ToMap() map[ACIdentifier]string {
+	labelsMap := make(map[ACIdentifier]string)
 	for _, lbl := range l {
 		labelsMap[lbl.Name] = lbl.Value
 	}
 	return labelsMap
 }
 
-// LabelsFromMap creates Labels from a map[ACName]string
-func LabelsFromMap(labelsMap map[ACName]string) (Labels, error) {
+// LabelsFromMap creates Labels from a map[ACIdentifier]string
+func LabelsFromMap(labelsMap map[ACIdentifier]string) (Labels, error) {
 	labels := Labels{}
 	for n, v := range labelsMap {
 		labels = append(labels, Label{Name: n, Value: v})

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/labels_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/labels_test.go
@@ -20,6 +20,18 @@ func TestLabels(t *testing.T) {
 			"",
 		},
 		{
+			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "arm64"}]`,
+			`bad arch "arm64" for linux`,
+		},
+		{
+			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "aarch64_be"}]`,
+			"",
+		},
+		{
+			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "arm64_be"}]`,
+			`bad arch "arm64_be" for linux`,
+		},
+		{
 			`[{"name": "os", "value": "linux"}, {"name": "arch", "value": "armv7l"}]`,
 			"",
 		},

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/port.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/port.go
@@ -46,11 +46,11 @@ func (p Port) MarshalJSON() ([]byte, error) {
 func (p Port) assertValid() error {
 	// Although there are no guarantees, most (if not all)
 	// transport protocols use 16 bit ports
-	if p.Port > 65535 {
-		return errors.New("port must be in 0-65535 range")
+	if p.Port > 65535 || p.Port < 1 {
+		return errors.New("port must be in 1-65535 range")
 	}
 	if p.Port+p.Count > 65536 {
-		return errors.New("end of port range must be in 0-65535 range")
+		return errors.New("end of port range must be in 1-65535 range")
 	}
 	return nil
 }

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/version.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/version.go
@@ -8,7 +8,7 @@ const (
 	// version represents the canonical version of the appc spec and tooling.
 	// For now, the schema and tooling is coupled with the spec itself, so
 	// this must be kept in sync with the VERSION file in the root of the repo.
-	version string = "0.5.2"
+	version string = "0.6.0"
 )
 
 var (

--- a/common/common.go
+++ b/common/common.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/aci"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
@@ -135,6 +136,19 @@ func SupportsOverlay() bool {
 		}
 	}
 	return false
+}
+
+// GetAppByImageName retrieves an app from the AppList whose image has the
+// specified name; if there is no such app, nil is returned. The returned
+// *RuntimeApp MUST be considered read-only.
+func GetAppByImageName(al schema.AppList, name types.ACIdentifier) *schema.RuntimeApp {
+	for _, a := range al {
+		if name.Equals(*a.Image.Name) {
+			aa := a
+			return &aa
+		}
+	}
+	return nil
 }
 
 // PrivateNetList implements the flag.Value interface to allow specification

--- a/pkg/aci/render.go
+++ b/pkg/aci/render.go
@@ -35,7 +35,7 @@ func RenderACIWithImageID(imageID types.Hash, dir string, ap acirenderer.ACIRegi
 
 // Given an image app name and optional labels, get the best matching image
 // available in the store, build its dependency list and render it inside dir
-func RenderACI(name types.ACName, labels types.Labels, dir string, ap acirenderer.ACIRegistry) error {
+func RenderACI(name types.ACIdentifier, labels types.Labels, dir string, ap acirenderer.ACIRegistry) error {
 	renderedACI, err := acirenderer.GetRenderedACI(name, labels, ap)
 	if err != nil {
 		return err

--- a/pkg/keystore/keystore.go
+++ b/pkg/keystore/keystore.go
@@ -79,11 +79,11 @@ func (ks *Keystore) CheckSignature(prefix string, signed, signature io.Reader) (
 }
 
 func checkSignature(ks *Keystore, prefix string, signed, signature io.Reader) (*openpgp.Entity, error) {
-	acname, err := types.NewACName(prefix)
+	acidentifier, err := types.NewACIdentifier(prefix)
 	if err != nil {
 		return nil, err
 	}
-	keyring, err := ks.loadKeyring(acname.String())
+	keyring, err := ks.loadKeyring(acidentifier.String())
 	if err != nil {
 		return nil, fmt.Errorf("keystore: error loading keyring %v", err)
 	}
@@ -97,20 +97,20 @@ func checkSignature(ks *Keystore, prefix string, signed, signature io.Reader) (*
 
 // DeleteTrustedKeyPrefix deletes the prefix trusted key identified by fingerprint.
 func (ks *Keystore) DeleteTrustedKeyPrefix(prefix, fingerprint string) error {
-	acname, err := types.NewACName(prefix)
+	acidentifier, err := types.NewACIdentifier(prefix)
 	if err != nil {
 		return err
 	}
-	return os.Remove(path.Join(ks.LocalPrefixPath, acname.String(), fingerprint))
+	return os.Remove(path.Join(ks.LocalPrefixPath, acidentifier.String(), fingerprint))
 }
 
 // MaskTrustedKeySystemPrefix masks the system prefix trusted key identified by fingerprint.
 func (ks *Keystore) MaskTrustedKeySystemPrefix(prefix, fingerprint string) (string, error) {
-	acname, err := types.NewACName(prefix)
+	acidentifier, err := types.NewACIdentifier(prefix)
 	if err != nil {
 		return "", err
 	}
-	dst := path.Join(ks.LocalPrefixPath, acname.String(), fingerprint)
+	dst := path.Join(ks.LocalPrefixPath, acidentifier.String(), fingerprint)
 	return dst, ioutil.WriteFile(dst, []byte(""), 0644)
 }
 
@@ -127,11 +127,11 @@ func (ks *Keystore) MaskTrustedKeySystemRoot(fingerprint string) (string, error)
 
 // StoreTrustedKeyPrefix stores the contents of public key r as a prefix trusted key.
 func (ks *Keystore) StoreTrustedKeyPrefix(prefix string, r io.Reader) (string, error) {
-	acname, err := types.NewACName(prefix)
+	acidentifier, err := types.NewACIdentifier(prefix)
 	if err != nil {
 		return "", err
 	}
-	return storeTrustedKey(path.Join(ks.LocalPrefixPath, acname.String()), r)
+	return storeTrustedKey(path.Join(ks.LocalPrefixPath, acidentifier.String()), r)
 }
 
 // StoreTrustedKeyRoot stores the contents of public key r as a root trusted key.
@@ -181,22 +181,22 @@ func entityFromFile(path string) (*openpgp.Entity, error) {
 }
 
 func (ks *Keystore) loadKeyring(prefix string) (openpgp.KeyRing, error) {
-	acname, err := types.NewACName(prefix)
+	acidentifier, err := types.NewACIdentifier(prefix)
 	if err != nil {
 		return nil, err
 	}
 	var keyring openpgp.EntityList
 	trustedKeys := make(map[string]*openpgp.Entity)
 
-	prefixRoot := strings.Split(acname.String(), "/")[0]
+	prefixRoot := strings.Split(acidentifier.String(), "/")[0]
 	paths := []struct {
 		root     string
 		fullPath string
 	}{
 		{ks.SystemRootPath, ks.SystemRootPath},
 		{ks.LocalRootPath, ks.LocalRootPath},
-		{path.Join(ks.SystemPrefixPath, prefixRoot), path.Join(ks.SystemPrefixPath, acname.String())},
-		{path.Join(ks.LocalPrefixPath, prefixRoot), path.Join(ks.LocalPrefixPath, acname.String())},
+		{path.Join(ks.SystemPrefixPath, prefixRoot), path.Join(ks.SystemPrefixPath, acidentifier.String())},
+		{path.Join(ks.LocalPrefixPath, prefixRoot), path.Join(ks.LocalPrefixPath, acidentifier.String())},
 	}
 	for _, p := range paths {
 		err := filepath.Walk(p.root, func(path string, info os.FileInfo, err error) error {

--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -153,7 +153,7 @@ func TestNewDiscoveryApp(t *testing.T) {
 			"foo.com/bar",
 			&discovery.App{
 				Name: "foo.com/bar",
-				Labels: map[types.ACName]string{
+				Labels: map[types.ACIdentifier]string{
 					"arch": defaultArch,
 					"os":   defaultOS,
 				},
@@ -164,7 +164,7 @@ func TestNewDiscoveryApp(t *testing.T) {
 			"www.abc.xyz/my/app,os=freebsd,arch=i386",
 			&discovery.App{
 				Name: "www.abc.xyz/my/app",
-				Labels: map[types.ACName]string{
+				Labels: map[types.ACIdentifier]string{
 					"arch": "i386",
 					"os":   "freebsd",
 				},
@@ -175,7 +175,7 @@ func TestNewDiscoveryApp(t *testing.T) {
 			"yes.com/no:v1.2.3",
 			&discovery.App{
 				Name: "yes.com/no",
-				Labels: map[types.ACName]string{
+				Labels: map[types.ACIdentifier]string{
 					"version": "v1.2.3",
 					"arch":    defaultArch,
 					"os":      defaultOS,
@@ -187,7 +187,7 @@ func TestNewDiscoveryApp(t *testing.T) {
 			"example.com/foo/haha,val=one",
 			&discovery.App{
 				Name: "example.com/foo/haha",
-				Labels: map[types.ACName]string{
+				Labels: map[types.ACIdentifier]string{
 					"val":  "one",
 					"arch": defaultArch,
 					"os":   defaultOS,
@@ -199,7 +199,7 @@ func TestNewDiscoveryApp(t *testing.T) {
 			"one.two/appname:three,os=four,foo=five,arch=six",
 			&discovery.App{
 				Name: "one.two/appname",
-				Labels: map[types.ACName]string{
+				Labels: map[types.ACIdentifier]string{
 					"version": "three",
 					"os":      "four",
 					"foo":     "five",

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -153,7 +153,7 @@ func (f *fetcher) addImageDeps(hash string, imgsl *list.List, seen map[string]st
 		return err
 	}
 	for _, d := range dependencies {
-		app, err := discovery.NewApp(d.App.String(), d.Labels.ToMap())
+		app, err := discovery.NewApp(d.ImageName.String(), d.Labels.ToMap())
 		if err != nil {
 			return err
 		}

--- a/stage0/entrypoint.go
+++ b/stage0/entrypoint.go
@@ -26,9 +26,9 @@ import (
 )
 
 const (
-	enterEntrypoint = "coreos.com/rkt/stage1/enter"
-	runEntrypoint   = "coreos.com/rkt/stage1/run"
-	gcEntrypoint    = "coreos.com/rkt/stage1/gc"
+	enterEntrypoint = "stage1-enter"
+	runEntrypoint   = "stage1-run"
+	gcEntrypoint    = "stage1-gc"
 )
 
 // getStage1Entrypoint retrieves the named entrypoint from the stage1 manifest for a given pod

--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -345,17 +345,12 @@ func (p *Pod) writeEnvFile(env types.Environment, id types.Hash) error {
 // PodToSystemd creates the appropriate systemd service unit files for
 // all the constituent apps of the Pod
 func (p *Pod) PodToSystemd(interactive bool) error {
-	for _, am := range p.Apps {
-		ra := p.Manifest.Apps.Get(am.Name)
-		if ra == nil {
-			// should never happen
-			panic("app not found in pod manifest")
-		}
+	for i := range p.Manifest.Apps {
+		ra := &p.Manifest.Apps[i]
 		if err := p.appToSystemd(ra, interactive); err != nil {
-			return fmt.Errorf("failed to transform app %q into systemd service: %v", am.Name, err)
+			return fmt.Errorf("failed to transform app %q into systemd service: %v", ra.Name, err)
 		}
 	}
-
 	return nil
 }
 
@@ -442,12 +437,8 @@ func (p *Pod) PodToNspawnArgs() ([]string, error) {
 		"--directory=" + common.Stage1RootfsPath(p.Root),
 	}
 
-	for _, am := range p.Apps {
-		ra := p.Manifest.Apps.Get(am.Name)
-		if ra == nil {
-			panic("could not find app in pod manifest!")
-		}
-		aa, err := p.appToNspawnArgs(ra)
+	for i := range p.Manifest.Apps {
+		aa, err := p.appToNspawnArgs(&p.Manifest.Apps[i])
 		if err != nil {
 			return nil, err
 		}

--- a/stage1/rootfs/aggregate/aci-manifest
+++ b/stage1/rootfs/aggregate/aci-manifest
@@ -18,15 +18,15 @@
     ],
     "annotations": [
         {
-            "name": "coreos.com/rkt/stage1/run",
+            "name": "stage1-run",
             "value": "/init"
         },
         {
-            "name": "coreos.com/rkt/stage1/enter",
+            "name": "stage1-enter",
             "value": "/enter"
         },
         {
-            "name": "coreos.com/rkt/stage1/gc",
+            "name": "stage1-gc",
             "value": "/gc"
         }
     ]

--- a/store/store.go
+++ b/store/store.go
@@ -524,7 +524,7 @@ func (s Store) GetImageManifest(key string) (*schema.ImageManifest, error) {
 // last one imported in the store).
 // If no version label is requested, ACIs marked as latest in the ACIInfo are
 // preferred.
-func (s Store) GetACI(name types.ACName, labels types.Labels) (string, error) {
+func (s Store) GetACI(name types.ACIdentifier, labels types.Labels) (string, error) {
 	var curaciinfo *ACIInfo
 	versionRequested := false
 	if _, ok := labels.Get("version"); ok {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -197,7 +197,7 @@ func TestGetImageManifest(t *testing.T) {
 
 func TestGetAci(t *testing.T) {
 	type test struct {
-		name     types.ACName
+		name     types.ACIdentifier
 		labels   types.Labels
 		expected int // the aci index to expect or -1 if not result expected,
 	}


### PR DESCRIPTION
Basically I pulled @iaguis 's PR #1037 with some modification:

- Iterate only on `podManifest.Apps` in `PodToSystemd()` and `PodToNspawnArgs()` in `stage1/init/pod.go`.

- Fetch the app name from the URL in the rkt metadata service. (Instead of computing the app name from the image image)

Unit tests and functional tests are passing.

/cc @jonboulle @iaguis 