### PR TITLE
rkt,stage0: validate OS/arch during run

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -76,11 +76,11 @@
 		},
 		{
 			"ImportPath": "github.com/appc/docker2aci/lib",
-			"Rev": "5a59e6910929afdeb54913c301692194d3160d09"
+			"Rev": "f4921ff41174ce78fb57899b7ce1a713b5339a5b"
 		},
 		{
 			"ImportPath": "github.com/appc/docker2aci/tarball",
-			"Rev": "5a59e6910929afdeb54913c301692194d3160d09"
+			"Rev": "f4921ff41174ce78fb57899b7ce1a713b5339a5b"
 		},
 		{
 			"ImportPath": "github.com/appc/goaci/proj2aci",

--- a/Godeps/_workspace/src/github.com/appc/docker2aci/lib/common/common.go
+++ b/Godeps/_workspace/src/github.com/appc/docker2aci/lib/common/common.go
@@ -140,6 +140,7 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 
 		if layerData.Architecture != "" {
 			arch := appctypes.MustACIdentifier("arch")
+			labels = append(labels, appctypes.Label{Name: *arch, Value: layerData.Architecture})
 			parentLabels = append(parentLabels, appctypes.Label{Name: *arch, Value: layerData.Architecture})
 		}
 	}

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -32,6 +32,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/rkt/common/apps"
+	"github.com/coreos/rkt/pkg/keystore"
+	"github.com/coreos/rkt/rkt/config"
+	"github.com/coreos/rkt/stage0"
+	"github.com/coreos/rkt/store"
+
 	docker2aci "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/docker2aci/lib"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/docker2aci/lib/common"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/aci"
@@ -40,10 +46,6 @@ import (
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/coreos/ioprogress"
 	"github.com/coreos/rkt/Godeps/_workspace/src/golang.org/x/crypto/openpgp"
 	pgperrors "github.com/coreos/rkt/Godeps/_workspace/src/golang.org/x/crypto/openpgp/errors"
-	"github.com/coreos/rkt/common/apps"
-	"github.com/coreos/rkt/pkg/keystore"
-	"github.com/coreos/rkt/rkt/config"
-	"github.com/coreos/rkt/store"
 )
 
 type imageActionData struct {
@@ -89,6 +91,19 @@ func (f *finder) findImage(img string, asc string, discover bool) (*types.Hash, 
 			panic(err)
 		}
 		return h, nil
+	}
+
+	// check if os and arch are valid early
+	u, err := url.Parse(img)
+	if err != nil {
+		return nil, fmt.Errorf("not a valid image reference (%s)", img)
+	}
+	if discover && u.Scheme == "" {
+		if app := newDiscoveryApp(img); app != nil {
+			if err := types.IsValidOSArch(app.Labels, stage0.ValidOSArch); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	// try fetching the image, potentially remotely

--- a/stage0/arch.go
+++ b/stage0/arch.go
@@ -1,0 +1,19 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stage0
+
+var ValidOSArch = map[string][]string{
+	"linux": []string{"amd64"},
+}

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -363,6 +363,22 @@ func Run(cfg RunConfig, dir string) {
 func prepareAppImage(cfg PrepareConfig, appName types.ACName, img types.Hash, cdir string, useOverlay bool) error {
 	log.Println("Loading image", img.String())
 
+	am, err := cfg.Store.GetImageManifest(img.String())
+	if err != nil {
+		return fmt.Errorf("error getting the manifest: %v", err)
+	}
+
+	if _, hasOS := am.Labels.Get("os"); !hasOS {
+		return fmt.Errorf("missing os label in the image manifest")
+	}
+	if _, hasArch := am.Labels.Get("arch"); !hasArch {
+		return fmt.Errorf("missing arch label in the image manifest")
+	}
+
+	if err := types.IsValidOSArch(am.Labels.ToMap(), ValidOSArch); err != nil {
+		return err
+	}
+
 	if useOverlay {
 		if err := cfg.Store.RenderTreeStore(img.String(), false); err != nil {
 			return fmt.Errorf("error rendering tree image: %v", err)

--- a/tests/test-auth-server/aci/aci.go
+++ b/tests/test-auth-server/aci/aci.go
@@ -57,7 +57,7 @@ func (t *aciToolkit) prepareACI() ([]byte, error) {
 }
 
 const (
-	manifestStr    = `{"acKind":"ImageManifest","acVersion":"0.5.1+git","name":"testprog","app":{"exec":["/prog"],"user":"0","group":"0"}}`
+	manifestStr    = `{"acKind":"ImageManifest","acVersion":"0.5.1+git","name":"testprog","app":{"exec":["/prog"],"user":"0","group":"0"},"labels":[{"name":"os","value":"linux"},{"name":"arch","value":"amd64"}]}`
 	testProgSrcStr = `
 package main
 


### PR DESCRIPTION
We also check during findImages so we don't start downloading an image
we know is not supported.

DO NOT MERGE until we bump the spec to a version including appc/spec#454 and we rebase this PR.

Fixes #271