### PR TITLE
Documentation: link to docker2aci docs

### DIFF
--- a/Documentation/running-docker-images.md
+++ b/Documentation/running-docker-images.md
@@ -71,4 +71,5 @@ $ rkt --insecure-skip-verify run sha512-c6d6efd98f506380ff128e473ca239ed
 ## How does it work?
 
 rkt leverages the [`docker2aci`](https://github.com/appc/docker2aci) library to transparently convert Docker images into rkt's native ACI format.
+To convert Docker images to ACI without necessarily having to run them, refer to the [docker2aci documentation](https://github.com/appc/docker2aci/blob/master/README.md).
 


### PR DESCRIPTION
The information about converting Docker images to ACI is there.

Fixes #787

Depends on appc/docker2aci#72