### PR TITLE
stage1: add ctrl-alt-del and poweroff targets

### DIFF
--- a/stage1/units/units.mk
+++ b/stage1/units/units.mk
@@ -10,7 +10,12 @@ LOCAL_UNIT_FILES := \
         $(MK_SRCDIR)/units/reaper.service \
         $(MK_SRCDIR)/units/sockets.target \
         $(MK_SRCDIR)/units/halt.target \
-
+        $(MK_SRCDIR)/units/systemd-reboot.service \
+        $(MK_SRCDIR)/units/reboot.target \
+        $(MK_SRCDIR)/units/poweroff.target
+LOCAL_CTRL_ALT_DEL := $(LOCAL_UNITDIR)/ctrl-alt-del.target
+LOCAL_UNIT_SYMLINKS := \
+        reboot.target:$(LOCAL_CTRL_ALT_DEL)
 $(call setup-stamp-file,LOCAL_STAMP)
 
 local-to-aci-unit = $(LOCAL_UNITDIR)/$(notdir $1)
@@ -23,14 +28,17 @@ $(foreach u,$(LOCAL_UNIT_FILES), \
         $(eval LOCAL_INSTALL_TRIPLETS += $u:$(_UNITS_MK_ACI_UNIT_):0644) \
         $(eval _UNITS_MK_ACI_UNIT_ :=))
 
-$(LOCAL_STAMP): $(LOCAL_ACI_UNIT_FILES) | $(LOCAL_UNIT_DIRS)
+$(LOCAL_STAMP): $(LOCAL_ACI_UNIT_FILES) | $(LOCAL_UNIT_DIRS) $(LOCAL_CTRL_ALT_DEL)
 	touch "$@"
 
 STAGE1_INSTALL_FILES += $(LOCAL_INSTALL_TRIPLETS)
+STAGE1_INSTALL_SYMLINKS += $(LOCAL_UNIT_SYMLINKS)
 STAGE1_INSTALL_DIRS += $(foreach d,$(LOCAL_UNIT_DIRS),$d:0755)
 STAGE1_STAMPS += $(LOCAL_STAMP)
 
 LOCAL_UNITDIR :=
+LOCAL_CTRL_ALT_DEL :=
+LOCAL_UNIT_SYMLINKS :=
 LOCAL_UNIT_DIRS :=
 LOCAL_UNIT_FILES :=
 LOCAL_STAMP :=

--- a/stage1/units/units/poweroff.target
+++ b/stage1/units/units/poweroff.target
@@ -1,0 +1,6 @@
+[Unit]
+Description=Poweroff
+DefaultDependencies=no
+Requires=reaper.service
+After=reaper.service
+AllowIsolate=yes

--- a/stage1/units/units/reboot.target
+++ b/stage1/units/units/reboot.target
@@ -1,0 +1,6 @@
+[Unit]
+Description=Reboot
+DefaultDependencies=no
+Requires=systemd-reboot.service
+After=systemd-reboot.service
+AllowIsolate=yes

--- a/stage1/units/units/systemd-reboot.service
+++ b/stage1/units/units/systemd-reboot.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Reboot
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl --force reboot


### PR DESCRIPTION
These targets are called by machinectl reboot and poweroff respectively.
In ctrl-alt-del we just reboot the system without saving the exit
statuses of the apps and the poweroff target is just the same as the
halt.target: it calls the reaper to save the exit statuses of the apps
and shuts down the container.