### PR TITLE
rkt:userns: print an error if user namespace is not supported #1276

### DIFF
--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -75,7 +75,11 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	if flagPrivateUsers && common.SupportsUserNS() {
+	if flagPrivateUsers {
+		if !common.SupportsUserNS() {
+			stderr("prepare: --private-users is not supported, kernel compiled without user namespace support")
+			return 1
+		}
 		privateUsers.SetRandomUidRange(uid.DefaultRangeCount)
 	}
 

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -149,7 +149,11 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	if flagPrivateUsers && common.SupportsUserNS() {
+	if flagPrivateUsers {
+		if !common.SupportsUserNS() {
+			stderr("run: --private-users is not supported, kernel compiled without user namespace support")
+			return 1
+		}
 		privateUsers.SetRandomUidRange(uid.DefaultRangeCount)
 	}
 


### PR DESCRIPTION
This fixes #1276, print an error message if user namespace was requested
but the kernel was compiled with CONFIG_USER_NS=n

Reported-by: Iago López Galeiras <iago@endocode.com>
Signed-off-by: Djalal Harouni <djalal@endocode.com>