### PR TITLE
stage1: fix version in manifest

### DIFF
--- a/Documentation/devel/release.md
+++ b/Documentation/devel/release.md
@@ -17,6 +17,7 @@ Let's get started:
 The rkt version is [hardcoded in the repository](https://github.com/coreos/rkt/blob/master/version/version.go#L17), so the first thing to do is bump it:
 - Run `scripts/bump-release v0.1.2`. This should generate two commits: a bump to the actual release (e.g. v0.1.2), and then a bump to the release+git (e.g. v0.1.2+git). The actual release version should only exist in a single commit!
 - Sanity check what the script did with `git diff HEAD^^` or similar. As well as changing the actual version, it also attempts to fix a bunch of references in the documentation etc.
+- Fix the commit `HEAD^^` so that the version in `stage1/rootfs/aggregate/aci-manifest` is correct.
 - If the script didn't work, yell at the author and/or fix it. It can almost certainly be improved.
 - File a PR and get a review from another [MAINTAINER](https://github.com/coreos/rkt/blob/master/MAINTAINERS). This is useful to a) sanity check the diff, and b) be very explicit/public that a release is happening
 - Ensure the CI on the release PR is green!

--- a/stage1/rootfs/aggregate/aci-manifest
+++ b/stage1/rootfs/aggregate/aci-manifest
@@ -5,7 +5,7 @@
     "labels": [
         {
             "name": "version",
-            "value": "0.0.1"
+            "value": "0.6.1+git"
         },
         {
             "name": "arch",


### PR DESCRIPTION
The version was still 0.0.1... It should follow rkt versioning.
```
$ sudo bin/rkt image list
KEY																		APPNAME
sha512-f910f96f18ef781e8fabfb6f8e37ba07c33d3dfc21e8f7b5be5f88a96d2da775	coreos.com/rkt/stage1:0.0.1
sha512-fa1cb92dc276b0f9bedf87981e61ecde93cc16432d2441f23aa006a42bb873df	coreos.com/etcd:v2.0.0
```