### PR TITLE
fetch: check signature identity before downloading

### DIFF
--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -344,7 +344,7 @@ func TestDownloading(t *testing.T) {
 				insecureSkipVerify: true,
 			},
 		}
-		_, aciFile, err := ft.fetch(tt.ACIURL, "", nil)
+		_, aciFile, err := ft.fetch("", tt.ACIURL, "", nil)
 		if err == nil {
 			defer os.Remove(aciFile.Name())
 		}


### PR DESCRIPTION
This is an optimization to avoid having to download the image twice when
the user forgets to use "rkt trust".

Note that this optimization does not help when downloading the signature
returns the HTTP error 202 (such as quay.io on the first conversion).

Fixes: https://github.com/coreos/rkt/issues/573#issuecomment-78361925

Fixes partially, but not completely: https://github.com/coreos/rkt/issues/776