### PR TITLE
functional tests: Properly remove patched ACIs

### DIFF
--- a/tests/rkt_caps_test.go
+++ b/tests/rkt_caps_test.go
@@ -85,8 +85,8 @@ func TestCaps(t *testing.T) {
 			stage2Args = append(stage2Args, "--capability="+tt.capIsolator)
 		}
 		stage1FileName := patchTestACI("rkt-inspect-print-caps-stage1.aci", stage1Args...)
-		stage2FileName := patchTestACI("rkt-inspect-print-caps-stage2.aci", stage2Args...)
 		defer os.Remove(stage1FileName)
+		stage2FileName := patchTestACI("rkt-inspect-print-caps-stage2.aci", stage2Args...)
 		defer os.Remove(stage2FileName)
 		stageFileNames := []string{stage1FileName, stage2FileName}
 

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -32,20 +32,12 @@ func TestFetch(t *testing.T) {
 
 	// Fetch the image for the first time, this should write the image to the
 	// on-disk store.
-
-	imagePath := patchTestACI(image, "--exec=/inspect --read-file")
-
-	oldHash := importImageAndFetchHash(t, ctx, imagePath)
-	os.Remove(imagePath)
+	oldHash := patchImportAndFetchHash(image, []string{"--exec=/inspect --read-file"}, t, ctx)
 
 	// Fetch the image with the same name but different content, the expecting
 	// result is that we should get a different hash since we are not fetching
 	// from the on-disk store.
-
-	imagePath = patchTestACI(image, "--exec=/inspect --read-file --write-file")
-
-	newHash := importImageAndFetchHash(t, ctx, imagePath)
-	os.Remove(imagePath)
+	newHash := patchImportAndFetchHash(image, []string{"--exec=/inspect --read-file --write-file"}, t, ctx)
 
 	if oldHash == newHash {
 		t.Fatalf("ACI hash should be different as the image has changed")

--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -34,27 +34,6 @@ import (
 
 const baseAppName = "rkt-inspect"
 
-func importImageAndFetchHash(t *testing.T, ctx *rktRunCtx, img string) string {
-	// Import the test image into store manually.
-	child, err := gexpect.Spawn(fmt.Sprintf("%s --insecure-skip-verify fetch %s", ctx.cmd(), img))
-	if err != nil {
-		t.Fatalf("Cannot exec rkt: %v", err)
-	}
-
-	// Read out the image hash.
-	result, out, err := expectRegexWithOutput(child, "sha512-[0-9a-f]{32}")
-	if err != nil || len(result) != 1 {
-		t.Fatalf("Error: %v\nOutput: %v", err, out)
-	}
-
-	err = child.Wait()
-	if err != nil {
-		t.Fatalf("rkt didn't terminate correctly: %v", err)
-	}
-
-	return result[0]
-}
-
 func generatePodManifestFile(t *testing.T, manifest *schema.PodManifest) string {
 	tmpDir := os.Getenv("FUNCTIONAL_TMP")
 	if tmpDir == "" {

--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -499,12 +499,8 @@ func TestPodManifest(t *testing.T) {
 			continue
 		}
 
-		var imagesToRemove []string
 		for j, v := range tt.images {
-			imageFile := patchTestACI(v.name, v.patches...)
-			hash := importImageAndFetchHash(t, ctx, imageFile)
-			imagesToRemove = append(imagesToRemove, imageFile)
-
+			hash := patchImportAndFetchHash(v.name, v.patches, t, ctx)
 			imgName := types.MustACIdentifier(v.name)
 			imgID, err := types.NewHash(hash)
 			if err != nil {
@@ -583,10 +579,5 @@ func TestPodManifest(t *testing.T) {
 			}
 		}
 		verifyHostFile(t, tmpdir, "file", i, tt.expectedResult)
-
-		// Remove testing images here to free some space, otherwise Semaphore CI might error.
-		for _, name := range imagesToRemove {
-			os.Remove(name)
-		}
 	}
 }

--- a/tests/rkt_socket_activation_test.go
+++ b/tests/rkt_socket_activation_test.go
@@ -64,6 +64,7 @@ func TestSocketActivation(t *testing.T) {
 	echoImage := patchTestACI("rkt-inspect-echo.aci",
 		"--exec=/echo-socket-activated",
 		fmt.Sprintf("--ports=%d-tcp,protocol=tcp,port=%d,socketActivated=true", port, port))
+	defer os.Remove(echoImage)
 
 	ctx := newRktRunCtx()
 	defer ctx.cleanup()

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -295,3 +295,10 @@ func importImageAndFetchHash(t *testing.T, ctx *rktRunCtx, img string) string {
 
 	return result[0]
 }
+
+func patchImportAndFetchHash(image string, patches []string, t *testing.T, ctx *rktRunCtx) string {
+	imagePath := patchTestACI(image, patches...)
+	defer os.Remove(imagePath)
+
+	return importImageAndFetchHash(t, ctx, imagePath)
+}

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
@@ -272,4 +273,25 @@ func getHash(filePath string) (string, error) {
 	}
 
 	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func importImageAndFetchHash(t *testing.T, ctx *rktRunCtx, img string) string {
+	// Import the test image into store manually.
+	child, err := gexpect.Spawn(fmt.Sprintf("%s --insecure-skip-verify fetch %s", ctx.cmd(), img))
+	if err != nil {
+		t.Fatalf("Cannot exec rkt: %v", err)
+	}
+
+	// Read out the image hash.
+	result, out, err := expectRegexWithOutput(child, "sha512-[0-9a-f]{32}")
+	if err != nil || len(result) != 1 {
+		t.Fatalf("Error: %v\nOutput: %v", err, out)
+	}
+
+	err = child.Wait()
+	if err != nil {
+		t.Fatalf("rkt didn't terminate correctly: %v", err)
+	}
+
+	return result[0]
 }


### PR DESCRIPTION
Some tests weren't removing the results of `patchTestACI` properly, that is - by deferring `os.Remove` right after the call to `patchTestACI`.

Caught that when working on make clean.