### PR TITLE
build: Fix equal make function for make 3.81

### DIFF
--- a/makelib/misc.mk
+++ b/makelib/misc.mk
@@ -87,10 +87,10 @@ endef
 # string.
 # Example: is_a_equal_to_b := $(if $(call equal,a,b),yes,no)
 define equal
-$(strip
-        $(eval _EQ_TMP_ := $(shell expr '$1' = '$2'))
-        $(filter $(_EQ_TMP_),1)
-        $(eval _EQ_TMP_ :=)
+$(strip \
+        $(eval _EQ_TMP_ := $(shell expr '$1' = '$2')) \
+        $(filter $(_EQ_TMP_),1) \
+        $(eval _EQ_TMP_ :=) \
 )
 endef
 


### PR DESCRIPTION
make 3.81 does not like unescaped stuff. It is not a problem for make
4.0 I have installed.

In this case, equal function always return empty value, which is then
interpreted as values not being equal, which in case of dependency
checking results in useless rebuilds.