### PR TITLE
fix #500 rkt trust --root

### DIFF
--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -27,10 +27,10 @@ When adding a trusted key, a prefix can scope the level of established trust to 
 # rkt trust --prefix=coreos.com/etcd
 ```
 
-To trust a key for an entire root domain, you must use the `--root` flag.
+To trust a key for an entire root domain, you must use the `--root` flag, with a path to a local key file (no discovery). 
 
 ```
-# rkt trust --root coreos.com
+# rkt trust --root ~/aci-pubkeys.gpg
 ```
 
 #### Trust a Key Using Meta Discovery
@@ -80,7 +80,6 @@ Added key for prefix "coreos.com/etcd" at "/etc/rkt/trustedkeys/prefix.d/coreos.
 
 Trusted public keys can be pre-populated by placing them in the appropriate location on disk for the desired prefix.
 
-_Depends on https://github.com/coreos/rkt/issues/500_
 ```
 $ ls -l /etc/rkt/trustedkeys/
 [insert example of root key vs prefixed key]

--- a/rkt/trust.go
+++ b/rkt/trust.go
@@ -41,7 +41,7 @@ var (
 PUBKEY may be either a local file or URL,
 PREFIX scopes the applicability of PUBKEY to image names sharing PREFIX.
 Meta discovery of PUBKEY at PREFIX will be attempted if no PUBKEY is specified.
---root must be specified to add keys with no prefix.`,
+--root must be specified to add keys with no prefix; path to a key file must be given (no discovery).`,
 		Run: runWrapper(runTrust),
 	}
 	flagPrefix    string
@@ -52,7 +52,7 @@ Meta discovery of PUBKEY at PREFIX will be attempted if no PUBKEY is specified.
 func init() {
 	cmdRkt.AddCommand(cmdTrust)
 	cmdTrust.Flags().StringVar(&flagPrefix, "prefix", "", "prefix to limit trust to")
-	cmdTrust.Flags().BoolVar(&flagRoot, "root", false, "add root key without a prefix")
+	cmdTrust.Flags().BoolVar(&flagRoot, "root", false, "add root key from filesystem without a prefix")
 	cmdTrust.Flags().BoolVar(&flagAllowHTTP, "insecure-allow-http", false, "allow HTTP use for key discovery and/or retrieval")
 }
 


### PR DESCRIPTION
Using `trust` with `--root` needs a local key file (#500).

Changed doc, help, and error msg accordingly.

Removed note on line 83 in `commands.md` as it seems not relevant to #500

Does not solve this part of original post: 
> Oddly, this outputs nothing at all:
> ./rkt trust --prefix coreos.com