### PR TITLE
selinux: check if selinuxPath exists.

### DIFF
--- a/pkg/selinux/selinux.go
+++ b/pkg/selinux/selinux.go
@@ -68,7 +68,10 @@ func SetDisabled() {
 // processes.  The existence of an selinuxfs mount is used to determine
 // whether selinux is currently enabled or not.
 func getSelinuxMountPoint() string {
-	return "/sys/fs/selinux"
+	if _, err := os.Stat(selinuxPath); os.IsNotExist(err) {
+		return ""
+	}
+	return selinuxPath
 }
 
 // SelinuxEnabled returns whether selinux is currently enabled.


### PR DESCRIPTION
When rkt is compiled with selinux support (selinux tag) but selinux is disabled
the selinux mount point doesn't exists. Actually it's not checked so rkt thinks
selinux is enabled. It will then fail mounting overlayfs with selinux labels.

This patch checks for the existence of /sys/fs/selinux. 

Note: This is different than the check done in https://github.com/opencontainers/runc/blob/master/libcontainer/selinux/selinux.go#L55 that needs an additional package.

