### PR TITLE
stage1/cgroup: replace string with resource.Quantity.

### DIFF
--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -246,14 +246,12 @@ func (p *Pod) appToSystemd(ra *schema.RuntimeApp, interactive bool) error {
 	for _, i := range app.Isolators {
 		switch v := i.Value().(type) {
 		case *types.ResourceMemory:
-			limit := v.Limit().String()
-			opts, err = cgroup.MaybeAddIsolator(opts, "memory", limit)
+			opts, err = cgroup.MaybeAddIsolator(opts, "memory", v.Limit())
 			if err != nil {
 				return err
 			}
 		case *types.ResourceCPU:
-			limit := v.Limit().String()
-			opts, err = cgroup.MaybeAddIsolator(opts, "cpu", limit)
+			opts, err = cgroup.MaybeAddIsolator(opts, "cpu", v.Limit())
 			if err != nil {
 				return err
 			}

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -33,15 +33,15 @@
             {
                 "name": "resource/memory",
                 "value": {
-                    "request": "25M",
-                    "limit": "25M"
+                    "request": "25Mi",
+                    "limit": "25Mi"
                 }
             },
             {
                 "name": "resource/cpu",
                 "value": {
-                    "request": "50",
-                    "limit": "800"
+                    "request": "50m",
+                    "limit": "800m"
                 }
             }
         ],


### PR DESCRIPTION
This enables things like `"resource/cpu":{"limit","100m"}`,
or `"resource/cpu":{"limit":"0.01"}`, which is the Kubernetes's style.

Previously, we will try to parse "100m" as an integer, and fail.