### PR TITLE
autogen: more fixes for autogen script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /autom4te.cache
 /config.log
 /config.status
+/.config.args
 /configure
 /makelib/variables.mk
 /build-rkt-*

--- a/autogen.sh
+++ b/autogen.sh
@@ -9,7 +9,7 @@ autoreconf --install --warnings=all --force
 
 args=""
 if [ -f "$topdir/.config.args" ]; then
-	args="$args $(cat $topdir/.config.args)"
+	args="$(cat $topdir/.config.args)"
 fi
 
 echo
@@ -17,5 +17,5 @@ echo "----------------------------------------------------------------"
 echo "Initialized build system. For a common configuration please run:"
 echo "----------------------------------------------------------------"
 echo
-echo "$topdir/configure --with-stage1=coreos $args"
+echo "$topdir/configure $args"
 echo


### PR DESCRIPTION
autogen.sh script supports the file .config.args where I put the
following:
--with-stage1=src
--with-stage1-systemd-src=/home/tixxdz/code/github-work/systemd/systemd
--with-stage1-systemd-version=master

So it prints at the end these arguments especially for us who build from
source, this way we don't have to remember them each time.

Signed-off-by: Djalal Harouni <djalal@endocode.com>