### PR TITLE
store: print error reporting name and labels in GetACI.

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -581,7 +581,7 @@ nextKey:
 	if curaciinfo != nil {
 		return curaciinfo.BlobKey, nil
 	}
-	return "", fmt.Errorf("aci not found")
+	return "", fmt.Errorf("cannot find aci satisfying name: %q and labels: %s in the local store", name, labelsToString(labels))
 }
 
 func (ds Store) GetAllACIInfos(sortfields []string, ascending bool) ([]*ACIInfo, error) {

--- a/store/utils.go
+++ b/store/utils.go
@@ -17,7 +17,10 @@ package store
 import (
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
 // blockTransform creates a path slice from the given string to use as a
@@ -40,4 +43,37 @@ func blockTransform(s string) []string {
 func parseAlways(s string) *url.URL {
 	u, _ := url.Parse(s)
 	return u
+}
+
+func getLabelPriority(name types.ACIdentifier) int {
+	labelsPriority := map[types.ACIdentifier]int{
+		"version": 0,
+		"os":      1,
+		"arch":    2,
+	}
+	if i, ok := labelsPriority[name]; ok {
+		return i
+	}
+	return len(labelsPriority) + 1
+}
+
+// labelsSlice implements sort.Interface for types.Labels.
+type labelsSlice types.Labels
+
+func (p labelsSlice) Len() int { return len(p) }
+func (p labelsSlice) Less(i, j int) bool {
+	return getLabelPriority(p[i].Name) < getLabelPriority(p[j].Name)
+}
+func (p labelsSlice) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+
+func labelsToString(inLabels types.Labels) string {
+	// take a copy to void changing the original slice
+	labels := append(types.Labels(nil), inLabels...)
+	sort.Sort(labelsSlice(labels))
+
+	out := []string{}
+	for _, l := range labels {
+		out = append(out, fmt.Sprintf("%q:%q", l.Name, l.Value))
+	}
+	return "[" + strings.Join(out, ", ") + "]"
 }

--- a/store/utils_test.go
+++ b/store/utils_test.go
@@ -1,0 +1,40 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"testing"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+func TestLabelsToString(t *testing.T) {
+	tests := []struct {
+		labels types.Labels
+		out    string
+	}{
+		{types.Labels{}, `[]`},
+		{[]types.Label{{"label1", "value1"}}, `["label1":"value1"]`},
+		{[]types.Label{{"label1", "value1"}, {"version", "2.1.1"}}, `["version":"2.1.1", "label1":"value1"]`},
+		{[]types.Label{{"arch", "amd64"}, {"label1", "value1"}, {"os", "linux"}, {"version", "2.1.1"}}, `["version":"2.1.1", "os":"linux", "arch":"amd64", "label1":"value1"]`},
+	}
+
+	for i, tt := range tests {
+		out := labelsToString(tt.labels)
+		if out != tt.out {
+			t.Errorf("#%d: got %v, want %v", i, out, tt.out)
+		}
+	}
+}


### PR DESCRIPTION
Report provided name and labels in GetACI instead of a generic "aci not found"
error if it doesn't find an ACI matching them.

To get an ordered labels list, a new function labelsToString is added. It sorts
by label name giving precedence to the "version", "os" and "arch" (in this
order) labels.

Perhaps this function, if deemed useful, should be ported to appc/spec.