### PR TITLE
stage1: flavor src: build systemd v221 by default

### DIFF
--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -322,7 +322,7 @@ By default, rkt will send logs directly to stdout/stderr, allowing them to be ca
 On host systems running systemd, rkt will attempt to integrate with journald on the host.
 In this case, the logs can be accessed directly via journalctl.
 
-NOTE: Journald integration requires systemd version v219 or v220 in stage1.
+NOTE: Journald integration requires systemd version v219 or better in stage1.
 
 #### Accessing logs via journalctl
 

--- a/Documentation/hacking.md
+++ b/Documentation/hacking.md
@@ -59,12 +59,12 @@ $ sudo docker run -v $SRC:/opt/rkt -i -t golang:1.4 /bin/bash -c "apt-get update
 By default, rkt gets systemd from a CoreOS image to generate stage1. But it's also possible to build systemd from the sources. To do that, you can set the following environment variables:
 
 * `RKT_STAGE1_USR_FROM=none|coreos|src`: choose how to generate systemd for stage1
-* `RKT_STAGE1_SYSTEMD_VER=v219|v220|master`: if `RKT_STAGE1_USR_FROM=src`, choose the systemd branch or tag to build
+* `RKT_STAGE1_SYSTEMD_VER=v219|v220|v221|master`: if `RKT_STAGE1_USR_FROM=src`, choose the systemd branch or tag to build
 
 Example:
 
 ```
-RKT_STAGE1_USR_FROM=src RKT_STAGE1_SYSTEMD_VER=v220 ./build
+RKT_STAGE1_USR_FROM=src RKT_STAGE1_SYSTEMD_VER=v221 ./build
 ```
 
 ### Alternative stage1 paths

--- a/build
+++ b/build
@@ -27,7 +27,7 @@ case "${RKT_STAGE1_USR_FROM}" in
 		;;
 	src)
 		export RKT_STAGE1_SYSTEMD_SRC="${RKT_STAGE1_SYSTEMD_SRC:-https://github.com/systemd/systemd.git}"
-		export RKT_STAGE1_SYSTEMD_VER="${RKT_STAGE1_SYSTEMD_VER:-v220}"
+		export RKT_STAGE1_SYSTEMD_VER="${RKT_STAGE1_SYSTEMD_VER:-v221}"
 		echo "stage1 will be built from sources: $RKT_STAGE1_SYSTEMD_SRC $RKT_STAGE1_SYSTEMD_VER"
 		;;
 	*)

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -704,6 +704,8 @@ func systemdSupportsJournalLinking(version string) bool {
 		fallthrough
 	case version == "v220":
 		fallthrough
+	case version == "v221":
+		fallthrough
 	case version == "master":
 		return true
 	default:

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,7 +16,7 @@ Use the following build commands:
 ```
 ./tests/install-deps.sh            # Setup
 ./tests/run-build.sh none          # Thread 1
-./tests/run-build.sh src v220      # Thread 1
+./tests/run-build.sh src v221      # Thread 1
 ./tests/run-build.sh usr-from-host # Thread 1
 ./tests/run-build.sh coreos        # Thread 2
 ./tests/run-build.sh src master    # Thread 2


### PR DESCRIPTION
systemd v221 was released. Switch to this new version by default.