### PR TITLE
build: Split out deps generation to separate rules.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifneq ($(RKT_STAGE1_USR_FROM),none)
 TOPLEVEL_SUBDIRS += stage1
 endif
 
-$(call inc-many,actool.mk depsgentool.mk)
+$(call inc-many,depsgentool.mk actool.mk)
 $(call inc-many,$(foreach sd,$(TOPLEVEL_SUBDIRS),$(sd)/$(sd).mk))
 
 all: $(TOPLEVEL_STAMPS)

--- a/actool.mk
+++ b/actool.mk
@@ -1,12 +1,13 @@
 $(call setup-stamp-file,ACTOOL_STAMP)
 
 # variables for makelib/build_go_bin.mk
+BGB_STAMP := $(ACTOOL_STAMP)
 BGB_PKG_IN_REPO := Godeps/_workspace/src/github.com/appc/spec/actool
 BGB_BINARY := $(ACTOOL)
 
 CLEAN_FILES += $(ACTOOL)
 
-$(ACTOOL_STAMP): $(ACTOOL)
+$(ACTOOL_STAMP):
 	touch "$@"
 
 $(ACTOOL): $(MK_PATH) | $(BINDIR)

--- a/depsgentool.mk
+++ b/depsgentool.mk
@@ -1,13 +1,14 @@
 $(call setup-stamp-file,DEPSGENTOOL_STAMP)
 
 # variables for makelib/build_go_bin.mk
+BGB_STAMP := $(DEPSGENTOOL_STAMP)
 BGB_PKG_IN_REPO := tools/depsgen
 BGB_BINARY := $(DEPSGENTOOL)
 BGB_ADDITIONAL_GO_ENV := GOARCH=$(GOARCH_FOR_BUILD)
 
 CLEAN_FILES += $(DEPSGENTOOL)
 
-$(DEPSGENTOOL_STAMP): $(DEPSGENTOOL)
+$(DEPSGENTOOL_STAMP):
 	touch "$@"
 
 $(DEPSGENTOOL): $(MK_PATH) | $(TOOLSDIR)

--- a/makelib/aci_simple_go_bin.mk
+++ b/makelib/aci_simple_go_bin.mk
@@ -16,6 +16,7 @@ _ASGB_ACI_BINARY_ := $(ACIROOTFSDIR)/$(_ASGB_NAME_)
 $(call setup-stamp-file,_ASGB_STAMP_)
 
 # variables for makelib/build_go_bin.mk
+BGB_STAMP := $(_ASGB_STAMP_)
 BGB_BINARY := $(TOOLSDIR)/$(_ASGB_NAME_)
 BGB_PKG_IN_REPO := $(subst $(MK_TOPLEVEL_SRCDIR)/,,$(MK_SRCDIR))
 
@@ -26,7 +27,7 @@ STAGE1_STAMPS += $(_ASGB_STAMP_)
 $(BGB_BINARY): $(_ASGB_PATH_) | $(TOOLSDIR)
 $(_ASGB_ACI_BINARY_) $(BGB_BINARY): $(MK_PATH)
 
-$(_ASGB_STAMP_): $(_ASGB_ACI_BINARY_)
+$(_ASGB_STAMP_):
 	touch "$@"
 
 $(BGB_BINARY): $(_ASGB_PATH_)

--- a/rkt/rkt.mk
+++ b/rkt/rkt.mk
@@ -5,6 +5,7 @@ $(call setup-stamp-file,RKT_STAMP)
 RKT_BINARY := $(BINDIR)/$(LOCAL_NAME)
 
 # variables for makelib/build_go_bin.mk
+BGB_STAMP := $(RKT_STAMP)
 BGB_BINARY := $(RKT_BINARY)
 BGB_PKG_IN_REPO := $(subst $(MK_TOPLEVEL_SRCDIR)/,,$(MK_SRCDIR))
 BGB_GO_FLAGS := $(strip -ldflags "$(RKT_STAGE1_DEFAULT_ACI_LDFLAGS) $(RKT_STAGE1_IMAGE_LDFLAGS) $(RKT_VERSION_LDFLAGS)" $(RKT_TAGS))
@@ -12,7 +13,7 @@ BGB_GO_FLAGS := $(strip -ldflags "$(RKT_STAGE1_DEFAULT_ACI_LDFLAGS) $(RKT_STAGE1
 CLEAN_FILES += $(BGB_BINARY)
 TOPLEVEL_STAMPS += $(RKT_STAMP)
 
-$(RKT_STAMP): $(BGB_BINARY)
+$(RKT_STAMP):
 	touch "$@"
 
 $(BGB_BINARY): $(MK_PATH) | $(BINDIR)

--- a/stage1/net-plugins/net-plugins.mk
+++ b/stage1/net-plugins/net-plugins.mk
@@ -32,6 +32,8 @@ CLEAN_FILES += $(LOCAL_PLUGINS)
 STAGE1_STAMPS += $(LOCAL_STAMP)
 
 define LOCAL_GENERATE_BUILD_PLUGIN_RULE
+# variables for makelib/build_go_bin.mk
+BGB_STAMP := $(LOCAL_STAMP)
 BGB_BINARY := $$(call LOCAL_NAME_TO_BUILT_PLUGIN,$1)
 BGB_PKG_IN_REPO := Godeps/_workspace/src/github.com/appc/cni/plugins/$1
 $$(BGB_BINARY): | $$(TOOLSDIR)

--- a/stage1/usr_from_src/usr_from_src.mk
+++ b/stage1/usr_from_src/usr_from_src.mk
@@ -21,6 +21,7 @@ UFS_LIB_SYMLINK := $(ACIROOTFSDIR)/lib
 UFS_LIB64_SYMLINK := $(ACIROOTFSDIR)/lib64
 
 $(call setup-stamp-file,UFS_STAMP)
+$(call setup-stamp-file,UFS_ROOTFS_STAMP,/rootfs)
 $(call setup-stamp-file,UFS_SYSTEMD_CLONE_AND_PATCH_STAMP,/systemd_clone_and_patch/$(UFS_SYSTEMD_DESC))
 $(call setup-stamp-file,UFS_SYSTEMD_BUILD_STAMP,/systemd_build/$(UFS_SYSTEMD_DESC))
 
@@ -30,12 +31,15 @@ STAGE1_COPY_SO_DEPS := yes
 
 $(call inc-one,bash.mk)
 
+$(UFS_STAMP): $(UFS_ROOTFS_STAMP)
+	touch "$@"
+
 -include $(UFS_ROOTFS_DEPMK)
-$(call forward-vars,$(UFS_STAMP), \
+$(call forward-vars,$(UFS_ROOTFS_STAMP), \
 	UFS_ROOTFSDIR ACIROOTFSDIR RKT_STAGE1_SYSTEMD_VER DEPSGENTOOL \
 	UFS_ROOTFS_DEPMK)
-# $(UFS_STAMP): | $(UFS_LIB_SYMLINK) $(UFS_LIB64_SYMLINK)
-$(UFS_STAMP): $(UFS_SYSTEMD_BUILD_STAMP) $(DEPSGENTOOL_STAMP) | $(ACIROOTFSDIR)
+# $(UFS_ROOTFS_STAMP): | $(UFS_LIB_SYMLINK) $(UFS_LIB64_SYMLINK)
+$(UFS_ROOTFS_STAMP): $(UFS_SYSTEMD_BUILD_STAMP) $(DEPSGENTOOL_STAMP) | $(ACIROOTFSDIR)
 	set -e; \
 	cp -af "$(UFS_ROOTFSDIR)/." "$(ACIROOTFSDIR)"; \
 	ln -sf 'src' "$(ACIROOTFSDIR)/flavor"; \

--- a/stage1/usr_from_src/usr_from_src.mk
+++ b/stage1/usr_from_src/usr_from_src.mk
@@ -4,7 +4,7 @@ UFS_SYSTEMD_SRCDIR := $(UFS_SYSTEMDDIR)/src
 UFS_SYSTEMD_BUILDDIR := $(UFS_SYSTEMDDIR)/build
 
 $(call setup-dep-file,UFS_PATCHES_DEPMK,$(UFS_SYSTEMD_DESC)-systemd-patches)
-$(call setup-dep-file,UFS_MAIN_STAMP_DEPMK,$(UFS_SYSTEMD_DESC)-systemd-install)
+$(call setup-dep-file,UFS_ROOTFS_DEPMK,$(UFS_SYSTEMD_DESC)-systemd-install)
 
 UFS_ROOTFSDIR := $(UFS_SYSTEMDDIR)/rootfs
 
@@ -30,17 +30,17 @@ STAGE1_COPY_SO_DEPS := yes
 
 $(call inc-one,bash.mk)
 
--include $(UFS_MAIN_STAMP_DEPMK)
+-include $(UFS_ROOTFS_DEPMK)
 $(call forward-vars,$(UFS_STAMP), \
 	UFS_ROOTFSDIR ACIROOTFSDIR RKT_STAGE1_SYSTEMD_VER DEPSGENTOOL \
-	UFS_MAIN_STAMP_DEPMK)
+	UFS_ROOTFS_DEPMK)
 # $(UFS_STAMP): | $(UFS_LIB_SYMLINK) $(UFS_LIB64_SYMLINK)
 $(UFS_STAMP): $(UFS_SYSTEMD_BUILD_STAMP) $(DEPSGENTOOL_STAMP) | $(ACIROOTFSDIR)
 	set -e; \
 	cp -af "$(UFS_ROOTFSDIR)/." "$(ACIROOTFSDIR)"; \
 	ln -sf 'src' "$(ACIROOTFSDIR)/flavor"; \
 	echo "$(RKT_STAGE1_SYSTEMD_VER)" >"$(ACIROOTFSDIR)/systemd-version"; \
-	"$(DEPSGENTOOL)" glob --target='$$(UFS_STAMP)' $$(find "$(UFS_ROOTFSDIR)" -type f) >"$(UFS_MAIN_STAMP_DEPMK)"; \
+	"$(DEPSGENTOOL)" glob --target='$$(UFS_STAMP)' $$(find "$(UFS_ROOTFSDIR)" -type f) >"$(UFS_ROOTFS_DEPMK)"; \
 	touch "$@"
 
 $(call forward-vars,$(UFS_SYSTEMD_BUILD_STAMP), \

--- a/tests/functional.mk
+++ b/tests/functional.mk
@@ -37,6 +37,8 @@ $(FTST_IMAGE): $(FTST_IMAGE_MANIFEST) $(FTST_ACI_INSPECT) $(FTST_ACI_ECHO_SERVER
 	ln -sf /inspect $(FTST_IMAGE_ROOTFSDIR)/inspect-link
 	"$(ACTOOL)" build --overwrite "$(FTST_IMAGE_DIR)" "$@"
 
+# variables for makelib/build_go_bin.mk
+BGB_STAMP := $(FTST_FUNCTIONAL_TESTS_STAMP)
 BGB_BINARY := $(FTST_INSPECT_BINARY)
 BGB_PKG_IN_REPO := $(subst $(MK_TOPLEVEL_SRCDIR)/,,$(MK_SRCDIR))/inspect
 BGB_GO_FLAGS := -a -installsuffix cgo
@@ -49,6 +51,8 @@ $(call forward-vars,$(FTST_EMPTY_IMAGE), \
 $(FTST_EMPTY_IMAGE): $(FTST_EMPTY_IMAGE_MANIFEST) | $(FTST_EMPTY_IMAGE_ROOTFSDIR)
 	"$(ACTOOL)" build --overwrite "$(FTST_EMPTY_IMAGE_DIR)" "$@"
 
+# variables for makelib/build_go_bin.mk
+BGB_STAMP := $(FTST_FUNCTIONAL_TESTS_STAMP)
 BGB_BINARY := $(FTST_ECHO_SERVER_BINARY)
 BGB_PKG_IN_REPO := $(subst $(MK_TOPLEVEL_SRCDIR)/,,$(MK_SRCDIR))/echo-socket-activated
 BGB_GO_FLAGS := -a -installsuffix cgo


### PR DESCRIPTION
Previously depsgen was run inside some other rules. That required them to depend on DEPSGENTOOL_STAMP. If depsgen sources were modified, then those rules would be executed again, so deps would be regenerated. But alongside some other unrelated actions were performed (patching the sources, building some stuff or else).