### PR TITLE
rkt: create a real temp dir for docker2aci images

### DIFF
--- a/rkt/images.go
+++ b/rkt/images.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -383,10 +384,15 @@ func (f *fetcher) fetch(appName string, aciURL, ascURL string, ascFile *os.File,
 	if u.Scheme == "docker" {
 		registryURL := strings.TrimPrefix(aciURL, "docker://")
 
-		tmpDir, err := f.s.TmpDir()
+		storeTmpDir, err := f.s.TmpDir()
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("error creating temporary dir for docker to ACI conversion: %v", err)
 		}
+		tmpDir, err := ioutil.TempDir(storeTmpDir, "docker2aci-")
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		defer os.RemoveAll(tmpDir)
 
 		indexName := docker2aci.GetIndexName(registryURL)
 		user := ""


### PR DESCRIPTION
We were writing the output file of docker2aci.Convert to the same temp
directory. Since the file name for a converted image is always the same
this was causing file corruption when fetching the same  docker image
with rkt several times in parallel.

We fixed that issue upstream in
https://github.com/appc/docker2aci/pull/76

In addition to the upstream fix, this patch makes the temporary
directory where rkt saves the converted docker image different in each
execution.

cc @yifan-gu @sgotti 