### PR TITLE
replaced hyphen with underscore in version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.68])
-AC_INIT([rkt], [0.8.0-rc1+git], [https://github.com/coreos/rkt/issues])
+AC_INIT([rkt], [0.8.0_rc1+git], [https://github.com/coreos/rkt/issues])
 
 dnl if version ends with +git, append a short git-hash.
 AS_IF([test `expr match 'AC_PACKAGE_VERSION' '.*+git$'` -gt 0],


### PR DESCRIPTION
RPM version strings cannot contain hyphens. The version string set in configure.ac in preparation for 0.8.0 release is "0.8.0-rc1+git".  The hyphen has to be removed to make this a valid RPM version string.

Replacing the hyphen (-) with an underscore (_) allows RPM builds to pass using the reported version string verbatim and without alteration.