### PR TITLE
store: trick go vet into not complaining

### DIFF
--- a/store/store_test.go
+++ b/store/store_test.go
@@ -273,7 +273,9 @@ func TestGetAci(t *testing.T) {
 				},
 				{
 					"example.com/test02",
-					types.Labels{
+					// Workaround for https://github.com/golang/go/issues/6820 :
+					// `go vet` does not correctly detect types.Labels as a container
+					[]types.Label{
 						{
 							Name:  "version",
 							Value: "1.0.0",
@@ -283,7 +285,7 @@ func TestGetAci(t *testing.T) {
 				},
 				{
 					"example.com/test02",
-					types.Labels{
+					[]types.Label{
 						{
 							Name:  "version",
 							Value: "2.0.0",

--- a/tests/tests.mk
+++ b/tests/tests.mk
@@ -9,13 +9,6 @@ TST_GOFMT_DIRS := $(foreach d,$(TST_DIRS_WITH_GOFILES),./$d)
 TST_GO_VET_PACKAGES := $(foreach d,$(TST_DIRS_WITH_GOFILES),$(REPO_PATH)/$d)
 TST_GO_TEST_PACKAGES := $(foreach d,$(TST_DIRS_WITH_TESTGOFILES),$(REPO_PATH)/$d)
 
-# Workaround for https://github.com/golang/go/issues/6820
-# Disable go vet on Semaphore for store/store_test.go
-# TODO: remove this when Semaphore updates their go installation
-ifeq ($(SEMAPHORE),true)
-TST_GO_VET_PACKAGES := $(filter-out github.com/coreos/rkt/store,$(TST_GO_VET_PACKAGES))
-endif
-
 $(TST_SHORT_TESTS_STAMP): TST_GOFMT_DIRS := $(TST_GOFMT_DIRS)
 $(TST_SHORT_TESTS_STAMP): RKT_TAGS := $(RKT_TAGS)
 $(TST_SHORT_TESTS_STAMP): TST_GO_VET_PACKAGES := $(TST_GO_VET_PACKAGES)


### PR DESCRIPTION
`go vet` does not track types across packages and so assumes
types.Labels is a struct rather than a container; consequently, it
complains about unkeyed fields in store_test.go
To work around this, use a []types.Label and have go automatically
convert the type instead.

Re-enables go vet checking on Semaphore.

https://github.com/golang/go/issues/6820