### PR TITLE
Makes the data directory configurable

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -66,7 +66,7 @@ this type, define `type` as `basic` and the `credentials` field as a map
 with two keys - `user` and `password`. These fields must be specified and
 cannot be empty. For example:
 
-```
+```js
 {
 	"rktKind": "auth",
 	"rktVersion": "v1",
@@ -83,7 +83,7 @@ OAuth Bearer Token authentication requires only a token. To use this type,
 define `type` as `oauth` and the `credentials` field as a map with only one
 key - `token`. This field must be specified and cannot be empty. For example:
 
-```
+```js
 {
 	"rktKind": "auth",
 	"rktVersion": "v1",
@@ -103,7 +103,7 @@ consider this system configuration:
 
 `/usr/lib/rkt/auth.d/coreos.json`:
 
-```
+```js
 {
 	"rktKind": "auth",
 	"rktVersion": "v1",
@@ -125,7 +125,7 @@ configuration and the following local configurations:
 
 `/etc/rkt/auth.d/specific-coreos.json`:
 
-```
+```js
 {
 	"rktKind": "auth",
 	"rktVersion": "v1",
@@ -140,7 +140,7 @@ configuration and the following local configurations:
 
 `/etc/rkt/auth.d/specific-tectonic.json`:
 
-```
+```js
 {
 	"rktKind": "auth",
 	"rktVersion": "v1",
@@ -155,7 +155,7 @@ configuration and the following local configurations:
 The result is that when downloading data from `kubernetes.io`, `rkt` still
 sends `Authorization: Bearer common-token`, but when downloading from
 `coreos.com`, it sends `Authorization: Basic Zm9vOmJhcg==` (i.e. `foo:bar`
-encoded in base64). For `tectonic.com`, it will send 
+encoded in base64). For `tectonic.com`, it will send
 `Authorization: Bearer tectonic-token`.
 
 Note that _within_ a particular configuration directory (either system or
@@ -195,7 +195,7 @@ Some popular Docker registries:
 
 Example `dockerAuth` configuration:
 
-```
+```js
 {
 	"rktKind": "dockerAuth",
 	"rktVersion": "v1",
@@ -214,7 +214,7 @@ credentials used for each registry. For example, given this system configuration
 
 In `/usr/lib/rkt/auth.d/docker.json`:
 
-```
+```js
 {
 	"rktKind": "dockerAuth",
 	"rktVersion": "v1",
@@ -236,7 +236,7 @@ configuration and the following local configuration:
 
 `/etc/rkt/auth.d/specific-quay.json`:
 
-```
+```js
 {
 	"rktKind": "dockerAuth",
 	"rktVersion": "v1",
@@ -250,7 +250,7 @@ configuration and the following local configuration:
 
 `/etc/rkt/auth.d/specific-gcr.json`:
 
-```
+```js
 {
 	"rktKind": "dockerAuth",
 	"rktVersion": "v1",
@@ -270,3 +270,45 @@ and password `gle`.
 Note that _within_ a particular configuration directory (either system or
 local), it is a syntax error for the same Docker registry to be defined in
 multiple files.
+
+### rktKind: `paths`
+
+This kind of configuration is used to customize the various paths that
+rkt uses. The configuration files should be placed inside a `paths.d` subdirectory
+(e.g. in `/usr/lib/rkt/paths.d` or `/etc/rkt/paths.d`).
+
+#### rktVersion: `v1`
+
+##### Description and examples
+
+This version of `paths` configuration specifies one additional field:
+`data`.
+
+The `data` field is a string that defines where container image data and running
+containers are stored. If its value is not overriden, it is `/var/lib/rkt` by
+default.
+
+For example, to store container images in your home partition instead of the
+root partition:
+
+`/etc/rkt/paths.d/paths.json`
+```js
+{
+	"rktKind": "paths",
+	"rktVersion": "v1",
+	"data": "/home/me/rkt"
+}
+```
+
+##### Override semantics
+
+Overriding is done for each directory. Not specifying a directory leaves it as
+its default path.
+
+The `data` directory can be specified via the `--data` command line argument .
+If this is provided, this takes precedence over any configuration files.
+
+Configuration files can be added to the system configuration
+(`/usr/lib/rkt/paths.d`) and the local configuration (`/etc/rkt/paths.d`). If
+there are configurations in both, the local configuration takes precedence. If
+there are multiple configurations in the same directory, an error occurs.

--- a/Documentation/devel/on-disk-format.md
+++ b/Documentation/devel/on-disk-format.md
@@ -2,7 +2,7 @@ On disk format
 ==============
 
 The data directory is normally `/var/lib/rkt` but rkt can be requested to use
-another directory via the `--dir` command line argument.
+another directory via the `--data` command line argument.
 
 #### CAS database
 
@@ -28,4 +28,3 @@ the CAS.
 
 The [configuration](https://github.com/coreos/rkt/blob/master/Documentation/configuration.md)
 on-disk format is documented separately.
-

--- a/rkt/config/config.go
+++ b/rkt/config/config.go
@@ -38,11 +38,16 @@ type BasicCredentials struct {
 	Password string
 }
 
+type ConfigurablePaths struct {
+	DataDir string
+}
+
 // Config is a single place where configuration for rkt frontend needs
 // resides.
 type Config struct {
 	AuthPerHost                  map[string]Headerer
 	DockerCredentialsPerRegistry map[string]BasicCredentials
+	Paths                        ConfigurablePaths
 }
 
 type configParser interface {
@@ -145,6 +150,9 @@ func newConfig() *Config {
 	return &Config{
 		AuthPerHost:                  make(map[string]Headerer),
 		DockerCredentialsPerRegistry: make(map[string]BasicCredentials),
+		Paths: ConfigurablePaths{
+			DataDir: "",
+		},
 	}
 }
 
@@ -278,5 +286,8 @@ func mergeConfigs(config *Config, subconfig *Config) {
 	}
 	for registry, creds := range subconfig.DockerCredentialsPerRegistry {
 		config.DockerCredentialsPerRegistry[registry] = creds
+	}
+	if subconfig.Paths.DataDir != "" {
+		config.Paths.DataDir = subconfig.Paths.DataDir
 	}
 }

--- a/rkt/config/config_test.go
+++ b/rkt/config/config_test.go
@@ -121,6 +121,32 @@ func TestDockerAuthConfigFormat(t *testing.T) {
 	}
 }
 
+func TestPathsConfigFormat(t *testing.T) {
+	tmpPath := os.TempDir()
+	tests := []struct {
+		contents string
+		expected ConfigurablePaths
+		fail     bool
+	}{
+		{"bogus contents", ConfigurablePaths{DataDir: ""}, true},
+		{`{"bogus": {"foo": "bar"}}`, ConfigurablePaths{DataDir: ""}, true},
+		{`{"rktKind": "foo"}`, ConfigurablePaths{DataDir: ""}, true},
+		{`{"rktKind": "paths", "rktVersion": "foo"}`, ConfigurablePaths{DataDir: ""}, true},
+		{`{"rktKind": "paths", "rktVersion": "v1", "data": "` + tmpPath + `"}`, ConfigurablePaths{DataDir: tmpPath}, false},
+	}
+	for _, tt := range tests {
+		cfg, err := getConfigFromContents(tt.contents, "paths")
+		if vErr := verifyFailure(tt.fail, tt.contents, err); vErr != nil {
+			t.Errorf("%v", vErr)
+		} else if !tt.fail {
+			result := cfg.Paths
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Error("Got unexpected results\nResult:\n", result, "\n\nExpected:\n", tt.expected)
+			}
+		}
+	}
+}
+
 func verifyFailure(shouldFail bool, contents string, err error) error {
 	var vErr error = nil
 	if err != nil {

--- a/rkt/config/paths.go
+++ b/rkt/config/paths.go
@@ -1,0 +1,47 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type configurablePathsV1 struct {
+	Data string `json:"data"`
+}
+
+func init() {
+	addParser("paths", "v1", &configurablePathsV1{})
+	// Look in 'paths.d' subdir for configs of type paths
+	registerSubDir("paths.d", []string{"paths"})
+}
+
+func (p *configurablePathsV1) parse(config *Config, raw []byte) error {
+	var dirs configurablePathsV1
+	if err := json.Unmarshal(raw, &dirs); err != nil {
+		return err
+	}
+	if dirs.Data != "" {
+		if config.Paths.DataDir != "" {
+			// A clash has occurred. Data dir has been defined more than once in
+			// the same directory
+			return fmt.Errorf("Error processing the data directory. Verify that it has not been defined more than once in the same config directory.")
+		}
+		config.Paths.DataDir = dirs.Data
+	}
+
+	return nil
+}

--- a/rkt/enter.go
+++ b/rkt/enter.go
@@ -93,7 +93,7 @@ func runEnter(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("Cannot open store: %v", err)
 		return 1

--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -60,7 +60,7 @@ func runFetch(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("fetch: cannot open store: %v", err)
 		return 1

--- a/rkt/image_cat_manifest.go
+++ b/rkt/image_cat_manifest.go
@@ -43,7 +43,7 @@ func runImageCatManifest(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("image cat-manifest: cannot open store: %v", err)
 		return 1

--- a/rkt/image_export.go
+++ b/rkt/image_export.go
@@ -44,7 +44,7 @@ func runImageExport(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("image export: cannot open store: %v", err)
 		return 1

--- a/rkt/image_extract.go
+++ b/rkt/image_extract.go
@@ -52,7 +52,7 @@ func runImageExtract(cmd *cobra.Command, args []string) (exit int) {
 	}
 	outputDir := args[1]
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("image extract: cannot open store: %v", err)
 		return 1

--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -183,7 +183,7 @@ func runImages(cmd *cobra.Command, args []string) (exit int) {
 		fmt.Fprintf(tabOut, "%s\n", strings.Join(headerFields, "\t"))
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("images: cannot open store: %v\n", err)
 		return 1

--- a/rkt/image_render.go
+++ b/rkt/image_render.go
@@ -51,7 +51,7 @@ func runImageRender(cmd *cobra.Command, args []string) (exit int) {
 	}
 	outputDir := args[1]
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("image render: cannot open store: %v", err)
 		return 1

--- a/rkt/image_rm.go
+++ b/rkt/image_rm.go
@@ -40,7 +40,7 @@ func runRmImage(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("rkt: cannot open store: %v", err)
 		return 1

--- a/rkt/install.go
+++ b/rkt/install.go
@@ -41,7 +41,7 @@ var (
 		Run:   runWrapper(runInstall),
 	}
 
-	// dirs relative to globalFlags.Dir
+	// dirs relative to data directory
 	dirs = map[string]os.FileMode{
 		".":                        os.FileMode(0755),
 		"tmp":                      os.FileMode(0775),
@@ -171,7 +171,7 @@ func setPermissions(path string, uid int, gid int, perm os.FileMode) error {
 
 func createDirStructure(gid int) error {
 	for dir, perm := range dirs {
-		path := filepath.Join(globalFlags.Dir, dir)
+		path := filepath.Join(getDataDir(), dir)
 
 		if err := os.MkdirAll(path, perm); err != nil {
 			return fmt.Errorf("error creating %q directory: %v", path, err)
@@ -259,7 +259,7 @@ func runInstall(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	casDirPerm := dirs["cas"]
-	casPath := filepath.Join(globalFlags.Dir, "cas")
+	casPath := filepath.Join(getDataDir(), "cas")
 	if err := setCasDirPermissions(casPath, gid, casDirPerm); err != nil {
 		stderr("install: error setting cas permissions: %v", err)
 		return 1

--- a/rkt/list.go
+++ b/rkt/list.go
@@ -44,7 +44,7 @@ func init() {
 }
 
 func runList(cmd *cobra.Command, args []string) (exit int) {
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("list: cannot open store: %v", err)
 		return 1

--- a/rkt/pods_test.go
+++ b/rkt/pods_test.go
@@ -119,7 +119,7 @@ func TestWalkPods(t *testing.T) {
 		}
 		defer os.RemoveAll(d)
 
-		globalFlags.Dir = d
+		cmdRkt.PersistentFlags().Set("data", d)
 		if err := initPods(); err != nil {
 			t.Fatalf("error initializing pods: %v", err)
 		}

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -98,16 +98,17 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	if globalFlags.Dir == "" {
+	dataDir := getDataDir()
+	if dataDir == "" {
 		log.Printf("dir unset - using temporary directory")
-		globalFlags.Dir, err = ioutil.TempDir("", "rkt")
+		dataDir, err = ioutil.TempDir("", "rkt")
 		if err != nil {
 			stderr("prepare: error creating temporary directory: %v", err)
 			return 1
 		}
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(dataDir)
 	if err != nil {
 		stderr("prepare: cannot open store: %v", err)
 		return 1

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -167,10 +167,11 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	if globalFlags.Dir == "" {
+	dataDir := getDataDir()
+	if dataDir == "" {
 		log.Printf("dir unset - using temporary directory")
 		var err error
-		globalFlags.Dir, err = ioutil.TempDir("", "rkt")
+		dataDir, err = ioutil.TempDir("", "rkt")
 		if err != nil {
 			stderr("error creating temporary directory: %v", err)
 			return 1
@@ -187,7 +188,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(dataDir)
 	if err != nil {
 		stderr("run: cannot open store: %v", err)
 		return 1

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -59,17 +59,18 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	if globalFlags.Dir == "" {
+	dataDir := getDataDir()
+	if dataDir == "" {
 		log.Printf("dir unset - using temporary directory")
 		var err error
-		globalFlags.Dir, err = ioutil.TempDir("", "rkt")
+		dataDir, err = ioutil.TempDir("", "rkt")
 		if err != nil {
 			stderr("error creating temporary directory: %v", err)
 			return 1
 		}
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(dataDir)
 	if err != nil {
 		stderr("prepared-run: cannot open store: %v", err)
 		return 1

--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -430,7 +430,7 @@ func TestPodManifest(t *testing.T) {
 								{"FILE", "/dir/file"},
 							},
 							MountPoints: []types.MountPoint{
-								{"dir", "/dir", false},
+								{"data", "/dir", false},
 							},
 						},
 					},
@@ -445,13 +445,13 @@ func TestPodManifest(t *testing.T) {
 								{"CONTENT", "host:foo"},
 							},
 							MountPoints: []types.MountPoint{
-								{"dir", "/dir", false},
+								{"data", "/dir", false},
 							},
 						},
 					},
 				},
 				Volumes: []types.Volume{
-					{"dir", "host", tmpdir, nil},
+					{"data", "host", tmpdir, nil},
 				},
 			},
 			true,

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -93,7 +93,7 @@ type rktRunCtx struct {
 func newRktRunCtx() *rktRunCtx {
 	return &rktRunCtx{
 		directories: []*dirDesc{
-			newDirDesc("datadir-", "data", "dir"),
+			newDirDesc("datadir-", "data", "data"),
 			newDirDesc("localdir-", "local configuration", "local-config"),
 			newDirDesc("systemdir-", "system configuration", "system-config"),
 		},


### PR DESCRIPTION
Adds a new category of config called "directories" which is intended to
allow the user to configure various paths. At the moment, it supports
one - the data directory. By setting this, you can control where image
files are stored without having to give a CLI argument.