### PR TITLE
kvm: volumes support

### DIFF
--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -78,6 +78,7 @@ import (
 	"github.com/coreos/rkt/common/cgroup"
 	"github.com/coreos/rkt/networking"
 	"github.com/coreos/rkt/pkg/sys"
+	"github.com/coreos/rkt/stage1/init/kvm"
 )
 
 const (
@@ -292,9 +293,12 @@ func getArgsEnv(p *Pod, flavor string, debug bool) ([]string, []string, error) {
 			args = append(args, "--debug")
 		}
 
-		// TODO: host volume sharing with 9p
 		// TODO: append additional networks settings
 		// args = append(args, network/volumes args...)
+
+		// host volume sharing with 9p
+		nsargs := kvm.VolumesToKvmDiskArgs(p.Manifest.Volumes)
+		args = append(args, nsargs...)
 
 		return args, env, nil
 
@@ -538,7 +542,7 @@ func stage1() int {
 		return 2
 	}
 
-	if err = p.PodToSystemd(interactive); err != nil {
+	if err = p.PodToSystemd(interactive, flavor); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to configure systemd: %v\n", err)
 		return 2
 	}

--- a/stage1/init/kvm/doc.go
+++ b/stage1/init/kvm/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// kvm package provides supporting functions for kvm flavor
+// such as: VM networking, volume sharing
+package kvm

--- a/stage1/init/kvm/mount.go
+++ b/stage1/init/kvm/mount.go
@@ -1,0 +1,217 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// mount.go provides functions for creating mount units for managing
+// inner(kind=empty) and external(kind=host) volumes.
+// note: used only for kvm flavor (lkvm based)
+//
+// Idea.
+// For example when we have two volumes:
+// 1) --volume=hostdata,kind=host,source=/host/some_data_to_share
+// 2) --volume=temporary,kind=empty
+// then in stage1/rootfs rkt creates two folders (in rootfs of guest)
+// 1) /mnt/hostdata - which is mounted through 9p host thanks to
+//					lkvm --9p=/host/some_data_to_share,hostdata flag shared to quest
+// 2) /mnt/temporary - is created as empty directory in guest
+//
+// both of them are then bind mounted to /opt/stage2/<application/<mountPoint.path>
+// for every application, that has mountPoints specified in ACI json
+// - host mounting is realized by podToSystemdHostMountUnits (for whole pod),
+//   which creates mount.units (9p) required and ordered before all applications
+//   service units
+// - bind mounting is realized by appToSystemdMountUnits (for each app),
+//   which creates mount.units (bind) required and ordered before particular application
+// note: systemd mount units require /usr/bin/mount
+package kvm
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/coreos/go-systemd/unit"
+	"github.com/coreos/rkt/common"
+)
+
+const (
+	// location within stage1 rootfs where shared volumes will be put
+	// (or empty directories for kind=empty)
+	stage1MntDir = "/mnt/"
+)
+
+// serviceUnitName returns a systemd service unit name for the given app name.
+// note: it was shamefully copy-pasted from stage1/init/path.go
+// TODO: extract common functions from path.go
+func serviceUnitName(appName types.ACName) string {
+	return appName.String() + ".service"
+}
+
+// installNewMountUnit creates and installs new mount unit in default
+// systemd location (/usr/lib/systemd/system) in pod stage1 filesystem.
+// root is a stage1 relative to pod filesystem path like /var/lib/uuid/rootfs/
+// (from Pod.Root).
+// beforeAndrequiredBy creates systemd unit dependency (can be space separated
+// for multi).
+func installNewMountUnit(root, what, where, fsType, options, beforeAndrequiredBy, unitsDir string) error {
+
+	opts := []*unit.UnitOption{
+		unit.NewUnitOption("Unit", "Description", fmt.Sprintf("Mount unit for %s", where)),
+		unit.NewUnitOption("Unit", "DefaultDependencies", "false"),
+		unit.NewUnitOption("Unit", "Before", beforeAndrequiredBy),
+		unit.NewUnitOption("Mount", "What", what),
+		unit.NewUnitOption("Mount", "Where", where),
+		unit.NewUnitOption("Mount", "Type", fsType),
+		unit.NewUnitOption("Mount", "Options", options),
+		unit.NewUnitOption("Install", "RequiredBy", beforeAndrequiredBy),
+	}
+
+	unitsPath := filepath.Join(root, unitsDir)
+	unitName := unit.UnitNamePathEscape(where + ".mount")
+	unitBytes, err := ioutil.ReadAll(unit.Serialize(opts))
+	if err != nil {
+		return fmt.Errorf("failed to serialize mount unit file to bytes %q: %v", unitName, err)
+	}
+
+	err = ioutil.WriteFile(filepath.Join(unitsPath, unitName), unitBytes, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to create mount unit file %q: %v", unitName, err)
+	}
+
+	log.Printf("mount unit created: %q in %q (what=%q, where=%q)", unitName, unitsPath, what, where)
+	return nil
+}
+
+// PodToSystemdHostMountUnits create host shared remote file system
+// mounts (using e.g. 9p) according to https://www.kernel.org/doc/Documentation/filesystems/9p.txt.
+// Additionally it creates required directories in stage1MntDir and then prepares
+// bind mount unit for each app.
+// "root" parameter is stage1 root filesystem path.
+// appNames are used to create before/required dependency between mount unit and
+// app service units.
+func PodToSystemdHostMountUnits(root string, volumes []types.Volume, appNames []types.ACName, unitsDir string) error {
+
+	// pod volumes need to mount p9 qemu mount_tags
+	for _, vol := range volumes {
+		// only host shared volumes
+
+		name := vol.Name.String() // acts as a mount tag 9p
+		// /var/lib/.../pod/run/rootfs/mnt/{volumeName}
+		mountPoint := filepath.Join(root, stage1MntDir, name)
+
+		// for kind "empty" that will be shared among applications
+		log.Printf("creating an empty volume folder for sharing: %q", mountPoint)
+		err := os.MkdirAll(mountPoint, 0700)
+		if err != nil {
+			return err
+		}
+
+		// serviceNames for ordering and requirements dependency for apps
+		serviceNames := []string{}
+		for _, appName := range appNames {
+			serviceNames = append(serviceNames, serviceUnitName(appName))
+		}
+
+		// for host kind we create a mount unit to mount host shared folder
+		if vol.Kind == "host" {
+			err = installNewMountUnit(root,
+				name, // what (source) in 9p it is a channel tag which equals to volume.Name/mountPoint.name
+				filepath.Join(stage1MntDir, name), // where - destination
+				"9p",                            // fsType
+				"trans=virtio",                  // 9p specific options
+				strings.Join(serviceNames, " "), // space separated list of services for unit dependency
+				unitsDir,
+			)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// AppToSystemdMountUnits prepare bind mount unit for empty or host kind mounting
+// between stage1 rootfs and chrooted filesystem for application
+func AppToSystemdMountUnits(root string, appName types.ACName, mountPoints []types.MountPoint, unitsDir string) error {
+
+	for _, mountPoint := range mountPoints {
+
+		name := mountPoint.Name.String()
+		// source relative to stage1 rootfs to relative pod root
+		whatPath := filepath.Join(stage1MntDir, name)
+		whatFullPath := filepath.Join(root, whatPath)
+
+		// destination relative to stage1 rootfs and relative to pod root
+		wherePath := filepath.Join(common.RelAppRootfsPath(appName), mountPoint.Path)
+		whereFullPath := filepath.Join(root, wherePath)
+
+		// readOnly
+		mountOptions := "bind"
+		if mountPoint.ReadOnly {
+			mountOptions += ",ro"
+		}
+
+		// assertion to make sure that "what" exists (created earlier by podToSystemdHostMountUnits)
+		log.Printf("checking required source path: %q", whatFullPath)
+		if _, err := os.Stat(whatFullPath); os.IsNotExist(err) {
+			return fmt.Errorf("app requires a volume that is not defined in Pod (try adding --volume=%s,kind=empty)!", name)
+		}
+
+		// optionally prepare app directory
+		log.Printf("optionally preparing destination path: %q", whereFullPath)
+		err := os.MkdirAll(whereFullPath, 0700)
+		if err != nil {
+			return fmt.Errorf("failed to prepare dir for mountPoint %v: %v", mountPoint.Name, err)
+		}
+
+		// install new mount unit for bind mount /mnt/volumeName -> /opt/stage2/{app-id}/rootfs/{{mountPoint.Path}}
+		err = installNewMountUnit(
+			root,      // where put a mount unit
+			whatPath,  // what - stage1 rootfs /mnt/VolumeName
+			wherePath, // where - inside chroot app filesystem
+			"bind",    // fstype
+			mountOptions,
+			serviceUnitName(appName),
+			unitsDir,
+		)
+		if err != nil {
+			return fmt.Errorf("cannot install new mount unit for app %q: %v", appName.String(), err)
+		}
+
+	}
+	return nil
+}
+
+// VolumesToKvmDiskArgs prepares argument list to be passed to lkvm to configure
+// shared volumes (only for "host" kind).
+// Example return is ["--9p,src/folder,9ptag"].
+func VolumesToKvmDiskArgs(volumes []types.Volume) []string {
+	args := []string{}
+
+	for _, vol := range volumes {
+		mountTag := vol.Name.String() // tag/channel name for virtio
+		if vol.Kind == "host" {
+			// eg. --9p=/home/jon/srcdir,tag
+			arg := "--9p=" + vol.Source + "," + mountTag
+			log.Printf("stage1: --disk argument: %#v\n", arg)
+			args = append(args, arg)
+		}
+	}
+
+	return args
+}

--- a/stage1/init/kvm/mount_test.go
+++ b/stage1/init/kvm/mount_test.go
@@ -1,0 +1,65 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvm
+
+import (
+	"testing"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+func TestVolumesToKvmDiskArgs(t *testing.T) {
+	tests := []struct {
+		volumes  []types.Volume
+		expected []string
+	}{
+		{ // one host volume - one argument
+			volumes:  []types.Volume{{Name: types.ACName("foo"), Kind: "host", Source: "src1"}},
+			expected: []string{"--9p=src1,foo"},
+		},
+		{ // on empty volume - no arguments
+			volumes:  []types.Volume{{Name: types.ACName("foo"), Kind: "empty", Source: "src1"}},
+			expected: []string{},
+		},
+		{ // two host volumes
+			volumes: []types.Volume{
+				{Name: types.ACName("foo"), Kind: "host", Source: "src1"},
+				{Name: types.ACName("bar"), Kind: "host", Source: "src2"},
+			},
+			expected: []string{"--9p=src1,foo", "--9p=src2,bar"},
+		},
+		{ // mix host and empty
+			volumes: []types.Volume{
+				{Name: types.ACName("foo"), Kind: "host", Source: "src1"},
+				{Name: types.ACName("baz"), Kind: "empty", Source: "src1"},
+				{Name: types.ACName("bar"), Kind: "host", Source: "src2"},
+			},
+			expected: []string{"--9p=src1,foo", "--9p=src2,bar"},
+		},
+	}
+
+	for i, tt := range tests {
+		got := VolumesToKvmDiskArgs(tt.volumes)
+		if len(got) != len(tt.expected) {
+			t.Errorf("#%d: expected %v elements got %v", i, len(tt.expected), len(got))
+		} else {
+			for iarg, argExpected := range tt.expected {
+				if got[iarg] != argExpected {
+					t.Errorf("#%d: arg %d expected `%v` got `%v`", i, iarg, argExpected, got[i])
+				}
+			}
+		}
+	}
+}

--- a/stage1/usr_from_coreos/manifest.d/systemd
+++ b/stage1/usr_from_coreos/manifest.d/systemd
@@ -1,5 +1,6 @@
 bin/coredumpctl
 bin/journalctl
+bin/mount
 bin/systemctl
 bin/systemd-analyze
 bin/systemd-ask-password


### PR DESCRIPTION
because kvm flavor doesn't use systemd-nspwan, we cannot utilize
its feature to bind mount demanded volumes (both kinds), so this
commit moves that responsibility to systemd (idea thx to xnox)

how it works - check the [mount.go "package" docs](https://github.com/intelsdi-x/rkt/commit/c3b08193f17b7b7c093c84986f0d6bebe2495739#diff-5e4f009487e0dd19a243aaca7de5862bR18) for idea or commit message 

**TODOs**:
- [x] code reorganization (kvm subpackge - take #1219 into account)
- [ ] add rkt functional tests (**but first need to deal with [failures](https://github.com/intelsdi-x/rkt/issues?q=is%3Aopen+is%3Aissue+label%3Atests)**)
- [x] ACE validator says "mount point problem": `[    0.269975] ace-validator[85]: 2015/07/21 20:30:16 WARN: "/db" is not a mount point (againts "/") fsid are equal: syscall.Fsid{X__val:[2]int32{-926896844, 1387030233}} == syscall.Fsid{X__val:[2]int32{-926896844, 1387030233}}
`  closing because not related to kvm ( iaguis's https://github.com/coreos/rkt/pull/1176#issuecomment-127546032 )
- [x] investigate systemd templates as mount units (impossible because mount unit type is marked with ['no_instances' flag](https://github.com/systemd/systemd/blob/master/src/core/mount.c#L1846) and got errors from [here](https://github.com/systemd/systemd/blob/bd37a92297a89f00d03757cf860dff9a8ae59b16/src/core/unit.c#L181)
- [x] path creation move to path.go (invalid I don't want to mess `path.go` with additional 7 functions to build all what/where host/app combination folder names, which logic is strictly kvm flavor specific)
- [x] escaping of name of volumes, because are used for directory names (vol name is an ACName type so is valid as 9p tag or folder name)
- [x] ACE validator "AC_APP_NAME not proper" 
`[    0.263976] ace-validator[84]: ==> AC_APP_NAME not set appropriately (need "ace-validator-main", got "coreos.com/ace-validator-main")` (#1199)