### PR TITLE
networking: fail to run if specified nets were not found

### DIFF
--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -42,7 +42,7 @@ func init() {
 	cmdRkt.AddCommand(cmdRunPrepared)
 
 	cmdRunPrepared.Flags().Var(&flagPrivateNet, "private-net", "give pod a private network")
-	cmdRunPrepared.Flags().Lookup("private-net").NoOptDefVal = "true"
+	cmdRunPrepared.Flags().Lookup("private-net").NoOptDefVal = "all"
 	cmdRunPrepared.Flags().BoolVar(&flagInteractive, "interactive", false, "the pod is interactive")
 	cmdRunPrepared.Flags().BoolVar(&flagMDSRegister, "mds-register", true, "register pod with metadata service")
 }

--- a/stage1/net/conf/99-default-restricted.conf
+++ b/stage1/net/conf/99-default-restricted.conf
@@ -1,5 +1,5 @@
 {
-	"name": "default",
+	"name": "default-restricted",
 	"type": "ptp",
 	"ipMasq": false,
 	"ipam": {


### PR DESCRIPTION
If --private-net=foo,bar and either foo or bar is not found,
error out with the appropriate error message.

Also fixes --private-net to imply --private-net=all
in run-prepared cmd.

Fixes #1216