### PR TITLE
rkt: handle http caching (ETag and Cache-Control max-age)

### DIFF
--- a/store/schema.go
+++ b/store/schema.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// Incremental db version at the current code revision.
-	dbVersion = 1
+	dbVersion = 2
 )
 
 // Statement to run when creating a db. These are the statements to create the
@@ -33,7 +33,7 @@ var dbCreateStmts = [...]string{
 	fmt.Sprintf("INSERT INTO version VALUES (%d)", dbVersion),
 
 	// remote table. The primary key is "aciurl".
-	"CREATE TABLE IF NOT EXISTS remote (aciurl string, sigurl string, etag string, blobkey string);",
+	"CREATE TABLE IF NOT EXISTS remote (aciurl string, sigurl string, etag string, blobkey string, cachemaxage int, downloadtime time);",
 	"CREATE UNIQUE INDEX IF NOT EXISTS aciurlidx ON remote (aciurl)",
 
 	// aciinfo table. The primary key is "blobkey" and it matches the key used to save that aci in the blob store


### PR DESCRIPTION
This should replace #319. Thanks @hectorj2f  !

this patch handles ETag and Cache-Control: max-age server headers.

It saves the Etag, the max-age and the current download time in the store's
remote data.

Before downloading it checks if the current time is before the download time
plus maxage, if so it uses the current store image.
During an ACI download it also sends the saved ETag, if the server answers with
a 304 Not Modified status then the store image is used.

The signature will be downloaded anyway because it's not cached in the store
and it's usually downloaded before the ACI.

This patch also provides db migration code (to version 2) and related tests as
the store's remote struct changed.

Signed-off-by: Simone Gotti <simone.gotti@gmail.com>
Co-Authored-By: Hector Fernandez <hector@elasticbox.com>