### PR TITLE
rkt: user namespace support through chown at extract time

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -34,9 +34,10 @@ const (
 	stage1Dir = "/stage1"
 	stage2Dir = "/opt/stage2"
 
-	EnvLockFd               = "RKT_LOCK_FD"
-	Stage1IDFilename        = "stage1ID"
-	OverlayPreparedFilename = "overlay-prepared"
+	EnvLockFd                    = "RKT_LOCK_FD"
+	Stage1IDFilename             = "stage1ID"
+	OverlayPreparedFilename      = "overlay-prepared"
+	PrivateUsersPreparedFilename = "private-users-prepared"
 
 	MetadataServicePort    = 2375
 	MetadataServiceRegSock = "/run/rkt/metadata-svc.sock"

--- a/common/common.go
+++ b/common/common.go
@@ -132,6 +132,15 @@ func SupportsOverlay() bool {
 	return false
 }
 
+// SupportsUserNS returns whether the kernel has CONFIG_USER_NS set
+func SupportsUserNS() bool {
+	if _, err := os.Stat("/proc/self/uid_map"); err == nil {
+		return true
+	}
+
+	return false
+}
+
 // PrivateNetList implements the flag.Value interface to allow specification
 // of -private-net with and without values
 type PrivateNetList struct {

--- a/pkg/aci/render.go
+++ b/pkg/aci/render.go
@@ -17,6 +17,8 @@ package aci
 import (
 	"fmt"
 
+	"github.com/coreos/rkt/pkg/uid"
+
 	ptar "github.com/coreos/rkt/pkg/tar"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/pkg/acirenderer"
@@ -25,32 +27,32 @@ import (
 
 // Given an imageID, start with the matching image available in the store,
 // build its dependency list and render it inside dir
-func RenderACIWithImageID(imageID types.Hash, dir string, ap acirenderer.ACIRegistry) error {
+func RenderACIWithImageID(imageID types.Hash, dir string, ap acirenderer.ACIRegistry, uidRange uid.UidRange) error {
 	renderedACI, err := acirenderer.GetRenderedACIWithImageID(imageID, ap)
 	if err != nil {
 		return err
 	}
-	return renderImage(renderedACI, dir, ap)
+	return renderImage(renderedACI, dir, ap, uidRange)
 }
 
 // Given an image app name and optional labels, get the best matching image
 // available in the store, build its dependency list and render it inside dir
-func RenderACI(name types.ACIdentifier, labels types.Labels, dir string, ap acirenderer.ACIRegistry) error {
+func RenderACI(name types.ACIdentifier, labels types.Labels, dir string, ap acirenderer.ACIRegistry, uidRange uid.UidRange) error {
 	renderedACI, err := acirenderer.GetRenderedACI(name, labels, ap)
 	if err != nil {
 		return err
 	}
-	return renderImage(renderedACI, dir, ap)
+	return renderImage(renderedACI, dir, ap, uidRange)
 }
 
 // Given an already populated dependency list, it will extract, under the provided
 // directory, the rendered ACI
-func RenderACIFromList(imgs acirenderer.Images, dir string, ap acirenderer.ACIProvider) error {
+func RenderACIFromList(imgs acirenderer.Images, dir string, ap acirenderer.ACIProvider, uidRange uid.UidRange) error {
 	renderedACI, err := acirenderer.GetRenderedACIFromList(imgs, ap)
 	if err != nil {
 		return err
 	}
-	return renderImage(renderedACI, dir, ap)
+	return renderImage(renderedACI, dir, ap, uidRange)
 }
 
 // Given a RenderedACI, it will extract, under the provided directory, the
@@ -58,7 +60,7 @@ func RenderACIFromList(imgs acirenderer.Images, dir string, ap acirenderer.ACIPr
 // The manifest will be extracted from the upper ACI.
 // No file overwriting is done as it should usually be called
 // providing an empty directory.
-func renderImage(renderedACI acirenderer.RenderedACI, dir string, ap acirenderer.ACIProvider) error {
+func renderImage(renderedACI acirenderer.RenderedACI, dir string, ap acirenderer.ACIProvider, uidRange uid.UidRange) error {
 	for _, ra := range renderedACI {
 		rs, err := ap.ReadStream(ra.Key)
 		if err != nil {
@@ -66,7 +68,7 @@ func renderImage(renderedACI acirenderer.RenderedACI, dir string, ap acirenderer
 		}
 
 		// Overwrite is not needed. If a file needs to be overwritten then the renderedACI builder has a bug
-		if err := ptar.ExtractTar(rs, dir, false, ra.FileMap); err != nil {
+		if err := ptar.ExtractTar(rs, dir, false, uidRange.UidShift, uidRange.UidCount, ra.FileMap); err != nil {
 			rs.Close()
 			return fmt.Errorf("error extracting ACI: %v", err)
 		}

--- a/pkg/aci/render.go
+++ b/pkg/aci/render.go
@@ -27,7 +27,7 @@ import (
 
 // Given an imageID, start with the matching image available in the store,
 // build its dependency list and render it inside dir
-func RenderACIWithImageID(imageID types.Hash, dir string, ap acirenderer.ACIRegistry, uidRange uid.UidRange) error {
+func RenderACIWithImageID(imageID types.Hash, dir string, ap acirenderer.ACIRegistry, uidRange *uid.UidRange) error {
 	renderedACI, err := acirenderer.GetRenderedACIWithImageID(imageID, ap)
 	if err != nil {
 		return err
@@ -37,7 +37,7 @@ func RenderACIWithImageID(imageID types.Hash, dir string, ap acirenderer.ACIRegi
 
 // Given an image app name and optional labels, get the best matching image
 // available in the store, build its dependency list and render it inside dir
-func RenderACI(name types.ACIdentifier, labels types.Labels, dir string, ap acirenderer.ACIRegistry, uidRange uid.UidRange) error {
+func RenderACI(name types.ACIdentifier, labels types.Labels, dir string, ap acirenderer.ACIRegistry, uidRange *uid.UidRange) error {
 	renderedACI, err := acirenderer.GetRenderedACI(name, labels, ap)
 	if err != nil {
 		return err
@@ -47,7 +47,7 @@ func RenderACI(name types.ACIdentifier, labels types.Labels, dir string, ap acir
 
 // Given an already populated dependency list, it will extract, under the provided
 // directory, the rendered ACI
-func RenderACIFromList(imgs acirenderer.Images, dir string, ap acirenderer.ACIProvider, uidRange uid.UidRange) error {
+func RenderACIFromList(imgs acirenderer.Images, dir string, ap acirenderer.ACIProvider, uidRange *uid.UidRange) error {
 	renderedACI, err := acirenderer.GetRenderedACIFromList(imgs, ap)
 	if err != nil {
 		return err
@@ -60,7 +60,7 @@ func RenderACIFromList(imgs acirenderer.Images, dir string, ap acirenderer.ACIPr
 // The manifest will be extracted from the upper ACI.
 // No file overwriting is done as it should usually be called
 // providing an empty directory.
-func renderImage(renderedACI acirenderer.RenderedACI, dir string, ap acirenderer.ACIProvider, uidRange uid.UidRange) error {
+func renderImage(renderedACI acirenderer.RenderedACI, dir string, ap acirenderer.ACIProvider, uidRange *uid.UidRange) error {
 	for _, ra := range renderedACI {
 		rs, err := ap.ReadStream(ra.Key)
 		if err != nil {
@@ -68,7 +68,7 @@ func renderImage(renderedACI acirenderer.RenderedACI, dir string, ap acirenderer
 		}
 
 		// Overwrite is not needed. If a file needs to be overwritten then the renderedACI builder has a bug
-		if err := ptar.ExtractTar(rs, dir, false, uidRange.UidShift, uidRange.UidCount, ra.FileMap); err != nil {
+		if err := ptar.ExtractTar(rs, dir, false, uidRange, ra.FileMap); err != nil {
 			rs.Close()
 			return fmt.Errorf("error extracting ACI: %v", err)
 		}

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -123,8 +123,8 @@ func CopyTree(src, dest string, uidrange *uid.UidRange) error {
 			return fmt.Errorf("unsupported mode: %v", mode)
 		}
 
-		var srcUid uint64 = uint64(info.Sys().(*syscall.Stat_t).Uid)
-		var srcGid uint64 = uint64(info.Sys().(*syscall.Stat_t).Gid)
+		var srcUid = info.Sys().(*syscall.Stat_t).Uid
+		var srcGid = info.Sys().(*syscall.Stat_t).Gid
 
 		if uidrange.UidCount > 0 && (srcUid >= uidrange.UidCount || srcGid >= uidrange.UidCount) {
 			return fmt.Errorf("source contains out of range uid/gid")

--- a/pkg/tar/chroot.go
+++ b/pkg/tar/chroot.go
@@ -100,8 +100,8 @@ func ExtractTar(rs io.Reader, dir string, overwrite bool, uidShift uint64, uidCo
 	defer w.Close()
 	enc := json.NewEncoder(w)
 	cmd := mcEntrypoint.Cmd(dir, strconv.FormatBool(overwrite),
-	                        strconv.FormatUint(uidShift, 10),
-				strconv.FormatUint(uidCount, 10))
+		strconv.FormatUint(uidShift, 10),
+		strconv.FormatUint(uidCount, 10))
 	cmd.ExtraFiles = []*os.File{r}
 
 	cmd.Stdin = rs

--- a/pkg/tar/chroot.go
+++ b/pkg/tar/chroot.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/coreos/rkt/pkg/multicall"
 	"github.com/coreos/rkt/pkg/sys"
+	"github.com/coreos/rkt/pkg/uid"
 )
 
 const (
@@ -65,8 +66,7 @@ func extractTarCommand() error {
 		return fmt.Errorf("error parsing uidShift argument: %v", err)
 	}
 
-	uidShift := uint32(us)
-	uidCount := uint32(uc)
+	uidRange := &uid.UidRange{Shift: uint32(us), Count: uint32(uc)}
 
 	if err := syscall.Chroot(dir); err != nil {
 		return fmt.Errorf("failed to chroot in %s: %v", dir, err)
@@ -80,7 +80,7 @@ func extractTarCommand() error {
 	if err := json.NewDecoder(fileMapFile).Decode(&fileMap); err != nil {
 		return fmt.Errorf("error decoding fileMap: %v", err)
 	}
-	if err := extractTar(tar.NewReader(os.Stdin), overwrite, fileMap, uidShift, uidCount); err != nil {
+	if err := extractTar(tar.NewReader(os.Stdin), overwrite, fileMap, uidRange); err != nil {
 		return fmt.Errorf("error extracting tar: %v", err)
 	}
 
@@ -95,7 +95,7 @@ func extractTarCommand() error {
 // If overwrite is true, existing files will be overwritten.
 // The extraction is executed by fork/exec()ing a new process. The new process
 // needs the CAP_SYS_CHROOT capability.
-func ExtractTar(rs io.Reader, dir string, overwrite bool, uidShift uint32, uidCount uint32, pwl PathWhitelistMap) error {
+func ExtractTar(rs io.Reader, dir string, overwrite bool, uidRange *uid.UidRange, pwl PathWhitelistMap) error {
 	r, w, err := os.Pipe()
 	if err != nil {
 		return err
@@ -103,8 +103,8 @@ func ExtractTar(rs io.Reader, dir string, overwrite bool, uidShift uint32, uidCo
 	defer w.Close()
 	enc := json.NewEncoder(w)
 	cmd := mcEntrypoint.Cmd(dir, strconv.FormatBool(overwrite),
-		strconv.FormatUint(uint64(uidShift), 10),
-		strconv.FormatUint(uint64(uidCount), 10))
+		strconv.FormatUint(uint64(uidRange.Shift), 10),
+		strconv.FormatUint(uint64(uidRange.Count), 10))
 	cmd.ExtraFiles = []*os.File{r}
 
 	cmd.Stdin = rs

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -40,7 +40,7 @@ type PathWhitelistMap map[string]struct{}
 // extractTar extracts a tarball (from a tar.Reader) into the root directory
 // if pwl is not nil, only the paths in the map are extracted.
 // If overwrite is true, existing files will be overwritten.
-func extractTar(tr *tar.Reader, overwrite bool, pwl PathWhitelistMap, uidShift uint64, uidCount uint64) error {
+func extractTar(tr *tar.Reader, overwrite bool, pwl PathWhitelistMap, uidShift uint32, uidCount uint32) error {
 	um := syscall.Umask(0)
 	defer syscall.Umask(um)
 
@@ -84,7 +84,7 @@ Tar:
 // extractFile extracts the file described by hdr from the given tarball into
 // the root directory.
 // If overwrite is true, existing files will be overwritten.
-func extractFile(tr *tar.Reader, hdr *tar.Header, overwrite bool, uidShift uint64, uidCount uint64) error {
+func extractFile(tr *tar.Reader, hdr *tar.Header, overwrite bool, uidShift uint32, uidCount uint32) error {
 	p := filepath.Join("/", hdr.Name)
 	fi := hdr.FileInfo()
 	typ := hdr.Typeflag
@@ -165,7 +165,7 @@ func extractFile(tr *tar.Reader, hdr *tar.Header, overwrite bool, uidShift uint6
 		return fmt.Errorf("unsupported type: %v", typ)
 	}
 
-	if uidCount != 0 && (uint64(hdr.Uid) >= uidCount || uint64(hdr.Gid) >= uidCount) {
+	if uidCount != 0 && (uint32(hdr.Uid) >= uidCount || uint32(hdr.Gid) >= uidCount) {
 		return fmt.Errorf("archive contains out of range uid/gid")
 	}
 	if err := os.Lchown(p, hdr.Uid+int(uidShift), hdr.Gid+int(uidShift)); err != nil {

--- a/pkg/tar/tar_test.go
+++ b/pkg/tar/tar_test.go
@@ -249,7 +249,7 @@ func TestExtractTarFolders(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	defer os.RemoveAll(tmpdir)
-	err = ExtractTar(containerTar, tmpdir, false, nil)
+	err = ExtractTar(containerTar, tmpdir, false, 0, 0, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -397,7 +397,7 @@ func TestExtractTarPWL(t *testing.T) {
 
 	pwl := make(PathWhitelistMap)
 	pwl["folder/foo.txt"] = struct{}{}
-	err = ExtractTar(containerTar, tmpdir, false, pwl)
+	err = ExtractTar(containerTar, tmpdir, false, 0, 0, pwl)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -502,7 +502,7 @@ func TestExtractTarOverwrite(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	defer containerTar1.Close()
-	err = ExtractTar(containerTar1, tmpdir, false, nil)
+	err = ExtractTar(containerTar1, tmpdir, false, 0, 0, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -582,7 +582,7 @@ func TestExtractTarOverwrite(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	defer containerTar2.Close()
-	err = ExtractTar(containerTar2, tmpdir, true, nil)
+	err = ExtractTar(containerTar2, tmpdir, true, 0, 0, nil)
 
 	expectedFiles := []*fileInfo{
 		&fileInfo{path: "hello.txt", typeflag: tar.TypeReg, size: 8, contents: "newhello"},
@@ -658,7 +658,7 @@ func TestExtractTarTimes(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	err = ExtractTar(containerTar, tmpdir, false, nil)
+	err = ExtractTar(containerTar, tmpdir, false, 0, 0, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/tar/tar_test.go
+++ b/pkg/tar/tar_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/coreos/rkt/pkg/multicall"
 	"github.com/coreos/rkt/pkg/sys"
+	"github.com/coreos/rkt/pkg/uid"
 )
 
 func init() {
@@ -249,7 +250,7 @@ func TestExtractTarFolders(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	defer os.RemoveAll(tmpdir)
-	err = ExtractTar(containerTar, tmpdir, false, 0, 0, nil)
+	err = ExtractTar(containerTar, tmpdir, false, uid.NewBlankUidRange(), nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -397,7 +398,7 @@ func TestExtractTarPWL(t *testing.T) {
 
 	pwl := make(PathWhitelistMap)
 	pwl["folder/foo.txt"] = struct{}{}
-	err = ExtractTar(containerTar, tmpdir, false, 0, 0, pwl)
+	err = ExtractTar(containerTar, tmpdir, false, uid.NewBlankUidRange(), pwl)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -502,7 +503,7 @@ func TestExtractTarOverwrite(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	defer containerTar1.Close()
-	err = ExtractTar(containerTar1, tmpdir, false, 0, 0, nil)
+	err = ExtractTar(containerTar1, tmpdir, false, uid.NewBlankUidRange(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -582,7 +583,7 @@ func TestExtractTarOverwrite(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	defer containerTar2.Close()
-	err = ExtractTar(containerTar2, tmpdir, true, 0, 0, nil)
+	err = ExtractTar(containerTar2, tmpdir, true, uid.NewBlankUidRange(), nil)
 
 	expectedFiles := []*fileInfo{
 		&fileInfo{path: "hello.txt", typeflag: tar.TypeReg, size: 8, contents: "newhello"},
@@ -658,7 +659,7 @@ func TestExtractTarTimes(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	err = ExtractTar(containerTar, tmpdir, false, 0, 0, nil)
+	err = ExtractTar(containerTar, tmpdir, false, uid.NewBlankUidRange(), nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/uid/uid.go
+++ b/pkg/uid/uid.go
@@ -106,16 +106,16 @@ func SerializeUidRange(uidrange UidRange) string {
 	return uidrangeStr
 }
 
-func UnserializeUidRange(uidrange string) (*UidRange) {
-	ur := NewUidRange(0, 0)
+func UnserializeUidRange(uidrange string) (UidRange, error) {
+	ur := UidRange{0, 0}
 
 	uidshift, uidcount, err := ParseSerializedUidRange(uidrange)
 	if err != nil {
-		return ur
+		return ur, err
 	}
 
 	ur.UidShift = uidshift
 	ur.UidCount = uidcount
 
-	return ur
+	return ur, nil
 }

--- a/pkg/uid/uid.go
+++ b/pkg/uid/uid.go
@@ -31,7 +31,7 @@ type UidRange struct {
 	UidCount uint64
 }
 
-func NewUidRange(uidshift uint64, uidcount uint64) (*UidRange) {
+func NewUidRange(uidshift uint64, uidcount uint64) *UidRange {
 	ur := &UidRange{
 		uidshift,
 		uidcount,
@@ -39,7 +39,7 @@ func NewUidRange(uidshift uint64, uidcount uint64) (*UidRange) {
 	return ur
 }
 
-func GenerateContainerID(containerid uint64) (uint64) {
+func GenerateContainerID(containerid uint64) uint64 {
 	var containerID uint64 = containerid
 
 	if containerID < 0x00010000 {
@@ -50,7 +50,7 @@ func GenerateContainerID(containerid uint64) (uint64) {
 	return containerID
 }
 
-func GenerateUidShift(containerid uint64) (uint64) {
+func GenerateUidShift(containerid uint64) uint64 {
 	var uidShift uint64
 	rand.Seed(time.Now().UnixNano())
 	containerUid := rand.Intn(0x0000FFFF)
@@ -60,7 +60,7 @@ func GenerateUidShift(containerid uint64) (uint64) {
 	return uidShift
 }
 
-func GenerateUidRange(containerid uint64, uidcount uint64) (*UidRange) {
+func GenerateUidRange(containerid uint64, uidcount uint64) *UidRange {
 	uidShift := GenerateUidShift(containerid)
 	ur := NewUidRange(uidShift, uidcount)
 	return ur

--- a/pkg/uid/uid.go
+++ b/pkg/uid/uid.go
@@ -44,7 +44,7 @@ func GenerateContainerID(containerid uint64) (uint64) {
 
 	if containerID < 0x00010000 {
 		rand.Seed(time.Now().UnixNano())
-		containerID = uint64(rand.Int63n(0xFFFFFFFF) | 0X00010000)
+		containerID = uint64(rand.Int63n(0xFFFDFFFF)) + 0X00010000
 	}
 
 	return containerID
@@ -95,7 +95,7 @@ func ParseSerializedUidRange(uidrange string) (uidShift uint64, uidCount uint64,
 	return
 }
 
-func SerializeUidRange(uidrange *UidRange) string {
+func SerializeUidRange(uidrange UidRange) string {
 	var uidrangeStr string = ""
 
 	uidshift := strconv.FormatUint(uidrange.UidShift, 10)

--- a/pkg/uid/uid.go
+++ b/pkg/uid/uid.go
@@ -1,0 +1,50 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uid
+
+import (
+	"math/rand"
+	"time"
+)
+
+// A UidRange structure used to set uidshift and its range.
+type UidRange struct {
+	UidShift uint64
+	UidCount uint64
+}
+
+func NewUidRange(uidshift uint64, uidcount uint64) (*UidRange) {
+	ur := &UidRange{
+		uidshift,
+		uidcount,
+	}
+	return ur
+}
+
+func GenerateUidRange(containerid uint64, uidcount uint64) (*UidRange) {
+	var containerId uint64 = containerid
+	rand.Seed(time.Now().UnixNano())
+	containerUid := rand.Intn(0x0000FFFF)
+
+	if containerId < 0x00010000 {
+		rand.Seed(time.Now().UnixNano())
+		containerId = uint64(rand.Int63n(0xFFFFFFFF) & 0xFFFF0000)
+	} 
+
+	containerId = containerId | uint64(containerUid)
+
+	ur := NewUidRange(containerId, uidcount)
+	return ur
+}

--- a/rkt/image_extract.go
+++ b/rkt/image_extract.go
@@ -21,8 +21,8 @@ import (
 	"syscall"
 
 	"github.com/coreos/rkt/pkg/fileutil"
-	"github.com/coreos/rkt/pkg/uid"
 	"github.com/coreos/rkt/pkg/tar"
+	"github.com/coreos/rkt/pkg/uid"
 	"github.com/coreos/rkt/store"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"

--- a/rkt/image_extract.go
+++ b/rkt/image_extract.go
@@ -21,6 +21,7 @@ import (
 	"syscall"
 
 	"github.com/coreos/rkt/pkg/fileutil"
+	"github.com/coreos/rkt/pkg/uid"
 	"github.com/coreos/rkt/pkg/tar"
 	"github.com/coreos/rkt/store"
 
@@ -120,7 +121,7 @@ func runImageExtract(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	if err := tar.ExtractTar(aci, extractDir, false, nil); err != nil {
+	if err := tar.ExtractTar(aci, extractDir, false, 0, 0, nil); err != nil {
 		stderr("image extract: error extracting ACI: %v", err)
 		return 1
 	}
@@ -130,7 +131,8 @@ func runImageExtract(cmd *cobra.Command, args []string) (exit int) {
 		if err := os.Rename(rootfsDir, absOutputDir); err != nil {
 			if e, ok := err.(*os.LinkError); ok && e.Err == syscall.EXDEV {
 				// it's on a different device, fall back to copying
-				if err := fileutil.CopyTree(rootfsDir, absOutputDir); err != nil {
+				uidRange := uid.NewUidRange(0, 0)
+				if err := fileutil.CopyTree(rootfsDir, absOutputDir, uidRange); err != nil {
 					stderr("image extract: error copying ACI rootfs: %v", err)
 					return 1
 				}

--- a/rkt/image_extract.go
+++ b/rkt/image_extract.go
@@ -121,7 +121,7 @@ func runImageExtract(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	if err := tar.ExtractTar(aci, extractDir, false, 0, 0, nil); err != nil {
+	if err := tar.ExtractTar(aci, extractDir, false, uid.NewBlankUidRange(), nil); err != nil {
 		stderr("image extract: error extracting ACI: %v", err)
 		return 1
 	}
@@ -131,8 +131,7 @@ func runImageExtract(cmd *cobra.Command, args []string) (exit int) {
 		if err := os.Rename(rootfsDir, absOutputDir); err != nil {
 			if e, ok := err.(*os.LinkError); ok && e.Err == syscall.EXDEV {
 				// it's on a different device, fall back to copying
-				uidRange := uid.NewUidRange(0, 0)
-				if err := fileutil.CopyTree(rootfsDir, absOutputDir, uidRange); err != nil {
+				if err := fileutil.CopyTree(rootfsDir, absOutputDir, uid.NewBlankUidRange()); err != nil {
 					stderr("image extract: error copying ACI rootfs: %v", err)
 					return 1
 				}

--- a/rkt/image_render.go
+++ b/rkt/image_render.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/coreos/rkt/pkg/fileutil"
+	"github.com/coreos/rkt/pkg/uid"
 	"github.com/coreos/rkt/store"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
@@ -118,7 +119,8 @@ func runImageRender(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	cachedTreePath := s.GetTreeStoreRootFS(key)
-	if err := fileutil.CopyTree(cachedTreePath, rootfsOutDir); err != nil {
+	uidrange := uid.NewUidRange(0, 0)
+	if err := fileutil.CopyTree(cachedTreePath, rootfsOutDir, uidrange); err != nil {
 		stderr("image render: error copying ACI rootfs: %v", err)
 		return 1
 	}

--- a/rkt/image_render.go
+++ b/rkt/image_render.go
@@ -119,8 +119,7 @@ func runImageRender(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	cachedTreePath := s.GetTreeStoreRootFS(key)
-	uidrange := uid.NewUidRange(0, 0)
-	if err := fileutil.CopyTree(cachedTreePath, rootfsOutDir, uidrange); err != nil {
+	if err := fileutil.CopyTree(cachedTreePath, rootfsOutDir, uid.NewBlankUidRange()); err != nil {
 		stderr("image render: error copying ACI rootfs: %v", err)
 		return 1
 	}

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -52,6 +52,7 @@ func init() {
 	cmdPrepare.Flags().BoolVar(&flagQuiet, "quiet", false, "suppress superfluous output on stdout, print only the UUID on success")
 	cmdPrepare.Flags().BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	cmdPrepare.Flags().BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
+	cmdPrepare.Flags().BoolVar(&flagPrivateUsers, "private-users", false, "Run within user namespaces.")
 	cmdPrepare.Flags().Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
 	cmdPrepare.Flags().BoolVar(&flagLocal, "local", false, "use only local images (do not discover or download from remote URLs)")
 	cmdPrepare.Flags().StringVar(&flagPodManifest, "pod-manifest", "", "the path to the pod manifest. If it's non-empty, then only '--quiet' and '--no-overlay' will have effects")
@@ -65,11 +66,15 @@ func init() {
 func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	var err error
 	origStdout := os.Stdout
+	var privateUsers string = ""
 	if flagQuiet {
 		if os.Stdout, err = os.Open("/dev/null"); err != nil {
 			stderr("prepare: unable to open /dev/null")
 			return 1
 		}
+	}
+
+	if flagPrivateUsers && common.SupportsUserNS() {
 	}
 
 	if err = parseApps(&rktApps, args, cmd.Flags(), true); err != nil {
@@ -148,6 +153,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	pcfg := stage0.PrepareConfig{
 		CommonConfig: cfg,
 		UseOverlay:   !flagNoOverlay && common.SupportsOverlay(),
+		PrivateUsers: privateUsers,
 	}
 
 	if len(flagPodManifest) > 0 {

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -155,7 +155,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	pcfg := stage0.PrepareConfig{
 		CommonConfig: cfg,
 		UseOverlay:   !flagNoOverlay && common.SupportsOverlay(),
-		PrivateUsers: &privateUsers,
+		PrivateUsers: privateUsers,
 	}
 
 	if len(flagPodManifest) > 0 {

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -53,7 +53,7 @@ func init() {
 	cmdPrepare.Flags().BoolVar(&flagQuiet, "quiet", false, "suppress superfluous output on stdout, print only the UUID on success")
 	cmdPrepare.Flags().BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	cmdPrepare.Flags().BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
-	cmdPrepare.Flags().BoolVar(&flagPrivateUsers, "private-users", false, "Run within user namespaces.")
+	cmdPrepare.Flags().BoolVar(&flagPrivateUsers, "private-users", false, "Run within user namespaces (experimental).")
 	cmdPrepare.Flags().Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
 	cmdPrepare.Flags().BoolVar(&flagLocal, "local", false, "use only local images (do not discover or download from remote URLs)")
 	cmdPrepare.Flags().StringVar(&flagPodManifest, "pod-manifest", "", "the path to the pod manifest. If it's non-empty, then only '--quiet' and '--no-overlay' will have effects")

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
 	"github.com/coreos/rkt/common"
+	"github.com/coreos/rkt/pkg/uid"
 	"github.com/coreos/rkt/stage0"
 	"github.com/coreos/rkt/store"
 )
@@ -66,7 +67,7 @@ func init() {
 func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	var err error
 	origStdout := os.Stdout
-	var privateUsers string = ""
+	var privateUsers uid.UidRange
 	if flagQuiet {
 		if os.Stdout, err = os.Open("/dev/null"); err != nil {
 			stderr("prepare: unable to open /dev/null")
@@ -75,6 +76,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	if flagPrivateUsers && common.SupportsUserNS() {
+		uid.SetUidRange(&privateUsers, 0, 0x10000)
 	}
 
 	if err = parseApps(&rktApps, args, cmd.Flags(), true); err != nil {
@@ -153,7 +155,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	pcfg := stage0.PrepareConfig{
 		CommonConfig: cfg,
 		UseOverlay:   !flagNoOverlay && common.SupportsOverlay(),
-		PrivateUsers: privateUsers,
+		PrivateUsers: &privateUsers,
 	}
 
 	if len(flagPodManifest) > 0 {

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -67,7 +67,7 @@ func init() {
 func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	var err error
 	origStdout := os.Stdout
-	var privateUsers uid.UidRange
+	privateUsers := uid.NewBlankUidRange()
 	if flagQuiet {
 		if os.Stdout, err = os.Open("/dev/null"); err != nil {
 			stderr("prepare: unable to open /dev/null")
@@ -76,7 +76,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	if flagPrivateUsers && common.SupportsUserNS() {
-		uid.SetUidRange(&privateUsers, 0x10000)
+		privateUsers.SetRandomUidRange(uid.DefaultRangeCount)
 	}
 
 	if err = parseApps(&rktApps, args, cmd.Flags(), true); err != nil {

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -76,7 +76,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	if flagPrivateUsers && common.SupportsUserNS() {
-		uid.SetUidRange(&privateUsers, 0, 0x10000)
+		uid.SetUidRange(&privateUsers, 0x10000)
 	}
 
 	if err = parseApps(&rktApps, args, cmd.Flags(), true); err != nil {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -30,9 +30,9 @@ import (
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/pkg/label"
+	"github.com/coreos/rkt/pkg/uid"
 	"github.com/coreos/rkt/stage0"
 	"github.com/coreos/rkt/store"
-	"github.com/coreos/rkt/pkg/uid"
 )
 
 var (

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -84,7 +84,7 @@ func init() {
 	cmdRun.Flags().Lookup("private-net").NoOptDefVal = "all"
 	cmdRun.Flags().BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	cmdRun.Flags().BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
-	cmdRun.Flags().BoolVar(&flagPrivateUsers, "private-users", false, "Run within user namespaces.")
+	cmdRun.Flags().BoolVar(&flagPrivateUsers, "private-users", false, "Run within user namespaces (experimental).")
 	cmdRun.Flags().Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
 	cmdRun.Flags().BoolVar(&flagInteractive, "interactive", false, "run pod interactively. If true, only one image may be supplied.")
 	cmdRun.Flags().BoolVar(&flagLocal, "local", false, "use only local images (do not discover or download from remote URLs)")

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -32,6 +32,7 @@ import (
 	"github.com/coreos/rkt/pkg/label"
 	"github.com/coreos/rkt/stage0"
 	"github.com/coreos/rkt/store"
+	"github.com/coreos/rkt/pkg/uid"
 )
 
 var (
@@ -141,7 +142,7 @@ func getStage1Hash(s *store.Store, stage1ImagePath string) (*types.Hash, error) 
 }
 
 func runRun(cmd *cobra.Command, args []string) (exit int) {
-	var privateUsers string = ""
+	var privateUsers uid.UidRange
 	err := parseApps(&rktApps, args, cmd.Flags(), true)
 	if err != nil {
 		stderr("run: error parsing app image arguments: %v", err)
@@ -149,6 +150,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	if flagPrivateUsers && common.SupportsUserNS() {
+		uid.SetUidRange(&privateUsers, 0, 0x10000)
 	}
 
 	if len(flagPorts) > 0 && !flagPrivateNet.Any() {
@@ -250,7 +252,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 	pcfg := stage0.PrepareConfig{
 		CommonConfig: cfg,
 		UseOverlay:   !flagNoOverlay && common.SupportsOverlay(),
-		PrivateUsers: privateUsers,
+		PrivateUsers: &privateUsers,
 	}
 
 	if len(flagPodManifest) > 0 {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -54,6 +54,7 @@ End the image arguments with a lone "---" to resume argument parsing.`,
 	flagVolumes      volumeList
 	flagPorts        portList
 	flagPrivateNet   common.PrivateNetList
+	flagPrivateUsers bool
 	flagInheritEnv   bool
 	flagExplicitEnv  envMap
 	flagInteractive  bool
@@ -82,6 +83,7 @@ func init() {
 	cmdRun.Flags().Lookup("private-net").NoOptDefVal = "all"
 	cmdRun.Flags().BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	cmdRun.Flags().BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
+	cmdRun.Flags().BoolVar(&flagPrivateUsers, "private-users", false, "Run within user namespaces.")
 	cmdRun.Flags().Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
 	cmdRun.Flags().BoolVar(&flagInteractive, "interactive", false, "run pod interactively. If true, only one image may be supplied.")
 	cmdRun.Flags().BoolVar(&flagLocal, "local", false, "use only local images (do not discover or download from remote URLs)")
@@ -139,10 +141,14 @@ func getStage1Hash(s *store.Store, stage1ImagePath string) (*types.Hash, error) 
 }
 
 func runRun(cmd *cobra.Command, args []string) (exit int) {
+	var privateUsers string = ""
 	err := parseApps(&rktApps, args, cmd.Flags(), true)
 	if err != nil {
 		stderr("run: error parsing app image arguments: %v", err)
 		return 1
+	}
+
+	if flagPrivateUsers && common.SupportsUserNS() {
 	}
 
 	if len(flagPorts) > 0 && !flagPrivateNet.Any() {
@@ -244,6 +250,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 	pcfg := stage0.PrepareConfig{
 		CommonConfig: cfg,
 		UseOverlay:   !flagNoOverlay && common.SupportsOverlay(),
+		PrivateUsers: privateUsers,
 	}
 
 	if len(flagPodManifest) > 0 {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -252,7 +252,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 	pcfg := stage0.PrepareConfig{
 		CommonConfig: cfg,
 		UseOverlay:   !flagNoOverlay && common.SupportsOverlay(),
-		PrivateUsers: &privateUsers,
+		PrivateUsers: privateUsers,
 	}
 
 	if len(flagPodManifest) > 0 {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -150,7 +150,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	if flagPrivateUsers && common.SupportsUserNS() {
-		uid.SetUidRange(&privateUsers, 0, 0x10000)
+		uid.SetUidRange(&privateUsers, 0x10000)
 	}
 
 	if len(flagPorts) > 0 && !flagPrivateNet.Any() {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -142,7 +142,7 @@ func getStage1Hash(s *store.Store, stage1ImagePath string) (*types.Hash, error) 
 }
 
 func runRun(cmd *cobra.Command, args []string) (exit int) {
-	var privateUsers uid.UidRange
+	privateUsers := uid.NewBlankUidRange()
 	err := parseApps(&rktApps, args, cmd.Flags(), true)
 	if err != nil {
 		stderr("run: error parsing app image arguments: %v", err)
@@ -150,7 +150,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	if flagPrivateUsers && common.SupportsUserNS() {
-		uid.SetUidRange(&privateUsers, 0x10000)
+		privateUsers.SetRandomUidRange(uid.DefaultRangeCount)
 	}
 
 	if len(flagPorts) > 0 && !flagPrivateNet.Any() {

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -59,7 +59,7 @@ type PrepareConfig struct {
 	Ports        []types.ExposedPort // list of ports that rkt will expose on the host
 	UseOverlay   bool                // prepare pod with overlay fs
 	PodManifest  string              // use the pod manifest specified by the user, this will ignore flags such as '--volume', '--port', etc.
-	PrivateUsers *uid.UidRange	 // User namespaces
+	PrivateUsers uid.UidRange	 // User namespaces
 }
 
 // configuration parameters needed by Run
@@ -417,7 +417,7 @@ func prepareAppImage(cfg PrepareConfig, appName types.ACName, img types.Hash, cd
 			return fmt.Errorf("error creating image directory: %v", err)
 		}
 
-		if err := aci.RenderACIWithImageID(img, ad, cfg.Store); err != nil {
+		if err := aci.RenderACIWithImageID(img, ad, cfg.Store, cfg.PrivateUsers); err != nil {
 			return fmt.Errorf("error rendering ACI: %v", err)
 		}
 	}
@@ -474,7 +474,7 @@ func prepareStage1Image(cfg PrepareConfig, img types.Hash, cdir string, useOverl
 
 		destRootfs := filepath.Join(s1, "rootfs")
 		cachedTreePath := cfg.Store.GetTreeStoreRootFS(img.String())
-		if err := fileutil.CopyTree(cachedTreePath, destRootfs); err != nil {
+		if err := fileutil.CopyTree(cachedTreePath, destRootfs, &cfg.PrivateUsers); err != nil {
 			return fmt.Errorf("error rendering ACI: %v", err)
 		}
 	}

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -58,6 +58,7 @@ type PrepareConfig struct {
 	Ports       []types.ExposedPort // list of ports that rkt will expose on the host
 	UseOverlay  bool                // prepare pod with overlay fs
 	PodManifest string              // use the pod manifest specified by the user, this will ignore flags such as '--volume', '--port', etc.
+	PrivateUsers string             // User namespaces
 }
 
 // configuration parameters needed by Run

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -43,6 +43,7 @@ import (
 	"github.com/coreos/rkt/pkg/aci"
 	"github.com/coreos/rkt/pkg/fileutil"
 	"github.com/coreos/rkt/pkg/label"
+	"github.com/coreos/rkt/pkg/uid"
 	"github.com/coreos/rkt/pkg/sys"
 	"github.com/coreos/rkt/store"
 	"github.com/coreos/rkt/version"
@@ -51,14 +52,14 @@ import (
 // configuration parameters required by Prepare
 type PrepareConfig struct {
 	CommonConfig
-	Apps        *apps.Apps          // apps to prepare
-	InheritEnv  bool                // inherit parent environment into apps
-	ExplicitEnv []string            // always set these environment variables for all the apps
-	Volumes     []types.Volume      // list of volumes that rkt can provide to applications
-	Ports       []types.ExposedPort // list of ports that rkt will expose on the host
-	UseOverlay  bool                // prepare pod with overlay fs
-	PodManifest string              // use the pod manifest specified by the user, this will ignore flags such as '--volume', '--port', etc.
-	PrivateUsers string             // User namespaces
+	Apps         *apps.Apps          // apps to prepare
+	InheritEnv   bool                // inherit parent environment into apps
+	ExplicitEnv  []string            // always set these environment variables for all the apps
+	Volumes      []types.Volume      // list of volumes that rkt can provide to applications
+	Ports        []types.ExposedPort // list of ports that rkt will expose on the host
+	UseOverlay   bool                // prepare pod with overlay fs
+	PodManifest  string              // use the pod manifest specified by the user, this will ignore flags such as '--volume', '--port', etc.
+	PrivateUsers *uid.UidRange	 // User namespaces
 }
 
 // configuration parameters needed by Run

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -43,8 +43,8 @@ import (
 	"github.com/coreos/rkt/pkg/aci"
 	"github.com/coreos/rkt/pkg/fileutil"
 	"github.com/coreos/rkt/pkg/label"
-	"github.com/coreos/rkt/pkg/uid"
 	"github.com/coreos/rkt/pkg/sys"
+	"github.com/coreos/rkt/pkg/uid"
 	"github.com/coreos/rkt/store"
 	"github.com/coreos/rkt/version"
 )
@@ -59,7 +59,7 @@ type PrepareConfig struct {
 	Ports        []types.ExposedPort // list of ports that rkt will expose on the host
 	UseOverlay   bool                // prepare pod with overlay fs
 	PodManifest  string              // use the pod manifest specified by the user, this will ignore flags such as '--volume', '--port', etc.
-	PrivateUsers uid.UidRange	 // User namespaces
+	PrivateUsers uid.UidRange        // User namespaces
 }
 
 // configuration parameters needed by Run

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -271,7 +271,7 @@ func Prepare(cfg PrepareConfig, dir string, uuid *types.UUID) error {
 
 	if cfg.PrivateUsers.UidShift > 0 {
 		// mark the pod as prepared for user namespaces
-		uidrangeStr := uid.SerializeUidRange(cfg.PrivateUsers)
+		uidrangeStr := cfg.PrivateUsers.String()
 
 		if err := ioutil.WriteFile(filepath.Join(dir, common.PrivateUsersPreparedFilename), []byte(uidrangeStr), 0700); err != nil {
 			return fmt.Errorf("error writing userns marker file: %v", err)

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -556,7 +556,7 @@ func stage1() int {
 		return 2
 	}
 
-	if err = p.PodToSystemd(interactive, flavor); err != nil {
+	if err = p.PodToSystemd(interactive, flavor, PrivateUsers); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to configure systemd: %v\n", err)
 		return 2
 	}

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -125,18 +125,20 @@ func mirrorLocalZoneInfo(root string) {
 }
 
 var (
-	debug       bool
-	privNet     common.PrivateNetList
-	interactive bool
-	mdsToken    string
-	localhostIP net.IP
-	localConfig string
+	debug        bool
+	privNet      common.PrivateNetList
+	interactive  bool
+	PrivateUsers string
+	mdsToken     string
+	localhostIP  net.IP
+	localConfig  string
 )
 
 func init() {
 	flag.BoolVar(&debug, "debug", false, "Run in debug mode")
 	flag.Var(&privNet, "private-net", "Setup private network")
 	flag.BoolVar(&interactive, "interactive", false, "The pod is interactive")
+	flag.StringVar(&PrivateUsers, "private-users", "", "Run within user namespace. Can be set to [=UIDBASE[:NUIDS]]")
 	flag.StringVar(&mdsToken, "mds-token", "", "MDS auth token")
 	flag.StringVar(&localConfig, "local-config", common.DefaultLocalConfigDir, "Local config path")
 	// this ensures that main runs only on main thread (thread group leader).
@@ -381,6 +383,10 @@ func getArgsEnv(p *Pod, flavor string, debug bool, n *networking.Networking) ([]
 	if !debug {
 		args = append(args, "--quiet")             // silence most nspawn output (log_warning is currently not covered by this)
 		env = append(env, "SYSTEMD_LOG_LEVEL=err") // silence log_warning too
+	}
+
+	if len(PrivateUsers) > 0 {
+		args = append(args, "--private-users="+PrivateUsers)
 	}
 
 	keepUnit, err := isRunningFromUnitFile()

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -128,7 +128,7 @@ var (
 	debug        bool
 	privNet      common.PrivateNetList
 	interactive  bool
-	PrivateUsers string
+	privateUsers string
 	mdsToken     string
 	localhostIP  net.IP
 	localConfig  string
@@ -138,7 +138,7 @@ func init() {
 	flag.BoolVar(&debug, "debug", false, "Run in debug mode")
 	flag.Var(&privNet, "private-net", "Setup private network")
 	flag.BoolVar(&interactive, "interactive", false, "The pod is interactive")
-	flag.StringVar(&PrivateUsers, "private-users", "", "Run within user namespace. Can be set to [=UIDBASE[:NUIDS]]")
+	flag.StringVar(&privateUsers, "private-users", "", "Run within user namespace. Can be set to [=UIDBASE[:NUIDS]]")
 	flag.StringVar(&mdsToken, "mds-token", "", "MDS auth token")
 	flag.StringVar(&localConfig, "local-config", common.DefaultLocalConfigDir, "Local config path")
 	// this ensures that main runs only on main thread (thread group leader).
@@ -385,8 +385,8 @@ func getArgsEnv(p *Pod, flavor string, debug bool, n *networking.Networking) ([]
 		env = append(env, "SYSTEMD_LOG_LEVEL=err") // silence log_warning too
 	}
 
-	if len(PrivateUsers) > 0 {
-		args = append(args, "--private-users="+PrivateUsers)
+	if len(privateUsers) > 0 {
+		args = append(args, "--private-users="+privateUsers)
 	}
 
 	keepUnit, err := isRunningFromUnitFile()
@@ -556,7 +556,7 @@ func stage1() int {
 		return 2
 	}
 
-	if err = p.PodToSystemd(interactive, flavor, PrivateUsers); err != nil {
+	if err = p.PodToSystemd(interactive, flavor, privateUsers); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to configure systemd: %v\n", err)
 		return 2
 	}

--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -343,19 +343,18 @@ func (p *Pod) writeEnvFile(env types.Environment, appName types.ACName, privateU
 		fmt.Fprintf(&ef, "%s=%s\000", e.Name, e.Value)
 	}
 
-	uidRange, err := uid.UnserializeUidRange(privateUsers)
-	if err != nil {
+	uidRange := uid.NewBlankUidRange()
+	if err := uidRange.Deserialize([]byte(privateUsers)); err != nil {
 		return err
 	}
 
 	envFilePath := EnvFilePath(p.Root, appName)
-
 	if err := ioutil.WriteFile(envFilePath, ef.Bytes(), 0644); err != nil {
 		return err
 	}
 
-	if uidRange.UidShift != 0 && uidRange.UidCount != 0 {
-		if err := os.Chown(envFilePath, int(uidRange.UidShift), int(uidRange.UidShift)); err != nil {
+	if uidRange.Shift != 0 && uidRange.Count != 0 {
+		if err := os.Chown(envFilePath, int(uidRange.Shift), int(uidRange.Shift)); err != nil {
 			return err
 		}
 	}

--- a/store/backup.go
+++ b/store/backup.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	"github.com/coreos/rkt/pkg/fileutil"
+	"github.com/coreos/rkt/pkg/uid"
 )
 
 // createBackup backs a database up in a given directory. It basically
@@ -33,10 +34,11 @@ import (
 // is removed.
 func createBackup(dbDir, backupsDir string, limit int) error {
 	tmpBackupDir := filepath.Join(backupsDir, "tmp")
+	uidrange := uid.NewUidRange(0, 0)
 	if err := os.MkdirAll(backupsDir, defaultPathPerm); err != nil {
 		return err
 	}
-	if err := fileutil.CopyTree(dbDir, tmpBackupDir); err != nil {
+	if err := fileutil.CopyTree(dbDir, tmpBackupDir, uidrange); err != nil {
 		return err
 	}
 	defer os.RemoveAll(tmpBackupDir)

--- a/store/backup.go
+++ b/store/backup.go
@@ -34,11 +34,10 @@ import (
 // is removed.
 func createBackup(dbDir, backupsDir string, limit int) error {
 	tmpBackupDir := filepath.Join(backupsDir, "tmp")
-	uidrange := uid.NewUidRange(0, 0)
 	if err := os.MkdirAll(backupsDir, defaultPathPerm); err != nil {
 		return err
 	}
-	if err := fileutil.CopyTree(dbDir, tmpBackupDir, uidrange); err != nil {
+	if err := fileutil.CopyTree(dbDir, tmpBackupDir, uid.NewBlankUidRange()); err != nil {
 		return err
 	}
 	defer os.RemoveAll(tmpBackupDir)

--- a/store/tree.go
+++ b/store/tree.go
@@ -30,8 +30,8 @@ import (
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/pkg/tarheader"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/pkg/aci"
-	"github.com/coreos/rkt/pkg/uid"
 	"github.com/coreos/rkt/pkg/sys"
+	"github.com/coreos/rkt/pkg/uid"
 )
 
 const (

--- a/store/tree.go
+++ b/store/tree.go
@@ -30,6 +30,7 @@ import (
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/pkg/tarheader"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/pkg/aci"
+	"github.com/coreos/rkt/pkg/uid"
 	"github.com/coreos/rkt/pkg/sys"
 )
 
@@ -50,6 +51,7 @@ type TreeStore struct {
 // before Write)
 func (ts *TreeStore) Write(key string, s *Store) error {
 	treepath := filepath.Join(ts.path, key)
+	var uidRange uid.UidRange
 	fi, _ := os.Stat(treepath)
 	if fi != nil {
 		return fmt.Errorf("treestore: path %s already exists", treepath)
@@ -61,7 +63,7 @@ func (ts *TreeStore) Write(key string, s *Store) error {
 	if err := os.MkdirAll(treepath, 0755); err != nil {
 		return fmt.Errorf("treestore: cannot create treestore directory %s: %v", treepath, err)
 	}
-	err = aci.RenderACIWithImageID(*imageID, treepath, s)
+	err = aci.RenderACIWithImageID(*imageID, treepath, s, uidRange)
 	if err != nil {
 		return fmt.Errorf("treestore: cannot render aci: %v", err)
 	}

--- a/store/tree.go
+++ b/store/tree.go
@@ -51,7 +51,6 @@ type TreeStore struct {
 // before Write)
 func (ts *TreeStore) Write(key string, s *Store) error {
 	treepath := filepath.Join(ts.path, key)
-	var uidRange uid.UidRange
 	fi, _ := os.Stat(treepath)
 	if fi != nil {
 		return fmt.Errorf("treestore: path %s already exists", treepath)
@@ -63,7 +62,7 @@ func (ts *TreeStore) Write(key string, s *Store) error {
 	if err := os.MkdirAll(treepath, 0755); err != nil {
 		return fmt.Errorf("treestore: cannot create treestore directory %s: %v", treepath, err)
 	}
-	err = aci.RenderACIWithImageID(*imageID, treepath, s, uidRange)
+	err = aci.RenderACIWithImageID(*imageID, treepath, s, uid.NewBlankUidRange())
 	if err != nil {
 		return fmt.Errorf("treestore: cannot render aci: %v", err)
 	}


### PR DESCRIPTION
The last patch "stage1:userns: add a workaround to make env file world writable" is just a work around. Will fix it later.

Alban and others asked to this PR so we can have a first review especially from @sgotti 

This is part of https://github.com/coreos/rkt/issues/986 and it is an update of https://github.com/coreos/rkt/pull/1027 
I will close PR https://github.com/coreos/rkt/pull/1027