### PR TITLE
scripts/vagrant: use new build system

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure('2') do |config|
-    # grab Ubuntu 14.04 official image
-    config.vm.box = "ubuntu/trusty64" # Ubuntu 14.04
+    # grab Ubuntu 15.04 official image
+    config.vm.box = "ubuntu/vivid64" # Ubuntu 15.04
 
     # fix issues with slow dns http://serverfault.com/a/595010
     config.vm.provider :virtualbox do |vb, override|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,8 @@ Vagrant.configure('2') do |config|
     config.vm.provider :virtualbox do |vb, override|
         vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
         vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+        # add more ram, the default isn't enough for the build
+        vb.customize ["modifyvm", :id, "--memory", "768"]
     end
 
     # install Build Dependencies (GOLANG)

--- a/scripts/vagrant/install-go.sh
+++ b/scripts/vagrant/install-go.sh
@@ -3,7 +3,7 @@
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
-VERSION=1.4.1
+VERSION=1.4.2
 OS=linux
 ARCH=amd64
 

--- a/scripts/vagrant/install-rkt.sh
+++ b/scripts/vagrant/install-rkt.sh
@@ -16,13 +16,8 @@ if ! [ -d app-spec ]; then
   popd
 fi
 
-which unsquash || sudo apt-get install -y squashfs-tools
+which unsquash || sudo apt-get install -y squashfs-tools autoconf libcapture-tiny-perl
 
 pushd /vagrant
-./build
-sudo cp -v bin/* /usr/local/bin
-
-cat << EOF | sudo tee /etc/profile.d/99rkt.sh
-  export PATH=$PWD/bin:\$PATH
-  export GOPATH=$PWD/gopath:\$GOPATH
-EOF
+./autogen.sh && ./configure && make BUILDDIR=build-rkt
+sudo cp -v build-rkt/bin/* /usr/local/bin

--- a/scripts/vagrant/install-rkt.sh
+++ b/scripts/vagrant/install-rkt.sh
@@ -3,7 +3,7 @@
 set -xe
 export DEBIAN_FRONTEND=noninteractive
 
-APP_SPEC_VERSION=0.4.1
+APP_SPEC_VERSION=0.6.1
 
 if ! [ -d app-spec ]; then
   echo "Install actool ${APP_SPEC_VERSION}"


### PR DESCRIPTION
Now that the build system changed, the vagrant scripts were not
working.