### PR TITLE
rkt: fix --private-net without arguments

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -143,8 +143,6 @@ type PrivateNetList struct {
 	mapping map[string]bool
 }
 
-func (i *PrivateNetList) IsBoolFlag() bool { return true }
-
 func (l *PrivateNetList) String() string {
 	return strings.Join(l.Strings(), ",")
 }

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -74,6 +74,7 @@ func init() {
 	cmdRun.Flags().Var(&flagVolumes, "volume", "volumes to mount into the pod")
 	cmdRun.Flags().Var(&flagPorts, "port", "ports to expose on the host (requires --private-net)")
 	cmdRun.Flags().Var(&flagPrivateNet, "private-net", "give pod a private network that defaults to the default network plus all user-configured networks. Can be limited to a comma-separated list of network names")
+	cmdRun.Flags().Lookup("private-net").NoOptDefVal = "true"
 	cmdRun.Flags().BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	cmdRun.Flags().BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
 	cmdRun.Flags().Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -42,6 +42,7 @@ func init() {
 	cmdRkt.AddCommand(cmdRunPrepared)
 
 	cmdRunPrepared.Flags().Var(&flagPrivateNet, "private-net", "give pod a private network")
+	cmdRunPrepared.Flags().Lookup("private-net").NoOptDefVal = "true"
 	cmdRunPrepared.Flags().BoolVar(&flagInteractive, "interactive", false, "the pod is interactive")
 }
 


### PR DESCRIPTION
starting from spf13/pflag#20 it accepts also `--flag value` while
before `--flag=value` was needed. Additionally it supports default values
for flags specified without an explicit value (`--flag`) (which is
different from the default value for flags not passed as arguments).

In that case, the `--flag=value` is needed for flags that can have a
default value because the parser won't know if the argument after
`--flag` is the flag's value or another argument.

That fix also changed the way flags are handled and removed the use of
the boolFlag interface as now default values can be provided for every
type (not just bool) by setting the NoOptDefVal variable.

This patch fixes rkt to use the new behavior.