### PR TITLE
store: Backup a database when migrating.

### DIFF
--- a/store/backup.go
+++ b/store/backup.go
@@ -1,0 +1,95 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/coreos/rkt/pkg/fileutil"
+)
+
+// createBackup backs a database up in a given directory. It basically
+// copies this directory into a given backups directory. The backups
+// directory has a simple structure - a directory inside named "0" is
+// the most recent backup. A directory name for oldest backup is
+// deduced from a given limit. For instance, for limit being 5 the
+// name for the oldest backup would be "4". If a backups number
+// exceeds the given limit then only newest ones are kept and the rest
+// is removed.
+func createBackup(dbDir, backupsDir string, limit int) error {
+	tmpBackupDir := filepath.Join(backupsDir, "tmp")
+	if err := os.MkdirAll(backupsDir, defaultPathPerm); err != nil {
+		return err
+	}
+	if err := fileutil.CopyTree(dbDir, tmpBackupDir); err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpBackupDir)
+	// prune backups
+	if err := pruneOldBackups(backupsDir, limit-1); err != nil {
+		return err
+	}
+	if err := shiftBackups(backupsDir, limit-2); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpBackupDir, filepath.Join(backupsDir, "0")); err != nil {
+		return err
+	}
+	return nil
+}
+
+// pruneOldBackups removes old backups, that is - directories with
+// names greater or equal than given limit.
+func pruneOldBackups(dir string, limit int) error {
+	if list, err := ioutil.ReadDir(dir); err != nil {
+		return err
+	} else {
+		for _, fi := range list {
+			if num, err := strconv.Atoi(fi.Name()); err != nil {
+				// directory name is not a number,
+				// leave it alone
+				continue
+			} else if num < limit {
+				// directory name is a number lower
+				// than a limit, leave it alone
+				continue
+			}
+			path := filepath.Join(dir, fi.Name())
+			if err := os.RemoveAll(path); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// shiftBackups renames all directories with names being numbers up to
+// oldest to names with numbers greater by one.
+func shiftBackups(dir string, oldest int) error {
+	if oldest < 0 {
+		return nil
+	}
+	for i := oldest; i >= 0; i-- {
+		current := filepath.Join(dir, strconv.Itoa(i))
+		inc := filepath.Join(dir, strconv.Itoa(i+1))
+		if err := os.Rename(current, inc); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}

--- a/store/backup_test.go
+++ b/store/backup_test.go
@@ -1,0 +1,126 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// TestBackup tests backup creation with limit 4
+func TestBackup(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	dbDir := filepath.Join(dir, "db")
+	backupsDir := filepath.Join(dir, "db-backups")
+	limit := 4
+
+	for i := 0; i < limit*2; i++ {
+		if err := os.RemoveAll(dbDir); err != nil {
+			t.Fatalf("error removing dbdir: %v", err)
+		}
+		if err := os.MkdirAll(dbDir, 0755); err != nil {
+			t.Fatalf("error creating dbdir: %v", err)
+		}
+		if err := touch(filepath.Join(dbDir, strconv.Itoa(i))); err != nil {
+			t.Fatalf("error creating a file: %v", err)
+		}
+		if err := createBackup(dbDir, backupsDir, limit); err != nil {
+			t.Fatalf("error creating a backup: %v", err)
+		}
+		if err := checkBackups(backupsDir, limit, i); err != nil {
+			t.Fatalf("error checking the backup: %v", err)
+		}
+	}
+}
+
+func touch(fileName string) error {
+	file, err := os.Create(fileName)
+	if err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkBackups(backupsDir string, limit, i int) error {
+	expected := getExpectedTree(limit, i)
+	return checkDirectory(backupsDir, expected)
+}
+
+// Expectations for limit L
+//
+// for iteration I (0, 1, 2, ...)
+// at most D directories (where D = min(L,I + 1)
+// dir 0 with file I
+// dir 1 with file I - 1
+// ...
+// dir D - 1 with file I - L
+func getExpectedTree(limit, iteration int) map[string]string {
+	dirCount := iteration
+	if iteration > limit {
+		dirCount = limit
+	}
+	expected := make(map[string]string, dirCount)
+	for j := 0; j <= dirCount; j++ {
+		expected[strconv.Itoa(j)] = strconv.Itoa(iteration - j)
+	}
+	return expected
+}
+
+func checkDirectory(dir string, expected map[string]string) error {
+	list, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, fi := range list {
+		if !fi.IsDir() {
+			return fmt.Errorf("%s is not a directory", fi.Name())
+		}
+		dirName := fi.Name()
+		if _, err := strconv.Atoi(dirName); err != nil {
+			return fmt.Errorf("Name is not a number: %v", err)
+		}
+		expectedFileName, ok := expected[dirName]
+		if !ok {
+			return fmt.Errorf("Unexpected name found: %s", dirName)
+		}
+		subList, err := ioutil.ReadDir(filepath.Join(dir, dirName))
+		if err != nil {
+			return fmt.Errorf("Failed to get a list of files in %s: %v",
+				dirName, err)
+		}
+		filesCount := len(subList)
+		if filesCount != 1 {
+			return fmt.Errorf("Expected only 1 file in %s, got %d",
+				dirName, filesCount)
+		}
+		gottenFileName := subList[0].Name()
+		if gottenFileName != expectedFileName {
+			return fmt.Errorf("Expected %s in %s, got %s",
+				expectedFileName, dirName, gottenFileName)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This feature is a clearly developer-oriented one. We do not restore
backups - migrations happen inside transactions, so on failure all the
changes will be rolled back.

Here we create "db-backups" directory inside "cas" directory and store
at most 5 backups.

Fixes #748.