### PR TITLE
rkt/status.go: add 'app-' prefix to exit codes.

### DIFF
--- a/rkt/status.go
+++ b/rkt/status.go
@@ -93,7 +93,7 @@ func printStatus(p *pod) error {
 
 		stdout("pid=%d\nexited=%t", pid, p.isExited)
 		for app, stat := range stats {
-			stdout("%s=%d", app, stat)
+			stdout("app-%s=%d", app, stat)
 		}
 	}
 	return nil

--- a/tests/rkt_exit_test.go
+++ b/tests/rkt_exit_test.go
@@ -34,7 +34,7 @@ func TestExitCode(t *testing.T) {
 			`%s --debug --insecure-skip-verify run --mds-register=false %s ;`+
 			`UUID=$(%s list --full|grep exited|awk '{print $1}') ;`+
 			`echo -n 'status=' ;`+
-			`%s status $UUID|grep '^rkt-inspect.*=[0-9]*$'|cut -d= -f2"`,
+			`%s status $UUID|grep '^app-rkt-inspect.*=[0-9]*$'|cut -d= -f2"`,
 			ctx.cmd(), imageFile,
 			ctx.cmd(),
 			ctx.cmd())


### PR DESCRIPTION
This helps to parse the exit code without ambiguity. (e.g. an app can be named "exited" or "pid"...)