### PR TITLE
keystore: accept binary signatures

### DIFF
--- a/pkg/keystore/keystoretest/opengpg.go
+++ b/pkg/keystore/keystoretest/opengpg.go
@@ -33,7 +33,7 @@ type KeyDetails struct {
 
 // NewMessageAndSignature generates a new random message signed by the given entity.
 // NewMessageAndSignature returns message, signature and an error if any.
-func NewMessageAndSignature(armoredPrivateKey string) (io.Reader, io.Reader, error) {
+func NewMessageAndSignature(armoredPrivateKey string) (io.ReadSeeker, io.ReadSeeker, error) {
 	entityList, err := openpgp.ReadArmoredKeyRing(bytes.NewBufferString(armoredPrivateKey))
 	if err != nil {
 		return nil, nil, err
@@ -46,5 +46,5 @@ func NewMessageAndSignature(armoredPrivateKey string) (io.Reader, io.Reader, err
 	if err := openpgp.ArmoredDetachSign(signature, entityList[0], bytes.NewReader(message), nil); err != nil {
 		return nil, nil, err
 	}
-	return bytes.NewBuffer(message), signature, nil
+	return bytes.NewReader(message), bytes.NewReader(signature.Bytes()), nil
 }

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -447,7 +447,7 @@ func (f *fetcher) fetch(appName string, aciURL, ascURL string, ascFile *os.File,
 		if _, err := ascFile.Seek(0, 0); err != nil {
 			return nil, nil, nil, fmt.Errorf("error seeking signature file: %v", err)
 		}
-		if entity, err = f.ks.CheckSignature(appName, bytes.NewBuffer([]byte{}), ascFile); err != nil {
+		if entity, err = f.ks.CheckSignature(appName, bytes.NewReader([]byte{}), ascFile); err != nil {
 			if _, ok := err.(pgperrors.SignatureError); !ok {
 				return nil, nil, nil, err
 			}


### PR DESCRIPTION
Previously, rkt only accepted armored signatures. There is no good
reasons not to accept binary signatures as well.

It will help with older versions of the ACE validator before
https://github.com/appc/spec/pull/460