### PR TITLE
fix AC_APP_NAME by using name from manifest

### DIFF
--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -171,9 +171,7 @@ func (p *Pod) appToSystemd(ra *schema.RuntimeApp, interactive bool) error {
 
 	env := app.Environment
 
-	// TOOD(yifan): AC_APP_NAME here is actually an image name.
-	// Think of changing AC_APP_NAME to AC_IMAGE_NAME.
-	env.Set("AC_APP_NAME", imgName.String())
+	env.Set("AC_APP_NAME", appName.String())
 	env.Set("AC_METADATA_URL", p.MetadataServiceURL)
 
 	if err := p.writeEnvFile(env, appName); err != nil {


### PR DESCRIPTION
adhere to appc spec in AC_APP_NAME by using full name found
in manifest instead of image name, as required by spec:
`"AC_APP_NAME name of the application, as defined in the image manifest"`

fixes ace-validator fail:

```
[ 3464.555222] ace-validator[10]: ==> AC_APP_NAME not set appropriately (need "ace-validator-main", got "coreos.com/ace-validator-main")
```

when run like this:
```
sudo rkt --insecure-skip-verify --debug run --mds-register=false --volume=database,kind=host,source=database --private-net ace-validator-main.aci ace-validator-sidekick.aci
```

@yifan-gu PTAL, maybe your ["TODO comment"](https://github.com/coreos/rkt/blob/master/stage1%2Finit%2Fpod.go#L174) is invalid now and should be deleted ? (AFAIK there is no such thing as AC_IMAGE_NAME in spec)