### PR TITLE
rkt/prepare.go: Suppress the logging message when --quiet=true.

### DIFF
--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -70,6 +70,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 			stderr("prepare: unable to open /dev/null")
 			return 1
 		}
+		log.SetOutput(os.Stdout)
 	}
 
 	if err = parseApps(&rktApps, args, cmd.Flags(), true); err != nil {


### PR DESCRIPTION
Before:
```shell
$ sudo rkt prepare --quiet --pod-manifest pod
2015/07/28 18:03:46 Preparing stage1
2015/07/28 18:03:46 Loading image sha512-3480cea23d4ccb992c66f1ce1a9850c6512fa0c5ff7c52c8c20ae9e32929643d
2015/07/28 18:03:47 Writing pod manifest
e14ce6fb-8bc6-4718-8aaf-f900005d8215
```
After:
```shell
$ sudo rkt prepare --quiet --pod-manifest pod
e14ce6fb-8bc6-4718-8aaf-f900005d8215
```