### PR TITLE
stage1: flavor=src: fix git clone directory

### DIFF
--- a/stage1/rootfs/usr_from_src/Makefile
+++ b/stage1/rootfs/usr_from_src/Makefile
@@ -85,10 +85,10 @@ systemd.src: Makefile patches/*
 	{ [ ! -e systemd ] || rm -Rf systemd; }
 	mkdir systemd
 	if [ "$(RKT_STAGE1_SYSTEMD_VER)" = "HEAD" ]; then \
-		git clone $(RKT_STAGE1_SYSTEMD_SRC) ; \
+		git clone $(RKT_STAGE1_SYSTEMD_SRC) systemd ; \
 		PATCHES_DIR=patches/master ; \
 	else \
-		git clone --branch $(RKT_STAGE1_SYSTEMD_VER) $(RKT_STAGE1_SYSTEMD_SRC) ; \
+		git clone --branch $(RKT_STAGE1_SYSTEMD_VER) $(RKT_STAGE1_SYSTEMD_SRC) systemd ; \
 		PATCHES_DIR=patches/$(RKT_STAGE1_SYSTEMD_VER) ; \
 	fi ; \
 	if [ -d $$PATCHES_DIR ]; then \


### PR DESCRIPTION
When compiling the src flavor, systemd will be cloned from the URL given
in $RKT_STAGE1_SYSTEMD_SRC. The Makefile assumed that
$RKT_STAGE1_SYSTEMD_SRC ends with "systemd" but that might not be the
case. Fix the Makefile.