### PR TITLE
rkt: add cleanup command

### DIFF
--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -548,3 +548,20 @@ Garbage collecting pod "21b1cb32-c156-4d26-82ae-eda1ab60f595"
 Garbage collecting pod "5dd42e9c-7413-49a9-9113-c2a8327d08ab"
 Garbage collecting pod "f07a4070-79a9-4db0-ae65-a090c9c393a3"
 ```
+
+### rkt rm
+
+Cleans up all resources (files, network objects) associated with a pod just like `rkt gc`.
+This command can be used to immediately free resources without waiting for garbage collection to run.
+
+```
+rkt rm c138310f
+```
+
+Instead of passing UUID on command line, rm command can read the UUID from a text file.
+This can be paired with `--uuid-file-save` to remove pods by name:
+
+```
+rkt run --uuid-files-save=/run/rkt-uuids/mypod ...
+rkt rm --uuid-file=/run/rkt-uuids/mypod
+```

--- a/rkt/enter.go
+++ b/rkt/enter.go
@@ -63,22 +63,21 @@ func runEnter(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	pid := podUUID.String()
-	p, err := getPod(pid)
+	p, err := getPod(podUUID)
 	if err != nil {
-		stderr("Failed to open pod %q: %v", pid, err)
+		stderr("Failed to open pod %q: %v", podUUID, err)
 		return 1
 	}
 	defer p.Close()
 
 	if !p.isRunning() {
-		stderr("Pod %q isn't currently running", pid)
+		stderr("Pod %q isn't currently running", podUUID)
 		return 1
 	}
 
 	podPID, err := p.getPID()
 	if err != nil {
-		stderr("Unable to determine the pid for pod %q: %v", pid, err)
+		stderr("Unable to determine the pid for pod %q: %v", podUUID, err)
 		return 1
 	}
 

--- a/rkt/rm.go
+++ b/rkt/rm.go
@@ -1,0 +1,117 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+package main
+
+import (
+	"os"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
+)
+
+var (
+	cmdRm = &cobra.Command{
+		Use:   "rm [--uuid-file=FILE] UUID",
+		Short: "Remove all files and resources associated with an exited pod",
+		Run:   runWrapper(runRm),
+	}
+	flagUUIDFile string
+)
+
+func init() {
+	cmdRkt.AddCommand(cmdRm)
+	cmdRm.Flags().StringVar(&flagUUIDFile, "uuid-file", "", "read pod UUID from file instead of argument")
+}
+
+func runRm(cmd *cobra.Command, args []string) (exit int) {
+	var podUUID *types.UUID
+	var err error
+
+	switch {
+	case len(args) == 0 && flagUUIDFile != "":
+		podUUID, err = readUUIDFromFile(flagUUIDFile)
+		if err != nil {
+			stderr("Unable to read UUID from file: %v", err)
+			return 1
+		}
+
+	case len(args) == 1 && flagUUIDFile == "":
+		podUUID, err = resolveUUID(args[0])
+		if err != nil {
+			stderr("Unable to resolve UUID: %v", err)
+			return 1
+		}
+	default:
+		cmd.Usage()
+		return 1
+	}
+
+	p, err := getPod(podUUID)
+	if err != nil {
+		stderr("Cannot get pod: %v", err)
+		return 1
+	}
+
+	return removePod(p)
+}
+
+func removePod(p *pod) int {
+	switch {
+	case p.isRunning():
+		stderr("Pod is currently running")
+		return 1
+
+	case p.isEmbryo, p.isPreparing:
+		stderr("Pod is currently being prepared")
+		return 1
+
+	case p.isExitedDeleting, p.isDeleting:
+		stderr("Pod is currently being deleted")
+		return 1
+
+	case p.isAbortedPrepare:
+		stderr("Moving failed prepare %q to garbage", p.uuid)
+		if err := p.xToGarbage(); err != nil && err != os.ErrNotExist {
+			stderr("Rename error: %v", err)
+			return 1
+		}
+
+	case p.isPrepared:
+		stderr("Moving expired prepared pod %q to garbage", p.uuid)
+		if err := p.xToGarbage(); err != nil && err != os.ErrNotExist {
+			stderr("Rename error: %v", err)
+			return 1
+		}
+
+	case p.isExited:
+		if err := p.xToExitedGarbage(); err != nil && err != os.ErrNotExist {
+			stderr("Rename error: %v", err)
+			return 1
+		}
+
+	case p.isExitedGarbage, p.isGarbage:
+	}
+
+	if err := p.ExclusiveLock(); err != nil {
+		stderr("Unable to acquire exclusive lock: %v", err)
+		return 1
+	}
+
+	deletePod(p)
+
+	return 0
+}

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -47,17 +47,18 @@ which will instead be appended to the preceding image app's exec arguments.
 End the image arguments with a lone "---" to resume argument parsing.`,
 		Run: runWrapper(runRun),
 	}
-	flagStage1Image string
-	flagVolumes     volumeList
-	flagPorts       portList
-	flagPrivateNet  common.PrivateNetList
-	flagInheritEnv  bool
-	flagExplicitEnv envMap
-	flagInteractive bool
-	flagNoOverlay   bool
-	flagLocal       bool
-	flagPodManifest string
-	flagMDSRegister bool
+	flagStage1Image  string
+	flagVolumes      volumeList
+	flagPorts        portList
+	flagPrivateNet   common.PrivateNetList
+	flagInheritEnv   bool
+	flagExplicitEnv  envMap
+	flagInteractive  bool
+	flagNoOverlay    bool
+	flagLocal        bool
+	flagPodManifest  string
+	flagMDSRegister  bool
+	flagUUIDFileSave string
 )
 
 func init() {
@@ -83,6 +84,7 @@ func init() {
 	cmdRun.Flags().BoolVar(&flagLocal, "local", false, "use only local images (do not discover or download from remote URLs)")
 	cmdRun.Flags().StringVar(&flagPodManifest, "pod-manifest", "", "the path to the pod manifest. If it's non-empty, then only '--private-net', '--no-overlay' and '--interactive' will have effects")
 	cmdRun.Flags().BoolVar(&flagMDSRegister, "mds-register", true, "register pod with metadata service")
+	cmdRun.Flags().StringVar(&flagUUIDFileSave, "uuid-file-save", "", "write out pod UUID to specified file")
 
 	// per-app flags
 	cmdRun.Flags().Var((*appAsc)(&rktApps), "signature", "local signature file to use in validating the preceding image")
@@ -173,6 +175,15 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 	if err != nil {
 		stderr("Error creating new pod: %v", err)
 		return 1
+	}
+
+	// if requested, write out pod UUID early so "rkt rm" can
+	// clean it up even if something goes wrong
+	if flagUUIDFileSave != "" {
+		if err := writeUUIDToFile(p.uuid, flagUUIDFileSave); err != nil {
+			stderr("Error saving pod UUID to file: %v", err)
+			return 1
+		}
 	}
 
 	processLabel, mountLabel, err := label.InitLabels(nil)

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -75,7 +75,7 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	p, err := getPod(podUUID.String())
+	p, err := getPod(podUUID)
 	if err != nil {
 		stderr("prepared-run: cannot get pod: %v", err)
 		return 1

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -50,7 +50,7 @@ func runStatus(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	p, err := getPod(podUUID.String())
+	p, err := getPod(podUUID)
 	if err != nil {
 		stderr("Unable to get pod: %v", err)
 		return 1

--- a/rkt/uuid.go
+++ b/rkt/uuid.go
@@ -17,7 +17,9 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
@@ -64,4 +66,18 @@ func resolveUUID(uuid string) (*types.UUID, error) {
 	}
 
 	return u, nil
+}
+
+func readUUIDFromFile(path string) (*types.UUID, error) {
+	uuid, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	uuid = bytes.TrimSpace(uuid)
+
+	return types.NewUUID(string(uuid))
+}
+
+func writeUUIDToFile(uuid *types.UUID, path string) error {
+	return ioutil.WriteFile(path, []byte(uuid.String()), 0644)
 }


### PR DESCRIPTION
Cleans up specified pod without waiting for
the GC to run. Pod UUID can by specified as an
argument or via file that contains the UUID.

Also adds --uuid-file-save to run command to
save the pod UUID for cleanup command to consume.

Fixes #1171