### PR TITLE
metadata-svc: implement token based container auth

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -102,8 +102,8 @@ func ImageManifestPath(root string, imageID types.Hash) string {
 }
 
 // MetadataServicePublicURL returns the public URL used to host the metadata service
-func MetadataServicePublicURL(ip net.IP) string {
-	return fmt.Sprintf("http://%v:%v", ip, MetadataServicePort)
+func MetadataServicePublicURL(ip net.IP, token string) string {
+	return fmt.Sprintf("http://%v:%v/%v", ip, MetadataServicePort, token)
 }
 
 func GetRktLockFD() (int, error) {

--- a/stage1/init/registration.go
+++ b/stage1/init/registration.go
@@ -39,7 +39,7 @@ Make sure metadata service is currently running.
 For more information on running metadata service,
 see https://github.com/coreos/rkt/blob/master/Documentation/metadata-service.md`)
 
-func registerPod(p *Pod, ip net.IP) (rerr error) {
+func registerPod(p *Pod, token string) (rerr error) {
 	uuid := p.UUID.String()
 
 	cmf, err := os.Open(common.PodManifestPath(p.Root))
@@ -48,7 +48,7 @@ func registerPod(p *Pod, ip net.IP) (rerr error) {
 		return
 	}
 
-	pth := fmt.Sprintf("/pods/%v?ip=%v", uuid, ip.To4().String())
+	pth := fmt.Sprintf("/pods/%v?token=%v", uuid, token)
 	err = httpRequest("PUT", pth, cmf)
 	cmf.Close()
 	if err != nil {


### PR DESCRIPTION
Per https://github.com/appc/spec/pull/327, use bearer token
instead of IP to authenticate containers.