### PR TITLE
functional tests: GC containers before removing temp directory

### DIFF
--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -66,6 +66,10 @@ func (d *dirDesc) cleanup() {
 	if d.dir == "" {
 		return
 	}
+	cmd := exec.Command("../bin/rkt", fmt.Sprintf("--dir=%s", d.dir), "gc", "--grace-period=0s")
+	if err := cmd.Run(); err != nil {
+		panic(fmt.Sprintf("Failed to GC (data directory: %s): %v", d.dir, err))
+	}
 	if err := os.RemoveAll(d.dir); err != nil {
 		panic(fmt.Sprintf("Failed to remove temporary %s directory %q: %s", d.desc, d.dir, err))
 	}


### PR DESCRIPTION
Now that the overlay fs is not mounted in a separate mount namespace
mounts will stay in host's mount namespace and to unmount them we need
to run the GC. Tests were failing because we tried to remove the
temp directory with a mounted filesystem inside.

This commit runs the GC before removing the temp directory.