### PR TITLE
functional tests: remove CircleCI

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -27,20 +27,6 @@ git clean -ffdx                    # Post Thread
 
 Select `Ubuntu 14.04 LTS v1503 (beta with Docker support)`.
 
-## CircleCI
-
-Ideally the tests will also run on [CircleCI](https://circleci.com), but there is currently a known issue because access to the cgroup filesystems is restricted - more info [here](https://github.com/coreos/rkt/issues/600#issuecomment-87655911)
-
-Assuming this can be resolved, the following configuration can be used:
-
-```circle.yml
-test:
-  override:
-    - ./tests/install-deps.sh
-    - RKT_STAGE1_USR_FROM=src ./build
-    - ./test
-```
-
 ## Manually running the functional tests
 
 Make sure that `--enable-functional-tests` is passed to configure

--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -13,15 +13,4 @@ if [ "${CI-}" == true ] ; then
 		sudo apt-get update -qq || true
 		sudo apt-get install -y libcapture-tiny-perl # used by tools/
 	fi
-
-	# https://circleci.com/
-	if [ "${CIRCLECI-}" == true ] ; then
-		sudo apt-get update -qq
-		sudo apt-get install -y libtool intltool # for ./autogen.sh
-		sudo apt-get install -y cpio realpath squashfs-tools
-		sudo apt-get install -y strace gdb libcap-ng-utils
-		sudo apt-get install -y coreutils # systemd needs a recent /bin/ln
-		sudo apt-get install -y gperf libcap-dev linux-headers-3.13.0-34-generic linux-libc-dev libseccomp-dev # systemd deps
-		sudo apt-get install -y git # cloning a tag of systemd
-	fi
 fi


### PR DESCRIPTION
Functional tests never worked with CircleCI so let's remove it from the
documentation and the install-deps script to avoid confusions.