### PR TITLE
dist: update GC-related units

### DIFF
--- a/dist/init/systemd/rkt-gc.service
+++ b/dist/init/systemd/rkt-gc.service
@@ -1,3 +1,7 @@
+[Unit]
+Description=Garbage Collection for rkt
+
 [Service]
+Environment=GRACE_PERIOD=24h
 Type=oneshot
-ExecStart=/usr/bin/rkt gc --grace-period=5m
+ExecStart=/usr/bin/rkt gc --grace-period=${GRACE_PERIOD}

--- a/dist/init/systemd/rkt-gc.timer
+++ b/dist/init/systemd/rkt-gc.timer
@@ -1,6 +1,9 @@
+[Unit]
+Description=Periodic Garbage Collection for rkt
+
 [Timer]
 OnActiveSec=0s
-OnUnitActiveSec=5m
+OnUnitActiveSec=12h
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Use less aggressive values for the garbage collection and make it easy
for a user to modify the grace period via a drop-in.