### PR TITLE
stage1: use --link-journal=try-guest in systemd-nspawn

### DIFF
--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -338,7 +338,7 @@ NOTE: Journald integration requires systemd version v219 or v220 in stage1.
 
 #### Accessing logs via journalctl
 
-To get the logs you need to get pod's machine name. You can use machinectl
+To get the logs of a running pod you need to get pod's machine name. You can use machinectl
 
 ```
 $ machinectl
@@ -358,15 +358,13 @@ f241c969-1710-445a-8129-d3a7ffdd9a60    busybox running
 
 Pod's machine name will be the pod's UUID with a `rkt-` prefix.
 
-Then you can use systemd's journalctl with `_HOSTNAME` set to the machine name:
+Then you can use systemd's journalctl:
 
 ```
-$ journalctl -m _HOSTNAME=rkt-f241c969-1710-445a-8129-d3a7ffdd9a60
+$ sudo journalctl -M rkt-f241c969-1710-445a-8129-d3a7ffdd9a60
 
 [...]
 ```
-
-rkt doesn't integrate with `journalctl -M` yet (see https://github.com/coreos/rkt/issues/947).
 
 ### rkt status
 

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -324,7 +324,7 @@ func getArgsEnv(p *Pod, flavor string, systemdStage1Version string, debug bool) 
 			log.Fatalf("error writing /etc/machine-id: %v\n", err)
 		}
 
-		args = append(args, "--link-journal=try-host")
+		args = append(args, "--link-journal=try-guest")
 	}
 
 	if !debug {


### PR DESCRIPTION
Now that we mount the overlay fs on the host mount namespace, we can
access the container's log directory from the host and hence we can
start systemd-nspawn with --link-journal=try-guest. This has two
benefits:

* The logs get removed with a garbage collector pass. Before (with
  try-host), they were stored in the host's /var/log/journal directory
  and they were ignored by the GC. Since systemd doesn't have a way to
  limit the contents of /var/log/journal, only the contents of a
  specific machine directory, it kept growing and growing.

* journalctl -M rkt-machine works now.

Fixes #947