### PR TITLE
stage1: remove OnFailureJobMode=isolate

### DIFF
--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -201,7 +201,6 @@ func (p *Pod) appToSystemd(ra *schema.RuntimeApp, interactive bool) error {
 	opts := []*unit.UnitOption{
 		unit.NewUnitOption("Unit", "Description", name),
 		unit.NewUnitOption("Unit", "DefaultDependencies", "false"),
-		unit.NewUnitOption("Unit", "OnFailureJobMode", "isolate"),
 		unit.NewUnitOption("Unit", "OnFailure", "reaper.service"),
 		unit.NewUnitOption("Unit", "Wants", "exit-watcher.service"),
 		unit.NewUnitOption("Service", "Restart", "no"),


### PR DESCRIPTION
It was causing systemd in stage1 to block on shutdown.

When systemd starts the shutdown process it will broadcast SIGTERM to
every process. That will make exit-watcher.service and the app service
stop.

exit-watcher.service has the property

    ExecStopPost=/usr/bin/systemctl isolate reaper.service

and the app service has the property

    OnFailureJobMode=isolate

That means both will try to run in isolate mode and sometimes that was
getting systemd to a state where it's not executing any job:

    -bash-4.3# systemctl --no-pager list-jobs
    JOB UNIT                        TYPE  STATE
     30 halt.target                 stop  waiting
     18 exit-watcher.service        stop  waiting
     17 default.target              stop  waiting
     19 systemd-journald.service    stop  waiting
     16 system-prepare\x2dapp.slice stop  waiting
     13 reaper.service              start waiting

So it will stay blocked until something kills it (e.g. the unit that started
rkt on the host).

Removing OnFailureJobMode=isolate is fine because the app unit has the option

    OnFailure=reaper.service

and reaper.service will save the apps' statuses and trigger a shutdown via
"systemctl halt --force".

The TestServiceFile functional test was failing sometimes with

    RUN TestServiceFile
    --- FAIL: TestServiceFile (10.02s)
            rkt_service_file_test.go:105: Test unit found in list, should be stopped

and with this commit I can't reproduce it anymore.

To validate my theory, I also tried without this commit but catching
SIGTERM in the test program and exiting with status 0 so the unit
doesn't fail and OnFailureJobMode doesn't get triggered and I couldn't
reproduce the failure either.