### PR TITLE
kvm: lkvm patches (includes quiet patch)

### DIFF
--- a/stage1/usr_from_kvm/lkvm.mk
+++ b/stage1/usr_from_kvm/lkvm.mk
@@ -5,39 +5,55 @@ LKVM_BINARY := $(LKVM_SRCDIR)/lkvm-static
 LKVM_ACI_BINARY := $(ACIROOTFSDIR)/lkvm
 LKVM_GIT := https://kernel.googlesource.com/pub/scm/linux/kernel/git/will/kvmtool
 # just last published version (for reproducible builds), not for any other reason 
-# cat be set to master to follow to upstream
-# LKVM_VERSION := master
 LKVM_VERSION := 4095fac878f618ae5e7384a1dc65ee34b6e05217
+
+LKVM_STUFFDIR := $(MK_SRCDIR)/lkvm
+LKVM_PATCHES := $(abspath $(LKVM_STUFFDIR)/patches/*.patch)
+
+$(call setup-stamp-file,LKVM_PATCH_STAMP,/patch_lkvm)
+$(call setup-dep-file,LKVM_PATCHES_DEPMK)
 
 UFK_STAMPS += $(LKVM_STAMP)
 INSTALL_FILES += $(LKVM_BINARY):$(LKVM_ACI_BINARY):-
 CREATE_DIRS += $(LKVM_TMP)
 
+
 $(LKVM_STAMP): $(LKVM_ACI_BINARY)
 	touch "$@"
 
 $(LKVM_BINARY): LKVM_SRCDIR := $(LKVM_SRCDIR)
-$(LKVM_BINARY):
+$(LKVM_BINARY): $(LKVM_PATCH_STAMP)
 	$(MAKE) -C "$(LKVM_SRCDIR)" lkvm-static
 
+-include $(LKVM_PATCHES_DEPMK)
+$(LKVM_PATCH_STAMP): GO_ENV := $(GO_ENV)
+$(LKVM_PATCH_STAMP): DEPSGENTOOL := $(DEPSGENTOOL)
+$(LKVM_PATCH_STAMP): LKVM_PATCHES := $(LKVM_PATCHES)
+$(LKVM_PATCH_STAMP): LKVM_PATCHES_DEPMK := $(LKVM_PATCHES_DEPMK)
+$(LKVM_PATCH_STAMP): LKVM_SRCDIR := $(LKVM_SRCDIR)
+$(LKVM_PATCH_STAMP): $(LKVM_SRCDIR)/Makefile $(DEPSGENTOOL_STAMP)
+	set -e; \
+	shopt -s nullglob; \
+	$(GO_ENV) "$(DEPSGENTOOL)" glob --target '$$(LKVM_SRCDIR)/Makefile' --suffix=.patch $(LKVM_PATCHES) >"$(LKVM_PATCHES_DEPMK)"; \
+	for p in $(LKVM_PATCHES); do \
+		patch --directory="$(LKVM_SRCDIR)" --strip=1 --forward <"$${p}"; \
+	done; \
+	touch "$@"
+
+# add remote only if not added 
+# don't fetch existing (commit cannot change)
 $(LKVM_SRCDIR)/Makefile: LKVM_GIT := $(LKVM_GIT)
 $(LKVM_SRCDIR)/Makefile: LKVM_SRCDIR := $(LKVM_SRCDIR)
 $(LKVM_SRCDIR)/Makefile: LKVM_VERSION := $(LKVM_VERSION)
 $(LKVM_SRCDIR)/Makefile: | $(LKVM_TMP)
 	set -e; \
 	mkdir -p $(LKVM_SRCDIR); cd $(LKVM_SRCDIR); \
-	git init; \
-	git remote add origin "$(LKVM_GIT)"; \
-	git fetch --depth=1 origin $(LKVM_VERSION); \
-	git checkout $(LKVM_VERSION)
-	# git clone --depth=1 "$(LKVM_GIT)" "$(LKVM_SRCDIR)"
-
-GR_TARGET := $(LKVM_BINARY)
-GR_SRCDIR := $(LKVM_SRCDIR)
-GR_BRANCH := master
-GR_PREREQS := $(LKVM_SRCDIR)/Makefile
-
-include makelib/git-refresh.mk
+ 	git init; \
+	git remote | grep --silent origin || git remote add origin "$(LKVM_GIT)"; \
+	git rev-parse --quiet --verify HEAD >/dev/null || git fetch --depth=1 origin $(LKVM_VERSION) && git checkout --quiet $(LKVM_VERSION); \
+	git reset --hard; \
+	git clean -ffdx; \
+	touch "$@"
 
 LKVM_STAMP :=
 LKVM_TMP :=
@@ -46,3 +62,8 @@ LKVM_BINARY :=
 LKVM_ACI_BINARY :=
 LKVM_GIT :=
 LKVM_VERSION := 
+LKVM_STUFFDIR := 
+LKVM_PATCHES := 
+LKVM_PATCH_STAMP :=
+LKVM_PATCHES_DEPMK :=
+

--- a/stage1/usr_from_kvm/lkvm/patches/quiet-booting.patch
+++ b/stage1/usr_from_kvm/lkvm/patches/quiet-booting.patch
@@ -1,0 +1,111 @@
+diff --git a/arm/kvm.c b/arm/kvm.c
+index d0e4a20..d795c5f 100644
+--- a/arm/kvm.c
++++ b/arm/kvm.c
+@@ -54,7 +54,7 @@ void kvm__arch_read_term(struct kvm *kvm)
+ 	}
+ }
+ 
+-void kvm__arch_set_cmdline(char *cmdline, bool video)
++void kvm__arch_set_cmdline(char *cmdline, bool video, bool earlyprintk)
+ {
+ }
+ 
+diff --git a/builtin-run.c b/builtin-run.c
+index 1ee75ad..d63fe4c 100644
+--- a/builtin-run.c
++++ b/builtin-run.c
+@@ -591,7 +591,8 @@ static struct kvm *kvm_cmd_run_init(int argc, const char **argv)
+                 kvm->cfg.network = DEFAULT_NETWORK;
+ 
+ 	memset(real_cmdline, 0, sizeof(real_cmdline));
+-	kvm__arch_set_cmdline(real_cmdline, kvm->cfg.vnc || kvm->cfg.sdl || kvm->cfg.gtk);
++	// rkt: do earlyprintk only when do_debug_print
++	kvm__arch_set_cmdline(real_cmdline, kvm->cfg.vnc || kvm->cfg.sdl || kvm->cfg.gtk, do_debug_print);
+ 
+ 	if (strlen(real_cmdline) > 0)
+ 		strcat(real_cmdline, " ");
+@@ -640,10 +641,13 @@ static struct kvm *kvm_cmd_run_init(int argc, const char **argv)
+ 
+ 	kvm->cfg.real_cmdline = real_cmdline;
+ 
+-	printf("  # %s run -k %s -m %Lu -c %d --name %s\n", KVM_BINARY_NAME,
+-		kvm->cfg.kernel_filename,
+-		(unsigned long long)kvm->cfg.ram_size / 1024 / 1024,
+-		kvm->cfg.nrcpus, kvm->cfg.guest_name);
++	// rkt: debug print only when asked 
++	if (do_debug_print) {
++		printf("  # %s run -k %s -m %Lu -c %d --name %s\n", KVM_BINARY_NAME,
++			kvm->cfg.kernel_filename,
++			(unsigned long long)kvm->cfg.ram_size / 1024 / 1024,
++			kvm->cfg.nrcpus, kvm->cfg.guest_name);
++	}
+ 
+ 	if (init_list__init(kvm) < 0)
+ 		die ("Initialisation failed");
+diff --git a/include/kvm/kvm.h b/include/kvm/kvm.h
+index 37155db..70fb099 100644
+--- a/include/kvm/kvm.h
++++ b/include/kvm/kvm.h
+@@ -100,7 +100,7 @@ int kvm__get_sock_by_instance(const char *name);
+ int kvm__enumerate_instances(int (*callback)(const char *name, int pid));
+ void kvm__remove_socket(const char *name);
+ 
+-void kvm__arch_set_cmdline(char *cmdline, bool video);
++void kvm__arch_set_cmdline(char *cmdline, bool video, bool earlyprintk);
+ void kvm__arch_init(struct kvm *kvm, const char *hugetlbfs_path, u64 ram_size);
+ void kvm__arch_delete_ram(struct kvm *kvm);
+ int kvm__arch_setup_firmware(struct kvm *kvm);
+diff --git a/mips/kvm.c b/mips/kvm.c
+index 1925f38..028b0c3 100644
+--- a/mips/kvm.c
++++ b/mips/kvm.c
+@@ -51,7 +51,7 @@ void kvm__arch_delete_ram(struct kvm *kvm)
+ 	munmap(kvm->ram_start, kvm->ram_size);
+ }
+ 
+-void kvm__arch_set_cmdline(char *cmdline, bool video)
++void kvm__arch_set_cmdline(char *cmdline, bool video, bool earlyprintk)
+ {
+ 
+ }
+diff --git a/powerpc/kvm.c b/powerpc/kvm.c
+index b4c3310..e6c78d8 100644
+--- a/powerpc/kvm.c
++++ b/powerpc/kvm.c
+@@ -84,7 +84,7 @@ void kvm__init_ram(struct kvm *kvm)
+ 	kvm__register_mem(kvm, phys_start, phys_size, host_mem);
+ }
+ 
+-void kvm__arch_set_cmdline(char *cmdline, bool video)
++void kvm__arch_set_cmdline(char *cmdline, bool video, bool earlyprintk)
+ {
+ 	/* We don't need anything unusual in here. */
+ }
+diff --git a/x86/kvm.c b/x86/kvm.c
+index 512ad67..3cd783d 100644
+--- a/x86/kvm.c
++++ b/x86/kvm.c
+@@ -118,14 +118,19 @@ void kvm__init_ram(struct kvm *kvm)
+ }
+ 
+ /* Arch-specific commandline setup */
+-void kvm__arch_set_cmdline(char *cmdline, bool video)
++void kvm__arch_set_cmdline(char *cmdline, bool video, bool earlyprintk)
+ {
+ 	strcpy(cmdline, "noapic noacpi pci=conf1 reboot=k panic=1 i8042.direct=1 "
+ 				"i8042.dumbkbd=1 i8042.nopnp=1");
+ 	if (video)
+ 		strcat(cmdline, " video=vesafb console=tty0");
+-	else
+-		strcat(cmdline, " console=ttyS0 earlyprintk=serial i8042.noaux=1");
++	else {
++		// earlyprintk only when asked
++		strcat(cmdline, " console=ttyS0 i8042.noaux=1");
++		if (earlyprintk)
++			strcat(cmdline, " earlyprintk=serial");
++	}
++
+ }
+ 
+ /* Architecture-specific KVM init */


### PR DESCRIPTION
includes:
- patch for quiet kernel booting (lkvm earlyprink option is only
         appended when lkvm run with --debug flag)
- fix for refreshing sources of lkvm (optional git fetch)
- possibility to add another patches for lkvm
- fixes lkvm version freeze (git-refresh removed)
