### PR TITLE
build: Fix overriding BUILDDIR variable

### DIFF
--- a/makelib/variables.mk.in
+++ b/makelib/variables.mk.in
@@ -49,7 +49,7 @@ RKT_RUN_FUNCTIONAL_TESTS := @RKT_RUN_FUNCTIONAL_TESTS@
 
 # build-related directories and binaries
 BUILDDIR ?= $(MK_TOPLEVEL_ABS_SRCDIR)/build-$(distdir)
-BUILDDIR := $(abspath $(BUILDDIR))
+override BUILDDIR := $(abspath $(BUILDDIR))
 
 MAKETOOLSDIR := $(MK_TOPLEVEL_SRCDIR)/tools
 STAMPSDIR := $(BUILDDIR)/stamps


### PR DESCRIPTION
When calling "make BUILDDIR=some/dir" the BUILDDIR variable's origin
becomes "command line". Further modifications of variable of such
origin are ignored unless they are done with "override" directive.