### PR TITLE
replace image id with app name for identifying apps within pod.

### DIFF
--- a/Documentation/devel/architecture.md
+++ b/Documentation/devel/architecture.md
@@ -39,8 +39,8 @@ a pod manifest compliant with the ACE spec will be generated, and the filesystem
 /stage1/manifest
 /stage1/rootfs/init
 /stage1/rootfs/opt
-/stage1/rootfs/opt/stage2/sha512-648db489d57363b29f1597d4312b2129
-/stage1/rootfs/opt/stage2/sha512-0c45e8c0ab2b3cdb9ec6649073d5c6c4
+/stage1/rootfs/opt/stage2/0
+/stage1/rootfs/opt/stage2/1
 ```
 
 where:

--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -14,7 +14,7 @@ This separation of concerns is reflected in the file-system and layout of the co
 
 0. Stage 0: `rkt` executable, and the Pod Manifest created at "/var/lib/rkt/pods/$uuid/pod".
 1. Stage 1: "stage1.aci", made available at "/var/lib/rkt/pods/$uuid/stage1" by `rkt run`.
-2. Stage 2: "$app.aci", made available at "/var/lib/rkt/pods/$uuid/stage1/rootfs/opt/stage2/$imageid" by `rkt run`.
+2. Stage 2: "$app.aci", made available at "/var/lib/rkt/pods/$uuid/stage1/rootfs/opt/stage2/$index" by `rkt run`, where $index is the position of the app in the pod manifest.
 
 The stage 1 implementation is what creates the execution environment for the contained applications.  This occurs via entrypoints from stage 0 on behalf of `rkt run` and `rkt enter`.  These entrypoints are nothing more than executable programs located via Annotations from within the stage 1 ACI manifest, and executed from within the stage 1 of a given pod at "/var/lib/rkt/pods/$uuid/stage1/rootfs".
 
@@ -62,9 +62,9 @@ An alternative stage 1 would need to do whatever is appropriate for entering the
 #### Arguments
 
 1. PID of the process that is PID 1 in the container. rkt finds that PID by one of the two supported methods described in the `rkt run` section.
-2. image id of the specific application to enter
-3. cmd to execute
-4. any cmd arguments
+2. index of the specific application in the pod manifest to enter.
+3. cmd to execute.
+4. any cmd arguments.
 
 
 

--- a/common/cgroup/cgroup.go
+++ b/common/cgroup/cgroup.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/coreos/go-systemd/unit"
 )
 
@@ -191,7 +190,7 @@ func GetOwnCgroupPath(controller string) (string, error) {
 // CreateCgroups mounts the cgroup controllers hierarchy for the container but
 // leaves the subcgroup for each app read-write so the systemd inside stage1
 // can apply isolators to them
-func CreateCgroups(root string, subcgroup string, appHashes []types.Hash) error {
+func CreateCgroups(root string, subcgroup string, serviceNames []string) error {
 	cgroupsFile, err := os.Open("/proc/cgroups")
 	if err != nil {
 		return err
@@ -255,9 +254,7 @@ func CreateCgroups(root string, subcgroup string, appHashes []types.Hash) error 
 
 		// 3c. Create cgroup directories and mount the files we need over
 		// themselves so they stay read-write
-		for _, a := range appHashes {
-			serviceName := types.ShortHash(a.String()) + ".service"
-
+		for _, serviceName := range serviceNames {
 			appCgroup := filepath.Join(subcgroupPath, serviceName)
 			if err := os.MkdirAll(appCgroup, 0755); err != nil {
 				return err

--- a/common/common.go
+++ b/common/common.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/aci"
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
 const (
@@ -66,39 +65,40 @@ func PodManifestPath(root string) string {
 	return filepath.Join(root, "pod")
 }
 
-// AppImagesPath returns the path where the app images live
-func AppImagesPath(root string) string {
+// AppsPath returns the path where the apps within a pod live.
+func AppsPath(root string) string {
 	return filepath.Join(Stage1RootfsPath(root), stage2Dir)
 }
 
-// AppImagePath returns the path where an app image (i.e. unpacked ACI) is rooted (i.e.
-// where its contents are extracted during stage0), based on the app image ID.
-func AppImagePath(root string, imageID types.Hash) string {
-	return filepath.Join(AppImagesPath(root), types.ShortHash(imageID.String()))
+// AppPath returns the path where an app is rooted (i.e.
+// where its ACI is extracted during stage0), based on the position of the app
+// in the pod manifest.
+func AppPath(root string, index int) string {
+	return filepath.Join(AppsPath(root), strconv.Itoa(index))
 }
 
 // AppRootfsPath returns the path to an app's rootfs.
-// imageID should be the app image ID.
-func AppRootfsPath(root string, imageID types.Hash) string {
-	return filepath.Join(AppImagePath(root, imageID), aci.RootfsDir)
+// index is the position of the app in the pod manifest.
+func AppRootfsPath(root string, index int) string {
+	return filepath.Join(AppPath(root, index), aci.RootfsDir)
 }
 
-// RelAppImagePath returns the path of an application image relative to the
-// stage1 chroot
-func RelAppImagePath(imageID types.Hash) string {
-	return filepath.Join(stage2Dir, types.ShortHash(imageID.String()))
+// RelAppPath returns the path of an app relative to the stage1 chroot,
+// based on the position of the app in the pod manfiest.
+func RelAppPath(index int) string {
+	return filepath.Join(stage2Dir, strconv.Itoa(index))
 }
 
-// RelAppImagePath returns the path of an application's rootfs relative to the
-// stage1 chroot
-func RelAppRootfsPath(imageID types.Hash) string {
-	return filepath.Join(RelAppImagePath(imageID), aci.RootfsDir)
+// RelAppRootfsPath returns the path of an app's rootfs relative to the stage1 chroot.
+// index is the position of the app in the pod manifest.
+func RelAppRootfsPath(index int) string {
+	return filepath.Join(RelAppPath(index), aci.RootfsDir)
 }
 
-// ImageManifestPath returns the path to the app's manifest file inside the expanded ACI.
-// id should be the app image ID.
-func ImageManifestPath(root string, imageID types.Hash) string {
-	return filepath.Join(AppImagePath(root, imageID), aci.ManifestFile)
+// ImageManifestPath returns the path to the app's manifest file inside a pod.
+// index is the position of the app in the pod manifest.
+func ImageManifestPath(root string, index int) string {
+	return filepath.Join(AppPath(root, index), aci.ManifestFile)
 }
 
 // MetadataServicePublicURL returns the public URL used to host the metadata service

--- a/rkt/list.go
+++ b/rkt/list.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
 	common "github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/networking/netinfo"
+	"github.com/coreos/rkt/store"
 )
 
 var (
@@ -43,33 +44,34 @@ func init() {
 }
 
 func runList(cmd *cobra.Command, args []string) (exit int) {
+	s, err := store.NewStore(globalFlags.Dir)
+	if err != nil {
+		stderr("list: cannot open store: %v", err)
+		return 1
+	}
+
 	if !flagNoLegend {
-		fmt.Fprintf(tabOut, "UUID\tACI\tSTATE\tNETWORKS\n")
+		fmt.Fprintf(tabOut, "UUID\tAPP\tACI\tSTATE\tNETWORKS\n")
 	}
 
 	if err := walkPods(includeMostDirs, func(p *pod) {
-		m := schema.PodManifest{}
-		app_zero := ""
+		pm := schema.PodManifest{}
 
 		if !p.isPreparing && !p.isAbortedPrepare && !p.isExitedDeleting {
 			// TODO(vc): we should really hold a shared lock here to prevent gc of the pod
-			manifFile, err := p.readFile(common.PodManifestPath(""))
+			pmf, err := p.readFile(common.PodManifestPath(""))
 			if err != nil {
-				stderr("Unable to read manifest: %v", err)
+				stderr("Unable to read pod manifest: %v", err)
 				return
 			}
-
-			err = m.UnmarshalJSON(manifFile)
-			if err != nil {
-				stderr("Unable to load manifest: %v", err)
+			if err := pm.UnmarshalJSON(pmf); err != nil {
+				stderr("Unable to load pod manifest: %v", err)
 				return
 			}
-
-			if len(m.Apps) == 0 {
+			if len(pm.Apps) == 0 {
 				stderr("Pod contains zero apps")
 				return
 			}
-			app_zero = m.Apps[0].Name.String()
 		}
 
 		uuid := ""
@@ -79,9 +81,18 @@ func runList(cmd *cobra.Command, args []string) (exit int) {
 			uuid = p.uuid.String()[:8]
 		}
 
-		fmt.Fprintf(tabOut, "%s\t%s\t%s\t%s\n", uuid, app_zero, p.getState(), fmtNets(p.nets))
-		for i := 1; i < len(m.Apps); i++ {
-			fmt.Fprintf(tabOut, "\t%s\n", m.Apps[i].Name.String())
+		for i, app := range pm.Apps {
+			// Retrieve the image from the store.
+			im, err := s.GetImageManifest(app.Image.ID.String())
+			if err != nil {
+				stderr("Unable to load image manifest: %v", err)
+			}
+
+			if i == 0 {
+				fmt.Fprintf(tabOut, "%s\t%s\t%s\t%s\t%s\n", uuid, app.Name.String(), im.Name.String(), p.getState(), fmtNets(p.nets))
+			} else {
+				fmt.Fprintf(tabOut, "\t%s\t%s\t\t\n", app.Name.String(), im.Name.String())
+			}
 		}
 	}); err != nil {
 		stderr("Failed to get pod handles: %v", err)

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -159,7 +159,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		pcfg.Apps = &rktApps
 	}
 
-	if err = stage0.Prepare(pcfg, p.path(), p.uuid); err != nil {
+	if _, err := stage0.Prepare(pcfg, p.path(), p.uuid); err != nil {
 		stderr("prepare: error setting up stage0: %v", err)
 		return 1
 	}

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -189,7 +189,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		pcfg.Apps = &rktApps
 	}
 
-	err = stage0.Prepare(pcfg, p.path(), p.uuid)
+	pm, err := stage0.Prepare(pcfg, p.path(), p.uuid)
 	if err != nil {
 		stderr("run: error setting up stage0: %v", err)
 		return 1
@@ -214,17 +214,10 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		LockFd:       lfd,
 		Interactive:  flagInteractive,
 	}
-
-	if len(flagPodManifest) > 0 {
-		imgs, err := p.getAppsHashes()
-		if err != nil {
-			stderr("run: cannot get the image hashes in the pod manifest: %v", err)
-			return 1
-		}
-		rcfg.Images = imgs
-	} else {
-		rcfg.Images = rktApps.GetImageIDs()
+	for i := range pm.Apps {
+		rcfg.Images = append(rcfg.Images, pm.Apps[i].Image.ID)
 	}
+
 	stage0.Run(rcfg, p.path()) // execs, never returns
 
 	return 1

--- a/stage0/enter.go
+++ b/stage0/enter.go
@@ -22,20 +22,16 @@ import (
 	"path/filepath"
 	"strconv"
 	"syscall"
-
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
 // Enter enters the pod/app by exec()ing the stage1's /enter similar to /init
 // /enter can expect to have its CWD set to the app root.
-// imageID and command are supplied to /enter on argv followed by any arguments.
+// index and command are supplied to /enter on argv followed by any arguments.
 // stage1Path is the path of the stage1 rootfs
-func Enter(cdir string, podPID int, imageID *types.Hash, stage1Path string, cmdline []string) error {
+func Enter(cdir string, podPID int, index int, stage1Path string, cmdline []string) error {
 	if err := os.Chdir(cdir); err != nil {
 		return fmt.Errorf("error changing to dir: %v", err)
 	}
-
-	id := types.ShortHash(imageID.String())
 
 	ep, err := getStage1Entrypoint(cdir, enterEntrypoint)
 	if err != nil {
@@ -44,7 +40,7 @@ func Enter(cdir string, podPID int, imageID *types.Hash, stage1Path string, cmdl
 
 	argv := []string{filepath.Join(stage1Path, ep)}
 	argv = append(argv, strconv.Itoa(podPID))
-	argv = append(argv, id)
+	argv = append(argv, strconv.Itoa(index))
 	argv = append(argv, cmdline...)
 	if err := syscall.Exec(argv[0], argv, os.Environ()); err != nil {
 		return fmt.Errorf("error execing enter: %v", err)

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -116,9 +116,9 @@ func imageNameToAppName(name types.ACIdentifier) (*types.ACName, error) {
 }
 
 // generatePodManifest creates the pod manifest from the command line input.
-// It returns the pod manifest as []byte on success.
+// It returns the pod manifest and the serialized bytes.
 // This is invoked if no pod manifest is specified at the command line.
-func generatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
+func generatePodManifest(cfg PrepareConfig, dir string) (*schema.PodManifest, []byte, error) {
 	pm := schema.PodManifest{
 		ACKind: "PodManifest",
 		Apps:   make(schema.AppList, 0),
@@ -126,13 +126,14 @@ func generatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
 
 	v, err := types.NewSemVer(version.Version)
 	if err != nil {
-		return nil, fmt.Errorf("error creating version: %v", err)
+		return nil, nil, fmt.Errorf("error creating version: %v", err)
 	}
 	pm.ACVersion = *v
 
 	if err := cfg.Apps.Walk(func(app *apps.App) error {
 		img := app.ImageID
-		am, err := prepareAppImage(cfg, img, dir, cfg.UseOverlay)
+
+		am, err := prepareAppImage(cfg, img, len(pm.Apps), dir, cfg.UseOverlay)
 		if err != nil {
 			return fmt.Errorf("error setting up image %s: %v", img, err)
 		}
@@ -146,6 +147,7 @@ func generatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
 		if am.App == nil {
 			return fmt.Errorf("error: image %s has no app section", img)
 		}
+
 		ra := schema.RuntimeApp{
 			// TODO(vc): leverage RuntimeApp.Name for disambiguating the apps
 			Name: *appName,
@@ -167,7 +169,7 @@ func generatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
 		pm.Apps = append(pm.Apps, ra)
 		return nil
 	}); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// TODO(jonboulle): check that app mountpoint expectations are
@@ -177,82 +179,83 @@ func generatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
 
 	pmb, err := json.Marshal(pm)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling pod manifest: %v", err)
+		return nil, nil, fmt.Errorf("error marshalling pod manifest: %v", err)
 	}
-	return pmb, nil
+	return &pm, pmb, nil
 }
 
 // validatePodManifest reads the user-specified pod manifest, prepares the app images
 // and validates the pod manifest. If the pod manifest passes validation, it returns
-// the manifest as []byte.
+// the pod manifest and its serialized bytes.
 // TODO(yifan): More validation in the future.
-func validatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
+func validatePodManifest(cfg PrepareConfig, dir string) (*schema.PodManifest, []byte, error) {
 	pmb, err := ioutil.ReadFile(cfg.PodManifest)
 	if err != nil {
-		return nil, fmt.Errorf("error reading pod manifest: %v", err)
+		return nil, nil, fmt.Errorf("error reading pod manifest: %v", err)
 	}
 	var pm schema.PodManifest
 	if err := json.Unmarshal(pmb, &pm); err != nil {
-		return nil, fmt.Errorf("error unmarshaling pod manifest: %v", err)
+		return nil, nil, fmt.Errorf("error unmarshaling pod manifest: %v", err)
 	}
 
 	appNames := make(map[types.ACName]struct{})
-	for _, ra := range pm.Apps {
+	for i, ra := range pm.Apps {
 		img := ra.Image
-		am, err := prepareAppImage(cfg, img.ID, dir, cfg.UseOverlay)
+		am, err := prepareAppImage(cfg, img.ID, i, dir, cfg.UseOverlay)
 		if err != nil {
-			return nil, fmt.Errorf("error setting up image %s: %v", img.ID, err)
+			return nil, nil, fmt.Errorf("error setting up image %s: %v", img, err)
 		}
 		if _, ok := appNames[ra.Name]; ok {
-			return nil, fmt.Errorf("error: multiple apps with name %s", ra.Name)
+			return nil, nil, fmt.Errorf("error: multiple apps with name %s", ra.Name)
 		}
 		appNames[ra.Name] = struct{}{}
 		if ra.App == nil && am.App == nil {
-			return nil, fmt.Errorf("error: no app section in the pod manifest or the image manifest")
+			return nil, nil, fmt.Errorf("error: no app section in the pod manifest or the image manifest")
 		}
 	}
-	return pmb, nil
+	return &pm, pmb, nil
 }
 
 // Prepare sets up a pod based on the given config.
-func Prepare(cfg PrepareConfig, dir string, uuid *types.UUID) error {
+func Prepare(cfg PrepareConfig, dir string, uuid *types.UUID) (*schema.PodManifest, error) {
 	log.Printf("Preparing stage1")
 	if err := prepareStage1Image(cfg, cfg.Stage1Image, dir, cfg.UseOverlay); err != nil {
-		return fmt.Errorf("error preparing stage1: %v", err)
+		return nil, fmt.Errorf("error preparing stage1: %v", err)
 	}
 
+	var pm *schema.PodManifest
 	var pmb []byte
 	var err error
 	if len(cfg.PodManifest) > 0 {
-		pmb, err = validatePodManifest(cfg, dir)
+		pm, pmb, err = validatePodManifest(cfg, dir)
 	} else {
-		pmb, err = generatePodManifest(cfg, dir)
+		pm, pmb, err = generatePodManifest(cfg, dir)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	log.Printf("Writing pod manifest")
 	fn := common.PodManifestPath(dir)
 	if err := ioutil.WriteFile(fn, pmb, 0700); err != nil {
-		return fmt.Errorf("error writing pod manifest: %v", err)
+		return nil, fmt.Errorf("error writing pod manifest: %v", err)
 	}
 
 	fn = path.Join(dir, common.Stage1IDFilename)
 	if err := ioutil.WriteFile(fn, []byte(cfg.Stage1Image.String()), 0700); err != nil {
-		return fmt.Errorf("error writing stage1 ID: %v", err)
+		return nil, fmt.Errorf("error writing stage1 ID: %v", err)
 	}
 
 	if cfg.UseOverlay {
 		// mark the pod as prepared with overlay
 		f, err := os.Create(filepath.Join(dir, common.OverlayPreparedFilename))
 		if err != nil {
-			return fmt.Errorf("error writing overlay marker file: %v", err)
+			return nil, fmt.Errorf("error writing overlay marker file: %v", err)
 		}
 		defer f.Close()
 	}
 
-	return nil
+	return pm, nil
 }
 
 func preparedWithOverlay(dir string) (bool, error) {
@@ -303,8 +306,8 @@ func Run(cfg RunConfig, dir string) {
 	}
 	log.Printf("Wrote filesystem to %s\n", dir)
 
-	for _, img := range cfg.Images {
-		if err := setupAppImage(cfg, img, dir, useOverlay); err != nil {
+	for i, img := range cfg.Images {
+		if err := setupAppImage(cfg, img, i, dir, useOverlay); err != nil {
 			log.Fatalf("error setting up app image: %v", err)
 		}
 	}
@@ -347,10 +350,10 @@ func Run(cfg RunConfig, dir string) {
 }
 
 // prepareAppImage renders and verifies the tree cache of the app image that
-// corresponds to the given hash.
+// corresponds to its position in the pod manifest.
 // When useOverlay is false, it attempts to render and expand the app image
 // TODO(jonboulle): tighten up the Hash type here; currently it is partially-populated (i.e. half-length sha512)
-func prepareAppImage(cfg PrepareConfig, img types.Hash, cdir string, useOverlay bool) (*schema.ImageManifest, error) {
+func prepareAppImage(cfg PrepareConfig, img types.Hash, index int, cdir string, useOverlay bool) (*schema.ImageManifest, error) {
 	log.Println("Loading image", img.String())
 
 	if useOverlay {
@@ -364,7 +367,7 @@ func prepareAppImage(cfg PrepareConfig, img types.Hash, cdir string, useOverlay 
 			}
 		}
 	} else {
-		ad := common.AppImagePath(cdir, img)
+		ad := common.AppPath(cdir, index)
 		err := os.MkdirAll(ad, 0755)
 		if err != nil {
 			return nil, fmt.Errorf("error creating image directory: %v", err)
@@ -384,10 +387,10 @@ func prepareAppImage(cfg PrepareConfig, img types.Hash, cdir string, useOverlay 
 }
 
 // setupAppImage mounts the overlay filesystem for the app image that
-// corresponds to the given hash. Then, it creates the tmp directory.
+// corresponds to its position in the pod manifest. Then, it creates the tmp directory.
 // When useOverlay is false it just creates the tmp directory for this app.
-func setupAppImage(cfg RunConfig, img types.Hash, cdir string, useOverlay bool) error {
-	ad := common.AppImagePath(cdir, img)
+func setupAppImage(cfg RunConfig, img types.Hash, index int, cdir string, useOverlay bool) error {
+	ad := common.AppPath(cdir, index)
 	if useOverlay {
 		err := os.MkdirAll(ad, 0776)
 		if err != nil {

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -492,12 +492,16 @@ func stage1() int {
 		return 3
 	}
 
-	appHashes := p.GetAppHashes()
+	var serviceNames []string
+	for i := range p.Manifest.Apps {
+		serviceNames = append(serviceNames, ServiceUnitName(i))
+	}
+
 	s1Root := common.Stage1RootfsPath(p.Root)
 	machineID := p.GetMachineID()
 	subcgroup, err := getContainerSubCgroup(machineID)
 	if err == nil {
-		if err := cgroup.CreateCgroups(s1Root, subcgroup, appHashes); err != nil {
+		if err := cgroup.CreateCgroups(s1Root, subcgroup, serviceNames); err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating cgroups: %v\n", err)
 			return 5
 		}

--- a/stage1/init/path.go
+++ b/stage1/init/path.go
@@ -17,10 +17,11 @@
 package main
 
 import (
+	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/common"
 )
 
@@ -31,56 +32,59 @@ const (
 	socketsWantsDir = unitsDir + "/sockets.target.wants"
 )
 
-// ServiceUnitName returns a systemd service unit name for the given imageID
-func ServiceUnitName(imageID types.Hash) string {
-	return types.ShortHash(imageID.String()) + ".service"
+// ServiceUnitName returns a systemd service unit name based on the position of the
+// app in the pod manifest.
+func ServiceUnitName(index int) string {
+	return fmt.Sprintf("app-%d.service", index)
 }
 
-// ServiceUnitPath returns the path to the systemd service file for the given
-// imageID
-func ServiceUnitPath(root string, imageID types.Hash) string {
-	return filepath.Join(common.Stage1RootfsPath(root), unitsDir, ServiceUnitName(imageID))
+// ServiceUnitPath returns the path to the systemd service file based on the position
+// of the app in the pod manifest.
+func ServiceUnitPath(root string, index int) string {
+	return filepath.Join(common.Stage1RootfsPath(root), unitsDir, ServiceUnitName(index))
 }
 
-// RelEnvFilePath returns the path to the environment file for the given imageID
-// relative to the pod's root
-func RelEnvFilePath(imageID types.Hash) string {
-	return filepath.Join(envDir, types.ShortHash(imageID.String()))
+// RelEnvFilePath returns the path to the environment file relative to the pod's root.
+func RelEnvFilePath(index int) string {
+	return filepath.Join(envDir, strconv.Itoa(index))
 }
 
-// EnvFilePath returns the path to the environment file for the given imageID
-func EnvFilePath(root string, imageID types.Hash) string {
-	return filepath.Join(common.Stage1RootfsPath(root), RelEnvFilePath(imageID))
+// EnvFilePath returns the path to the environment file based on the position of the
+// app in the pod manifest.
+func EnvFilePath(root string, index int) string {
+	return filepath.Join(common.Stage1RootfsPath(root), RelEnvFilePath(index))
 }
 
-// ServiceWantPath returns the systemd default.target want symlink path for the
-// given imageID
-func ServiceWantPath(root string, imageID types.Hash) string {
-	return filepath.Join(common.Stage1RootfsPath(root), defaultWantsDir, ServiceUnitName(imageID))
+// ServiceWantPath returns the systemd default.target want symlink path based on the
+// position of the app in the pod manifest.
+func ServiceWantPath(root string, index int) string {
+	return filepath.Join(common.Stage1RootfsPath(root), defaultWantsDir, ServiceUnitName(index))
 }
 
 // InstantiatedPrepareAppUnitName returns the systemd service unit name for prepare-app
-// instantiated for the given root
-func InstantiatedPrepareAppUnitName(imageID types.Hash) string {
+// instantiated for the given root based on its position in the pod manifest.
+func InstantiatedPrepareAppUnitName(index int) string {
 	// Naming respecting escaping rules, see systemd.unit(5) and systemd-escape(1)
-	escaped_root := common.RelAppRootfsPath(imageID)
+	escaped_root := common.RelAppRootfsPath(index)
 	escaped_root = strings.Replace(escaped_root, "-", "\\x2d", -1)
 	escaped_root = strings.Replace(escaped_root, "/", "-", -1)
 	return "prepare-app@" + escaped_root + ".service"
 }
 
-// SocketUnitName returns a systemd socket unit name for the given imageID
-func SocketUnitName(imageID types.Hash) string {
-	return imageID.String() + ".socket"
+// SocketUnitName returns a systemd socket unit name based on the position of the app in
+// the pod manifest.
+func SocketUnitName(index int) string {
+	return fmt.Sprintf("app-%d.socket", index)
 }
 
-// SocketUnitPath returns the path to the systemd socket file for the given imageID
-func SocketUnitPath(root string, imageID types.Hash) string {
-	return filepath.Join(common.Stage1RootfsPath(root), unitsDir, SocketUnitName(imageID))
+// SocketUnitPath returns the path to the systemd socket file based on the position of
+// the app in the pod manifest.
+func SocketUnitPath(root string, index int) string {
+	return filepath.Join(common.Stage1RootfsPath(root), unitsDir, SocketUnitName(index))
 }
 
-// SocketWantPath returns the systemd sockets.target.wants symlink path for the
-// given imageID
-func SocketWantPath(root string, imageID types.Hash) string {
-	return filepath.Join(common.Stage1RootfsPath(root), socketsWantsDir, SocketUnitName(imageID))
+// SocketWantPath returns the systemd sockets.target.wants symlink path based on the position
+// of the app in the pod manifest.
+func SocketWantPath(root string, index int) string {
+	return filepath.Join(common.Stage1RootfsPath(root), socketsWantsDir, SocketUnitName(index))
 }

--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -86,10 +86,6 @@ func LoadPod(root string, uuid *types.UUID) (*Pod, error) {
 		if err = json.Unmarshal(buf, am); err != nil {
 			return nil, fmt.Errorf("failed unmarshalling app manifest %q: %v", ampath, err)
 		}
-		name := am.Name.String()
-		if _, ok := p.Apps[name]; ok {
-			return nil, fmt.Errorf("got multiple definitions for app: %s", name)
-		}
 		if app.App == nil {
 			p.Manifest.Apps[i].App = am.App
 		}

--- a/stage1/init/registration.go
+++ b/stage1/init/registration.go
@@ -62,8 +62,8 @@ func registerPod(p *Pod, ip net.IP) (rerr error) {
 		}
 	}()
 
-	for _, app := range p.Manifest.Apps {
-		ampath := common.ImageManifestPath(p.Root, app.Image.ID)
+	for i, app := range p.Manifest.Apps {
+		ampath := common.ImageManifestPath(p.Root, i)
 		amf, err := os.Open(ampath)
 		if err != nil {
 			rerr = fmt.Errorf("failed reading app manifest %q: %v", ampath, err)

--- a/stage1/rootfs/aggregate/scripts/reaper.sh
+++ b/stage1/rootfs/aggregate/scripts/reaper.sh
@@ -5,7 +5,7 @@ SYSCTL=/usr/bin/systemctl
 
 cd /opt/stage2
 for app in *; do
-        status=$(${SYSCTL} show --property ExecMainStatus "${app}.service")
+        status=$(${SYSCTL} show --property ExecMainStatus "app-${app}.service")
         echo "${status#*=}" > "/rkt/status/$app"
 done
 

--- a/stage1/rootfs/enter/enter.c
+++ b/stage1/rootfs/enter/enter.c
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
 	/* The parameters list is specified in
 	 * Documentation/devel/stage1-implementors-guide.md */
 	exit_if(argc < 4,
-		"Usage: %s pid imageid cmd [args...]", argv[0])
+		"Usage: %s pid index cmd [args...]", argv[0])
 
 	pid = atoi(argv[1]);
 	root_fd = openpidfd(pid, "root");

--- a/tests/rkt_exit_test.go
+++ b/tests/rkt_exit_test.go
@@ -34,7 +34,7 @@ func TestExitCode(t *testing.T) {
 			`%s --debug --insecure-skip-verify run ./rkt-inspect-exit.aci ;`+
 			`UUID=$(%s list --full|grep exited|awk '{print $1}') ;`+
 			`echo -n 'status=' ;`+
-			`%s status $UUID|grep '^sha512-.*=[0-9]*$'|cut -d= -f2"`,
+			`%s status $UUID|grep '^rkt-inspect.*=[0-9]*$'|cut -d= -f2"`,
 			ctx.cmd(), ctx.cmd(), ctx.cmd())
 		t.Logf("%s\n", cmd)
 		child, err := gexpect.Spawn(cmd)


### PR DESCRIPTION
Not ready for review yet.

This PR does:
- Exposing app name to user.
- Replacing stage2 rootfs dir name with the numeric index of the app in the podmanifest. (`/opt/stage2/sha512-xxx/`=> `opt/stage2/0/`)
- <del> Replacing app's systemd service file names with the app's name. (`sha512-xxx.service` => `foo.service`) </del>

Need to update `rkt status` `rkt enter` and fix a bug for `rkt list`
Two functional tests are failing, will fix as well.

