### PR TITLE
fetch: introduce new option --trust-key-from-https

### DIFF
--- a/rkt/images.go
+++ b/rkt/images.go
@@ -415,7 +415,7 @@ func (f *fetcher) fetch(appName string, aciURL, ascURL string, ascFile *os.File,
 	}
 
 	// attempt to automatically fetch the public key in case it is available on a TLS connection.
-	if !globalFlags.InsecureSkipVerify && appName != "" {
+	if globalFlags.TrustKeysFromHttps && !globalFlags.InsecureSkipVerify && appName != "" {
 		pkls, err := getPubKeyLocations(appName, false, globalFlags.Debug)
 		if err != nil {
 			stderr("Error determining key location: %v", err)

--- a/rkt/rkt.go
+++ b/rkt/rkt.go
@@ -44,6 +44,7 @@ var (
 		Debug              bool
 		Help               bool
 		InsecureSkipVerify bool
+		TrustKeysFromHttps bool
 	}{}
 
 	cmdExitCode int
@@ -60,6 +61,7 @@ func init() {
 	cmdRkt.PersistentFlags().StringVar(&globalFlags.SystemConfigDir, "system-config", common.DefaultSystemConfigDir, "system configuration directory")
 	cmdRkt.PersistentFlags().StringVar(&globalFlags.LocalConfigDir, "local-config", common.DefaultLocalConfigDir, "local configuration directory")
 	cmdRkt.PersistentFlags().BoolVar(&globalFlags.InsecureSkipVerify, "insecure-skip-verify", false, "skip all TLS, image or fingerprint verification")
+	cmdRkt.PersistentFlags().BoolVar(&globalFlags.TrustKeysFromHttps, "trust-keys-from-https", true, "automatically trust gpg keys fetched from https")
 }
 
 func init() {


### PR DESCRIPTION
The default is true, so by default keys will be fetched automatically
when it is possible to do so through https.

The user can add --trust-key-from-https=false to disable it.

This is part of https://github.com/coreos/rkt/issues/481