### PR TITLE
Use last-ditch manifest parser for error reporting

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -84,38 +84,38 @@
 		},
 		{
 			"ImportPath": "github.com/appc/spec/aci",
-			"Comment": "v0.6.1",
-			"Rev": "25f997957b604657dd558fe5da664a8f1b2a12b7"
+			"Comment": "v0.6.1-40-g598462d",
+			"Rev": "598462da7b2415ae960b85f80006a04c97d630af"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/actool",
-			"Comment": "v0.6.1",
-			"Rev": "25f997957b604657dd558fe5da664a8f1b2a12b7"
+			"Comment": "v0.6.1-40-g598462d",
+			"Rev": "598462da7b2415ae960b85f80006a04c97d630af"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/discovery",
-			"Comment": "v0.6.1",
-			"Rev": "25f997957b604657dd558fe5da664a8f1b2a12b7"
+			"Comment": "v0.6.1-40-g598462d",
+			"Rev": "598462da7b2415ae960b85f80006a04c97d630af"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/acirenderer",
-			"Comment": "v0.6.1",
-			"Rev": "25f997957b604657dd558fe5da664a8f1b2a12b7"
+			"Comment": "v0.6.1-40-g598462d",
+			"Rev": "598462da7b2415ae960b85f80006a04c97d630af"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/device",
-			"Comment": "v0.6.1",
-			"Rev": "25f997957b604657dd558fe5da664a8f1b2a12b7"
+			"Comment": "v0.6.1-40-g598462d",
+			"Rev": "598462da7b2415ae960b85f80006a04c97d630af"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/tarheader",
-			"Comment": "v0.6.1",
-			"Rev": "25f997957b604657dd558fe5da664a8f1b2a12b7"
+			"Comment": "v0.6.1-40-g598462d",
+			"Rev": "598462da7b2415ae960b85f80006a04c97d630af"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/schema",
-			"Comment": "v0.6.1",
-			"Rev": "25f997957b604657dd558fe5da664a8f1b2a12b7"
+			"Comment": "v0.6.1-40-g598462d",
+			"Rev": "598462da7b2415ae960b85f80006a04c97d630af"
 		},
 		{
 			"ImportPath": "github.com/camlistore/lock",
@@ -274,6 +274,11 @@
 		{
 			"ImportPath": "golang.org/x/tools/go/vcs",
 			"Rev": "27e692e6ec36d8f48be794f32553e1400c70dbf2"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/api/resource",
+			"Comment": "v1.0.2",
+			"Rev": "e310e619fc1ac4f3238bf5ebe9e7033bf5d47ee2"
 		},
 		{
 			"ImportPath": "speter.net/go/exp/math/dec/inf",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -72,11 +72,11 @@
 		},
 		{
 			"ImportPath": "github.com/appc/docker2aci/lib",
-			"Rev": "5a59e6910929afdeb54913c301692194d3160d09"
+			"Rev": "d03b0eaec1777d69b4cd0535c782249c5777dccb"
 		},
 		{
 			"ImportPath": "github.com/appc/docker2aci/tarball",
-			"Rev": "5a59e6910929afdeb54913c301692194d3160d09"
+			"Rev": "d03b0eaec1777d69b4cd0535c782249c5777dccb"
 		},
 		{
 			"ImportPath": "github.com/appc/goaci/proj2aci",

--- a/Godeps/_workspace/src/github.com/appc/docker2aci/lib/common/common.go
+++ b/Godeps/_workspace/src/github.com/appc/docker2aci/lib/common/common.go
@@ -22,8 +22,13 @@ import (
 )
 
 const (
-	defaultTag    = "latest"
-	schemaVersion = "0.5.1"
+	defaultTag                = "latest"
+	schemaVersion             = "0.6.1"
+	appcDockerV1RegistryURL   = "appc.io/docker/v1/registryurl"
+	appcDockerV1Repository    = "appc.io/docker/v1/repository"
+	appcDockerV1Tag           = "appc.io/docker/v1/tag"
+	appcDockerV1ImageID       = "appc.io/docker/v1/imageid"
+	appcDockerV1ParentImageID = "appc.io/docker/v1/parentimageid"
 )
 
 func ParseDockerURL(arg string) *types.ParsedDockerURL {
@@ -83,12 +88,13 @@ func ValidateACI(aciPath string) error {
 	}
 	defer aciFile.Close()
 
-	reader, err := aci.NewCompressedTarReader(aciFile)
+	tr, err := aci.NewCompressedTarReader(aciFile)
 	if err != nil {
 		return err
 	}
+	defer tr.Close()
 
-	if err := aci.ValidateArchive(reader); err != nil {
+	if err := aci.ValidateArchive(tr.Reader); err != nil {
 		return err
 	}
 
@@ -140,6 +146,7 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 
 		if layerData.Architecture != "" {
 			arch := appctypes.MustACIdentifier("arch")
+			labels = append(labels, appctypes.Label{Name: *arch, Value: layerData.Architecture})
 			parentLabels = append(parentLabels, appctypes.Label{Name: *arch, Value: layerData.Architecture})
 		}
 	}
@@ -157,6 +164,11 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 		commentKey := appctypes.MustACIdentifier("docker-comment")
 		annotations = append(annotations, appctypes.Annotation{Name: *commentKey, Value: layerData.Comment})
 	}
+
+	annotations = append(annotations, appctypes.Annotation{Name: *appctypes.MustACIdentifier(appcDockerV1RegistryURL), Value: dockerURL.IndexURL})
+	annotations = append(annotations, appctypes.Annotation{Name: *appctypes.MustACIdentifier(appcDockerV1Repository), Value: dockerURL.ImageName})
+	annotations = append(annotations, appctypes.Annotation{Name: *appctypes.MustACIdentifier(appcDockerV1ImageID), Value: layerData.ID})
+	annotations = append(annotations, appctypes.Annotation{Name: *appctypes.MustACIdentifier(appcDockerV1ParentImageID), Value: layerData.Parent})
 
 	genManifest.Labels = labels
 	genManifest.Annotations = annotations
@@ -201,6 +213,8 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 		parentImageName := appctypes.MustACIdentifier(parentImageNameString)
 
 		genManifest.Dependencies = append(genManifest.Dependencies, appctypes.Dependency{ImageName: *parentImageName, Labels: parentLabels})
+
+		annotations = append(annotations, appctypes.Annotation{Name: *appctypes.MustACIdentifier(appcDockerV1Tag), Value: dockerURL.Tag})
 	}
 
 	return genManifest, nil
@@ -339,10 +353,11 @@ func writeACI(layer io.ReadSeeker, manifest schema.ImageManifest, curPwl []strin
 
 		return nil
 	}
-	reader, err := aci.NewCompressedTarReader(layer)
+	tr, err := aci.NewCompressedTarReader(layer)
 	if err == nil {
+		defer tr.Close()
 		// write files in rootfs/
-		if err := tarball.Walk(*reader, convWalker); err != nil {
+		if err := tarball.Walk(*tr.Reader, convWalker); err != nil {
 			return nil, err
 		}
 	} else {

--- a/Godeps/_workspace/src/github.com/appc/spec/aci/layout.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/aci/layout.go
@@ -40,6 +40,7 @@ import (
 	"strings"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
 const (
@@ -48,6 +49,14 @@ const (
 	// Path to rootfs directory inside the layout
 	RootfsDir = "rootfs"
 )
+
+type ErrOldVersion struct {
+	version types.SemVer
+}
+
+func (e ErrOldVersion) Error() string {
+	return fmt.Sprintf("ACVersion too old. Found major version %v, expected %v", e.version.Major, schema.AppContainerVersion.Major)
+}
 
 var (
 	ErrNoRootFS   = errors.New("no rootfs found in layout")
@@ -163,6 +172,11 @@ func validate(imOK bool, im io.Reader, rfsOK bool, files []string) error {
 	var a schema.ImageManifest
 	if err := a.UnmarshalJSON(b); err != nil {
 		return fmt.Errorf("image manifest validation failed: %v", err)
+	}
+	if a.ACVersion.LessThanMajor(schema.AppContainerVersion) {
+		return ErrOldVersion{
+			version: a.ACVersion,
+		}
 	}
 	for _, f := range files {
 		if !strings.HasPrefix(f, "rootfs") {

--- a/Godeps/_workspace/src/github.com/appc/spec/aci/layout_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/aci/layout_test.go
@@ -15,10 +15,13 @@
 package aci
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
 )
 
 func newValidateLayoutTest() (string, error) {
@@ -36,7 +39,7 @@ func newValidateLayoutTest() (string, error) {
 	}
 
 	evilManifestBody := "malformedManifest"
-	manifestBody := `{"acKind":"ImageManifest","acVersion":"0.3.0","name":"example.com/app"}`
+	manifestBody := fmt.Sprintf(`{"acKind":"ImageManifest","acVersion":"%s","name":"example.com/app"}`, schema.AppContainerVersion)
 
 	evilManifestPath := "rootfs/manifest"
 	evilManifestPath = path.Join(td, evilManifestPath)

--- a/Godeps/_workspace/src/github.com/appc/spec/actool/manifest.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/actool/manifest.go
@@ -63,7 +63,7 @@ var (
 		  [--capability=CAP_SYS_ADMIN,CAP_NET_ADMIN]
 		  [--mounts=work,path=/opt,readOnly=true[:work2,...]]
 		  [--ports=query,protocol=tcp,port=8080[:query2,...]]
-		  [--isolators=resource/cpu,request=50,limit=100[:resource/memory,...]]
+		  [--isolators=resource/cpu,request=50m,limit=100m[:resource/memory,...]]
 		  [--replace]
 		  INPUT_ACI_FILE
 		  [OUTPUT_ACI_FILE]`,
@@ -145,23 +145,31 @@ func patchManifest(im *schema.ImageManifest) error {
 		im.Name = *name
 	}
 
+	var app *types.App = im.App
 	if patchExec != "" {
-		im.App.Exec = strings.Split(patchExec, " ")
+		if app == nil {
+			// if the original manifest was missing an app and
+			// patchExec is set let's assume the user is trying to
+			// inject one...
+			app = &types.App{}
+		}
+		app.Exec = strings.Split(patchExec, " ")
+	}
+
+	if patchUser != "" || patchGroup != "" || patchCaps != "" || patchMounts != "" || patchPorts != "" || patchIsolators != "" {
+		// ...but if we still don't have an app and the user is trying
+		// to patch one of its other parameters, it's an error
+		if app == nil {
+			return fmt.Errorf("no app in the supplied manifest and no exec command provided")
+		}
 	}
 
 	if patchUser != "" {
-		im.App.User = patchUser
-	}
-	if patchGroup != "" {
-		im.App.Group = patchGroup
+		app.User = patchUser
 	}
 
-	var app *types.App
-	if patchCaps != "" || patchMounts != "" || patchPorts != "" || patchIsolators != "" {
-		app = im.App
-		if app == nil {
-			return fmt.Errorf("no app in the manifest")
-		}
+	if patchGroup != "" {
+		app.Group = patchGroup
 	}
 
 	if patchCaps != "" {
@@ -404,6 +412,7 @@ func runPatchManifest(args []string) (exit int) {
 		stderr("patch-manifest: Cannot extract %s: %v", inputFile, err)
 		return 1
 	}
+	defer tr.Close()
 
 	var newManifest []byte
 
@@ -422,7 +431,7 @@ func runPatchManifest(args []string) (exit int) {
 		}
 	}
 
-	err = extractManifest(tr, tw, false, newManifest)
+	err = extractManifest(tr.Reader, tw, false, newManifest)
 	if err != nil {
 		stderr("patch-manifest: Unable to read %s: %v", inputFile, err)
 		return 1
@@ -459,8 +468,9 @@ func runCatManifest(args []string) (exit int) {
 		stderr("cat-manifest: Cannot extract %s: %v", inputFile, err)
 		return 1
 	}
+	defer tr.Close()
 
-	err = extractManifest(tr, nil, true, nil)
+	err = extractManifest(tr.Reader, nil, true, nil)
 	if err != nil {
 		stderr("cat-manifest: Unable to read %s: %v", inputFile, err)
 		return 1

--- a/Godeps/_workspace/src/github.com/appc/spec/actool/validate.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/actool/validate.go
@@ -15,12 +15,7 @@
 package main
 
 import (
-	"archive/tar"
-	"compress/bzip2"
-	"compress/gzip"
-	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -107,17 +102,21 @@ func runValidate(args []string) (exit int) {
 				stderr("%s: valid image layout", path)
 			}
 		case typeAppImage:
-			fr, err := maybeDecompress(fh)
+			tr, err := aci.NewCompressedTarReader(fh)
 			if err != nil {
 				stderr("%s: error decompressing file: %v", path, err)
 				return 1
 			}
-			tr := tar.NewReader(fr)
-			err = aci.ValidateArchive(tr)
+			err = aci.ValidateArchive(tr.Reader)
+			tr.Close()
 			fh.Close()
 			if err != nil {
-				stderr("%s: error validating: %v", path, err)
-				exit = 1
+				if e, ok := err.(aci.ErrOldVersion); ok {
+					stderr("%s: warning: %v", path, e)
+				} else {
+					stderr("%s: error validating: %v", path, err)
+					exit = 1
+				}
 			} else if globalFlags.Debug {
 				stderr("%s: valid app container image", path)
 			}
@@ -175,35 +174,4 @@ func detectValType(file *os.File) (string, error) {
 	default:
 		return "", nil
 	}
-}
-
-func maybeDecompress(rs io.ReadSeeker) (io.Reader, error) {
-	// TODO(jonboulle): this is a bit redundant with detectValType
-	typ, err := aci.DetectFileType(rs)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := rs.Seek(0, 0); err != nil {
-		return nil, err
-	}
-	var r io.Reader
-	switch typ {
-	case aci.TypeGzip:
-		r, err = gzip.NewReader(rs)
-		if err != nil {
-			return nil, fmt.Errorf("error reading gzip: %v", err)
-		}
-	case aci.TypeBzip2:
-		r = bzip2.NewReader(rs)
-	case aci.TypeXz:
-		r = aci.XzReader(rs)
-	case aci.TypeTar:
-		r = rs
-	case aci.TypeUnknown:
-		return nil, errors.New("unknown filetype")
-	default:
-		// should never happen
-		panic(fmt.Sprintf("bad type returned from DetectFileType: %v", typ))
-	}
-	return r, nil
 }

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/image.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/image.go
@@ -1,0 +1,44 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lastditch
+
+import (
+	"encoding/json"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+type ImageManifest struct {
+	ACVersion string `json:"acVersion"`
+	ACKind    string `json:"acKind"`
+	Name      string `json:"name"`
+}
+
+// a type just to avoid a recursion during unmarshalling
+type imageManifest ImageManifest
+
+func (im *ImageManifest) UnmarshalJSON(data []byte) error {
+	i := imageManifest(*im)
+	err := json.Unmarshal(data, &i)
+	if err != nil {
+		return err
+	}
+	if i.ACKind != string(schema.ImageManifestKind) {
+		return types.InvalidACKindError(schema.ImageManifestKind)
+	}
+	*im = ImageManifest(i)
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/image_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/image_test.go
@@ -1,0 +1,70 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lastditch
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+func TestImageManifestWithInvalidName(t *testing.T) {
+	invalidName := "example.com/test!"
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.6.1",
+		    "name": "` + invalidName + `"
+		}
+		`
+	if types.ValidACIdentifier.MatchString(invalidName) {
+		t.Fatalf("%q is an unexpectedly valid name", invalidName)
+	}
+	expected := ImageManifest{
+		ACKind:    "ImageManifest",
+		ACVersion: "0.6.1",
+		Name:      invalidName,
+	}
+	im := ImageManifest{}
+	if err := im.UnmarshalJSON([]byte(imj)); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(im, expected) {
+		t.Errorf("did not get expected image manifest, got: %v, expected: %v", im, expected)
+	}
+}
+
+func TestBogusImageManifest(t *testing.T) {
+	bogus := []string{`
+		{
+		    "acKind": "Bogus",
+		    "acVersion": "0.6.1",
+		}
+		`, `
+		<html>
+		    <head>
+		        <title>Certainly not a JSON</title>
+		    </head>
+		</html>`,
+	}
+
+	for _, str := range bogus {
+		im := ImageManifest{}
+		if im.UnmarshalJSON([]byte(str)) == nil {
+			t.Errorf("bogus image manifest unmarshalled successfully: %s", str)
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/pod.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/pod.go
@@ -1,0 +1,56 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lastditch
+
+import (
+	"encoding/json"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+type PodManifest struct {
+	ACVersion string  `json:"acVersion"`
+	ACKind    string  `json:"acKind"`
+	Apps      AppList `json:"apps"`
+}
+
+type AppList []RuntimeApp
+
+type RuntimeApp struct {
+	Name  string `json:"name"`
+	Image Image  `json:"image"`
+}
+
+type Image struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+}
+
+// a type just to avoid a recursion during unmarshalling
+type podManifest PodManifest
+
+func (pm *PodManifest) UnmarshalJSON(data []byte) error {
+	p := podManifest(*pm)
+	err := json.Unmarshal(data, &p)
+	if err != nil {
+		return err
+	}
+	if p.ACKind != string(schema.PodManifestKind) {
+		return types.InvalidACKindError(schema.PodManifestKind)
+	}
+	*pm = PodManifest(p)
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/pod_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch/pod_test.go
@@ -1,0 +1,155 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lastditch
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestInvalidPodManifest(t *testing.T) {
+	// empty image JSON
+	eImgJ := "{}"
+	// empty image instance
+	eImgI := imgI("", "")
+	tests := []struct {
+		desc     string
+		json     string
+		expected PodManifest
+	}{
+		{
+			desc:     "Check an empty pod manifest",
+			json:     podJ("", ""),
+			expected: podI(AppList{}),
+		},
+		{
+			desc:     "Check a pod manifest with an invalid app name",
+			json:     podJ(appJ("!", eImgJ, ""), ""),
+			expected: podI(AppList{appI("!", eImgI)}),
+		},
+		{
+			desc:     "Check a pod manifest with duplicated app names",
+			json:     podJ(appJ("a", eImgJ, "")+","+appJ("a", eImgJ, ""), ""),
+			expected: podI(AppList{appI("a", eImgI), appI("a", eImgI)}),
+		},
+		{
+			desc:     "Check a pod manifest with an invalid image name and ID",
+			json:     podJ(appJ("?", imgJ("!!!", "&&&", ""), ""), ""),
+			expected: podI(AppList{appI("?", imgI("!!!", "&&&"))}),
+		},
+		{
+			desc:     "Check if we ignore extra fields in a pod",
+			json:     podJ("", `"ports": [],`),
+			expected: podI(AppList{}),
+		},
+		{
+			desc:     "Check if we ignore extra fields in an app",
+			json:     podJ(appJ("a", eImgJ, `"mounts": [],`), `"ports": [],`),
+			expected: podI(AppList{appI("a", eImgI)}),
+		},
+		{
+			desc:     "Check if we ignore extra fields in an image",
+			json:     podJ(appJ("a", imgJ("i", "id", `"labels": [],`), `"mounts": [],`), `"ports": [],`),
+			expected: podI(AppList{appI("a", imgI("i", "id"))}),
+		},
+	}
+	for _, tt := range tests {
+		got := PodManifest{}
+		if err := got.UnmarshalJSON([]byte(tt.json)); err != nil {
+			t.Errorf("%s: unexpected error during unmarshalling pod manifest: %v", tt.desc, err)
+		}
+		if !reflect.DeepEqual(tt.expected, got) {
+			t.Errorf("%s: did not get expected pod manifest, got: %v, expected: %v", tt.desc, got, tt.expected)
+		}
+	}
+}
+
+func TestBogusPodManifest(t *testing.T) {
+	bogus := []string{`
+		{
+		    "acKind": "Bogus",
+		    "acVersion": "0.6.1",
+		}
+		`, `
+		<html>
+		    <head>
+		        <title>Certainly not a JSON</title>
+		    </head>
+		</html>`,
+	}
+
+	for _, str := range bogus {
+		pm := PodManifest{}
+		if pm.UnmarshalJSON([]byte(str)) == nil {
+			t.Errorf("bogus pod manifest unmarshalled successfully: %s", str)
+		}
+	}
+}
+
+// podJ returns a pod manifest JSON with given apps
+func podJ(apps, extra string) string {
+	return `
+		{
+		    ` + extra + `
+		    "acKind": "PodManifest",
+		    "acVersion": "0.6.1",
+		    "apps": [` + apps + `]
+		}`
+}
+
+// podI returns a pod manifest instance with given apps
+func podI(apps AppList) PodManifest {
+	return PodManifest{
+		ACVersion: "0.6.1",
+		ACKind:    "PodManifest",
+		Apps:      apps,
+	}
+}
+
+// appJ returns an app JSON snippet with given name and image
+func appJ(name, image, extra string) string {
+	return `
+		{
+		    ` + extra + `
+		    "name": "` + name + `",
+		    "image": ` + image + `
+		}`
+}
+
+// appI returns an app instance with given name and image
+func appI(name string, image Image) RuntimeApp {
+	return RuntimeApp{
+		Name:  name,
+		Image: image,
+	}
+}
+
+// imgJ returns an image JSON snippet with given name and id
+func imgJ(name, id, extra string) string {
+	return `
+		{
+		    ` + extra + `
+		    "name": "` + name + `",
+		    "id": "` + id + `"
+		}`
+}
+
+// imgI returns an image instance with given name and id
+func imgI(name, id string) Image {
+	return Image{
+		Name: name,
+		ID:   id,
+	}
+}

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_resources.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_resources.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
+	"github.com/coreos/rkt/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource"
 )
 
 var (

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_test.go
@@ -98,7 +98,7 @@ func TestIsolatorUnmarshal(t *testing.T) {
 		{
 			`{
 				"name": "resource/cpu",
-				"value": {"request": "30", "limit": "1"}
+				"value": {"request": "30m", "limit": "1m"}
 			}`,
 			false,
 		},
@@ -153,7 +153,7 @@ func TestIsolatorsGetByName(t *testing.T) {
 		[
 			{
 				"name": "resource/cpu",
-				"value": {"request": "30", "limit": "1"}
+				"value": {"request": "30m", "limit": "1m"}
 			},
 			{
 				"name": "resource/memory",
@@ -202,9 +202,21 @@ func TestIsolatorsGetByName(t *testing.T) {
 			var r Resource = v
 			glimit := r.Limit()
 			grequest := r.Request()
-			if glimit.Value() != tt.wlimit || grequest.Value() != tt.wrequest {
-				t.Errorf("#%d: glimit=%v, want %v, grequest=%v, want %v", i, glimit.Value(), tt.wlimit, grequest.Value(), tt.wrequest)
+
+			var vlimit, vrequest int64
+			if tt.name == "resource/cpu" {
+				vlimit, vrequest = glimit.MilliValue(), grequest.MilliValue()
+			} else {
+				vlimit, vrequest = glimit.Value(), grequest.Value()
 			}
+
+			if vlimit != tt.wlimit {
+				t.Errorf("#%d: glimit=%v, want %v", i, vlimit, tt.wlimit)
+			}
+			if vrequest != tt.wrequest {
+				t.Errorf("#%d: grequest=%v, want %v", i, vrequest, tt.wrequest)
+			}
+
 		case LinuxCapabilitiesSet:
 			var s LinuxCapabilitiesSet = v
 			if !reflect.DeepEqual(s.Set(), tt.wset) {

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/semver.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/semver.go
@@ -44,6 +44,21 @@ func NewSemVer(s string) (*SemVer, error) {
 	return &v, nil
 }
 
+func (sv SemVer) LessThanMajor(versionB SemVer) bool {
+	majorA := semver.Version(sv).Major
+	majorB := semver.Version(versionB).Major
+	if majorA < majorB {
+		return true
+	}
+	return false
+}
+
+func (sv SemVer) LessThanExact(versionB SemVer) bool {
+	vA := semver.Version(sv)
+	vB := semver.Version(versionB)
+	return vA.LessThan(vB)
+}
+
 func (sv SemVer) String() string {
 	s := semver.Version(sv)
 	return s.String()

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/version.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/version.go
@@ -22,7 +22,7 @@ const (
 	// version represents the canonical version of the appc spec and tooling.
 	// For now, the schema and tooling is coupled with the spec itself, so
 	// this must be kept in sync with the VERSION file in the root of the repo.
-	version string = "0.6.1"
+	version string = "0.6.1+git"
 )
 
 var (

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource/quantity.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource/quantity.go
@@ -1,0 +1,429 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"regexp"
+	"strings"
+
+	flag "github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/pflag"
+	"github.com/coreos/rkt/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf"
+)
+
+// Quantity is a fixed-point representation of a number.
+// It provides convenient marshaling/unmarshaling in JSON and YAML,
+// in addition to String() and Int64() accessors.
+//
+// The serialization format is:
+//
+// <quantity>        ::= <signedNumber><suffix>
+//   (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+// <digit>           ::= 0 | 1 | ... | 9
+// <digits>          ::= <digit> | <digit><digits>
+// <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits>
+// <sign>            ::= "+" | "-"
+// <signedNumber>    ::= <number> | <sign><number>
+// <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI>
+// <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+//   (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+// <decimalSI>       ::= m | "" | k | M | G | T | P | E
+//   (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+// <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+//
+// No matter which of the three exponent forms is used, no quantity may represent
+// a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal
+// places. Numbers larger or more precise will be capped or rounded up.
+// (E.g.: 0.1m will rounded up to 1m.)
+// This may be extended in the future if we require larger or smaller quantities.
+//
+// When a Quantity is parsed from a string, it will remember the type of suffix
+// it had, and will use the same type again when it is serialized.
+//
+// Before serializing, Quantity will be put in "canonical form".
+// This means that Exponent/suffix will be adjusted up or down (with a
+// corresponding increase or decrease in Mantissa) such that:
+//   a. No precision is lost
+//   b. No fractional digits will be emitted
+//   c. The exponent (or suffix) is as large as possible.
+// The sign will be omitted unless the number is negative.
+//
+// Examples:
+//   1.5 will be serialized as "1500m"
+//   1.5Gi will be serialized as "1536Mi"
+//
+// NOTE: We reserve the right to amend this canonical format, perhaps to
+//   allow 1.5 to be canonical.
+// TODO: Remove above disclaimer after all bikeshedding about format is over,
+//   or after March 2015.
+//
+// Note that the quantity will NEVER be internally represented by a
+// floating point number. That is the whole point of this exercise.
+//
+// Non-canonical values will still parse as long as they are well formed,
+// but will be re-emitted in their canonical form. (So always use canonical
+// form, or don't diff.)
+//
+// This format is intended to make it difficult to use these numbers without
+// writing some sort of special handling code in the hopes that that will
+// cause implementors to also use a fixed point implementation.
+type Quantity struct {
+	// Amount is public, so you can manipulate it if the accessor
+	// functions are not sufficient.
+	Amount *inf.Dec
+
+	// Change Format at will. See the comment for Canonicalize for
+	// more details.
+	Format
+}
+
+// Format lists the three possible formattings of a quantity.
+type Format string
+
+const (
+	DecimalExponent = Format("DecimalExponent") // e.g., 12e6
+	BinarySI        = Format("BinarySI")        // e.g., 12Mi (12 * 2^20)
+	DecimalSI       = Format("DecimalSI")       // e.g., 12M  (12 * 10^6)
+)
+
+// MustParse turns the given string into a quantity or panics; for tests
+// or others cases where you know the string is valid.
+func MustParse(str string) Quantity {
+	q, err := ParseQuantity(str)
+	if err != nil {
+		panic(fmt.Errorf("cannot parse '%v': %v", str, err))
+	}
+	return *q
+}
+
+const (
+	// splitREString is used to separate a number from its suffix; as such,
+	// this is overly permissive, but that's OK-- it will be checked later.
+	splitREString = "^([+-]?[0-9.]+)([eEimkKMGTP]*[-+]?[0-9]*)$"
+)
+
+var (
+	// splitRE is used to get the various parts of a number.
+	splitRE = regexp.MustCompile(splitREString)
+
+	// Errors that could happen while parsing a string.
+	ErrFormatWrong = errors.New("quantities must match the regular expression '" + splitREString + "'")
+	ErrNumeric     = errors.New("unable to parse numeric part of quantity")
+	ErrSuffix      = errors.New("unable to parse quantity's suffix")
+
+	// Commonly needed big.Int values-- treat as read only!
+	bigTen      = big.NewInt(10)
+	bigZero     = big.NewInt(0)
+	bigOne      = big.NewInt(1)
+	bigThousand = big.NewInt(1000)
+	big1024     = big.NewInt(1024)
+
+	// Commonly needed inf.Dec values-- treat as read only!
+	decZero      = inf.NewDec(0, 0)
+	decOne       = inf.NewDec(1, 0)
+	decMinusOne  = inf.NewDec(-1, 0)
+	decThousand  = inf.NewDec(1000, 0)
+	dec1024      = inf.NewDec(1024, 0)
+	decMinus1024 = inf.NewDec(-1024, 0)
+
+	// Largest (in magnitude) number allowed.
+	maxAllowed = inf.NewDec((1<<63)-1, 0) // == max int64
+
+	// The maximum value we can represent milli-units for.
+	// Compare with the return value of Quantity.Value() to
+	// see if it's safe to use Quantity.MilliValue().
+	MaxMilliValue = int64(((1 << 63) - 1) / 1000)
+)
+
+// ParseQuantity turns str into a Quantity, or returns an error.
+func ParseQuantity(str string) (*Quantity, error) {
+	parts := splitRE.FindStringSubmatch(strings.TrimSpace(str))
+	// regexp returns are entire match, followed by an entry for each () section.
+	if len(parts) != 3 {
+		return nil, ErrFormatWrong
+	}
+
+	amount := new(inf.Dec)
+	if _, ok := amount.SetString(parts[1]); !ok {
+		return nil, ErrNumeric
+	}
+
+	base, exponent, format, ok := quantitySuffixer.interpret(suffix(parts[2]))
+	if !ok {
+		return nil, ErrSuffix
+	}
+
+	// So that no one but us has to think about suffixes, remove it.
+	if base == 10 {
+		amount.SetScale(amount.Scale() + inf.Scale(-exponent))
+	} else if base == 2 {
+		// numericSuffix = 2 ** exponent
+		numericSuffix := big.NewInt(1).Lsh(bigOne, uint(exponent))
+		ub := amount.UnscaledBig()
+		amount.SetUnscaledBig(ub.Mul(ub, numericSuffix))
+	}
+
+	// Cap at min/max bounds.
+	sign := amount.Sign()
+	if sign == -1 {
+		amount.Neg(amount)
+	}
+	// This rounds non-zero values up to the minimum representable
+	// value, under the theory that if you want some resources, you
+	// should get some resources, even if you asked for way too small
+	// of an amount.
+	// Arguably, this should be inf.RoundHalfUp (normal rounding), but
+	// that would have the side effect of rounding values < .5m to zero.
+	if v, ok := amount.Unscaled(); v != int64(0) || !ok {
+		amount.Round(amount, 3, inf.RoundUp)
+	}
+
+	// The max is just a simple cap.
+	if amount.Cmp(maxAllowed) > 0 {
+		amount.Set(maxAllowed)
+	}
+	if format == BinarySI && amount.Cmp(decOne) < 0 && amount.Cmp(decZero) > 0 {
+		// This avoids rounding and hopefully confusion, too.
+		format = DecimalSI
+	}
+	if sign == -1 {
+		amount.Neg(amount)
+	}
+
+	return &Quantity{amount, format}, nil
+}
+
+// removeFactors divides in a loop; the return values have the property that
+// d == result * factor ^ times
+// d may be modified in place.
+// If d == 0, then the return values will be (0, 0)
+func removeFactors(d, factor *big.Int) (result *big.Int, times int) {
+	q := big.NewInt(0)
+	m := big.NewInt(0)
+	for d.Cmp(bigZero) != 0 {
+		q.DivMod(d, factor, m)
+		if m.Cmp(bigZero) != 0 {
+			break
+		}
+		times++
+		d, q = q, d
+	}
+	return d, times
+}
+
+// Canonicalize returns the canonical form of q and its suffix (see comment on Quantity).
+//
+// Note about BinarySI:
+// * If q.Format is set to BinarySI and q.Amount represents a non-zero value between
+//   -1 and +1, it will be emitted as if q.Format were DecimalSI.
+// * Otherwise, if q.Format is set to BinarySI, frational parts of q.Amount will be
+//   rounded up. (1.1i becomes 2i.)
+func (q *Quantity) Canonicalize() (string, suffix) {
+	if q.Amount == nil {
+		return "0", ""
+	}
+
+	// zero is zero always
+	if q.Amount.Cmp(&inf.Dec{}) == 0 {
+		return "0", ""
+	}
+
+	format := q.Format
+	switch format {
+	case DecimalExponent, DecimalSI:
+	case BinarySI:
+		if q.Amount.Cmp(decMinus1024) > 0 && q.Amount.Cmp(dec1024) < 0 {
+			// This avoids rounding and hopefully confusion, too.
+			format = DecimalSI
+		} else {
+			tmp := &inf.Dec{}
+			tmp.Round(q.Amount, 0, inf.RoundUp)
+			if tmp.Cmp(q.Amount) != 0 {
+				// Don't lose precision-- show as DecimalSI
+				format = DecimalSI
+			}
+		}
+	default:
+		format = DecimalExponent
+	}
+
+	// TODO: If BinarySI formatting is requested but would cause rounding, upgrade to
+	// one of the other formats.
+	switch format {
+	case DecimalExponent, DecimalSI:
+		mantissa := q.Amount.UnscaledBig()
+		exponent := int(-q.Amount.Scale())
+		amount := big.NewInt(0).Set(mantissa)
+		// move all factors of 10 into the exponent for easy reasoning
+		amount, times := removeFactors(amount, bigTen)
+		exponent += times
+
+		// make sure exponent is a multiple of 3
+		for exponent%3 != 0 {
+			amount.Mul(amount, bigTen)
+			exponent--
+		}
+
+		suffix, _ := quantitySuffixer.construct(10, exponent, format)
+		number := amount.String()
+		return number, suffix
+	case BinarySI:
+		tmp := &inf.Dec{}
+		tmp.Round(q.Amount, 0, inf.RoundUp)
+
+		amount, exponent := removeFactors(tmp.UnscaledBig(), big1024)
+		suffix, _ := quantitySuffixer.construct(2, exponent*10, format)
+		number := amount.String()
+		return number, suffix
+	}
+	return "0", ""
+}
+
+// String formats the Quantity as a string.
+func (q *Quantity) String() string {
+	number, suffix := q.Canonicalize()
+	return number + string(suffix)
+}
+
+// MarshalJSON implements the json.Marshaller interface.
+func (q Quantity) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + q.String() + `"`), nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface.
+func (q *Quantity) UnmarshalJSON(value []byte) error {
+	str := string(value)
+	parsed, err := ParseQuantity(strings.Trim(str, `"`))
+	if err != nil {
+		return err
+	}
+	// This copy is safe because parsed will not be referred to again.
+	*q = *parsed
+	return nil
+}
+
+// NewQuantity returns a new Quantity representing the given
+// value in the given format.
+func NewQuantity(value int64, format Format) *Quantity {
+	return &Quantity{
+		Amount: inf.NewDec(value, 0),
+		Format: format,
+	}
+}
+
+// NewMilliQuantity returns a new Quantity representing the given
+// value * 1/1000 in the given format. Note that BinarySI formatting
+// will round fractional values, and will be changed to DecimalSI for
+// values x where (-1 < x < 1) && (x != 0).
+func NewMilliQuantity(value int64, format Format) *Quantity {
+	return &Quantity{
+		Amount: inf.NewDec(value, 3),
+		Format: format,
+	}
+}
+
+// Value returns the value of q; any fractional part will be lost.
+func (q *Quantity) Value() int64 {
+	if q.Amount == nil {
+		return 0
+	}
+	tmp := &inf.Dec{}
+	return tmp.Round(q.Amount, 0, inf.RoundUp).UnscaledBig().Int64()
+}
+
+// MilliValue returns the value of q * 1000; this could overflow an int64;
+// if that's a concern, call Value() first to verify the number is small enough.
+func (q *Quantity) MilliValue() int64 {
+	if q.Amount == nil {
+		return 0
+	}
+	tmp := &inf.Dec{}
+	return tmp.Round(tmp.Mul(q.Amount, decThousand), 0, inf.RoundUp).UnscaledBig().Int64()
+}
+
+// Set sets q's value to be value.
+func (q *Quantity) Set(value int64) {
+	if q.Amount == nil {
+		q.Amount = &inf.Dec{}
+	}
+	q.Amount.SetUnscaled(value)
+	q.Amount.SetScale(0)
+}
+
+// SetMilli sets q's value to be value * 1/1000.
+func (q *Quantity) SetMilli(value int64) {
+	if q.Amount == nil {
+		q.Amount = &inf.Dec{}
+	}
+	q.Amount.SetUnscaled(value)
+	q.Amount.SetScale(3)
+}
+
+// Copy is a convenience function that makes a deep copy for you. Non-deep
+// copies of quantities share pointers and you will regret that.
+func (q *Quantity) Copy() *Quantity {
+	if q.Amount == nil {
+		return NewQuantity(0, q.Format)
+	}
+	tmp := &inf.Dec{}
+	return &Quantity{
+		Amount: tmp.Set(q.Amount),
+		Format: q.Format,
+	}
+}
+
+// qFlag is a helper type for the Flag function
+type qFlag struct {
+	dest *Quantity
+}
+
+// Sets the value of the internal Quantity. (used by flag & pflag)
+func (qf qFlag) Set(val string) error {
+	q, err := ParseQuantity(val)
+	if err != nil {
+		return err
+	}
+	// This copy is OK because q will not be referenced again.
+	*qf.dest = *q
+	return nil
+}
+
+// Converts the value of the internal Quantity to a string. (used by flag & pflag)
+func (qf qFlag) String() string {
+	return qf.dest.String()
+}
+
+// States the type of flag this is (Quantity). (used by pflag)
+func (qf qFlag) Type() string {
+	return "quantity"
+}
+
+// QuantityFlag is a helper that makes a quantity flag (using standard flag package).
+// Will panic if defaultValue is not a valid quantity.
+func QuantityFlag(flagName, defaultValue, description string) *Quantity {
+	q := MustParse(defaultValue)
+	flag.Var(NewQuantityFlagValue(&q), flagName, description)
+	return &q
+}
+
+// NewQuantityFlagValue returns an object that can be used to back a flag,
+// pointing at the given Quantity variable.
+func NewQuantityFlagValue(q *Quantity) flag.Value {
+	return qFlag{q}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource/quantity_example_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource/quantity_example_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource_test
+
+import (
+	"fmt"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/api/resource"
+)
+
+func ExampleFormat() {
+	memorySize := resource.NewQuantity(5*1024*1024*1024, resource.BinarySI)
+	fmt.Printf("memorySize = %v\n", memorySize)
+
+	diskSize := resource.NewQuantity(5*1000*1000*1000, resource.DecimalSI)
+	fmt.Printf("diskSize = %v\n", diskSize)
+
+	cores := resource.NewMilliQuantity(5300, resource.DecimalSI)
+	fmt.Printf("cores = %v\n", cores)
+
+	// Output:
+	// memorySize = 5Gi
+	// diskSize = 5G
+	// cores = 5300m
+}
+
+func ExampleMustParse() {
+	memorySize := resource.MustParse("5Gi")
+	fmt.Printf("memorySize = %v (%v)\n", memorySize.Value(), memorySize.Format)
+
+	diskSize := resource.MustParse("5G")
+	fmt.Printf("diskSize = %v (%v)\n", diskSize.Value(), diskSize.Format)
+
+	cores := resource.MustParse("5300m")
+	fmt.Printf("milliCores = %v (%v)\n", cores.MilliValue(), cores.Format)
+
+	cores2 := resource.MustParse("5.4")
+	fmt.Printf("milliCores = %v (%v)\n", cores2.MilliValue(), cores2.Format)
+
+	// Output:
+	// memorySize = 5368709120 (BinarySI)
+	// diskSize = 5000000000 (DecimalSI)
+	// milliCores = 5300 (DecimalSI)
+	// milliCores = 5400 (DecimalSI)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource/quantity_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource/quantity_test.go
@@ -1,0 +1,517 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	//"reflect"
+	"encoding/json"
+	"testing"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/pflag"
+	"github.com/coreos/rkt/Godeps/_workspace/src/speter.net/go/exp/math/dec/inf"
+	fuzz "github.com/google/gofuzz"
+)
+
+var (
+	testQuantityFlag = QuantityFlag("quantityFlag", "1M", "dummy flag for testing the quantity flag mechanism")
+)
+
+func dec(i int64, exponent int) *inf.Dec {
+	// See the below test-- scale is the negative of an exponent.
+	return inf.NewDec(i, inf.Scale(-exponent))
+}
+
+func TestDec(t *testing.T) {
+	table := []struct {
+		got    *inf.Dec
+		expect string
+	}{
+		{dec(1, 0), "1"},
+		{dec(1, 1), "10"},
+		{dec(5, 2), "500"},
+		{dec(8, 3), "8000"},
+		{dec(2, 0), "2"},
+		{dec(1, -1), "0.1"},
+		{dec(3, -2), "0.03"},
+		{dec(4, -3), "0.004"},
+	}
+
+	for _, item := range table {
+		if e, a := item.expect, item.got.String(); e != a {
+			t.Errorf("expected %v, got %v", e, a)
+		}
+	}
+}
+
+// TestQuantityParseZero ensures that when a 0 quantity is passed, its string value is 0
+func TestQuantityParseZero(t *testing.T) {
+	zero := MustParse("0")
+	if expected, actual := "0", zero.String(); expected != actual {
+		t.Errorf("Expected %v, actual %v", expected, actual)
+	}
+}
+
+// Verifies that you get 0 as canonical value if internal value is 0, and not 0<suffix>
+func TestQuantityCanocicalizeZero(t *testing.T) {
+	val := MustParse("1000m")
+	x := val.Amount
+	y := dec(1, 0)
+	z := val.Amount.Sub(x, y)
+	zero := Quantity{z, DecimalSI}
+	if expected, actual := "0", zero.String(); expected != actual {
+		t.Errorf("Expected %v, actual %v", expected, actual)
+	}
+}
+
+func TestQuantityParse(t *testing.T) {
+	table := []struct {
+		input  string
+		expect Quantity
+	}{
+		{"0", Quantity{dec(0, 0), DecimalSI}},
+		{"0m", Quantity{dec(0, 0), DecimalSI}},
+		{"0Ki", Quantity{dec(0, 0), BinarySI}},
+		{"0k", Quantity{dec(0, 0), DecimalSI}},
+		{"0Mi", Quantity{dec(0, 0), BinarySI}},
+		{"0M", Quantity{dec(0, 0), DecimalSI}},
+		{"0Gi", Quantity{dec(0, 0), BinarySI}},
+		{"0G", Quantity{dec(0, 0), DecimalSI}},
+		{"0Ti", Quantity{dec(0, 0), BinarySI}},
+		{"0T", Quantity{dec(0, 0), DecimalSI}},
+
+		// Binary suffixes
+		{"1Ki", Quantity{dec(1024, 0), BinarySI}},
+		{"8Ki", Quantity{dec(8*1024, 0), BinarySI}},
+		{"7Mi", Quantity{dec(7*1024*1024, 0), BinarySI}},
+		{"6Gi", Quantity{dec(6*1024*1024*1024, 0), BinarySI}},
+		{"5Ti", Quantity{dec(5*1024*1024*1024*1024, 0), BinarySI}},
+		{"4Pi", Quantity{dec(4*1024*1024*1024*1024*1024, 0), BinarySI}},
+		{"3Ei", Quantity{dec(3*1024*1024*1024*1024*1024*1024, 0), BinarySI}},
+
+		{"10Ti", Quantity{dec(10*1024*1024*1024*1024, 0), BinarySI}},
+		{"100Ti", Quantity{dec(100*1024*1024*1024*1024, 0), BinarySI}},
+
+		// Decimal suffixes
+		{"3m", Quantity{dec(3, -3), DecimalSI}},
+		{"9", Quantity{dec(9, 0), DecimalSI}},
+		{"8k", Quantity{dec(8, 3), DecimalSI}},
+		{"7M", Quantity{dec(7, 6), DecimalSI}},
+		{"6G", Quantity{dec(6, 9), DecimalSI}},
+		{"5T", Quantity{dec(5, 12), DecimalSI}},
+		{"40T", Quantity{dec(4, 13), DecimalSI}},
+		{"300T", Quantity{dec(3, 14), DecimalSI}},
+		{"2P", Quantity{dec(2, 15), DecimalSI}},
+		{"1E", Quantity{dec(1, 18), DecimalSI}},
+
+		// Decimal exponents
+		{"1E-3", Quantity{dec(1, -3), DecimalExponent}},
+		{"1e3", Quantity{dec(1, 3), DecimalExponent}},
+		{"1E6", Quantity{dec(1, 6), DecimalExponent}},
+		{"1e9", Quantity{dec(1, 9), DecimalExponent}},
+		{"1E12", Quantity{dec(1, 12), DecimalExponent}},
+		{"1e15", Quantity{dec(1, 15), DecimalExponent}},
+		{"1E18", Quantity{dec(1, 18), DecimalExponent}},
+
+		// Nonstandard but still parsable
+		{"1e14", Quantity{dec(1, 14), DecimalExponent}},
+		{"1e13", Quantity{dec(1, 13), DecimalExponent}},
+		{"1e3", Quantity{dec(1, 3), DecimalExponent}},
+		{"100.035k", Quantity{dec(100035, 0), DecimalSI}},
+
+		// Things that look like floating point
+		{"0.001", Quantity{dec(1, -3), DecimalSI}},
+		{"0.0005k", Quantity{dec(5, -1), DecimalSI}},
+		{"0.005", Quantity{dec(5, -3), DecimalSI}},
+		{"0.05", Quantity{dec(5, -2), DecimalSI}},
+		{"0.5", Quantity{dec(5, -1), DecimalSI}},
+		{"0.00050k", Quantity{dec(5, -1), DecimalSI}},
+		{"0.00500", Quantity{dec(5, -3), DecimalSI}},
+		{"0.05000", Quantity{dec(5, -2), DecimalSI}},
+		{"0.50000", Quantity{dec(5, -1), DecimalSI}},
+		{"0.5e0", Quantity{dec(5, -1), DecimalExponent}},
+		{"0.5e-1", Quantity{dec(5, -2), DecimalExponent}},
+		{"0.5e-2", Quantity{dec(5, -3), DecimalExponent}},
+		{"0.5e0", Quantity{dec(5, -1), DecimalExponent}},
+		{"10.035M", Quantity{dec(10035, 3), DecimalSI}},
+
+		{"1.2e3", Quantity{dec(12, 2), DecimalExponent}},
+		{"1.3E+6", Quantity{dec(13, 5), DecimalExponent}},
+		{"1.40e9", Quantity{dec(14, 8), DecimalExponent}},
+		{"1.53E12", Quantity{dec(153, 10), DecimalExponent}},
+		{"1.6e15", Quantity{dec(16, 14), DecimalExponent}},
+		{"1.7E18", Quantity{dec(17, 17), DecimalExponent}},
+
+		{"9.01", Quantity{dec(901, -2), DecimalSI}},
+		{"8.1k", Quantity{dec(81, 2), DecimalSI}},
+		{"7.123456M", Quantity{dec(7123456, 0), DecimalSI}},
+		{"6.987654321G", Quantity{dec(6987654321, 0), DecimalSI}},
+		{"5.444T", Quantity{dec(5444, 9), DecimalSI}},
+		{"40.1T", Quantity{dec(401, 11), DecimalSI}},
+		{"300.2T", Quantity{dec(3002, 11), DecimalSI}},
+		{"2.5P", Quantity{dec(25, 14), DecimalSI}},
+		{"1.01E", Quantity{dec(101, 16), DecimalSI}},
+
+		// Things that saturate/round
+		{"3.001m", Quantity{dec(4, -3), DecimalSI}},
+		{"1.1E-3", Quantity{dec(2, -3), DecimalExponent}},
+		{"0.0001", Quantity{dec(1, -3), DecimalSI}},
+		{"0.0005", Quantity{dec(1, -3), DecimalSI}},
+		{"0.00050", Quantity{dec(1, -3), DecimalSI}},
+		{"0.5e-3", Quantity{dec(1, -3), DecimalExponent}},
+		{"0.9m", Quantity{dec(1, -3), DecimalSI}},
+		{"0.12345", Quantity{dec(124, -3), DecimalSI}},
+		{"0.12354", Quantity{dec(124, -3), DecimalSI}},
+		{"9Ei", Quantity{maxAllowed, BinarySI}},
+		{"9223372036854775807Ki", Quantity{maxAllowed, BinarySI}},
+		{"12E", Quantity{maxAllowed, DecimalSI}},
+
+		// We'll accept fractional binary stuff, too.
+		{"100.035Ki", Quantity{dec(10243584, -2), BinarySI}},
+		{"0.5Mi", Quantity{dec(.5*1024*1024, 0), BinarySI}},
+		{"0.05Gi", Quantity{dec(536870912, -1), BinarySI}},
+		{"0.025Ti", Quantity{dec(274877906944, -1), BinarySI}},
+
+		// Things written by trolls
+		{"0.000001Ki", Quantity{dec(2, -3), DecimalSI}}, // rounds up, changes format
+		{".001", Quantity{dec(1, -3), DecimalSI}},
+		{".0001k", Quantity{dec(100, -3), DecimalSI}},
+		{"1.", Quantity{dec(1, 0), DecimalSI}},
+		{"1.G", Quantity{dec(1, 9), DecimalSI}},
+	}
+
+	for _, item := range table {
+		got, err := ParseQuantity(item.input)
+		if err != nil {
+			t.Errorf("%v: unexpected error: %v", item.input, err)
+			continue
+		}
+		if e, a := item.expect.Amount, got.Amount; e.Cmp(a) != 0 {
+			t.Errorf("%v: expected %v, got %v", item.input, e, a)
+		}
+		if e, a := item.expect.Format, got.Format; e != a {
+			t.Errorf("%v: expected %#v, got %#v", item.input, e, a)
+		}
+	}
+
+	// Try the negative version of everything
+	desired := &inf.Dec{}
+	for _, item := range table {
+		got, err := ParseQuantity("-" + item.input)
+		if err != nil {
+			t.Errorf("-%v: unexpected error: %v", item.input, err)
+			continue
+		}
+		desired.Neg(item.expect.Amount)
+		if e, a := desired, got.Amount; e.Cmp(a) != 0 {
+			t.Errorf("%v: expected %v, got %v", item.input, e, a)
+		}
+		if e, a := item.expect.Format, got.Format; e != a {
+			t.Errorf("%v: expected %#v, got %#v", item.input, e, a)
+		}
+	}
+
+	// Try everything with an explicit +
+	for _, item := range table {
+		got, err := ParseQuantity("+" + item.input)
+		if err != nil {
+			t.Errorf("-%v: unexpected error: %v", item.input, err)
+			continue
+		}
+		if e, a := item.expect.Amount, got.Amount; e.Cmp(a) != 0 {
+			t.Errorf("%v: expected %v, got %v", item.input, e, a)
+		}
+		if e, a := item.expect.Format, got.Format; e != a {
+			t.Errorf("%v: expected %#v, got %#v", item.input, e, a)
+		}
+	}
+
+	invalid := []string{
+		"1.1.M",
+		"1+1.0M",
+		"0.1mi",
+		"0.1am",
+		"aoeu",
+		".5i",
+		"1i",
+		"-3.01i",
+	}
+	for _, item := range invalid {
+		_, err := ParseQuantity(item)
+		if err == nil {
+			t.Errorf("%v parsed unexpectedly", item)
+		}
+	}
+}
+
+func TestQuantityString(t *testing.T) {
+	table := []struct {
+		in     Quantity
+		expect string
+	}{
+		{Quantity{dec(1024*1024*1024, 0), BinarySI}, "1Gi"},
+		{Quantity{dec(300*1024*1024, 0), BinarySI}, "300Mi"},
+		{Quantity{dec(6*1024, 0), BinarySI}, "6Ki"},
+		{Quantity{dec(1001*1024*1024*1024, 0), BinarySI}, "1001Gi"},
+		{Quantity{dec(1024*1024*1024*1024, 0), BinarySI}, "1Ti"},
+		{Quantity{dec(5, 0), BinarySI}, "5"},
+		{Quantity{dec(500, -3), BinarySI}, "500m"},
+		{Quantity{dec(1, 9), DecimalSI}, "1G"},
+		{Quantity{dec(1000, 6), DecimalSI}, "1G"},
+		{Quantity{dec(1000000, 3), DecimalSI}, "1G"},
+		{Quantity{dec(1000000000, 0), DecimalSI}, "1G"},
+		{Quantity{dec(1, -3), DecimalSI}, "1m"},
+		{Quantity{dec(80, -3), DecimalSI}, "80m"},
+		{Quantity{dec(1080, -3), DecimalSI}, "1080m"},
+		{Quantity{dec(108, -2), DecimalSI}, "1080m"},
+		{Quantity{dec(10800, -4), DecimalSI}, "1080m"},
+		{Quantity{dec(300, 6), DecimalSI}, "300M"},
+		{Quantity{dec(1, 12), DecimalSI}, "1T"},
+		{Quantity{dec(1234567, 6), DecimalSI}, "1234567M"},
+		{Quantity{dec(1234567, -3), BinarySI}, "1234567m"},
+		{Quantity{dec(3, 3), DecimalSI}, "3k"},
+		{Quantity{dec(1025, 0), BinarySI}, "1025"},
+		{Quantity{dec(0, 0), DecimalSI}, "0"},
+		{Quantity{dec(0, 0), BinarySI}, "0"},
+		{Quantity{dec(1, 9), DecimalExponent}, "1e9"},
+		{Quantity{dec(1, -3), DecimalExponent}, "1e-3"},
+		{Quantity{dec(80, -3), DecimalExponent}, "80e-3"},
+		{Quantity{dec(300, 6), DecimalExponent}, "300e6"},
+		{Quantity{dec(1, 12), DecimalExponent}, "1e12"},
+		{Quantity{dec(1, 3), DecimalExponent}, "1e3"},
+		{Quantity{dec(3, 3), DecimalExponent}, "3e3"},
+		{Quantity{dec(3, 3), DecimalSI}, "3k"},
+		{Quantity{dec(0, 0), DecimalExponent}, "0"},
+	}
+	for _, item := range table {
+		got := item.in.String()
+		if e, a := item.expect, got; e != a {
+			t.Errorf("%#v: expected %v, got %v", item.in, e, a)
+		}
+	}
+	desired := &inf.Dec{} // Avoid modifying the values in the table.
+	for _, item := range table {
+		if item.in.Amount.Cmp(decZero) == 0 {
+			// Don't expect it to print "-0" ever
+			continue
+		}
+		q := item.in
+		q.Amount = desired.Neg(q.Amount)
+		if e, a := "-"+item.expect, q.String(); e != a {
+			t.Errorf("%#v: expected %v, got %v", item.in, e, a)
+		}
+	}
+}
+
+func TestQuantityParseEmit(t *testing.T) {
+	table := []struct {
+		in     string
+		expect string
+	}{
+		{"1Ki", "1Ki"},
+		{"1Mi", "1Mi"},
+		{"1Gi", "1Gi"},
+		{"1024Mi", "1Gi"},
+		{"1000M", "1G"},
+		{".000001Ki", "2m"},
+	}
+
+	for _, item := range table {
+		q, err := ParseQuantity(item.in)
+		if err != nil {
+			t.Errorf("Couldn't parse %v", item.in)
+			continue
+		}
+		if e, a := item.expect, q.String(); e != a {
+			t.Errorf("%#v: expected %v, got %v", item.in, e, a)
+		}
+	}
+	for _, item := range table {
+		q, err := ParseQuantity("-" + item.in)
+		if err != nil {
+			t.Errorf("Couldn't parse %v", item.in)
+			continue
+		}
+		if q.Amount.Cmp(decZero) == 0 {
+			continue
+		}
+		if e, a := "-"+item.expect, q.String(); e != a {
+			t.Errorf("%#v: expected %v, got %v", item.in, e, a)
+		}
+	}
+}
+
+var fuzzer = fuzz.New().Funcs(
+	func(q *Quantity, c fuzz.Continue) {
+		q.Amount = &inf.Dec{}
+		if c.RandBool() {
+			q.Format = BinarySI
+			if c.RandBool() {
+				q.Amount.SetScale(0)
+				q.Amount.SetUnscaled(c.Int63())
+				return
+			}
+			// Be sure to test cases like 1Mi
+			q.Amount.SetScale(0)
+			q.Amount.SetUnscaled(c.Int63n(1024) << uint(10*c.Intn(5)))
+			return
+		}
+		if c.RandBool() {
+			q.Format = DecimalSI
+		} else {
+			q.Format = DecimalExponent
+		}
+		if c.RandBool() {
+			q.Amount.SetScale(inf.Scale(c.Intn(4)))
+			q.Amount.SetUnscaled(c.Int63())
+			return
+		}
+		// Be sure to test cases like 1M
+		q.Amount.SetScale(inf.Scale(3 - c.Intn(15)))
+		q.Amount.SetUnscaled(c.Int63n(1000))
+	},
+)
+
+func TestJSON(t *testing.T) {
+	for i := 0; i < 500; i++ {
+		q := &Quantity{}
+		fuzzer.Fuzz(q)
+		b, err := json.Marshal(q)
+		if err != nil {
+			t.Errorf("error encoding %v", q)
+		}
+		q2 := &Quantity{}
+		err = json.Unmarshal(b, q2)
+		if err != nil {
+			t.Errorf("%v: error decoding %v", q, string(b))
+		}
+		if q2.Amount.Cmp(q.Amount) != 0 {
+			t.Errorf("Expected equal: %v, %v (json was '%v')", q, q2, string(b))
+		}
+	}
+}
+
+func TestMilliNewSet(t *testing.T) {
+	table := []struct {
+		value  int64
+		format Format
+		expect string
+		exact  bool
+	}{
+		{1, DecimalSI, "1m", true},
+		{1000, DecimalSI, "1", true},
+		{1234000, DecimalSI, "1234", true},
+		{1024, BinarySI, "1024m", false}, // Format changes
+		{1000000, "invalidFormatDefaultsToExponent", "1e3", true},
+		{1024 * 1024, BinarySI, "1048576m", false}, // Format changes
+	}
+
+	for _, item := range table {
+		q := NewMilliQuantity(item.value, item.format)
+		if e, a := item.expect, q.String(); e != a {
+			t.Errorf("Expected %v, got %v; %#v", e, a, q)
+		}
+		if !item.exact {
+			continue
+		}
+		q2, err := ParseQuantity(q.String())
+		if err != nil {
+			t.Errorf("Round trip failed on %v", q)
+		}
+		if e, a := item.value, q2.MilliValue(); e != a {
+			t.Errorf("Expected %v, got %v", e, a)
+		}
+	}
+
+	for _, item := range table {
+		q := NewQuantity(0, item.format)
+		q.SetMilli(item.value)
+		if e, a := item.expect, q.String(); e != a {
+			t.Errorf("Set: Expected %v, got %v; %#v", e, a, q)
+		}
+	}
+}
+
+func TestNewSet(t *testing.T) {
+	table := []struct {
+		value  int64
+		format Format
+		expect string
+	}{
+		{1, DecimalSI, "1"},
+		{1000, DecimalSI, "1k"},
+		{1234000, DecimalSI, "1234k"},
+		{1024, BinarySI, "1Ki"},
+		{1000000, "invalidFormatDefaultsToExponent", "1e6"},
+		{1024 * 1024, BinarySI, "1Mi"},
+	}
+
+	for _, item := range table {
+		q := NewQuantity(item.value, item.format)
+		if e, a := item.expect, q.String(); e != a {
+			t.Errorf("Expected %v, got %v; %#v", e, a, q)
+		}
+		q2, err := ParseQuantity(q.String())
+		if err != nil {
+			t.Errorf("Round trip failed on %v", q)
+		}
+		if e, a := item.value, q2.Value(); e != a {
+			t.Errorf("Expected %v, got %v", e, a)
+		}
+	}
+
+	for _, item := range table {
+		q := NewQuantity(0, item.format)
+		q.Set(item.value)
+		if e, a := item.expect, q.String(); e != a {
+			t.Errorf("Set: Expected %v, got %v; %#v", e, a, q)
+		}
+	}
+}
+
+func TestUninitializedNoCrash(t *testing.T) {
+	var q Quantity
+
+	q.Value()
+	q.MilliValue()
+	q.Copy()
+	q.String()
+	q.MarshalJSON()
+}
+
+func TestCopy(t *testing.T) {
+	q := NewQuantity(5, DecimalSI)
+	c := q.Copy()
+	c.Set(6)
+	if q.Value() == 6 {
+		t.Errorf("Copy didn't")
+	}
+}
+
+func TestQFlagSet(t *testing.T) {
+	qf := qFlag{&Quantity{}}
+	qf.Set("1Ki")
+	if e, a := "1Ki", qf.String(); e != a {
+		t.Errorf("Unexpected result %v != %v", e, a)
+	}
+}
+
+func TestQFlagIsPFlag(t *testing.T) {
+	var pfv pflag.Value = qFlag{}
+	if e, a := "quantity", pfv.Type(); e != a {
+		t.Errorf("Unexpected result %v != %v", e, a)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource/suffix.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/api/resource/suffix.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"strconv"
+)
+
+type suffix string
+
+// suffixer can interpret and construct suffixes.
+type suffixer interface {
+	interpret(suffix) (base, exponent int, fmt Format, ok bool)
+	construct(base, exponent int, fmt Format) (s suffix, ok bool)
+}
+
+// quantitySuffixer handles suffixes for all three formats that quantity
+// can handle.
+var quantitySuffixer = newSuffixer()
+
+type bePair struct {
+	base, exponent int
+}
+
+type listSuffixer struct {
+	suffixToBE map[suffix]bePair
+	beToSuffix map[bePair]suffix
+}
+
+func (ls *listSuffixer) addSuffix(s suffix, pair bePair) {
+	if ls.suffixToBE == nil {
+		ls.suffixToBE = map[suffix]bePair{}
+	}
+	if ls.beToSuffix == nil {
+		ls.beToSuffix = map[bePair]suffix{}
+	}
+	ls.suffixToBE[s] = pair
+	ls.beToSuffix[pair] = s
+}
+
+func (ls *listSuffixer) lookup(s suffix) (base, exponent int, ok bool) {
+	pair, ok := ls.suffixToBE[s]
+	if !ok {
+		return 0, 0, false
+	}
+	return pair.base, pair.exponent, true
+}
+
+func (ls *listSuffixer) construct(base, exponent int) (s suffix, ok bool) {
+	s, ok = ls.beToSuffix[bePair{base, exponent}]
+	return
+}
+
+type suffixHandler struct {
+	decSuffixes listSuffixer
+	binSuffixes listSuffixer
+}
+
+func newSuffixer() suffixer {
+	sh := &suffixHandler{}
+
+	sh.binSuffixes.addSuffix("Ki", bePair{2, 10})
+	sh.binSuffixes.addSuffix("Mi", bePair{2, 20})
+	sh.binSuffixes.addSuffix("Gi", bePair{2, 30})
+	sh.binSuffixes.addSuffix("Ti", bePair{2, 40})
+	sh.binSuffixes.addSuffix("Pi", bePair{2, 50})
+	sh.binSuffixes.addSuffix("Ei", bePair{2, 60})
+	// Don't emit an error when trying to produce
+	// a suffix for 2^0.
+	sh.decSuffixes.addSuffix("", bePair{2, 0})
+
+	sh.decSuffixes.addSuffix("m", bePair{10, -3})
+	sh.decSuffixes.addSuffix("", bePair{10, 0})
+	sh.decSuffixes.addSuffix("k", bePair{10, 3})
+	sh.decSuffixes.addSuffix("M", bePair{10, 6})
+	sh.decSuffixes.addSuffix("G", bePair{10, 9})
+	sh.decSuffixes.addSuffix("T", bePair{10, 12})
+	sh.decSuffixes.addSuffix("P", bePair{10, 15})
+	sh.decSuffixes.addSuffix("E", bePair{10, 18})
+
+	return sh
+}
+
+func (sh *suffixHandler) construct(base, exponent int, fmt Format) (s suffix, ok bool) {
+	switch fmt {
+	case DecimalSI:
+		return sh.decSuffixes.construct(base, exponent)
+	case BinarySI:
+		return sh.binSuffixes.construct(base, exponent)
+	case DecimalExponent:
+		if base != 10 {
+			return "", false
+		}
+		if exponent == 0 {
+			return "", true
+		}
+		return suffix("e" + strconv.FormatInt(int64(exponent), 10)), true
+	}
+	return "", false
+}
+
+func (sh *suffixHandler) interpret(suffix suffix) (base, exponent int, fmt Format, ok bool) {
+	// Try lookup tables first
+	if b, e, ok := sh.decSuffixes.lookup(suffix); ok {
+		return b, e, DecimalSI, true
+	}
+	if b, e, ok := sh.binSuffixes.lookup(suffix); ok {
+		return b, e, BinarySI, true
+	}
+
+	if len(suffix) > 1 && (suffix[0] == 'E' || suffix[0] == 'e') {
+		parsed, err := strconv.ParseInt(string(suffix[1:]), 10, 64)
+		if err != nil {
+			return 0, 0, DecimalExponent, false
+		}
+		return 10, int(parsed), DecimalExponent, true
+	}
+
+	return 0, 0, DecimalExponent, false
+}

--- a/store/store.go
+++ b/store/store.go
@@ -491,8 +491,8 @@ func (s Store) WriteRemote(remote *Remote) error {
 	return err
 }
 
-// Get the ImageManifest with the specified key.
-func (s Store) GetImageManifest(key string) (*schema.ImageManifest, error) {
+// Get the ImageManifest JSON bytes with the specified key.
+func (s Store) GetImageManifestJSON(key string) ([]byte, error) {
 	key, err := s.ResolveKey(key)
 	if err != nil {
 		return nil, fmt.Errorf("error resolving key: %v", err)
@@ -506,6 +506,15 @@ func (s Store) GetImageManifest(key string) (*schema.ImageManifest, error) {
 	imj, err := s.stores[imageManifestType].Read(key)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving image manifest: %v", err)
+	}
+	return imj, nil
+}
+
+// Get the ImageManifest with the specified key.
+func (s Store) GetImageManifest(key string) (*schema.ImageManifest, error) {
+	imj, err := s.GetImageManifestJSON(key)
+	if err != nil {
+		return nil, err
 	}
 	var im *schema.ImageManifest
 	if err = json.Unmarshal(imj, &im); err != nil {


### PR DESCRIPTION
DO NOT MERGE - pending on merge of last-ditch parser to appc/spec, on appc/spec and docker2aci release (because of compilation errors).

Example output of `rkt list`:
```
Unable to load manifest of pod 1ad35d47-34a4-4800-ac34-088f7a8f75ee: ACName must contain only lower case alphanumeric characters plus "-"
Invalid pod manifest - version: 0.7.0+git
  App: "!redis" from image "redis" (sha512-afe588bd39c1e5b6e85743d0fbfde921cc895eeee9e64dac8c31b4647a12577c)
Unable to load manifest of pod 22fc87d3-9c53-4b35-b83d-d3d19a865f9c: ACName must contain only lower case alphanumeric characters plus "-"
Invalid pod manifest - version: 0.7.0+git
  App: "busybox~" from image "busybox" (sha512-bf885104dc06468d8458c43d3f7f66774da77c62c09574de22d1bce17fd14df4)
UUID		APP	ACI		STATE	NETWORKS
2f969bfd	redis	redis		exited	
70020f80	busybox	busybox		exited	
7b6c7615	busybox	busybox		exited	
85390bde	redis	redis		exited	
8a1549f5	busybox	busybox		exited	
952a459a	etcd	coreos.com/etcd	exited	
bf59d559	etcd	coreos.com/etcd	exited	
ebaae473	etcd	coreos.com/etcd	exited
``` 