### PR TITLE
stage0: don't create app/tmp directory

### DIFF
--- a/stage0/run.go
+++ b/stage0/run.go
@@ -443,11 +443,6 @@ func setupAppImage(cfg RunConfig, appName types.ACName, img types.Hash, cdir str
 		}
 	}
 
-	err := os.MkdirAll(filepath.Join(ad, "rootfs/tmp"), 0777)
-	if err != nil {
-		return fmt.Errorf("error creating tmp directory: %v", err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This was creating the apps' /tmp directory with the wrong permissions
We're already creating it in prepare-app with the right ones.

Fixes #1321