### PR TITLE
rkt: handle multiple rendered images for the same imageID

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -31,12 +31,14 @@ import (
 )
 
 const (
-	stage1Dir = "/stage1"
-	stage2Dir = "/opt/stage2"
+	stage1Dir   = "/stage1"
+	stage2Dir   = "/opt/stage2"
+	appsInfoDir = "/appsinfo"
 
 	EnvLockFd                    = "RKT_LOCK_FD"
 	SELinuxContext               = "RKT_SELINUX_CONTEXT"
-	Stage1IDFilename             = "stage1ID"
+	Stage1TreeStoreIDFilename    = "stage1TreeStoreID"
+	AppTreeStoreIDFilename       = "treeStoreID"
 	OverlayPreparedFilename      = "overlay-prepared"
 	PrivateUsersPreparedFilename = "private-users-prepared"
 
@@ -96,6 +98,21 @@ func RelAppRootfsPath(appName types.ACName) string {
 // ImageManifestPath returns the path to the app's manifest file inside a pod.
 func ImageManifestPath(root string, appName types.ACName) string {
 	return filepath.Join(AppPath(root, appName), aci.ManifestFile)
+}
+
+// AppsInfoPath returns the path to the appsinfo directory inside a pod.
+func AppsInfoPath(root string) string {
+	return filepath.Join(root, appsInfoDir)
+}
+
+// AppInfoPath returns the path to the app's appsinfo directory inside a pod.
+func AppInfoPath(root string, appName types.ACName) string {
+	return filepath.Join(AppsInfoPath(root), appName.String())
+}
+
+// AppTreeStoreIDPath returns the path to the app's treeStoreID file inside a pod.
+func AppTreeStoreIDPath(root string, appName types.ACName) string {
+	return filepath.Join(AppInfoPath(root, appName), AppTreeStoreIDFilename)
 }
 
 // MetadataServicePublicURL returns the public URL used to host the metadata service

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -27,7 +27,7 @@ import (
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/pkg/device"
 )
 
-func copyRegularFile(src, dest string) (err error) {
+func CopyRegularFile(src, dest string) (err error) {
 	srcFile, err := os.Open(src)
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func copyRegularFile(src, dest string) (err error) {
 	return nil
 }
 
-func copySymlink(src, dest string) error {
+func CopySymlink(src, dest string) error {
 	symTarget, err := os.Readlink(src)
 	if err != nil {
 		return err
@@ -86,11 +86,11 @@ func CopyTree(src, dest string, uidRange *uid.UidRange) error {
 			}
 			dir.Close()
 		case mode.IsRegular():
-			if err := copyRegularFile(path, target); err != nil {
+			if err := CopyRegularFile(path, target); err != nil {
 				return err
 			}
 		case mode&os.ModeSymlink == os.ModeSymlink:
-			if err := copySymlink(path, target); err != nil {
+			if err := CopySymlink(path, target); err != nil {
 				return err
 			}
 		case mode&os.ModeCharDevice == os.ModeCharDevice:

--- a/rkt/enter.go
+++ b/rkt/enter.go
@@ -99,13 +99,13 @@ func runEnter(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	stage1ID, err := p.getStage1Hash()
+	stage1TreeStoreID, err := p.getStage1TreeStoreID()
 	if err != nil {
-		stderr("Error getting stage1 hash")
+		stderr("Error getting stage1 treeStoreID")
 		return 1
 	}
 
-	stage1RootFS := s.GetTreeStoreRootFS(stage1ID.String())
+	stage1RootFS := s.GetTreeStoreRootFS(stage1TreeStoreID)
 
 	if err = stage0.Enter(p.path(), podPID, *appName, stage1RootFS, argv); err != nil {
 		stderr("Enter failed: %v", err)

--- a/rkt/gc.go
+++ b/rkt/gc.go
@@ -190,12 +190,12 @@ func deletePod(p *pod) {
 			stderr("Cannot open store: %v", err)
 			return
 		}
-		stage1ID, err := p.getStage1Hash()
+		stage1TreeStoreID, err := p.getStage1TreeStoreID()
 		if err != nil {
-			stderr("Error getting stage1 hash")
+			stderr("Error getting stage1 treeStoreID")
 			return
 		}
-		stage1RootFS := s.GetTreeStoreRootFS(stage1ID.String())
+		stage1RootFS := s.GetTreeStoreRootFS(stage1TreeStoreID)
 
 		// execute stage1's GC
 		if err := stage0.GC(p.path(), p.uuid, stage1RootFS, globalFlags.Debug); err != nil {

--- a/rkt/image_render.go
+++ b/rkt/image_render.go
@@ -63,13 +63,15 @@ func runImageRender(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	if err := s.RenderTreeStore(key, false); err != nil {
+	id, err := s.RenderTreeStore(key, false)
+	if err != nil {
 		stderr("image render: error rendering ACI: %v", err)
 		return 1
 	}
-	if err := s.CheckTreeStore(key); err != nil {
+	if err := s.CheckTreeStore(id); err != nil {
 		stderr("image render: warning: tree cache is in a bad state. Rebuilding...")
-		if err := s.RenderTreeStore(key, true); err != nil {
+		var err error
+		if id, err = s.RenderTreeStore(key, true); err != nil {
 			stderr("image render: error rendering ACI: %v", err)
 			return 1
 		}
@@ -118,7 +120,7 @@ func runImageRender(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	cachedTreePath := s.GetTreeStoreRootFS(key)
+	cachedTreePath := s.GetTreeStoreRootFS(id)
 	if err := fileutil.CopyTree(cachedTreePath, rootfsOutDir, uid.NewBlankUidRange()); err != nil {
 		stderr("image render: error copying ACI rootfs: %v", err)
 		return 1

--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -840,18 +840,14 @@ func (p *pod) getPID() (pid int, err error) {
 	}
 }
 
-// getStage1Hash returns the hash of the stage1 image used in this pod
-func (p *pod) getStage1Hash() (*types.Hash, error) {
-	s1IDb, err := p.readFile(common.Stage1IDFilename)
+// getStage1TreeStoreID returns the treeStoreID of the stage1 image used in
+// this pod
+func (p *pod) getStage1TreeStoreID() (string, error) {
+	s1IDb, err := p.readFile(common.Stage1TreeStoreIDFilename)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	s1img, err := types.NewHash(string(s1IDb))
-	if err != nil {
-		return nil, err
-	}
-
-	return s1img, nil
+	return string(s1IDb), nil
 }
 
 // getAppsHashes returns a list of the app hashes in the pod
@@ -927,11 +923,11 @@ func (p *pod) getStatusDir() (string, error) {
 		// the pod uses overlay. Since the mount is in another mount
 		// namespace (or gone), return the status directory from the overlay
 		// upper layer
-		stage1Hash, err := p.getStage1Hash()
+		stage1TreeStoreID, err := p.getStage1TreeStoreID()
 		if err != nil {
 			return "", err
 		}
-		overlayStatusDir := fmt.Sprintf(overlayStatusDirTemplate, stage1Hash.String())
+		overlayStatusDir := fmt.Sprintf(overlayStatusDirTemplate, stage1TreeStoreID)
 
 		return overlayStatusDir, nil
 	}

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -119,12 +119,6 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s1img, err := p.getStage1Hash()
-	if err != nil {
-		stderr("prepared-run: unable to get stage1 Hash: %v", err)
-		return 1
-	}
-
 	apps, err := p.getApps()
 	if err != nil {
 		stderr("prepared-run: unable to get app list: %v", err)
@@ -133,10 +127,9 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 
 	rcfg := stage0.RunConfig{
 		CommonConfig: stage0.CommonConfig{
-			Store:       s,
-			Stage1Image: *s1img,
-			UUID:        p.uuid,
-			Debug:       globalFlags.Debug,
+			Store: s,
+			UUID:  p.uuid,
+			Debug: globalFlags.Debug,
 		},
 		PrivateNet:  flagPrivateNet,
 		LockFd:      lfd,

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -420,47 +420,52 @@ func TestTreeStore(t *testing.T) {
 	}
 
 	// Ask the store to render the treestore
-	err = s.RenderTreeStore(key, false)
+	id, err := s.RenderTreeStore(key, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Verify image Hash. Should be the same.
-	err = s.CheckTreeStore(key)
+	err = s.CheckTreeStore(id)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Change a file permission
-	rootfs := s.GetTreeStoreRootFS(key)
+	rootfs := s.GetTreeStoreRootFS(id)
 	err = os.Chmod(filepath.Join(rootfs, "a"), 0600)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Verify image Hash. Should be different
-	err = s.CheckTreeStore(key)
+	err = s.CheckTreeStore(id)
 	if err == nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Errorf("expected non-nil error!")
 	}
 
 	// rebuild the tree
-	err = s.RenderTreeStore(key, true)
+	prevID := id
+	id, err = s.RenderTreeStore(key, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	if id != prevID {
+		t.Fatalf("unexpected different IDs. prevID: %s, id: %s", prevID, id)
+	}
+
 	// Add a file
-	rootfs = s.GetTreeStoreRootFS(key)
+	rootfs = s.GetTreeStoreRootFS(id)
 	err = ioutil.WriteFile(filepath.Join(rootfs, "newfile"), []byte("newfile"), 0644)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Verify image Hash. Should be different
-	err = s.CheckTreeStore(key)
+	err = s.CheckTreeStore(id)
 	if err == nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Errorf("expected non-nil error!")
 	}
 }
 

--- a/store/tree_test.go
+++ b/store/tree_test.go
@@ -109,14 +109,16 @@ func TestTreeStoreWrite(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	id := "treestoreid01"
+
 	// Ask the store to render the treestore
-	err = s.treestore.Write(key, s)
+	err = s.treestore.Write(id, key, s)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Verify image Hash. Should be the same.
-	err = s.treestore.Check(key)
+	err = s.treestore.Check(id)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -142,19 +144,21 @@ func TestTreeStoreRemove(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	id := "treestoreid01"
+
 	// Test non existent dir
-	err = s.treestore.Remove(key)
+	err = s.treestore.Remove(id)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Test rendered tree
-	err = s.treestore.Write(key, s)
+	err = s.treestore.Write(id, key, s)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	err = s.treestore.Remove(key)
+	err = s.treestore.Remove(id)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/tests/rkt_image_list_test.go
+++ b/tests/rkt_image_list_test.go
@@ -171,12 +171,6 @@ func TestShortHash(t *testing.T) {
 			false,
 			"Writing pod manifest",
 		},
-		// Test that we can't remove referenced image
-		{
-			fmt.Sprintf("image rm %s", hash0),
-			false, // For some reason this exits with 0 when failing.
-			"cannot be removed",
-		},
 		// Test that 12-char hash works with image rm
 		{
 			fmt.Sprintf("image rm %s", hash1),


### PR DESCRIPTION
NOTE:
This is going to change the on disk format for pods, see #1132. This means that actually, after applying it, `rkt run-prepared`, `rkt gc` and other commands working on pods will fail to find the stage1 path for exitstent pods and possibly other problems.

If an image has dependencies, and they have changed, for the same imageID we
can have multiple different rendered images (#1198).

Until now this wasn't handled and rkt and the treestore used the imageID to
reference the rendered image.

This patch, does multiple things:

* the treestore now returns a treeStoreID on store.RenderTreeStore. The
treeStoreID is computed as an hash of the flattened dependency tree image keys.
In this way if some dependencies have changed a new ID will be generated and a
new image rendering will be done.

* rkt has to use this treeStoreID instead of the imageID and save it under appsinfo/$appname/.

 * for doing this, at prepare phase, the stage1 tree store ID and every app
treeStoreID is saved in the pod.

Additionally in this patch the prepare phase will create a pod with all the
needed data for the run phase without the need to keep the needed images in the
store (excluding the need of the treestore rendered images for overlayfs)
(previously store.GetImageManifest was called in the run phase).

Now `rkt image rm` just removes the image from the blob store.
All the rendered images in the tree store aren't touched by `rkt image rm`.
They will need a future patch for cleaning the unused one (a store gc). This
will probably add a reference count mechanism to the treestore, since just
retrieving the treeStoreIDs from the pods is quite racy (due to pods getting
created between getting the lists and removing the tree store rendered image).

This means that now we can remove any image in the store at any time after the
prepare phase.
