### PR TITLE
kvm: basic networking support

### DIFF
--- a/networking/kvm.go
+++ b/networking/kvm.go
@@ -152,6 +152,14 @@ func (n *Networking) teardownKvmNets() {
 		case "ptp":
 			// remove tuntap interface
 			tuntap.RemovePersistentIface(an.runtime.IfName, tuntap.Tap)
+			// remove masquerading if it was prepared
+			if an.conf.IPMasq {
+				chain := "CNI-" + an.conf.Name
+				ip.TeardownIPMasq(&net.IPNet{
+					IP:   an.runtime.IP,
+					Mask: net.IPMask(an.runtime.Mask),
+				}, chain)
+			}
 			// ugly hack again to directly call IPAM plugin to release IP
 			an.conf.Type = an.conf.IPAM.Type
 

--- a/networking/kvm.go
+++ b/networking/kvm.go
@@ -53,6 +53,9 @@ func setupTapDevice() (netlink.Link, error) {
 // in result it updates activeNet.runtime configuration with IP, Mask and HostIP
 func kvmSetupNetAddressing(network *Networking, n activeNet, ifName string) error {
 	// TODO: very ugly hack, that go through upper plugin, down to ipam plugin
+	if err := ip.EnableIP4Forward(); err != nil {
+		return fmt.Errorf("failed to enable forwarding: %v", err)
+	}
 	n.conf.Type = n.conf.IPAM.Type
 	output, err := network.execNetPlugin("ADD", &n, ifName)
 	if err != nil {

--- a/networking/kvm.go
+++ b/networking/kvm.go
@@ -1,0 +1,175 @@
+// kvm.go file provides networking supporting functions for kvm flavor
+package networking
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/cni/pkg/ip"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/cni/pkg/plugin"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/vishvananda/netlink"
+
+	"github.com/coreos/rkt/common"
+	"github.com/coreos/rkt/networking/tuntap"
+)
+
+// setupTapDevice creates persistent tap devices
+// and returns a newly created netlink.Link structure
+func setupTapDevice() (netlink.Link, error) {
+	ifName, err := tuntap.CreatePersistentIface(tuntap.Tap)
+	if err != nil {
+		return nil, fmt.Errorf("tuntap persist %v", err)
+	}
+	link, err := netlink.LinkByName(ifName)
+	if err != nil {
+		return nil, fmt.Errorf("cannot find link %q: %v", ifName, err)
+	}
+	err = netlink.LinkSetUp(link)
+	if err != nil {
+		return nil, fmt.Errorf("cannot set link up %q: %v", ifName, err)
+	}
+	return link, nil
+}
+
+func kvmSetupNetAddressing(network *Networking, n activeNet, ifName string) error {
+	// TODO: very ugly hack, that go through upper plugin, down to ipam plugin
+	n.conf.Type = n.conf.IPAM.Type
+	output, err := network.execNetPlugin("ADD", &n, ifName)
+	if err != nil {
+		return fmt.Errorf("problem executing network plugin %q (%q): %v", n.conf.Type, ifName, err)
+	}
+
+	result := plugin.Result{}
+	if err = json.Unmarshal(output, &result); err != nil {
+		return fmt.Errorf("error parsing %q result: %v", n.conf.Name, err)
+	}
+
+	if result.IP4 == nil {
+		return fmt.Errorf("net-plugin returned no IPv4 configuration")
+	}
+
+	n.runtime.IP, n.runtime.Mask, n.runtime.HostIP = result.IP4.IP.IP, net.IP(result.IP4.IP.Mask), result.IP4.Gateway
+	return nil
+}
+
+func kvmSetup(podRoot string, podID types.UUID, fps []ForwardedPort, privateNetList common.PrivateNetList, localConfig string) (*Networking, error) {
+	network := Networking{
+		podEnv: podEnv{
+			podRoot:      podRoot,
+			podID:        podID,
+			netsLoadList: privateNetList,
+			localConfig:  localConfig,
+		},
+	}
+	var e error
+	network.nets, e = network.loadNets()
+	if e != nil {
+		return nil, fmt.Errorf("error loading network definitions: %v", e)
+	}
+
+	for _, n := range network.nets {
+		switch n.conf.Type {
+		case "ptp":
+			link, err := setupTapDevice()
+			if err != nil {
+				return nil, err
+			}
+			ifName := link.Attrs().Name
+			n.runtime.IfName = ifName
+
+			err = kvmSetupNetAddressing(&network, n, ifName)
+			if err != nil {
+				return nil, err
+			}
+
+			// add address to host tap device
+			err = netlink.AddrAdd(
+				link,
+				&netlink.Addr{
+					IPNet: &net.IPNet{
+						IP:   n.runtime.HostIP,
+						Mask: net.IPMask(n.runtime.Mask),
+					},
+					Label: ifName,
+				})
+			if err != nil {
+				return nil, fmt.Errorf("cannot add address to host tap device %q: %v", ifName, err)
+			}
+
+			if n.conf.IPMasq {
+				chain := "CNI-" + n.conf.Name
+				if err = ip.SetupIPMasq(&net.IPNet{
+					IP:   n.runtime.IP,
+					Mask: net.IPMask(n.runtime.Mask),
+				}, chain); err != nil {
+					return nil, err
+				}
+			}
+		default:
+			return nil, fmt.Errorf("network %q have unsupported type: %q", n.conf.Name, n.conf.Type)
+		}
+	}
+	err := network.forwardPorts(fps, network.GetDefaultIP())
+	if err != nil {
+		return nil, err
+	}
+
+	return &network, nil
+}
+
+func (e *Networking) teardownKvmNets(nets []activeNet) {
+	for _, n := range nets {
+		switch n.conf.Type {
+		case "ptp":
+			tuntap.RemovePersistentIface(n.runtime.IfName, tuntap.Tap)
+			n.conf.Type = n.conf.IPAM.Type
+
+			_, err := e.execNetPlugin("DEL", &n, n.runtime.IfName)
+			if err != nil {
+				log.Printf("Error executing network plugin: %q", err)
+			}
+		default:
+			log.Printf("Unsupported network type: %q", n.conf.Type)
+		}
+	}
+}
+
+// NetParams exposes conf(NetConf)/runtime(NetInfo) data to stage1/init client
+type NetParams struct {
+	// runtime based information
+	HostIP  net.IP
+	GuestIP net.IP
+	Mask    net.IP
+	IfName  string
+	// TODO: required for other type of plugins, not yet available because what networking.Networking stores
+	// Net net.IPNet
+
+	// configuration based information
+	Name   string
+	Type   string
+	IPMasq bool
+}
+
+// GetNetworkParameters returns network parameters created
+// by plugins, which are required for stage1 executor to run (only for KVM)
+func (e *Networking) GetNetworkParameters() []NetParams {
+	np := []NetParams{}
+	_ = np
+	for _, an := range e.nets {
+		np = append(np, NetParams{
+			HostIP:  an.runtime.HostIP,
+			GuestIP: an.runtime.IP,
+			IfName:  an.runtime.IfName,
+			Mask:    an.runtime.Mask,
+			// Net: // TODO: from where
+			Name:   an.conf.Name,
+			Type:   an.conf.Type,
+			IPMasq: an.conf.IPMasq,
+		})
+	}
+
+	return np
+}

--- a/networking/kvm.go
+++ b/networking/kvm.go
@@ -1,3 +1,17 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // kvm.go file provides networking supporting functions for kvm flavor
 package networking
 
@@ -34,6 +48,9 @@ func setupTapDevice() (netlink.Link, error) {
 	return link, nil
 }
 
+// kvmSetupNetAddressing calls IPAM plugin (with a hack) to reserve an IP to be
+// used by newly create tuntap pair
+// in result it updates activeNet.runtime configuration with IP, Mask and HostIP
 func kvmSetupNetAddressing(network *Networking, n activeNet, ifName string) error {
 	// TODO: very ugly hack, that go through upper plugin, down to ipam plugin
 	n.conf.Type = n.conf.IPAM.Type
@@ -55,6 +72,9 @@ func kvmSetupNetAddressing(network *Networking, n activeNet, ifName string) erro
 	return nil
 }
 
+// kvmSetup prepare new Networking to be used in kvm environment based on tuntap pair interfaces
+// to allow communication with virtual machine created by lkvm tool
+// right now it only supports default "ptp" network type (other types ends with error)
 func kvmSetup(podRoot string, podID types.UUID, fps []ForwardedPort, privateNetList common.PrivateNetList, localConfig string) (*Networking, error) {
 	network := Networking{
 		podEnv: podEnv{
@@ -120,21 +140,40 @@ func kvmSetup(podRoot string, podID types.UUID, fps []ForwardedPort, privateNetL
 	return &network, nil
 }
 
-func (e *Networking) teardownKvmNets(nets []activeNet) {
-	for _, n := range nets {
-		switch n.conf.Type {
-		case "ptp":
-			tuntap.RemovePersistentIface(n.runtime.IfName, tuntap.Tap)
-			n.conf.Type = n.conf.IPAM.Type
+/*
+extend Networking struct with methods to clean up kvm specific network configurations
+*/
 
-			_, err := e.execNetPlugin("DEL", &n, n.runtime.IfName)
+// teardownKvmNets teardown every active networking from networking by
+// removing tuntap interface and releasing its ip from IPAM plugin
+func (n *Networking) teardownKvmNets() {
+	for _, an := range n.nets {
+		switch an.conf.Type {
+		case "ptp":
+			// remove tuntap interface
+			tuntap.RemovePersistentIface(an.runtime.IfName, tuntap.Tap)
+			// ugly hack again to directly call IPAM plugin to release IP
+			an.conf.Type = an.conf.IPAM.Type
+
+			_, err := n.execNetPlugin("DEL", &an, an.runtime.IfName)
 			if err != nil {
 				log.Printf("Error executing network plugin: %q", err)
 			}
 		default:
-			log.Printf("Unsupported network type: %q", n.conf.Type)
+			log.Printf("Unsupported network type: %q", an.conf.Type)
 		}
 	}
+}
+
+// kvmTeardown network teardown for kvm flavor based pods
+// similar to Networking.Teardown but without host namespaces
+func (n *Networking) kvmTeardown() {
+
+	if err := n.unforwardPorts(); err != nil {
+		log.Printf("Error removing forwarded ports (kvm): %v", err)
+	}
+	n.teardownKvmNets()
+
 }
 
 // NetParams exposes conf(NetConf)/runtime(NetInfo) data to stage1/init client

--- a/networking/netinfo/netinfo.go
+++ b/networking/netinfo/netinfo.go
@@ -30,6 +30,7 @@ type NetInfo struct {
 	IfName   string `json:"ifName"`
 	IP       net.IP `json:"ip"`
 	Args     string `json:"args"`
+	Mask     net.IP
 	HostIP   net.IP
 }
 

--- a/networking/netinfo/netinfo.go
+++ b/networking/netinfo/netinfo.go
@@ -30,8 +30,8 @@ type NetInfo struct {
 	IfName   string `json:"ifName"`
 	IP       net.IP `json:"ip"`
 	Args     string `json:"args"`
-	Mask     net.IP // we used IP instead of IPMask because support for json serialization (we don't need specifc functionalities
-	HostIP   net.IP
+	Mask     net.IP `json:"mask"` // we used IP instead of IPMask because support for json serialization (we don't need specifc functionalities
+	HostIP   net.IP `json:"-"`
 }
 
 func LoadAt(cdirfd int) ([]NetInfo, error) {

--- a/networking/netinfo/netinfo.go
+++ b/networking/netinfo/netinfo.go
@@ -30,7 +30,7 @@ type NetInfo struct {
 	IfName   string `json:"ifName"`
 	IP       net.IP `json:"ip"`
 	Args     string `json:"args"`
-	Mask     net.IP
+	Mask     net.IP // we used IP instead of IPMask because support for json serialization (we don't need specifc functionalities
 	HostIP   net.IP
 }
 

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -131,11 +131,11 @@ func KvmSetup(podRoot string, podID types.UUID, fps []ForwardedPort, privateNetL
 			err = netlink.AddrAdd(
 				*link,
 				&netlink.Addr{
-					&net.IPNet{
-						n.runtime.HostIP,
-						net.IPMask(n.runtime.Mask),
+					IPNet: &net.IPNet{
+						IP:   n.runtime.HostIP,
+						Mask: net.IPMask(n.runtime.Mask),
 					},
-					ifName,
+					Label: ifName,
 				})
 			if err != nil {
 				return nil, fmt.Errorf("cannot add address to host tap device %q: %v", ifName, err)
@@ -144,8 +144,8 @@ func KvmSetup(podRoot string, podID types.UUID, fps []ForwardedPort, privateNetL
 			if n.conf.IPMasq {
 				chain := "CNI-" + n.conf.Name
 				if err = ip.SetupIPMasq(&net.IPNet{
-					n.runtime.IP,
-					net.IPMask(n.runtime.Mask),
+					IP:   n.runtime.IP,
+					Mask: net.IPMask(n.runtime.Mask),
 				}, chain); err != nil {
 					return nil, err
 				}

--- a/networking/podenv.go
+++ b/networking/podenv.go
@@ -26,7 +26,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/cni/pkg/plugin"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 
 	"github.com/coreos/rkt/common"
@@ -54,7 +53,7 @@ type podEnv struct {
 
 type activeNet struct {
 	confBytes []byte
-	conf      *plugin.NetConf
+	conf      *NetConf
 	runtime   *netinfo.NetInfo
 }
 
@@ -115,7 +114,7 @@ func (e *podEnv) setupNets(nets []activeNet) error {
 	for i, n = range nets {
 		log.Printf("Loading network %v with type %v", n.conf.Name, n.conf.Type)
 
-		n.runtime.IfName = fmt.Sprintf(ifnamePattern, i)
+		n.runtime.IfName = fmt.Sprintf(IfNamePattern, i)
 		if n.runtime.ConfPath, err = copyFileToDir(n.runtime.ConfPath, e.netDir()); err != nil {
 			return fmt.Errorf("error copying %q to %q: %v", n.runtime.ConfPath, e.netDir(), err)
 		}
@@ -184,7 +183,7 @@ func loadNet(filepath string) (*activeNet, error) {
 		return nil, err
 	}
 
-	n := &plugin.NetConf{}
+	n := &NetConf{}
 	if err = json.Unmarshal(bytes, n); err != nil {
 		return nil, fmt.Errorf("error loading %v: %v", filepath, err)
 	}

--- a/networking/tuntap/tuntap.go
+++ b/networking/tuntap/tuntap.go
@@ -1,0 +1,101 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tuntap
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	Tun = 0x1
+	Tap = 0x2
+
+	NoPi     = 0x1000
+	OneQueue = 0x2000
+	VnetHdr  = 0x4000
+	TunExcl  = 0x8000
+)
+
+type ifReq struct {
+	Name  [0x10]byte
+	Flags uint16
+	pad   [0x28 - 0x12]byte
+}
+
+type Interface struct {
+	name string
+	file *os.File
+}
+
+func Open(ifName string, kind uint16) (*Interface, error) {
+	if ifName == "" {
+		ifName = "tap%d"
+	}
+	file, err := os.OpenFile("/dev/net/tun", os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	var req ifReq
+	copy(req.Name[:15], ifName)
+	req.Flags = kind | NoPi | VnetHdr
+
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, file.Fd(), uintptr(syscall.TUNSETIFF), uintptr(unsafe.Pointer(&req)))
+	if errno != 0 {
+		file.Close()
+		return nil, fmt.Errorf("ioctl failed (TUNSETIFF): %v", errno)
+	}
+
+	return &Interface{
+		name: string(req.Name[:bytes.IndexByte(req.Name[:], 0)]),
+		file: file,
+	}, nil
+}
+
+func (iface *Interface) Close() error {
+	return iface.file.Close()
+}
+
+func operateOnIface(name string, kind uint16, persistency uintptr) (string, error) {
+	iface, err := Open(name, kind)
+	if err != nil {
+		return "", err
+	}
+
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, iface.file.Fd(), uintptr(syscall.TUNSETPERSIST), persistency)
+	err = iface.Close()
+	if err != nil {
+		return "", fmt.Errorf("iface close error : %v", err)
+	}
+
+	if errno != 0 {
+		return "", fmt.Errorf("ioctl failed (TUNSETPERSIST): %v", errno)
+	}
+
+	return iface.name, nil
+}
+
+func CreatePersistentIface(kind uint16) (string, error) {
+	return operateOnIface("", kind, 1)
+}
+
+func RemovePersistentIface(name string, kind uint16) error {
+	_, err := operateOnIface(name, kind, 0)
+	return err
+}

--- a/stage1/gc/gc.go
+++ b/stage1/gc/gc.go
@@ -65,13 +65,11 @@ func main() {
 
 func gcNetworking(podID *types.UUID) error {
 	flavor, err := os.Readlink(filepath.Join(common.Stage1RootfsPath("."), "flavor"))
-
 	if err != nil {
 		return fmt.Errorf("Failed to get stage1 flavor: %v\n", err)
 	}
 
-	var n *networking.Networking
-	n, err = networking.Load(".", podID)
+	n, err := networking.Load(".", podID)
 	switch {
 	case err == nil:
 		n.Teardown(flavor)

--- a/stage1/gc/gc.go
+++ b/stage1/gc/gc.go
@@ -22,10 +22,12 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 
+	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/networking"
 )
 
@@ -62,10 +64,17 @@ func main() {
 }
 
 func gcNetworking(podID *types.UUID) error {
-	n, err := networking.Load(".", podID)
+	flavor, err := os.Readlink(filepath.Join(common.Stage1RootfsPath("."), "flavor"))
+
+	if err != nil {
+		return fmt.Errorf("Failed to get stage1 flavor: %v\n", err)
+	}
+
+	var n *networking.Networking
+	n, err = networking.Load(".", podID)
 	switch {
 	case err == nil:
-		n.Teardown()
+		n.Teardown(flavor)
 	case os.IsNotExist(err):
 		// probably ran without --private-net
 	default:

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -236,7 +236,7 @@ func installAssets() error {
 }
 
 // getArgsEnv returns the nspawn args and env according to the usr used
-func getArgsEnv(p *Pod, flavor string, debug bool, n networking.Networking) ([]string, []string, error) {
+func getArgsEnv(p *Pod, flavor string, debug bool, n *networking.Networking) ([]string, []string, error) {
 	args := []string{}
 	env := os.Environ()
 
@@ -246,7 +246,7 @@ func getArgsEnv(p *Pod, flavor string, debug bool, n networking.Networking) ([]s
 		// TODO: move to path.go
 		kernelPath := filepath.Join(common.Stage1RootfsPath(p.Root), "bzImage")
 		lkvmPath := filepath.Join(common.Stage1RootfsPath(p.Root), "lkvm")
-		lkvmNetParams, kernelNetParams, err := kvm.GetKVMNetParams(n)
+		lkvmNetArgs, kernelNetParams, err := kvm.GetKVMNetArgs(n)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -293,7 +293,7 @@ func getArgsEnv(p *Pod, flavor string, debug bool, n networking.Networking) ([]s
 			"--params", strings.Join(kernelParams, " "),
 		}...,
 		)
-		args = append(args, lkvmNetParams...)
+		args = append(args, lkvmNetArgs...)
 
 		if debug {
 			args = append(args, "--debug")
@@ -540,7 +540,7 @@ func stage1() int {
 		}
 	} else {
 		if flavor == "kvm" {
-			fmt.Fprintf(os.Stderr, "Flavor kvm requires private network configuration.\n")
+			fmt.Fprintf(os.Stderr, "Flavor kvm requires private network configuration (try --private-net).\n")
 			return 6
 		}
 		if len(mdsToken) > 0 {
@@ -558,7 +558,7 @@ func stage1() int {
 		return 2
 	}
 
-	args, env, err := getArgsEnv(p, flavor, debug, *n)
+	args, env, err := getArgsEnv(p, flavor, debug, n)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		return 3

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -299,9 +299,6 @@ func getArgsEnv(p *Pod, flavor string, debug bool, n *networking.Networking) ([]
 			args = append(args, "--debug")
 		}
 
-		// TODO: append additional networks settings
-		// args = append(args, network/volumes args...)
-
 		// host volume sharing with 9p
 		nsargs := kvm.VolumesToKvmDiskArgs(p.Manifest.Volumes)
 		args = append(args, nsargs...)

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -235,28 +235,6 @@ func installAssets() error {
 	return proj2aci.PrepareAssets(assets, "./stage1/rootfs/", nil)
 }
 
-// getKVMNetParams returns additionall parameters that need to be passed to kernel and lkvm tool to configure networks properly
-func getKVMNetParams(network networking.Networking) ([]string, []string, error) {
-	lkvmParams := []string{}
-	kernelParams := []string{}
-
-	for i, netParams := range network.GetNetworkParameters() {
-		//
-
-		// https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt
-		// ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>
-		var gw string
-		if netParams.IPMasq {
-			gw = netParams.HostIP.String()
-		}
-		kernelParams = append(kernelParams, "ip="+netParams.GuestIP.String()+"::"+gw+":"+netParams.Mask.String()+":"+fmt.Sprintf(networking.IfNamePattern, i)+":::")
-
-		lkvmParams = append(lkvmParams, "--network", "mode=tap,tapif="+netParams.IfName+",host_ip="+netParams.HostIP.String()+",guest_ip="+netParams.GuestIP.String())
-	}
-
-	return lkvmParams, kernelParams, nil
-}
-
 // getArgsEnv returns the nspawn args and env according to the usr used
 func getArgsEnv(p *Pod, flavor string, debug bool, n networking.Networking) ([]string, []string, error) {
 	args := []string{}
@@ -268,7 +246,7 @@ func getArgsEnv(p *Pod, flavor string, debug bool, n networking.Networking) ([]s
 		// TODO: move to path.go
 		kernelPath := filepath.Join(common.Stage1RootfsPath(p.Root), "bzImage")
 		lkvmPath := filepath.Join(common.Stage1RootfsPath(p.Root), "lkvm")
-		lkvmNetParams, kernelNetParams, err := getKVMNetParams(n)
+		lkvmNetParams, kernelNetParams, err := kvm.GetKVMNetParams(n)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -539,11 +517,7 @@ func stage1() int {
 			return 6
 		}
 
-		if flavor == "kvm" {
-			n, err = networking.KvmSetup(root, p.UUID, fps, privNet, localConfig)
-		} else {
-			n, err = networking.Setup(root, p.UUID, fps, privNet, localConfig)
-		}
+		n, err = networking.Setup(root, p.UUID, fps, privNet, localConfig, flavor)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to setup network: %v\n", err)
 			return 6

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -235,8 +235,30 @@ func installAssets() error {
 	return proj2aci.PrepareAssets(assets, "./stage1/rootfs/", nil)
 }
 
+// getKVMNetParams returns additionall parameters that need to be passed to kernel and lkvm tool to configure networks properly
+func getKVMNetParams(network networking.Networking) ([]string, []string, error) {
+	lkvmParams := []string{}
+	kernelParams := []string{}
+
+	for i, netParams := range network.GetNetworkParameters() {
+		//
+
+		// https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt
+		// ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>
+		var gw string
+		if netParams.IPMasq {
+			gw = netParams.HostIP.String()
+		}
+		kernelParams = append(kernelParams, "ip="+netParams.GuestIP.String()+"::"+gw+":"+netParams.Mask.String()+":"+fmt.Sprintf(networking.IfNamePattern, i)+":::")
+
+		lkvmParams = append(lkvmParams, "--network", "mode=tap,tapif="+netParams.IfName+",host_ip="+netParams.HostIP.String()+",guest_ip="+netParams.GuestIP.String())
+	}
+
+	return lkvmParams, kernelParams, nil
+}
+
 // getArgsEnv returns the nspawn args and env according to the usr used
-func getArgsEnv(p *Pod, flavor string, debug bool) ([]string, []string, error) {
+func getArgsEnv(p *Pod, flavor string, debug bool, n networking.Networking) ([]string, []string, error) {
 	args := []string{}
 	env := os.Environ()
 
@@ -246,6 +268,10 @@ func getArgsEnv(p *Pod, flavor string, debug bool) ([]string, []string, error) {
 		// TODO: move to path.go
 		kernelPath := filepath.Join(common.Stage1RootfsPath(p.Root), "bzImage")
 		lkvmPath := filepath.Join(common.Stage1RootfsPath(p.Root), "lkvm")
+		lkvmNetParams, kernelNetParams, err := getKVMNetParams(n)
+		if err != nil {
+			return nil, nil, err
+		}
 
 		// TODO: base on resource isolators
 		cpu := 1
@@ -258,6 +284,7 @@ func getArgsEnv(p *Pod, flavor string, debug bool) ([]string, []string, error) {
 			"noreplace-smp",
 			"systemd.default_standard_error=journal+console",
 			"systemd.default_standard_output=journal+console",
+			strings.Join(kernelNetParams, " "),
 			// "systemd.default_standard_output=tty",
 			"tsc=reliable",
 			"MACHINEID=" + p.UUID.String(),
@@ -288,6 +315,7 @@ func getArgsEnv(p *Pod, flavor string, debug bool) ([]string, []string, error) {
 			"--params", strings.Join(kernelParams, " "),
 		}...,
 		)
+		args = append(args, lkvmNetParams...)
 
 		if debug {
 			args = append(args, "--debug")
@@ -497,6 +525,13 @@ func stage1() int {
 
 	mirrorLocalZoneInfo(p.Root)
 
+	flavor, _, err := p.getFlavor()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get stage1 flavor: %v\n", err)
+		return 3
+	}
+
+	var n *networking.Networking
 	if privNet.Any() {
 		fps, err := forwardedPorts(p)
 		if err != nil {
@@ -504,7 +539,11 @@ func stage1() int {
 			return 6
 		}
 
-		n, err := networking.Setup(root, p.UUID, fps, privNet, localConfig)
+		if flavor == "kvm" {
+			n, err = networking.KvmSetup(root, p.UUID, fps, privNet, localConfig)
+		} else {
+			n, err = networking.Setup(root, p.UUID, fps, privNet, localConfig)
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to setup network: %v\n", err)
 			return 6
@@ -512,7 +551,7 @@ func stage1() int {
 
 		if err = n.Save(); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to save networking state %v\n", err)
-			n.Teardown()
+			n.Teardown(flavor)
 			return 6
 		}
 
@@ -526,15 +565,13 @@ func stage1() int {
 			p.MetadataServiceURL = common.MetadataServicePublicURL(hostIP, mdsToken)
 		}
 	} else {
+		if flavor == "kvm" {
+			fmt.Fprintf(os.Stderr, "Flavor kvm requires private network configuration.\n")
+			return 6
+		}
 		if len(mdsToken) > 0 {
 			p.MetadataServiceURL = common.MetadataServicePublicURL(localhostIP, mdsToken)
 		}
-	}
-
-	flavor, _, err := p.getFlavor()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to get stage1 flavor: %v\n", err)
-		return 3
 	}
 
 	if err = p.WritePrepareAppTemplate(); err != nil {
@@ -547,7 +584,7 @@ func stage1() int {
 		return 2
 	}
 
-	args, env, err := getArgsEnv(p, flavor, debug)
+	args, env, err := getArgsEnv(p, flavor, debug, *n)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		return 3

--- a/stage1/init/kvm/network.go
+++ b/stage1/init/kvm/network.go
@@ -1,0 +1,29 @@
+package kvm
+
+import (
+	"fmt"
+
+	"github.com/coreos/rkt/networking"
+)
+
+// KVMNetParams returns additionall parameters that need to be passed to kernel and lkvm tool to configure networks properly
+func GetKVMNetParams(network networking.Networking) ([]string, []string, error) {
+	lkvmParams := []string{}
+	kernelParams := []string{}
+
+	for i, netParams := range network.GetNetworkParameters() {
+		//
+
+		// https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt
+		// ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>
+		var gw string
+		if netParams.IPMasq {
+			gw = netParams.HostIP.String()
+		}
+		kernelParams = append(kernelParams, "ip="+netParams.GuestIP.String()+"::"+gw+":"+netParams.Mask.String()+":"+fmt.Sprintf(networking.IfNamePattern, i)+":::")
+
+		lkvmParams = append(lkvmParams, "--network", "mode=tap,tapif="+netParams.IfName+",host_ip="+netParams.HostIP.String()+",guest_ip="+netParams.GuestIP.String())
+	}
+
+	return lkvmParams, kernelParams, nil
+}

--- a/stage1/init/kvm/network.go
+++ b/stage1/init/kvm/network.go
@@ -1,3 +1,17 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kvm
 
 import (
@@ -6,14 +20,13 @@ import (
 	"github.com/coreos/rkt/networking"
 )
 
-// KVMNetParams returns additionall parameters that need to be passed to kernel and lkvm tool to configure networks properly
-func GetKVMNetParams(network networking.Networking) ([]string, []string, error) {
-	lkvmParams := []string{}
+// GetKVMNetParams returns additional arguments that need to be passed to kernel and lkvm tool to configure networks properly
+// parameters are based on Network configuration extracted from Networking struct
+func GetKVMNetArgs(n *networking.Networking) ([]string, []string, error) {
+	lkvmArgs := []string{}
 	kernelParams := []string{}
 
-	for i, netParams := range network.GetNetworkParameters() {
-		//
-
+	for i, netParams := range n.GetNetworkParameters() {
 		// https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt
 		// ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>
 		var gw string
@@ -22,8 +35,8 @@ func GetKVMNetParams(network networking.Networking) ([]string, []string, error) 
 		}
 		kernelParams = append(kernelParams, "ip="+netParams.GuestIP.String()+"::"+gw+":"+netParams.Mask.String()+":"+fmt.Sprintf(networking.IfNamePattern, i)+":::")
 
-		lkvmParams = append(lkvmParams, "--network", "mode=tap,tapif="+netParams.IfName+",host_ip="+netParams.HostIP.String()+",guest_ip="+netParams.GuestIP.String())
+		lkvmArgs = append(lkvmArgs, "--network", "mode=tap,tapif="+netParams.IfName+",host_ip="+netParams.HostIP.String()+",guest_ip="+netParams.GuestIP.String())
 	}
 
-	return lkvmParams, kernelParams, nil
+	return lkvmArgs, kernelParams, nil
 }


### PR DESCRIPTION
Includes support for ptp mode (used in default and default restricted example modes).

Not tested:
- port forwarding (uses existing rkt code)
- ip masquerade (uses existing rkt code)

Not working:
- no support to additional routes in network configuration

Co-authored-by: Pawel Palucki <pawel.palucki@gmail.com>