### PR TITLE
rkt: fix fetchImageFromStore with missing os/arch labels.

### DIFF
--- a/rkt/image.go
+++ b/rkt/image.go
@@ -14,15 +14,7 @@
 
 package main
 
-import (
-	"fmt"
-
-	"github.com/coreos/rkt/store"
-
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/discovery"
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
-)
+import "github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
 
 var (
 	cmdImage = &cobra.Command{
@@ -33,29 +25,4 @@ var (
 
 func init() {
 	cmdRkt.AddCommand(cmdImage)
-}
-
-func getKeyFromAppOrHash(s *store.Store, input string) (string, error) {
-	var key string
-	if _, err := types.NewHash(input); err == nil {
-		key, err = s.ResolveKey(input)
-		if err != nil {
-			return "", fmt.Errorf("cannot resolve key: %v", err)
-		}
-	} else {
-		app, err := discovery.NewAppFromString(input)
-		if err != nil {
-			return "", fmt.Errorf("cannot parse the image name: %v", err)
-		}
-		labels, err := types.LabelsFromMap(app.Labels)
-		if err != nil {
-			return "", fmt.Errorf("invalid labels in the name: %v", err)
-		}
-		key, err = s.GetACI(app.Name, labels)
-		if err != nil {
-			return "", fmt.Errorf("cannot find image: %v", err)
-		}
-	}
-
-	return key, nil
 }

--- a/rkt/image_cat_manifest.go
+++ b/rkt/image_cat_manifest.go
@@ -49,7 +49,7 @@ func runImageCatManifest(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	key, err := getKeyFromAppOrHash(s, args[0])
+	key, err := getStoreKeyFromAppOrHash(s, args[0])
 	if err != nil {
 		stderr("image cat-manifest: %v", err)
 		return 1

--- a/rkt/image_export.go
+++ b/rkt/image_export.go
@@ -50,7 +50,7 @@ func runImageExport(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	key, err := getKeyFromAppOrHash(s, args[0])
+	key, err := getStoreKeyFromAppOrHash(s, args[0])
 	if err != nil {
 		stderr("image export: %v", err)
 		return 1

--- a/rkt/image_extract.go
+++ b/rkt/image_extract.go
@@ -57,7 +57,7 @@ func runImageExtract(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	key, err := getKeyFromAppOrHash(s, args[0])
+	key, err := getStoreKeyFromAppOrHash(s, args[0])
 	if err != nil {
 		stderr("image extract: %v", err)
 		return 1

--- a/rkt/image_render.go
+++ b/rkt/image_render.go
@@ -56,7 +56,7 @@ func runImageRender(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	key, err := getKeyFromAppOrHash(s, args[0])
+	key, err := getStoreKeyFromAppOrHash(s, args[0])
 	if err != nil {
 		stderr("image render: %v", err)
 		return 1


### PR DESCRIPTION
Some images imported in the store will not contain os/arch labels.
This will happen with os/arch independent images.

In this case fetchImageFromStore will fail because it retrieves the image name and
labels from the image name string calling newDiscoveryApp that by default
adds the os and arch label for the current os and arch.

Adding the current os and arch labels is correct for the discovery phase and
should be used only there.

Instead `rkt image cat-manifest/export/extract/renders` works as their logic
doesn't add a default os and arch label.

This patch unifies and uses the same logic also for fetchImageFromStore.