### PR TITLE
rkt: add image export and image extract subcommands

### DIFF
--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -395,3 +395,61 @@ Garbage collecting pod "21b1cb32-c156-4d26-82ae-eda1ab60f595"
 Garbage collecting pod "5dd42e9c-7413-49a9-9113-c2a8327d08ab"
 Garbage collecting pod "f07a4070-79a9-4db0-ae65-a090c9c393a3"
 ```
+
+### rkt image export
+
+There are cases where you might want to export the ACI from the store to copy to another machine, file server, etc.
+
+```
+$ rkt image export coreos.com/etcd etcd.aci
+$ tar xvf etcd.aci
+```
+
+NOTES:
+- A matching image must be fetched before doing this operation, rkt will not attempt to download an image first, this subcommand will incur no-network I/O.
+- The exported ACI file might be different than the original one because rkt image export always returns uncompressed ACIs.
+
+
+### rkt image extract/render
+
+For debugging or inspection you may want to extract an ACI to a directory on disk. There are a few different options depending on your use case but the basic command looks like this:
+
+```
+$ rkt image extract coreos.com/etcd etcd-extracted
+$ find etcd-extracted
+etcd-extracted
+etcd-extracted/manifest
+etcd-extracted/rootfs
+etcd-extracted/rootfs/etcd
+etcd-extracted/rootfs/etcdctl
+...
+```
+
+NOTE: Like with rkt image export, a matching image must be fetched before doing this operation.
+
+Now there are some flags that can be added to this:
+
+To get just the rootfs use:
+
+```
+$ rkt image extract --rootfs-only coreos.com/etcd etcd-extracted
+$ find etcd-extracted
+etcd-extracted
+etcd-extracted/etcd
+etcd-extracted/etcdctl
+...
+```
+
+If you want the image rendered as it would look ready-to-run inside of the rkt stage2 then use `rkt image render`. NOTE: this will not use overlayfs or any other mechanism. This is to simplify the cleanup: to remove the extracted files you can run a a simple `rm -Rf`.
+
+### rkt image cat-manifest
+
+For debugging or inspection you may want to extract an ACI manifest to stdout.
+
+```
+$ rkt image cat-manifest --pretty-print coreos.com/etcd
+{
+  "acVersion": "0.6.1",
+  "acKind": "ImageManifest",
+...
+```

--- a/rkt/image.go
+++ b/rkt/image.go
@@ -14,7 +14,15 @@
 
 package main
 
-import "github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/coreos/rkt/store"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/discovery"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
+)
 
 var (
 	cmdImage = &cobra.Command{
@@ -25,4 +33,29 @@ var (
 
 func init() {
 	cmdRkt.AddCommand(cmdImage)
+}
+
+func getKeyFromAppOrHash(s *store.Store, input string) (string, error) {
+	var key string
+	if _, err := types.NewHash(input); err == nil {
+		key, err = s.ResolveKey(input)
+		if err != nil {
+			return "", fmt.Errorf("cannot resolve key: %v", err)
+		}
+	} else {
+		app, err := discovery.NewAppFromString(input)
+		if err != nil {
+			return "", fmt.Errorf("cannot parse the image name: %v", err)
+		}
+		labels, err := types.LabelsFromMap(app.Labels)
+		if err != nil {
+			return "", fmt.Errorf("invalid labels in the name: %v", err)
+		}
+		key, err = s.GetACI(app.Name, labels)
+		if err != nil {
+			return "", fmt.Errorf("cannot find image: %v", err)
+		}
+	}
+
+	return key, nil
 }

--- a/rkt/image_cat_manifest.go
+++ b/rkt/image_cat_manifest.go
@@ -17,8 +17,6 @@ package main
 import (
 	"encoding/json"
 
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/discovery"
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/store"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
@@ -51,29 +49,10 @@ func runImageCatManifest(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	var key string
-	if _, err := types.NewHash(args[0]); err == nil {
-		key, err = s.ResolveKey(args[0])
-		if err != nil {
-			stderr("image cat-manifest: cannot resolve key: %v", err)
-			return 1
-		}
-	} else {
-		app, err := discovery.NewAppFromString(args[0])
-		if err != nil {
-			stderr("image cat-manifest: cannot parse the image name: %v", err)
-			return 1
-		}
-		labels, err := types.LabelsFromMap(app.Labels)
-		if err != nil {
-			stderr("image cat-manifest: invalid labels in the name: %v", err)
-			return 1
-		}
-		key, err = s.GetACI(app.Name, labels)
-		if err != nil {
-			stderr("image cat-manifest: cannot find image: %v", err)
-			return 1
-		}
+	key, err := getKeyFromAppOrHash(s, args[0])
+	if err != nil {
+		stderr("image cat-manifest: %v", err)
+		return 1
 	}
 
 	manifest, err := s.GetImageManifest(key)

--- a/rkt/image_export.go
+++ b/rkt/image_export.go
@@ -1,0 +1,96 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io"
+	"os"
+
+	"github.com/coreos/rkt/store"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
+)
+
+var (
+	cmdImageExport = &cobra.Command{
+		Use:   "export IMAGE OUTPUT_ACI_FILE",
+		Short: "export a stored image to an ACI file",
+		Long:  `IMAGE should be a string referencing an image: either a hash or an image name.`,
+		Run:   runWrapper(runImageExport),
+	}
+	flagOverwriteACI bool
+)
+
+func init() {
+	cmdImage.AddCommand(cmdImageExport)
+	cmdImageExport.Flags().BoolVar(&flagOverwriteACI, "overwrite", false, "overwrite output ACI")
+}
+
+func runImageExport(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) != 2 {
+		cmd.Usage()
+		return 1
+	}
+
+	s, err := store.NewStore(globalFlags.Dir)
+	if err != nil {
+		stderr("image export: cannot open store: %v", err)
+		return 1
+	}
+
+	key, err := getKeyFromAppOrHash(s, args[0])
+	if err != nil {
+		stderr("image export: %v", err)
+		return 1
+	}
+
+	aci, err := s.ReadStream(key)
+	if err != nil {
+		stderr("image export: error reading image: %v", err)
+		return 1
+	}
+	defer aci.Close()
+
+	mode := os.O_CREATE | os.O_WRONLY
+	if flagOverwriteACI {
+		mode |= os.O_TRUNC
+	} else {
+		mode |= os.O_EXCL
+	}
+	f, err := os.OpenFile(args[1], mode, 0644)
+	if err != nil {
+		if os.IsExist(err) {
+			stderr("image export: output ACI file exists (try --overwrite)")
+		} else {
+			stderr("image export: unable to open output ACI file %s: %v", args[1], err)
+		}
+		return 1
+	}
+	defer func() {
+		err := f.Close()
+		if err != nil {
+			stderr("image export: error closing output ACI file: %v", err)
+			exit = 1
+		}
+	}()
+
+	_, err = io.Copy(f, aci)
+	if err != nil {
+		stderr("image export: error writing to output ACI file: %v", err)
+		return 1
+	}
+
+	return 0
+}

--- a/rkt/image_extract.go
+++ b/rkt/image_extract.go
@@ -1,0 +1,145 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/coreos/rkt/pkg/fileutil"
+	"github.com/coreos/rkt/pkg/tar"
+	"github.com/coreos/rkt/store"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
+)
+
+var (
+	cmdImageExtract = &cobra.Command{
+		Use:   "extract IMAGE OUTPUT_DIR",
+		Short: "extract a stored image to a directory",
+		Long:  `IMAGE should be a string referencing an image: either a hash or an image name.`,
+		Run:   runWrapper(runImageExtract),
+	}
+	flagExtractRootfsOnly bool
+	flagExtractOverwrite  bool
+)
+
+func init() {
+	cmdImage.AddCommand(cmdImageExtract)
+	cmdImageExtract.Flags().BoolVar(&flagExtractRootfsOnly, "rootfs-only", false, "extract rootfs only")
+	cmdImageExtract.Flags().BoolVar(&flagExtractOverwrite, "overwrite", false, "overwrite output directory")
+}
+
+func runImageExtract(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) != 2 {
+		cmd.Usage()
+		return 1
+	}
+	outputDir := args[1]
+
+	s, err := store.NewStore(globalFlags.Dir)
+	if err != nil {
+		stderr("image extract: cannot open store: %v", err)
+		return 1
+	}
+
+	key, err := getKeyFromAppOrHash(s, args[0])
+	if err != nil {
+		stderr("image extract: %v", err)
+		return 1
+	}
+
+	aci, err := s.ReadStream(key)
+	if err != nil {
+		stderr("image extract: error reading ACI from the store: %v", err)
+		return 1
+	}
+
+	// ExtractTar needs an absolute path
+	absOutputDir, err := filepath.Abs(outputDir)
+	if err != nil {
+		stderr("image extract: error converting output to an absolute path: %v", err)
+		return 1
+	}
+
+	if _, err := os.Stat(absOutputDir); err == nil {
+		if !flagExtractOverwrite {
+			stderr("image extract: output directory exists (try --overwrite)")
+			return 1
+		}
+
+		// don't allow the user to delete the root filesystem by mistake
+		if absOutputDir == "/" {
+			stderr("image extract: this would delete your root filesystem. Refusing.")
+			return 1
+		}
+
+		if err := os.RemoveAll(absOutputDir); err != nil {
+			stderr("image extract: error removing existing output dir: %v", err)
+			return 1
+		}
+	}
+
+	// if the user only asks for the rootfs we extract the image to a temporary
+	// directory and then move/copy the rootfs to the output directory, if not
+	// we just extract the image to the output directory
+	extractDir := absOutputDir
+	if flagExtractRootfsOnly {
+		rktTmpDir, err := s.TmpDir()
+		if err != nil {
+			stderr("image extract: error creating rkt temporary directory: %v", err)
+			return 1
+		}
+
+		tmpDir, err := ioutil.TempDir(rktTmpDir, "rkt-image-extract-")
+		if err != nil {
+			stderr("image extract: error creating temporary directory: %v", err)
+			return 1
+		}
+		defer os.RemoveAll(tmpDir)
+
+		extractDir = tmpDir
+	} else {
+		if err := os.MkdirAll(absOutputDir, 0755); err != nil {
+			stderr("image extract: error creating output directory: %v", err)
+			return 1
+		}
+	}
+
+	if err := tar.ExtractTar(aci, extractDir, false, nil); err != nil {
+		stderr("image extract: error extracting ACI: %v", err)
+		return 1
+	}
+
+	if flagExtractRootfsOnly {
+		rootfsDir := filepath.Join(extractDir, "rootfs")
+		if err := os.Rename(rootfsDir, absOutputDir); err != nil {
+			if e, ok := err.(*os.LinkError); ok && e.Err == syscall.EXDEV {
+				// it's on a different device, fall back to copying
+				if err := fileutil.CopyTree(rootfsDir, absOutputDir); err != nil {
+					stderr("image extract: error copying ACI rootfs: %v", err)
+					return 1
+				}
+			} else {
+				stderr("image extract: error moving ACI rootfs: %v", err)
+				return 1
+			}
+		}
+	}
+
+	return 0
+}

--- a/rkt/image_render.go
+++ b/rkt/image_render.go
@@ -1,0 +1,127 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/coreos/rkt/pkg/fileutil"
+	"github.com/coreos/rkt/store"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
+)
+
+var (
+	cmdImageRender = &cobra.Command{
+		Use:   "render IMAGE OUTPUT_DIR",
+		Short: "render a stored image to a directory with all its dependencies",
+		Long:  `IMAGE should be a string referencing an image: either a hash or an image name.`,
+		Run:   runWrapper(runImageRender),
+	}
+	flagRenderRootfsOnly bool
+	flagRenderOverwrite  bool
+)
+
+func init() {
+	cmdImage.AddCommand(cmdImageRender)
+	cmdImageRender.Flags().BoolVar(&flagRenderRootfsOnly, "rootfs-only", false, "render rootfs only")
+	cmdImageRender.Flags().BoolVar(&flagRenderOverwrite, "overwrite", false, "overwrite output directory")
+}
+
+func runImageRender(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) != 2 {
+		cmd.Usage()
+		return 1
+	}
+	outputDir := args[1]
+
+	s, err := store.NewStore(globalFlags.Dir)
+	if err != nil {
+		stderr("image render: cannot open store: %v", err)
+		return 1
+	}
+
+	key, err := getKeyFromAppOrHash(s, args[0])
+	if err != nil {
+		stderr("image render: %v", err)
+		return 1
+	}
+
+	if err := s.RenderTreeStore(key, false); err != nil {
+		stderr("image render: error rendering ACI: %v", err)
+		return 1
+	}
+	if err := s.CheckTreeStore(key); err != nil {
+		stderr("image render: warning: tree cache is in a bad state. Rebuilding...")
+		if err := s.RenderTreeStore(key, true); err != nil {
+			stderr("image render: error rendering ACI: %v", err)
+			return 1
+		}
+	}
+
+	if _, err := os.Stat(outputDir); err == nil {
+		if !flagRenderOverwrite {
+			stderr("image render: output directory exists (try --overwrite)")
+			return 1
+		}
+
+		// don't allow the user to delete the root filesystem by mistake
+		if outputDir == "/" {
+			stderr("image extract: this would delete your root filesystem. Refusing.")
+			return 1
+		}
+
+		if err := os.RemoveAll(outputDir); err != nil {
+			stderr("image render: error removing existing output dir: %v", err)
+			return 1
+		}
+	}
+	rootfsOutDir := outputDir
+	if !flagRenderRootfsOnly {
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			stderr("image render: error creating output directory: %v", err)
+			return 1
+		}
+		rootfsOutDir = filepath.Join(rootfsOutDir, "rootfs")
+
+		manifest, err := s.GetImageManifest(key)
+		if err != nil {
+			stderr("image render: error getting manifest: %v", err)
+			return 1
+		}
+
+		mb, err := json.Marshal(manifest)
+		if err != nil {
+			stderr("image render: error marshalling image manifest: %v", err)
+			return 1
+		}
+
+		if err := ioutil.WriteFile(filepath.Join(outputDir, "manifest"), mb, 0700); err != nil {
+			stderr("image render: error writing image manifest: %v", err)
+			return 1
+		}
+	}
+
+	cachedTreePath := s.GetTreeStoreRootFS(key)
+	if err := fileutil.CopyTree(cachedTreePath, rootfsOutDir); err != nil {
+		stderr("image render: error copying ACI rootfs: %v", err)
+		return 1
+	}
+
+	return 0
+}

--- a/tests/build
+++ b/tests/build
@@ -19,7 +19,13 @@ echo -n dir2 > image/rootfs/dir2/file
 # Create base image
 ../bin/actool build --overwrite image rkt-inspect.aci
 
+# Create empty image
+[ -d empty-image/rootfs ] && rmdir empty-image/rootfs
+mkdir empty-image/rootfs
+../bin/actool build --overwrite empty-image rkt-empty.aci
+
 # Alternative images are created in tests themselves
 
 # Cleanup
 rm -rf image/rootfs
+rm -rf empty-image/rootfs

--- a/tests/empty-image/manifest
+++ b/tests/empty-image/manifest
@@ -1,0 +1,19 @@
+{
+    "acKind": "ImageManifest",
+    "acVersion": "0.6.1",
+    "name": "coreos.com/rkt-empty",
+    "labels": [
+        {
+            "name": "version",
+            "value": "1.0.0"
+        },
+        {
+            "name": "arch",
+            "value": "amd64"
+        },
+        {
+            "name": "os",
+            "value": "linux"
+        }
+    ]
+}

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -1,0 +1,122 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/ThomasRooney/gexpect"
+)
+
+const (
+	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.6.1","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+)
+
+// TestImageExport tests 'rkt image export', it will import some existing
+// image, export it with rkt image export and check that the exported ACI hash
+// matches the hash of the imported ACI
+func TestImageExport(t *testing.T) {
+	testImage := "rkt-inspect-image-export.aci"
+	testImageName := "coreos.com/rkt-image-export-test"
+	expectManifest := strings.Replace(manifestExportTemplate, "IMG_NAME", testImageName, -1)
+
+	tmpDir, err := ioutil.TempDir("", "rkt-TestImageExport-")
+	if err != nil {
+		panic(fmt.Sprintf("Cannot create temp dir: %v", err))
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tmpManifest, err := ioutil.TempFile(tmpDir, "manifest")
+	if err != nil {
+		panic(fmt.Sprintf("Cannot create temp manifest: %v", err))
+	}
+	defer tmpManifest.Close()
+	tmpManifestName := tmpManifest.Name()
+	if err := ioutil.WriteFile(tmpManifestName, []byte(expectManifest), 0600); err != nil {
+		panic(fmt.Sprintf("Cannot write to temp manifest: %v", err))
+	}
+	defer os.Remove(tmpManifestName)
+
+	patchTestACI(testImage, "--manifest", tmpManifestName)
+	defer os.Remove(testImage)
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
+
+	testImageKey := importImageAndFetchHash(t, ctx, testImage)
+
+	testImageHash, err := getHash(testImage)
+	if err != nil {
+		panic(fmt.Sprintf("Error getting image hash: %v", err))
+	}
+
+	tests := []struct {
+		image        string
+		shouldFind   bool
+		expectedHash string
+	}{
+		{
+			testImageName,
+			true,
+			testImageHash,
+		},
+		{
+			testImageKey,
+			true,
+			testImageHash,
+		},
+		{
+			"sha512-not-existed",
+			false,
+			"",
+		},
+		{
+			"some~random~aci~name",
+			false,
+			"",
+		},
+	}
+
+	for i, tt := range tests {
+		outputAciPath := filepath.Join(tmpDir, fmt.Sprintf("exported-%d.aci", i))
+		runCmd := fmt.Sprintf("%s image export %s %s", ctx.cmd(), tt.image, outputAciPath)
+		t.Logf("Running 'image export' test #%v: %v", i, runCmd)
+		child, err := gexpect.Spawn(runCmd)
+		if err != nil {
+			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
+		}
+
+		if err := child.Wait(); err != nil {
+			if !tt.shouldFind && err.Error() == "exit status 1" {
+				continue
+			} else if tt.shouldFind || err.Error() != "exit status 1" {
+				t.Fatalf("rkt didn't terminate correctly: %v", err)
+			}
+		}
+
+		exportedHash, err := getHash(outputAciPath)
+		if err != nil {
+			t.Fatalf("Error getting exported image hash: %v", err)
+		}
+
+		if exportedHash != tt.expectedHash {
+			t.Fatalf("Expected hash %q but got %s", tt.expectedHash, exportedHash)
+		}
+	}
+}

--- a/tests/rkt_image_extract_test.go
+++ b/tests/rkt_image_extract_test.go
@@ -1,0 +1,101 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/ThomasRooney/gexpect"
+)
+
+// TestImageExtract tests 'rkt image extract', it will import some existing
+// image with the inspect binary, extract it with rkt image extract and check
+// that the exported /inspect hash matches the original inspect binary hash
+func TestImageExtract(t *testing.T) {
+	testImage := "rkt-inspect.aci"
+	testImageName := "coreos.com/rkt-inspect"
+	inspectHash, err := getHash("inspect/inspect")
+	if err != nil {
+		panic("Cannot get inspect binary's hash")
+	}
+
+	tmpDir, err := ioutil.TempDir("", "rkt-TestImageRender-")
+	if err != nil {
+		panic(fmt.Sprintf("Cannot create temp dir: %v", err))
+	}
+	defer os.RemoveAll(tmpDir)
+
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
+
+	testImageShortHash := importImageAndFetchHash(t, ctx, testImage)
+
+	tests := []struct {
+		image        string
+		shouldFind   bool
+		expectedHash string
+	}{
+		{
+			testImageName,
+			true,
+			inspectHash,
+		},
+		{
+			testImageShortHash,
+			true,
+			inspectHash,
+		},
+		{
+			"sha512-not-existed",
+			false,
+			"",
+		},
+		{
+			"some~random~aci~name",
+			false,
+			"",
+		},
+	}
+
+	for i, tt := range tests {
+		outputPath := filepath.Join(tmpDir, fmt.Sprintf("extracted-%d", i))
+		runCmd := fmt.Sprintf("%s image extract --rootfs-only %s %s", ctx.cmd(), tt.image, outputPath)
+		t.Logf("Running 'image extract' test #%v: %v", i, runCmd)
+		child, err := gexpect.Spawn(runCmd)
+		if err != nil {
+			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
+		}
+
+		if err := child.Wait(); err != nil {
+			if !tt.shouldFind && err.Error() == "exit status 1" {
+				continue
+			} else if tt.shouldFind || err.Error() != "exit status 1" {
+				t.Fatalf("rkt didn't terminate correctly: %v", err)
+			}
+		}
+
+		extractedInspectHash, err := getHash(filepath.Join(outputPath, "inspect"))
+		if err != nil {
+			t.Fatalf("Cannot get rendered inspect binary's hash")
+		}
+		if extractedInspectHash != tt.expectedHash {
+			t.Fatalf("Expected /inspect hash %q but got %s", tt.expectedHash, extractedInspectHash)
+		}
+	}
+}

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -1,0 +1,123 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/ThomasRooney/gexpect"
+)
+
+const (
+	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.6.1","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+)
+
+// TestImageRender tests 'rkt image render', it will import some existing empty
+// image with a dependency on an image with the inspect binary, render it with
+// rkt image render and check that the exported image has the /inspect file and
+// that its hash matches the original inspect binary hash
+func TestImageRender(t *testing.T) {
+	baseImage := "rkt-inspect.aci"
+	emptyImage := "rkt-empty.aci"
+	testImage := "rkt-inspect-image-render.aci"
+	testImageName := "coreos.com/rkt-image-render-test"
+	inspectHash, err := getHash("inspect/inspect")
+	if err != nil {
+		panic("Cannot get inspect binary's hash")
+	}
+
+	expectManifest := strings.Replace(manifestRenderTemplate, "IMG_NAME", testImageName, -1)
+
+	tmpDir, err := ioutil.TempDir("", "rkt-TestImageRender-")
+	if err != nil {
+		panic(fmt.Sprintf("Cannot create temp dir: %v", err))
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tmpManifest, err := ioutil.TempFile(tmpDir, "manifest")
+	if err != nil {
+		panic(fmt.Sprintf("Cannot create temp manifest: %v", err))
+	}
+	if err := ioutil.WriteFile(tmpManifest.Name(), []byte(expectManifest), 0600); err != nil {
+		panic(fmt.Sprintf("Cannot write to temp manifest: %v", err))
+	}
+	defer os.Remove(tmpManifest.Name())
+
+	patchACI(emptyImage, testImage, "--manifest", tmpManifest.Name())
+	defer os.Remove(testImage)
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
+
+	_ = importImageAndFetchHash(t, ctx, baseImage)
+	testImageShortHash := importImageAndFetchHash(t, ctx, testImage)
+
+	tests := []struct {
+		image        string
+		shouldFind   bool
+		expectedHash string
+	}{
+		{
+			testImageName,
+			true,
+			inspectHash,
+		},
+		{
+			testImageShortHash,
+			true,
+			inspectHash,
+		},
+		{
+			"sha512-not-existed",
+			false,
+			"",
+		},
+		{
+			"some~random~aci~name",
+			false,
+			"",
+		},
+	}
+
+	for i, tt := range tests {
+		outputPath := filepath.Join(tmpDir, fmt.Sprintf("rendered-%d", i))
+		runCmd := fmt.Sprintf("%s image render --rootfs-only %s %s", ctx.cmd(), tt.image, outputPath)
+		t.Logf("Running 'image render' test #%v: %v", i, runCmd)
+		child, err := gexpect.Spawn(runCmd)
+		if err != nil {
+			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
+		}
+
+		if err := child.Wait(); err != nil {
+			if !tt.shouldFind && err.Error() == "exit status 1" {
+				continue
+			} else if tt.shouldFind || err.Error() != "exit status 1" {
+				t.Fatalf("rkt didn't terminate correctly: %v", err)
+			}
+		}
+
+		renderedInspectHash, err := getHash(filepath.Join(outputPath, "inspect"))
+		if err != nil {
+			t.Fatalf("Cannot get rendered inspect binary's hash")
+		}
+		if renderedInspectHash != tt.expectedHash {
+			t.Fatalf("Expected /inspect hash %q but got %s", tt.expectedHash, renderedInspectHash)
+		}
+	}
+}

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -15,7 +15,10 @@
 package main
 
 import (
+	"crypto/sha512"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -184,4 +187,20 @@ func patchTestACI(newFileName string, args ...string) {
 	if err != nil {
 		panic(fmt.Sprintf("Cannot create ACI: %v: %s\n", err, output))
 	}
+}
+
+func getHash(filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("error opening file: %v", err)
+	}
+
+	hash := sha512.New()
+	r := io.TeeReader(f, hash)
+
+	if _, err := io.Copy(ioutil.Discard, r); err != nil {
+		return "", fmt.Errorf("error reading file: %v", err)
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -174,6 +174,7 @@ func expectTimeoutWithOutput(p *gexpect.ExpectSubprocess, searchString string, t
 func patchTestACI(newFileName string, args ...string) {
 	var allArgs []string
 	allArgs = append(allArgs, "patch-manifest")
+	allArgs = append(allArgs, "--no-compression")
 	allArgs = append(allArgs, "--overwrite")
 	allArgs = append(allArgs, args...)
 	allArgs = append(allArgs, "rkt-inspect.aci")

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -174,19 +174,23 @@ func expectTimeoutWithOutput(p *gexpect.ExpectSubprocess, searchString string, t
 	return expectCommon(p, searchString, timeout)
 }
 
-func patchTestACI(newFileName string, args ...string) {
+func patchACI(inputFileName, newFileName string, args ...string) {
 	var allArgs []string
 	allArgs = append(allArgs, "patch-manifest")
 	allArgs = append(allArgs, "--no-compression")
 	allArgs = append(allArgs, "--overwrite")
 	allArgs = append(allArgs, args...)
-	allArgs = append(allArgs, "rkt-inspect.aci")
+	allArgs = append(allArgs, inputFileName)
 	allArgs = append(allArgs, newFileName)
 
 	output, err := exec.Command("../bin/actool", allArgs...).CombinedOutput()
 	if err != nil {
 		panic(fmt.Sprintf("Cannot create ACI: %v: %s\n", err, output))
 	}
+}
+
+func patchTestACI(newFileName string, args ...string) {
+	patchACI("rkt-inspect.aci", newFileName, args...)
 }
 
 func getHash(filePath string) (string, error) {


### PR DESCRIPTION
rkt image export exports an image from the internal rkt store to an ACI
file.

rkt image extract renders an image from the internal rkt store to a
directory.

Fixes #645

It was inspired by #649 but I didn't implement image render since I'm not sure what it means. Does it mean we render stage1+stage2 to a directory?

Also, it needs to run as root so it generates output artifacts owned by root. That's good for `rkt image extract` but maybe not so good for `rkt image export`.