### PR TITLE
functional tests: TestPodManifest: remove images from cas

### DIFF
--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -499,8 +499,10 @@ func TestPodManifest(t *testing.T) {
 			continue
 		}
 
+		var hashesToRemove []string
 		for j, v := range tt.images {
 			hash := patchImportAndFetchHash(v.name, v.patches, t, ctx)
+			hashesToRemove = append(hashesToRemove, hash)
 			imgName := types.MustACIdentifier(v.name)
 			imgID, err := types.NewHash(hash)
 			if err != nil {
@@ -579,5 +581,12 @@ func TestPodManifest(t *testing.T) {
 			}
 		}
 		verifyHostFile(t, tmpdir, "file", i, tt.expectedResult)
+
+		// we run the garbage collector and remove the imported images to save
+		// space
+		runGC(t, ctx)
+		for _, h := range hashesToRemove {
+			removeFromCas(t, ctx, h)
+		}
 	}
 }

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -302,3 +302,29 @@ func patchImportAndFetchHash(image string, patches []string, t *testing.T, ctx *
 
 	return importImageAndFetchHash(t, ctx, imagePath)
 }
+
+func runGC(t *testing.T, ctx *rktRunCtx) {
+	cmd := fmt.Sprintf("%s gc --grace-period=0s", ctx.cmd())
+	child, err := gexpect.Spawn(cmd)
+	if err != nil {
+		t.Fatalf("Cannot exec rkt: %v", err)
+	}
+
+	err = child.Wait()
+	if err != nil {
+		t.Fatalf("rkt didn't terminate correctly: %v", err)
+	}
+}
+
+func removeFromCas(t *testing.T, ctx *rktRunCtx, hash string) {
+	cmd := fmt.Sprintf("%s image rm %s", ctx.cmd(), hash)
+	child, err := gexpect.Spawn(cmd)
+	if err != nil {
+		t.Fatalf("Cannot exec rkt: %v", err)
+	}
+
+	err = child.Wait()
+	if err != nil {
+		t.Fatalf("rkt didn't terminate correctly: %v", err)
+	}
+}


### PR DESCRIPTION
Remove images from the CAS after each iteration of the test run to avoid
running out of space.

We also do a garbage collector run so can remove the images and to save
even more space.