### PR TITLE
Move mnt ns unshare into stage1

### DIFF
--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -917,9 +917,13 @@ func (p *pod) getAppCount() (int, error) {
 	return len(m.Apps), nil
 }
 
-func (p *pod) getStatusDir() (string, error) {
+func (p *pod) usesOverlay() bool {
 	_, err := p.openFile(common.OverlayPreparedFilename, syscall.O_RDONLY)
-	if err == nil {
+	return err == nil
+}
+
+func (p *pod) getStatusDir() (string, error) {
+	if p.usesOverlay() {
 		// the pod uses overlay. Since the mount is in another mount
 		// namespace (or gone), return the status directory from the overlay
 		// upper layer

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -282,24 +282,6 @@ func Run(cfg RunConfig, dir string) {
 		log.Fatalf("error: %v", err)
 	}
 
-	// create a separate mount namespace so the cgroup filesystems and/or
-	// overlay mounts are unmounted when exiting the pod
-	if err := syscall.Unshare(syscall.CLONE_NEWNS); err != nil {
-		log.Fatalf("error unsharing: %v", err)
-	}
-
-	// we recursively make / a "shared and slave" so mount events from the
-	// new namespace don't propagate to the host namespace but mount events
-	// from the host propagate to the new namespace and are forwarded to
-	// its peer group
-	// See https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt
-	if err := syscall.Mount("", "/", "none", syscall.MS_REC|syscall.MS_SLAVE, ""); err != nil {
-		log.Fatalf("error making / a slave mount: %v", err)
-	}
-	if err := syscall.Mount("", "/", "none", syscall.MS_REC|syscall.MS_SHARED, ""); err != nil {
-		log.Fatalf("error making / a shared and slave mount: %v", err)
-	}
-
 	log.Printf("Setting up stage1")
 	if err := setupStage1Image(cfg, cfg.Stage1Image, dir, useOverlay); err != nil {
 		log.Fatalf("error setting up stage1: %v", err)


### PR DESCRIPTION
NOT READY FOR MERGE! This is WIP PR to explore how to best handle https://github.com/coreos/rkt/issues/1054

This allows the networking setup to still run in the host ns.
The overlay mount also happens in host ns and gets cleaned by
by the gc process. The cgroups get mounted in the child ns.