### PR TITLE
rkt: call stage1 GC prior to overlayfs unmounts

### DIFF
--- a/rkt/gc.go
+++ b/rkt/gc.go
@@ -124,6 +124,12 @@ func emptyExitedGarbage(gracePeriod time.Duration) error {
 			}
 			stage1RootFS := s.GetTreeStoreRootFS(stage1ID.String())
 
+			// execute stage1's GC
+			if err := stage0.GC(p.path(), p.uuid, stage1RootFS, globalFlags.Debug); err != nil {
+				stderr("Stage1 GC of pod %q failed: %v", p.uuid, err)
+				return
+			}
+
 			if p.usesOverlay() {
 				apps, err := p.getAppsHashes()
 				if err != nil {
@@ -150,12 +156,6 @@ func emptyExitedGarbage(gracePeriod time.Duration) error {
 						return
 					}
 				}
-			}
-
-			// execute stage1's GC
-			if err := stage0.GC(p.path(), p.uuid, stage1RootFS, globalFlags.Debug); err != nil {
-				stderr("Stage1 GC of pod %q failed: %v", p.uuid, err)
-				return
 			}
 
 			if err := os.RemoveAll(gp); err != nil {


### PR DESCRIPTION
Doing it after results in stage1 disappearing and
GC can't find networking plugins to call.