### PR TITLE
fetch: automatically trust keys

### DIFF
--- a/common/fetch_keys.go
+++ b/common/fetch_keys.go
@@ -1,0 +1,233 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/coreos/rkt/pkg/keystore"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/discovery"
+	"github.com/coreos/rkt/Godeps/_workspace/src/golang.org/x/crypto/openpgp"
+)
+
+// GetPubKeyLocation either returns the locations supplied in argv or discovers one at prefix
+func GetPubKeyLocations(prefix string, args []string, allowHTTP bool, debug bool) ([]string, error) {
+	if len(args) > 0 {
+		return args, nil
+	}
+
+	if prefix == "" {
+		return nil, fmt.Errorf("at least one key or --prefix required")
+	}
+
+	kls, err := metaDiscoverPubKeyLocations(prefix, allowHTTP, debug)
+	if err != nil {
+		return nil, fmt.Errorf("--prefix meta discovery error: %v", err)
+	}
+
+	if len(kls) == 0 {
+		return nil, fmt.Errorf("meta discovery on %s resulted in no keys", prefix)
+	}
+
+	return kls, nil
+}
+
+// metaDiscoverPubKeyLocations discovers the public key through ACDiscovery by applying prefix as an ACApp
+func metaDiscoverPubKeyLocations(prefix string, allowHTTP bool, debug bool) ([]string, error) {
+	app, err := discovery.NewAppFromString(prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	ep, attempts, err := discovery.DiscoverPublicKeys(*app, allowHTTP)
+	if err != nil {
+		return nil, err
+	}
+
+	if debug {
+		for _, a := range attempts {
+			fmt.Fprintf(os.Stderr, "meta tag 'ac-discovery-pubkeys' not found on %s: %v\n", a.Prefix, a.Error)
+		}
+	}
+
+	return ep.Keys, nil
+}
+
+// GetPubKey retrieves a public key (if remote), and verifies it's a gpg key
+func GetPubKey(location string, allowHTTP bool) (*os.File, error) {
+	u, err := url.Parse(location)
+	if err != nil {
+		return nil, err
+	}
+
+	switch u.Scheme {
+	case "":
+		return os.Open(location)
+	case "http":
+		if !allowHTTP {
+			return nil, fmt.Errorf("--insecure-allow-http required for http URLs")
+		}
+		fallthrough
+	case "https":
+		return downloadKey(u.String())
+	}
+
+	return nil, fmt.Errorf("only http and https urls supported")
+}
+
+// downloadKey retrieves the file, storing it in a deleted tempfile
+func downloadKey(url string) (*os.File, error) {
+	tf, err := ioutil.TempFile("", "")
+	if err != nil {
+		return nil, fmt.Errorf("error creating tempfile: %v", err)
+	}
+	os.Remove(tf.Name()) // no need to keep the tempfile around
+
+	defer func() {
+		if err != nil {
+			tf.Close()
+		}
+	}()
+
+	res, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("error getting key: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bad HTTP status code: %d", res.StatusCode)
+	}
+
+	if _, err := io.Copy(tf, res.Body); err != nil {
+		return nil, fmt.Errorf("error copying key: %v", err)
+	}
+
+	tf.Seek(0, os.SEEK_SET)
+
+	return tf, nil
+}
+
+// AddKeys adds the keys listed in pkls at prefix
+func AddKeys(pkls []string, prefix string, allowHTTP bool, forceAccept bool, systemConfigDir, localConfigDir string) error {
+	config := keystore.NewConfig(systemConfigDir, localConfigDir)
+	ks := keystore.New(config)
+
+	for _, pkl := range pkls {
+		pk, err := GetPubKey(pkl, allowHTTP)
+		if err != nil {
+			return fmt.Errorf("error accessing key: %v", err)
+		}
+		defer pk.Close()
+
+		accepted, err := reviewKey(prefix, pkl, pk, forceAccept)
+		if err != nil {
+			return fmt.Errorf("error reviewing key: %v", err)
+		}
+
+		if !accepted {
+			fmt.Fprintf(os.Stderr, "Not trusting %q\n", pkl)
+			continue
+		}
+
+		if forceAccept {
+			fmt.Fprintf(os.Stderr, "Trusting %q for prefix %q without fingerprint review.\n", pkl, prefix)
+		} else {
+			fmt.Fprintf(os.Stderr, "Trusting %q for prefix %q after fingerprint review.\n", pkl, prefix)
+		}
+
+		if err := addPubKey(prefix, pk, ks); err != nil {
+			return fmt.Errorf("Error adding key: %v", err)
+		}
+	}
+	return nil
+}
+
+// addPubKey adds a key to the keystore
+func addPubKey(prefix string, key *os.File, ks *keystore.Keystore) (err error) {
+	var path string
+	if prefix == "" {
+		path, err = ks.StoreTrustedKeyRoot(key)
+		fmt.Fprintf(os.Stderr, "Added root key at %q\n", path)
+	} else {
+		path, err = ks.StoreTrustedKeyPrefix(prefix, key)
+		fmt.Fprintf(os.Stderr, "Added key for prefix %q at %q\n", prefix, path)
+	}
+
+	return
+}
+
+// reviewKey shows the key summary and conditionally asks the user to accept it
+func reviewKey(prefix string, location string, key *os.File, forceAccept bool) (bool, error) {
+	defer key.Seek(0, os.SEEK_SET)
+
+	kr, err := openpgp.ReadArmoredKeyRing(key)
+	if err != nil {
+		return false, fmt.Errorf("error reading key: %v", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Prefix: %q\nKey: %q\n", prefix, location)
+	for _, k := range kr {
+		fmt.Fprintf(os.Stderr, "GPG key fingerprint is: %s\n", fingerToString(k.PrimaryKey.Fingerprint))
+		for _, sk := range k.Subkeys {
+			fmt.Fprintf(os.Stderr, "    Subkey fingerprint: %s\n", fingerToString(sk.PublicKey.Fingerprint))
+		}
+		for n, _ := range k.Identities {
+			fmt.Fprintf(os.Stderr, "\t%s\n", n)
+		}
+	}
+
+	if !forceAccept {
+		in := bufio.NewReader(os.Stdin)
+		for {
+			fmt.Fprintf(os.Stderr, "Are you sure you want to trust this key (yes/no)?\n")
+			input, err := in.ReadString('\n')
+			if err != nil {
+				return false, fmt.Errorf("error reading input: %v", err)
+			}
+			switch input {
+			case "yes\n":
+				return true, nil
+			case "no\n":
+				return false, nil
+			default:
+				fmt.Fprintf(os.Stderr, "Please enter 'yes' or 'no'\n")
+			}
+		}
+	}
+	return true, nil
+}
+
+func fingerToString(fpr [20]byte) string {
+	str := ""
+	for i, b := range fpr {
+		if i > 0 && i%2 == 0 {
+			str += " "
+			if i == 10 {
+				str += " "
+			}
+		}
+		str += strings.ToUpper(fmt.Sprintf("%.2x", b))
+	}
+	return str
+}

--- a/common/fetch_keys.go
+++ b/common/fetch_keys.go
@@ -31,11 +31,7 @@ import (
 )
 
 // GetPubKeyLocation either returns the locations supplied in argv or discovers one at prefix
-func GetPubKeyLocations(prefix string, args []string, allowHTTP bool, debug bool) ([]string, error) {
-	if len(args) > 0 {
-		return args, nil
-	}
-
+func GetPubKeyLocations(prefix string, allowHTTP bool, debug bool) ([]string, error) {
 	if prefix == "" {
 		return nil, fmt.Errorf("at least one key or --prefix required")
 	}

--- a/pkg/keystore/keystore.go
+++ b/pkg/keystore/keystore.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/Godeps/_workspace/src/golang.org/x/crypto/openpgp"
-	"github.com/coreos/rkt/common"
 )
 
 // A Config structure is used to configure a Keystore.
@@ -47,9 +46,6 @@ type Keystore struct {
 
 // New returns a new Keystore based on config.
 func New(config *Config) *Keystore {
-	if config == nil {
-		config = defaultConfig
-	}
 	return &Keystore{config}
 }
 
@@ -60,15 +56,6 @@ func NewConfig(systemPath, localPath string) *Config {
 		SystemRootPath:   filepath.Join(systemPath, "trustedkeys", "root.d"),
 		SystemPrefixPath: filepath.Join(systemPath, "trustedkeys", "prefix.d"),
 	}
-}
-
-var defaultConfig = NewConfig(common.DefaultSystemConfigDir, common.DefaultLocalConfigDir)
-
-// CheckSignature is a convenience method for creating a Keystore with a default
-// configuration and invoking CheckSignature.
-func CheckSignature(prefix string, signed, signature io.ReadSeeker) (*openpgp.Entity, error) {
-	ks := New(defaultConfig)
-	return checkSignature(ks, prefix, signed, signature)
 }
 
 // CheckSignature takes a signed file and a detached signature and returns the signer
@@ -256,12 +243,19 @@ func fingerprintToFilename(fp [20]byte) string {
 // NewTestKeystore returns a KeyStore, the path to the temp directory, and
 // an error if any.
 func NewTestKeystore() (*Keystore, string, error) {
+	// The system and local config directories defined here are only for
+	// the tests so they can be arbitrary. For simplicity, we use the same
+	// values as common.DefaultSystemConfigDir and
+	// common.DefaultLocalConfigDir.
+	const TestSystemConfigDir = "/usr/lib/rkt"
+	const TestLocalConfigDir = "/etc/rkt"
+
 	dir, err := ioutil.TempDir("", "keystore-test")
 	if err != nil {
 		return nil, "", err
 	}
-	systemDir := filepath.Join(dir, common.DefaultSystemConfigDir)
-	localDir := filepath.Join(dir, common.DefaultLocalConfigDir)
+	systemDir := filepath.Join(dir, TestSystemConfigDir)
+	localDir := filepath.Join(dir, TestLocalConfigDir)
 	c := NewConfig(systemDir, localDir)
 	for _, path := range []string{c.LocalRootPath, c.SystemRootPath, c.LocalPrefixPath, c.SystemPrefixPath} {
 		if err := os.MkdirAll(path, 0755); err != nil {

--- a/rkt/fetch_keys.go
+++ b/rkt/fetch_keys.go
@@ -24,8 +24,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/coreos/rkt/pkg/keystore"
-
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/discovery"
 	"github.com/coreos/rkt/Godeps/_workspace/src/golang.org/x/crypto/openpgp"
 )
@@ -125,10 +123,7 @@ func downloadKey(url string) (*os.File, error) {
 }
 
 // addKeys adds the keys listed in pkls at prefix
-func addKeys(pkls []string, prefix string, allowHTTP bool, forceAccept bool, systemConfigDir, localConfigDir string) error {
-	config := keystore.NewConfig(systemConfigDir, localConfigDir)
-	ks := keystore.New(config)
-
+func addKeys(pkls []string, prefix string, allowHTTP bool, forceAccept bool) error {
 	for _, pkl := range pkls {
 		pk, err := GetPubKey(pkl, allowHTTP)
 		if err != nil {
@@ -152,7 +147,7 @@ func addKeys(pkls []string, prefix string, allowHTTP bool, forceAccept bool, sys
 			stderr("Trusting %q for prefix %q after fingerprint review.", pkl, prefix)
 		}
 
-		if err := addPubKey(prefix, pk, ks); err != nil {
+		if err := addPubKey(prefix, pk); err != nil {
 			return fmt.Errorf("Error adding key: %v", err)
 		}
 	}
@@ -160,7 +155,9 @@ func addKeys(pkls []string, prefix string, allowHTTP bool, forceAccept bool, sys
 }
 
 // addPubKey adds a key to the keystore
-func addPubKey(prefix string, key *os.File, ks *keystore.Keystore) (err error) {
+func addPubKey(prefix string, key *os.File) (err error) {
+	ks := getKeystore()
+
 	var path string
 	if prefix == "" {
 		path, err = ks.StoreTrustedKeyRoot(key)

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -34,7 +34,7 @@ import (
 	"time"
 
 	docker2aci "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/docker2aci/lib"
-	docker2acicommon "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/docker2aci/lib/common"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/docker2aci/lib/common"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/aci"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/discovery"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
@@ -252,7 +252,7 @@ func (f *fetcher) fetchSingleImage(img string, asc string, discover bool) (strin
 	switch u.Scheme {
 	case "http", "https", "file":
 	case "docker":
-		dockerURL := docker2acicommon.ParseDockerURL(path.Join(u.Host, u.Path))
+		dockerURL := common.ParseDockerURL(path.Join(u.Host, u.Path))
 		if dockerURL.Tag == "latest" {
 			latest = true
 		}

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -41,7 +41,6 @@ import (
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/coreos/ioprogress"
 	"github.com/coreos/rkt/Godeps/_workspace/src/golang.org/x/crypto/openpgp"
 	pgperrors "github.com/coreos/rkt/Godeps/_workspace/src/golang.org/x/crypto/openpgp/errors"
-	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/common/apps"
 	"github.com/coreos/rkt/pkg/keystore"
 	"github.com/coreos/rkt/rkt/config"
@@ -417,11 +416,11 @@ func (f *fetcher) fetch(appName string, aciURL, ascURL string, ascFile *os.File,
 
 	// attempt to automatically fetch the public key in case it is available on a TLS connection.
 	if !globalFlags.InsecureSkipVerify && appName != "" {
-		pkls, err := common.GetPubKeyLocations(appName, false, globalFlags.Debug)
+		pkls, err := getPubKeyLocations(appName, false, globalFlags.Debug)
 		if err != nil {
 			stderr("Error determining key location: %v", err)
 		} else {
-			if err := common.AddKeys(pkls, appName, false, true, globalFlags.SystemConfigDir, globalFlags.LocalConfigDir); err != nil {
+			if err := addKeys(pkls, appName, false, true, globalFlags.SystemConfigDir, globalFlags.LocalConfigDir); err != nil {
 				stderr("Error adding keys: %v", err)
 			}
 		}

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -420,7 +420,7 @@ func (f *fetcher) fetch(appName string, aciURL, ascURL string, ascFile *os.File,
 		if err != nil {
 			stderr("Error determining key location: %v", err)
 		} else {
-			if err := addKeys(pkls, appName, false, true); err != nil {
+			if err := addKeys(pkls, appName, false, true, false); err != nil {
 				stderr("Error adding keys: %v", err)
 			}
 		}

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -417,7 +417,7 @@ func (f *fetcher) fetch(appName string, aciURL, ascURL string, ascFile *os.File,
 
 	// attempt to automatically fetch the public key in case it is available on a TLS connection.
 	if !globalFlags.InsecureSkipVerify && appName != "" {
-		pkls, err := common.GetPubKeyLocations(appName, []string{}, false, globalFlags.Debug)
+		pkls, err := common.GetPubKeyLocations(appName, false, globalFlags.Debug)
 		if err != nil {
 			stderr("Error determining key location: %v", err)
 		} else {

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -420,7 +420,7 @@ func (f *fetcher) fetch(appName string, aciURL, ascURL string, ascFile *os.File,
 		if err != nil {
 			stderr("Error determining key location: %v", err)
 		} else {
-			if err := addKeys(pkls, appName, false, true, globalFlags.SystemConfigDir, globalFlags.LocalConfigDir); err != nil {
+			if err := addKeys(pkls, appName, false, true); err != nil {
 				stderr("Error adding keys: %v", err)
 			}
 		}

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -420,6 +420,7 @@ func (f *fetcher) fetch(appName string, aciURL, ascURL string, ascFile *os.File,
 		if err != nil {
 			stderr("Error determining key location: %v", err)
 		} else {
+			// no http, don't ask user for accepting the key, no overriding
 			if err := addKeys(pkls, appName, false, true, false); err != nil {
 				stderr("Error adding keys: %v", err)
 			}

--- a/rkt/trust.go
+++ b/rkt/trust.go
@@ -80,8 +80,7 @@ func runTrust(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	if err := addKeys(pkls, flagPrefix, flagAllowHTTP, globalFlags.InsecureSkipVerify,
-		globalFlags.SystemConfigDir, globalFlags.LocalConfigDir); err != nil {
+	if err := addKeys(pkls, flagPrefix, flagAllowHTTP, globalFlags.InsecureSkipVerify); err != nil {
 		stderr("Error adding keys: %v", err)
 		return 1
 	}

--- a/rkt/trust.go
+++ b/rkt/trust.go
@@ -22,8 +22,6 @@ import (
 	"net/url"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
-
-	"github.com/coreos/rkt/common"
 )
 
 var (
@@ -75,14 +73,14 @@ func runTrust(cmd *cobra.Command, args []string) (exit int) {
 	if len(args) != 0 {
 		pkls = args
 	} else {
-		pkls, err = common.GetPubKeyLocations(flagPrefix, flagAllowHTTP, globalFlags.Debug)
+		pkls, err = getPubKeyLocations(flagPrefix, flagAllowHTTP, globalFlags.Debug)
 		if err != nil {
 			stderr("Error determining key location: %v", err)
 			return 1
 		}
 	}
 
-	if err := common.AddKeys(pkls, flagPrefix, flagAllowHTTP, globalFlags.InsecureSkipVerify,
+	if err := addKeys(pkls, flagPrefix, flagAllowHTTP, globalFlags.InsecureSkipVerify,
 		globalFlags.SystemConfigDir, globalFlags.LocalConfigDir); err != nil {
 		stderr("Error adding keys: %v", err)
 		return 1

--- a/rkt/trust.go
+++ b/rkt/trust.go
@@ -80,7 +80,7 @@ func runTrust(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	if err := addKeys(pkls, flagPrefix, flagAllowHTTP, globalFlags.InsecureSkipVerify); err != nil {
+	if err := addKeys(pkls, flagPrefix, flagAllowHTTP, globalFlags.InsecureSkipVerify, true); err != nil {
 		stderr("Error adding keys: %v", err)
 		return 1
 	}

--- a/rkt/trust.go
+++ b/rkt/trust.go
@@ -69,10 +69,8 @@ func runTrust(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	var pkls []string
-	if len(args) != 0 {
-		pkls = args
-	} else {
+	pkls := args
+	if len(pkls) == 0 {
 		pkls, err = getPubKeyLocations(flagPrefix, flagAllowHTTP, globalFlags.Debug)
 		if err != nil {
 			stderr("Error determining key location: %v", err)
@@ -80,6 +78,7 @@ func runTrust(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
+	// allow override
 	if err := addKeys(pkls, flagPrefix, flagAllowHTTP, globalFlags.InsecureSkipVerify, true); err != nil {
 		stderr("Error adding keys: %v", err)
 		return 1

--- a/rkt/trust.go
+++ b/rkt/trust.go
@@ -71,10 +71,15 @@ func runTrust(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	pkls, err := common.GetPubKeyLocations(flagPrefix, args, flagAllowHTTP, globalFlags.Debug)
-	if err != nil {
-		stderr("Error determining key location: %v", err)
-		return 1
+	var pkls []string
+	if len(args) != 0 {
+		pkls = args
+	} else {
+		pkls, err = common.GetPubKeyLocations(flagPrefix, flagAllowHTTP, globalFlags.Debug)
+		if err != nil {
+			stderr("Error determining key location: %v", err)
+			return 1
+		}
 	}
 
 	if err := common.AddKeys(pkls, flagPrefix, flagAllowHTTP, globalFlags.InsecureSkipVerify,


### PR DESCRIPTION
Code for trust moved to common/fetch_keys.go for sharing between
commands 'rkt trust' and other fetch commands.

The keys are only trusted automatically if they are fetched via https
and the images are fetched via the discovery protocol.

Partially fixes #481.