### PR TITLE
force symlink creaton for inspect-link

### DIFF
--- a/tests/functional.mk
+++ b/tests/functional.mk
@@ -42,7 +42,7 @@ $(FTST_IMAGE): FTST_IMAGE_ROOTFSDIR := $(FTST_IMAGE_ROOTFSDIR)
 $(FTST_IMAGE): $(FTST_IMAGE_MANIFEST) $(FTST_ACI_INSPECT) $(FTST_ACI_ECHO_SERVER) | $(FTST_IMAGE_TEST_DIRS)
 	echo -n dir1 >$(FTST_IMAGE_ROOTFSDIR)/dir1/file
 	echo -n dir2 >$(FTST_IMAGE_ROOTFSDIR)/dir2/file
-	ln -s /inspect $(FTST_IMAGE_ROOTFSDIR)/inspect-link
+	ln -sf /inspect $(FTST_IMAGE_ROOTFSDIR)/inspect-link
 	"$(ACTOOL)" build --overwrite "$(FTST_IMAGE_DIR)" "$@"
 
 BGB_BINARY := $(FTST_INSPECT_BINARY)


### PR DESCRIPTION
Effectively ignores errors in succeeding builds where the symlink already
exists.

Fixes  #1251.