### PR TITLE
tests: forgot to change one ThomasRooney gexpect import

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,7 +1,7 @@
 # rkt functional tests
 
 This directory contains a set of functional tests for rkt.
-The tests use [gexpect](https://github.com/ThomasRooney/gexpect) to spawn various `rkt run` commands and look for expected output.
+The tests use [gexpect](https://github.com/steveeJ/gexpect) to spawn various `rkt run` commands and look for expected output.
 
 ## Semaphore
 

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/ThomasRooney/gexpect"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 )
 
 func TestRunOverrideExec(t *testing.T) {


### PR DESCRIPTION
We switched to steveeJ's fork but there was one test still using
ThomasRooney's which broke the build