### PR TITLE
rkt: move image-related commands as rkt image's subcommands

### DIFF
--- a/rkt/image.go
+++ b/rkt/image.go
@@ -19,7 +19,7 @@ import "github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
 var (
 	cmdImage = &cobra.Command{
 		Use:   "image [command]",
-		Short: "Operate on an image in the local store",
+		Short: "Operate on image(s) in the local store",
 	}
 )
 

--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -151,8 +151,8 @@ func (isa *ImagesSortAsc) Type() string {
 }
 
 var (
-	cmdImages = &cobra.Command{
-		Use:   "images",
+	cmdImageList = &cobra.Command{
+		Use:   "list",
 		Short: "List images in the local store",
 		Run:   runWrapper(runImages),
 	}
@@ -167,11 +167,11 @@ func init() {
 	flagImagesSortFields = []string{importTimeField}
 	flagImagesSortAsc = true
 
-	cmdRkt.AddCommand(cmdImages)
-	cmdImages.Flags().Var(&flagImagesFields, "fields", `comma separated list of fields to display. Accepted values: "key", "appname", "importtime", "latest"`)
-	cmdImages.Flags().Var(&flagImagesSortFields, "sort", `sort the output according to the provided comma separated list of fields. Accepted values: "appname", "importtime"`)
-	cmdImages.Flags().Var(&flagImagesSortAsc, "order", `choose the sorting order if at least one sort field is provided (--sort). Accepted values: "asc", "desc"`)
-	cmdImages.Flags().BoolVar(&flagNoLegend, "no-legend", false, "suppress a legend with the list")
+	cmdImage.AddCommand(cmdImageList)
+	cmdImageList.Flags().Var(&flagImagesFields, "fields", `comma separated list of fields to display. Accepted values: "key", "appname", "importtime", "latest"`)
+	cmdImageList.Flags().Var(&flagImagesSortFields, "sort", `sort the output according to the provided comma separated list of fields. Accepted values: "appname", "importtime"`)
+	cmdImageList.Flags().Var(&flagImagesSortAsc, "order", `choose the sorting order if at least one sort field is provided (--sort). Accepted values: "asc", "desc"`)
+	cmdImageList.Flags().BoolVar(&flagNoLegend, "no-legend", false, "suppress a legend with the list")
 }
 
 func runImages(cmd *cobra.Command, args []string) (exit int) {

--- a/rkt/image_rm.go
+++ b/rkt/image_rm.go
@@ -23,15 +23,15 @@ import (
 )
 
 var (
-	cmdRmImage = &cobra.Command{
-		Use:   "rmimage IMAGEID...",
+	cmdImageRm = &cobra.Command{
+		Use:   "rm IMAGEID...",
 		Short: "Remove image(s) with the given key(s) from the local store",
 		Run:   runWrapper(runRmImage),
 	}
 )
 
 func init() {
-	cmdRkt.AddCommand(cmdRmImage)
+	cmdImage.AddCommand(cmdImageRm)
 }
 
 func runRmImage(cmd *cobra.Command, args []string) (exit int) {

--- a/tests/rkt_image_rm_test.go
+++ b/tests/rkt_image_rm_test.go
@@ -117,7 +117,7 @@ func TestImageRm(t *testing.T) {
 }
 
 func getImageId(ctx *rktRunCtx, name string) (string, error) {
-	cmd := fmt.Sprintf(`/bin/sh -c "%s images --fields=key,appname --no-legend | grep %s | awk '{print $1}'"`, ctx.cmd(), name)
+	cmd := fmt.Sprintf(`/bin/sh -c "%s image list --fields=key,appname --no-legend | grep %s | awk '{print $1}'"`, ctx.cmd(), name)
 	child, err := gexpect.Spawn(cmd)
 	if err != nil {
 		return "", fmt.Errorf("Cannot exec rkt: %v", err)
@@ -139,7 +139,7 @@ func removeImageId(ctx *rktRunCtx, imageID string, shouldWork bool) error {
 	if shouldWork {
 		expect = rmImageOk
 	}
-	cmd := fmt.Sprintf("%s rmimage %s", ctx.cmd(), imageID)
+	cmd := fmt.Sprintf("%s image rm %s", ctx.cmd(), imageID)
 	child, err := gexpect.Spawn(cmd)
 	if err != nil {
 		return fmt.Errorf("Cannot exec: %v", err)


### PR DESCRIPTION
This patch moves `rkt images` to `rkt image list` and `rkt rmimage` to
`rkt image rm`.

This fixes #933,

I thought about adding some doc but perhaps it would be better first updating #649?