### PR TITLE
stage1: include ipvlan netplugin in build system

### DIFF
--- a/stage1/net-plugins/net-plugins.mk
+++ b/stage1/net-plugins/net-plugins.mk
@@ -1,4 +1,4 @@
-LOCAL_PLUGIN_NAMES := main/veth main/bridge main/macvlan ipam/host-local
+LOCAL_PLUGIN_NAMES := main/veth main/bridge main/macvlan main/ipvlan ipam/host-local
 LOCAL_ACI_PLUGINSDIR := $(ACIROOTFSDIR)/usr/lib/rkt/plugins/net
 LOCAL_HOST_LOCAL_PTP_SYMLINK := $(LOCAL_ACI_PLUGINSDIR)/host-local-ptp
 


### PR DESCRIPTION
Assuming it has been forgotten since migrating to the new build system.

Fixes #1146.