### PR TITLE
rkt: remove boolean properties of --private-net

### DIFF
--- a/Documentation/networking.md
+++ b/Documentation/networking.md
@@ -10,9 +10,9 @@ This means that the apps within the pod will share the network stack and the int
 ## Private networking mode
 
 If `rkt run` is started with the `--private-net` flag, the pod will be executed with its own network stack, with the default network plus all configured networks.
+This is equivalent to passing `--private-net=all`.
 Passing a list of comma separated network names as in `--private-net=net1,net2,net3,...` restricts the network stack to the specified networks.
 This can be useful for grouping certain pods together while separating others.
-If the list of network names contains no known networks the pod will end up with loop networking only.
 
 ### The default network
 The default network consists of a loopback device and a veth device.

--- a/common/common.go
+++ b/common/common.go
@@ -174,7 +174,7 @@ func (l *PrivateNetList) Any() bool {
 }
 
 func (l *PrivateNetList) All() bool {
-	return l.mapping["true"]
+	return l.mapping["all"]
 }
 
 func (l *PrivateNetList) Specific(net string) bool {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -75,7 +75,7 @@ func init() {
 	cmdRun.Flags().Var(&flagVolumes, "volume", "volumes to mount into the pod")
 	cmdRun.Flags().Var(&flagPorts, "port", "ports to expose on the host (requires --private-net)")
 	cmdRun.Flags().Var(&flagPrivateNet, "private-net", "give pod a private network that defaults to the default network plus all user-configured networks. Can be limited to a comma-separated list of network names")
-	cmdRun.Flags().Lookup("private-net").NoOptDefVal = "true"
+	cmdRun.Flags().Lookup("private-net").NoOptDefVal = "all"
 	cmdRun.Flags().BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	cmdRun.Flags().BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
 	cmdRun.Flags().Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")


### PR DESCRIPTION
This commit changes the behavior of --private-net. "--private-net=all" and
"--private-net" will enable all private networks. Otherwise there are no special
values. Like this, passing "true" or "false" will just attempt to load the
correspondingly named networks.

Partially fixes #1169.