### PR TITLE
kvm: network code refactoring: replace s/NetParams/netDescriber/

### DIFF
--- a/networking/kvm.go
+++ b/networking/kvm.go
@@ -196,39 +196,30 @@ func (n *Networking) kvmTeardown() {
 
 }
 
-// NetParams exposes conf(NetConf)/runtime(NetInfo) data to stage1/init client
-type NetParams struct {
-	// runtime based information
-	HostIP  net.IP
-	GuestIP net.IP
-	Mask    net.IP
-	IfName  string
-	// TODO: required for other type of plugins, not yet available because what networking.Networking stores
-	// Net net.IPNet
+// Following methods implements behavior of netDescriber by activeNet
+// (behavior required by stage1/init/kvm package and its kernel parameters configuration)
 
-	// configuration based information
-	Name   string
-	Type   string
-	IPMasq bool
+func (an activeNet) HostIP() net.IP {
+	return an.runtime.HostIP
+}
+func (an activeNet) GuestIP() net.IP {
+	return an.runtime.IP
+}
+func (an activeNet) IfName() string {
+	return an.runtime.IfName
+}
+func (an activeNet) Mask() net.IP {
+	return an.runtime.Mask
+}
+func (an activeNet) Name() string {
+	return an.conf.Name
+}
+func (an activeNet) IPMasq() bool {
+	return an.conf.IPMasq
 }
 
-// GetNetworkParameters returns network parameters created
+// GetActiveNetworks returns activeNets to be used as NetDescriptors
 // by plugins, which are required for stage1 executor to run (only for KVM)
-func (e *Networking) GetNetworkParameters() []NetParams {
-	np := []NetParams{}
-	_ = np
-	for _, an := range e.nets {
-		np = append(np, NetParams{
-			HostIP:  an.runtime.HostIP,
-			GuestIP: an.runtime.IP,
-			IfName:  an.runtime.IfName,
-			Mask:    an.runtime.Mask,
-			// Net: // TODO: from where
-			Name:   an.conf.Name,
-			Type:   an.conf.Type,
-			IPMasq: an.conf.IPMasq,
-		})
-	}
-
-	return np
+func (e *Networking) GetActiveNetworks() []activeNet {
+	return e.nets
 }

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -248,7 +248,8 @@ func getArgsEnv(p *Pod, flavor string, debug bool, n *networking.Networking) ([]
 		// TODO: move to path.go
 		kernelPath := filepath.Join(common.Stage1RootfsPath(p.Root), "bzImage")
 		lkvmPath := filepath.Join(common.Stage1RootfsPath(p.Root), "lkvm")
-		lkvmNetArgs, kernelNetParams, err := kvm.GetKVMNetArgs(n)
+		netDescriptions := kvm.GetNetworkDescriptions(n)
+		lkvmNetArgs, kernelNetParams, err := kvm.GetKVMNetArgs(netDescriptions)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/stage1/init/kvm/network.go
+++ b/stage1/init/kvm/network.go
@@ -16,26 +16,52 @@ package kvm
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/coreos/rkt/networking"
 )
 
-// GetKVMNetParams returns additional arguments that need to be passed to kernel and lkvm tool to configure networks properly
-// parameters are based on Network configuration extracted from Networking struct
-func GetKVMNetArgs(n *networking.Networking) ([]string, []string, error) {
+// GetNetworkDescriptions explicitly convert slice of activeNets to slice of netDescribers
+// which is slice required by GetKVMNetArgs
+func GetNetworkDescriptions(n *networking.Networking) []netDescriber {
+	nds := []netDescriber{}
+	for _, an := range n.GetActiveNetworks() {
+		nds = append(nds, an)
+	}
+	return nds
+}
+
+// netDescriber is something that describes network configuration
+type netDescriber interface {
+	HostIP() net.IP
+	GuestIP() net.IP
+	Mask() net.IP
+	IfName() string
+	IPMasq() bool
+}
+
+// GetKVMNetArgs returns additional arguments that need to be passed to kernel
+// and lkvm tool to configure networks properly.
+// Logic is based on Network configuration extracted from Networking struct
+// and essentially from activeNets that expose netDescriber behavior
+func GetKVMNetArgs(nds []netDescriber) ([]string, []string, error) {
+
 	lkvmArgs := []string{}
 	kernelParams := []string{}
 
-	for i, netParams := range n.GetNetworkParameters() {
+	for i, nd := range nds {
 		// https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt
 		// ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>
 		var gw string
-		if netParams.IPMasq {
-			gw = netParams.HostIP.String()
+		if nd.IPMasq() {
+			gw = nd.HostIP().String()
 		}
-		kernelParams = append(kernelParams, "ip="+netParams.GuestIP.String()+"::"+gw+":"+netParams.Mask.String()+"::"+fmt.Sprintf(networking.IfNamePattern, i)+":::")
+		kernelParam := fmt.Sprintf("ip=%s::%s:%s::%s:::", nd.GuestIP(), gw, nd.Mask(), fmt.Sprintf(networking.IfNamePattern, i))
+		kernelParams = append(kernelParams, kernelParam)
 
-		lkvmArgs = append(lkvmArgs, "--network", "mode=tap,tapif="+netParams.IfName+",host_ip="+netParams.HostIP.String()+",guest_ip="+netParams.GuestIP.String())
+		lkvmArgs = append(lkvmArgs, "--network")
+		lkvmArg := fmt.Sprintf("mode=tap,tapif=%s,host_ip=%s,guest_ip=%s", nd.IfName(), nd.HostIP(), nd.GuestIP())
+		lkvmArgs = append(lkvmArgs, lkvmArg)
 	}
 
 	return lkvmArgs, kernelParams, nil

--- a/stage1/init/kvm/network_test.go
+++ b/stage1/init/kvm/network_test.go
@@ -1,0 +1,116 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvm
+
+import (
+	"net"
+	"testing"
+)
+
+type testNetDescriber struct {
+	hostIP  net.IP
+	guestIP net.IP
+	mask    net.IP
+	ifName  string
+	ipMasq  bool
+}
+
+func (t testNetDescriber) HostIP() net.IP  { return t.hostIP }
+func (t testNetDescriber) GuestIP() net.IP { return t.guestIP }
+func (t testNetDescriber) Mask() net.IP    { return t.mask }
+func (t testNetDescriber) IfName() string  { return t.ifName }
+func (t testNetDescriber) IPMasq() bool    { return t.ipMasq }
+
+func TestGetKVMNetArgs(t *testing.T) {
+	tests := []struct {
+		netDescriptions []netDescriber
+		expectedLkvm    []string
+		expectedKernel  []string
+	}{
+		{ // without Masquerading - not gw passed to kernel
+			netDescriptions: []netDescriber{
+				testNetDescriber{
+					net.ParseIP("1.1.1.1"),
+					net.ParseIP("2.2.2.2"),
+					net.ParseIP("255.255.255.0"),
+					"fooInt",
+					false,
+				},
+			},
+			expectedLkvm:   []string{"--network", "mode=tap,tapif=fooInt,host_ip=1.1.1.1,guest_ip=2.2.2.2"},
+			expectedKernel: []string{"ip=2.2.2.2:::255.255.255.0::eth0:::"},
+		},
+		{ // extra gw passed to kernel on (thrid position)
+			netDescriptions: []netDescriber{
+				testNetDescriber{
+					net.ParseIP("1.1.1.1"),
+					net.ParseIP("2.2.2.2"),
+					net.ParseIP("255.255.255.0"),
+					"barInt", true},
+			},
+			expectedLkvm:   []string{"--network", "mode=tap,tapif=barInt,host_ip=1.1.1.1,guest_ip=2.2.2.2"},
+			expectedKernel: []string{"ip=2.2.2.2::1.1.1.1:255.255.255.0::eth0:::"},
+		},
+		{ // two networks
+			netDescriptions: []netDescriber{
+				testNetDescriber{
+					net.ParseIP("1.1.1.1"),
+					net.ParseIP("2.2.2.2"),
+					net.ParseIP("255.255.255.0"),
+					"fooInt",
+					false,
+				},
+				testNetDescriber{
+					net.ParseIP("1.1.1.1"),
+					net.ParseIP("2.2.2.2"),
+					net.ParseIP("255.255.255.0"),
+					"barInt", true},
+			},
+			expectedLkvm: []string{
+				"--network", "mode=tap,tapif=fooInt,host_ip=1.1.1.1,guest_ip=2.2.2.2",
+				"--network", "mode=tap,tapif=barInt,host_ip=1.1.1.1,guest_ip=2.2.2.2",
+			},
+			expectedKernel: []string{
+				"ip=2.2.2.2:::255.255.255.0::eth0:::",
+				"ip=2.2.2.2::1.1.1.1:255.255.255.0::eth1:::",
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		gotLkvm, gotKernel, err := GetKVMNetArgs(tt.netDescriptions)
+		if err != nil {
+			t.Errorf("got error: %s", err)
+		}
+		if len(gotLkvm) != len(tt.expectedLkvm) {
+			t.Errorf("#%d: expected lkvm %v elements got %v", i, len(tt.expectedLkvm), len(gotLkvm))
+		} else {
+			for iarg, argExpected := range tt.expectedLkvm {
+				if gotLkvm[iarg] != argExpected {
+					t.Errorf("#%d: lkvm arg %d expected `%v` got `%v`", i, iarg, argExpected, gotLkvm[iarg])
+				}
+			}
+		}
+		if len(gotKernel) != len(tt.expectedKernel) {
+			t.Errorf("#%d: expected kernel %v elements got %v", i, len(tt.expectedKernel), len(gotKernel))
+		} else {
+			for iarg, argExpected := range tt.expectedKernel {
+				if gotKernel[iarg] != argExpected {
+					t.Errorf("#%d: kernel arg %d expected `%v` got `%v`", i, iarg, argExpected, gotKernel[iarg])
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
**PR note**: this is just a refactoring it doesn't fix any issues or add any user features (other than maintainability and neatness :smile: ) + includes unit tests

It's effect of discussion from [here #1219] (https://github.com/coreos/rkt/pull/1219#discussion_r36347022)

Below some rationale from commit message:

> NetParams was used as carrier for dynamic/static network configuration
> provided by CNI plugin to virtual machine then used by lkvm tool (through
> kernel parameters).
>
> netDescriber is just an interface required by function that prepares
> arguments to kernel for kvm flavor and is implicitly implemented by
> activeNet.

/cc @eyakubovich 

