### PR TITLE
kvm: tun: give the network interface a name

### DIFF
--- a/networking/tuntap/tuntap.go
+++ b/networking/tuntap/tuntap.go
@@ -91,8 +91,8 @@ func operateOnIface(name string, kind uint16, persistency uintptr) (string, erro
 	return iface.name, nil
 }
 
-func CreatePersistentIface(kind uint16) (string, error) {
-	return operateOnIface("", kind, 1)
+func CreatePersistentIface(nameTemplate string, kind uint16) (string, error) {
+	return operateOnIface(nameTemplate, kind, 1)
 }
 
 func RemovePersistentIface(name string, kind uint16) error {


### PR DESCRIPTION
I tried to give the tap device a name so it's obvious it was created by rkt and that there would be a way for NetworkManager to ignore it. But the current patch does not work.

See also https://github.com/coreos/rkt/issues/1302

/cc @ppalucki @jellonek 