### PR TITLE
docs: Improve authentication docs a bit

### DIFF
--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -94,7 +94,7 @@ rkt uses HTTPS to locate and download remote ACIs and their attached signatures.
 
 The easiest way to fetch an ACI is through meta discovery. rkt will find and download the ACI and signature from a location that the creator has published on their website. This process is detailed in the [Application Container specification][appc-discovery].
 
-If you have previously trusted the image creator, it will be downloaded and verified: 
+If you have previously trusted the image creator, it will be downloaded and verified:
 
 ```
 # rkt fetch coreos.com/etcd:v2.0.0
@@ -102,7 +102,7 @@ rkt: searching for app image coreos.com/etcd:v2.0.0
 rkt: fetching image from https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.aci
 Downloading aci: [=======================================      ] 3.25 MB/3.7 MB
 Downloading signature from https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.sig
-rkt: signature verified: 
+rkt: signature verified:
   CoreOS ACI Builder <release@coreos.com>
 sha512-fa1cb92dc276b0f9bedf87981e61ecde
 ```
@@ -233,7 +233,7 @@ Volumes are defined in each ACI and are referenced by name. Volumes can be expos
 [rkt #378]: https://github.com/coreos/rkt/issues/378
 
 
-##### Mounting Host Volumes 
+##### Mounting Host Volumes
 
 For `host` volumes, the `--volume` flag allows you to specify each mount, its type and the location on the host. The volume is then mounted into each app running to the pod based on information defined in the ACI manifest.
 

--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -149,6 +149,10 @@ sha512-c4010045aec65aefa74770ef2bb648d9
 
 Docker images do not support signature verification.
 
+#### Authentication
+
+If you want to download an image from a private repository, then you will often need to pass credentials to be able to access it. rkt currently supports authentication for fetching images via https:// or docker:// protocols. To specify credentials you will have to write some configuration files. You can find the format of the configuration file and examples in the [configuration documentation](configuration.md). Note that the configuration kind for images downloaded via https:// and images downloaded via docker:// is different.
+
 ## Running Pods
 
 rkt can run ACIs based on name, hash, local file on disk or URL. If an ACI hasn't been cached on disk, rkt will attempt to find and download it.

--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -185,7 +185,7 @@ Docker registry. This field must be specified and cannot be empty.
 
 Currently, Docker registries only support basic HTTP authentication, so
 `credentials` field has two subfields - `user` and `password`. These
-fields have to be specified and cannot be empty.
+fields must be specified and cannot be empty.
 
 Some popular Docker registries:
 * index.docker.io (this is used when no Docker registry is

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ rkt: signature verified:
 sha512-1eba37d9b344b33d272181e176da111e
 ```
 
+Sometimes you will want to download an image from a private repository. This usually involves passing usernames and passwords or other kinds of credentials to the server. rkt currently supports authentication via configuration files. You can find configuration file format description (with examples!) in [configuration documentation](Documentation/configuration.md).
+
 For the curious, we can see the files written to disk in rkt's CAS:
 
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![rkt Logo](logos/rkt-horizontal-color.png)
 
-rkt (pronounced _"rock-it"_) is a CLI for running app containers on Linux. rkt is designed to be composable, secure, and fast. 
+rkt (pronounced _"rock-it"_) is a CLI for running app containers on Linux. rkt is designed to be composable, secure, and fast.
 
 Some of rkt's key features and goals include:
 - First-class integration with init systems ([systemd](Documentation/using-rkt-with-systemd.md), upstart) and cluster orchestration tools (fleet, Kubernetes)
@@ -17,7 +17,7 @@ For more on the background and motivation behind rkt, read the original [launch 
 
 ## App Container
 
-rkt is an implementation of the [App Container spec](Documentation/app-container.md). 
+rkt is an implementation of the [App Container spec](Documentation/app-container.md).
 rkt's native image format ([ACI](Documentation/app-container.md#ACI)) and runtime/execution environment ([pods](Documentation/app-container.md#pods)) are defined in the specification.
 
 ## Project status
@@ -62,7 +62,7 @@ To build ACIs, a simple way to get started is by using [`actool`](https://github
 Another good resource is the [appc build repository](https://github.com/appc/build-repository) which has resources for building ACIs from a number of popular projects and languages.
 There are also tools for converting [Docker images to ACIs](https://github.com/appc/docker2aci) (although note that rkt can [also run Docker images natively](Documentation/running-docker-images.md) directly from Docker repositories by using this library internally).
 
-The example below uses a pre-built ACI for [etcd](https://github.com/coreos/etcd) (you can see how this was built [here](https://github.com/coreos/etcd/blob/master/scripts/build-aci)).
+The example below uses a pre-built ACI for [etcd](https://github.com/coreos/etcd) (this was built by the [build-aci script](https://github.com/coreos/etcd/blob/master/scripts/build-aci)).
 
 ### Downloading an App Container Image (ACI)
 
@@ -81,7 +81,7 @@ Trusting "https://coreos.com/dist/pubkeys/aci-pubkeys.gpg" for prefix "coreos.co
 Added key for prefix "coreos.com/etcd" at "/etc/rkt/trustedkeys/prefix.d/coreos.com/etcd/8b86de38890ddb7291867b025210bd8888182190"
 ```
 
-A detailed, step-by-step guide for the signing procedure [is here](Documentation/getting-started-ubuntu-trusty.md#trust-the-coreos-signing-key).
+In Documentation, you can find a [detailed, step-by-step guide for the signing procedure](Documentation/getting-started-ubuntu-trusty.md#trust-the-coreos-signing-key).
 
 Now that we've trusted the CoreOS public key, we can fetch the ACI using `rkt fetch`:
 
@@ -91,7 +91,7 @@ rkt: searching for app image coreos.com/etcd:v2.0.4
 rkt: fetching image from https://github.com/coreos/etcd/releases/download/v2.0.4/etcd-v2.0.4-linux-amd64.aci
 Downloading aci: [==========================================   ] 3.47 MB/3.7 MB
 Downloading signature from https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.4-linux-amd64.aci.asc
-rkt: signature verified: 
+rkt: signature verified:
   CoreOS ACI Builder <release@coreos.com>
 sha512-1eba37d9b344b33d272181e176da111e
 ```

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -322,7 +322,7 @@ func (f *fetcher) fetchImageFrom(appName string, aciURL, ascURL, scheme string, 
 	}
 
 	if entity != nil && !f.insecureSkipVerify {
-		stderr("rkt: signature verified: ")
+		stderr("rkt: signature verified:")
 		for _, v := range entity.Identities {
 			stderr("  %s", v.Name)
 		}

--- a/rkt/trust.go
+++ b/rkt/trust.go
@@ -271,7 +271,7 @@ func reviewKey(prefix string, location string, key *os.File, forceAccept bool) (
 	if !forceAccept {
 		in := bufio.NewReader(os.Stdin)
 		for {
-			stderr("Are you sure you want to trust this key (yes/no)? ")
+			stderr("Are you sure you want to trust this key (yes/no)?")
 			input, err := in.ReadString('\n')
 			if err != nil {
 				return false, fmt.Errorf("error reading input: %v", err)


### PR DESCRIPTION
Just explain it a little bit and put links to main document about
configuration, which currently describes only authentication.

I decided against cooking another document only for authentication - the `configuration.md` describes the format quite extensively and has lots of examples.

Fixes #866.