### PR TITLE
networking: respect local-config flag

### DIFF
--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -45,10 +45,10 @@ The resolved entrypoint must inform rkt of its PID for the benefit of `rkt enter
 
 #### Arguments
 * `--debug` to activate debugging
-* `--private-net` to trigger the creation of a private network
+* `--private-net[=$NET1,$NET2,...]` to trigger the creation of a private network. special cases: no name and *all* load all networks
 * `--mds-token=$TOKEN` passes the auth token to the apps via `AC_METADATA_URL` env var
 * `--interactive` to run a pod interactively, that is, pass standard input to the application (only for pods with one application)
-
+* `--local-config=$PATH` to override the local configuration directory
 
 ### `rkt enter` => "coreos.com/rkt/stage1/enter"
 

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -52,7 +52,7 @@ type Networking struct {
 
 // Setup creates a new networking namespace and executes network plugins to
 // setup private networking. It returns in the new pod namespace
-func Setup(podRoot string, podID types.UUID, fps []ForwardedPort, privateNetList common.PrivateNetList) (*Networking, error) {
+func Setup(podRoot string, podID types.UUID, fps []ForwardedPort, privateNetList common.PrivateNetList, localConfig string) (*Networking, error) {
 	// TODO(jonboulle): currently podRoot is _always_ ".", and behaviour in other
 	// circumstances is untested. This should be cleaned up.
 	n := Networking{
@@ -60,6 +60,7 @@ func Setup(podRoot string, podID types.UUID, fps []ForwardedPort, privateNetList
 			podRoot:      podRoot,
 			podID:        podID,
 			netsLoadList: privateNetList,
+			localConfig:  localConfig,
 		},
 	}
 

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -226,6 +226,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		LockFd:       lfd,
 		Interactive:  flagInteractive,
 		MDSRegister:  flagMDSRegister,
+		LocalConfig:  globalFlags.LocalConfigDir,
 	}
 
 	imgs, err := p.getApps()

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -69,6 +69,7 @@ type RunConfig struct {
 	Interactive bool                  // whether the pod is interactive or not
 	MDSRegister bool                  // whether to register with metadata service or not
 	Images      schema.AppList        // application images (prepare gets them via Apps)
+	LocalConfig string                // Path to local configuration
 }
 
 // configuration shared by both Run and Prepare
@@ -326,6 +327,10 @@ func Run(cfg RunConfig, dir string) {
 		}
 
 		args = append(args, "--mds-token="+mdsToken)
+	}
+
+	if cfg.LocalConfig != "" {
+		args = append(args, "--local-config="+cfg.LocalConfig)
 	}
 
 	args = append(args, cfg.UUID.String())

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -128,6 +128,7 @@ var (
 	interactive bool
 	mdsToken    string
 	localhostIP net.IP
+	localConfig string
 )
 
 func init() {
@@ -135,7 +136,7 @@ func init() {
 	flag.Var(&privNet, "private-net", "Setup private network")
 	flag.BoolVar(&interactive, "interactive", false, "The pod is interactive")
 	flag.StringVar(&mdsToken, "mds-token", "", "MDS auth token")
-
+	flag.StringVar(&localConfig, "local-config", common.DefaultLocalConfigDir, "Local config path")
 	// this ensures that main runs only on main thread (thread group leader).
 	// since namespace ops (unshare, setns) are done for a single thread, we
 	// must ensure that the goroutine does not jump from OS thread to thread
@@ -456,7 +457,7 @@ func stage1() int {
 			return 6
 		}
 
-		n, err := networking.Setup(root, p.UUID, fps, privNet)
+		n, err := networking.Setup(root, p.UUID, fps, privNet, localConfig)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to setup network: %v\n", err)
 			return 6


### PR DESCRIPTION
If the local-config argument is provided to `rkt` it will be passed down all the
way to the network loading function. The network config dir will be the
local-config path joined with *net.d*.

Fixes #1172.