### PR TITLE
stage1: limit systemd log output

### DIFF
--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -342,7 +342,9 @@ func getArgsEnv(p *Pod, flavor string, systemdStage1Version string, debug bool) 
 	args = append(args, "--default-standard-output=tty") // redirect all service logs straight to tty
 	if !debug {
 		args = append(args, "--log-target=null") // silence systemd output inside pod
-		args = append(args, "--show-status=0")   // silence systemd initialization status output
+		// TODO remove --log-level=warning when we update stage1 to systemd v222
+		args = append(args, "--log-level=warning") // limit log output (systemd-shutdown ignores --log-target)
+		args = append(args, "--show-status=0")     // silence systemd initialization status output
 	}
 
 	return args, env, nil


### PR DESCRIPTION
systemd-shutdown currently ignores --log-target=null so it was printing
the messages

    Sending SIGTERM to remaining processes...
    Sending SIGKILL to remaining processes...
    Halting system.

This is fixed in systemd master but for now setting --log-level=warning
mutes these messages.