### PR TITLE
stage1: coreos: add missing libip4tc

### DIFF
--- a/stage1/usr_from_coreos/manifest.d/systemd
+++ b/stage1/usr_from_coreos/manifest.d/systemd
@@ -43,6 +43,9 @@ lib64/libgpg-error.so.0.10.0
 lib64/libitm.so
 lib64/libitm.so.1
 lib64/libitm.so.1.0.0
+lib64/libip4tc.so
+lib64/libip4tc.so.0
+lib64/libip4tc.so.0.1.0
 lib64/libkmod.so
 lib64/libkmod.so.2
 lib64/libkmod.so.2.2.5


### PR DESCRIPTION
Fixes #1188 