### PR TITLE
Functional tests: disabled on flavor=usr-from-host & host systemd < v220

### DIFF
--- a/tests/test
+++ b/tests/test
@@ -19,8 +19,10 @@
 GO=`which go`
 
 HOST_RUNNING_SYSTEMD=0
+HOST_SYSTEMD_VERSION=0
 if [ $(basename $(sudo readlink /proc/1/exe)) == systemd ] ; then
 	HOST_RUNNING_SYSTEMD=1
+	HOST_SYSTEMD_VERSION="$(sudo /proc/1/exe --version|head -1|sed 's/^systemd \([0-9]*\)$/\1/g')"
 fi
 
 STAGE1_SRC_FROM_HOST=0
@@ -28,8 +30,8 @@ if tar tvf ../bin/stage1.aci rootfs/flavor|grep -q usr-from-host ; then
 	STAGE1_SRC_FROM_HOST=1
 fi
 
-if [ $HOST_RUNNING_SYSTEMD -eq 0 -a $STAGE1_SRC_FROM_HOST -eq 1 ] ; then
-	echo "Cannot use stage1 compiled with usr-from-host because systemd is not installed."
+if [ $HOST_SYSTEMD_VERSION -lt 220 -a $STAGE1_SRC_FROM_HOST -eq 1 ] ; then
+	echo "Cannot use stage1 compiled with usr-from-host because systemd >= 220 is not installed."
 	echo "Functional tests disabled."
 	exit 0
 fi


### PR DESCRIPTION
When the host does not have systemd >= v220, we cannot use stage1 built
with flavor=usr-from-host.