### PR TITLE
stage1: fix garbage collection after unmount

### DIFF
--- a/stage1/gc/gc.go
+++ b/stage1/gc/gc.go
@@ -64,9 +64,17 @@ func main() {
 }
 
 func gcNetworking(podID *types.UUID) error {
+	var flavor string
+	// we first try to read the flavor from stage1 for backwards compatibility
 	flavor, err := os.Readlink(filepath.Join(common.Stage1RootfsPath("."), "flavor"))
 	if err != nil {
-		return fmt.Errorf("Failed to get stage1 flavor: %v\n", err)
+		// if we couldn't read the flavor from stage1 it could mean the overlay
+		// filesystem is already unmounted (e.g. the system has been rebooted).
+		// In that case we try to read it from the pod's root directory
+		flavor, err = os.Readlink("flavor")
+		if err != nil {
+			return fmt.Errorf("Failed to get stage1 flavor: %v\n", err)
+		}
 	}
 
 	n, err := networking.Load(".", podID)

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -242,6 +242,11 @@ func getArgsEnv(p *Pod, flavor string, debug bool, n *networking.Networking) ([]
 	args := []string{}
 	env := os.Environ()
 
+	// We store the pod's flavor so we can later garbage collect it correctly
+	if err := os.Symlink(flavor, filepath.Join(p.Root, flavorFile)); err != nil {
+		return nil, nil, fmt.Errorf("failed to create flavor symlink: %v", err)
+	}
+
 	switch flavor {
 	case "kvm":
 		// kernel and lkvm are relative path, because init has /var/lib/rkt/..../uuid as its working directory

--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -47,6 +47,11 @@ type Pod struct {
 	Networks           []string
 }
 
+const (
+	// Name of the file storing the pod's flavor
+	flavorFile = "flavor"
+)
+
 var (
 	defaultEnv = map[string]string{
 		"PATH":    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",


### PR DESCRIPTION
If we use overlayfs and we unmount the directories before
running rkt gc we won't have access to the stage1 directory but we need
the pod's flavor to do the correct GC (regular or LKVM).

We need to store the pod's flavor in the pod's root directory, trying
first in stage1 to keep backwards compatibility. This means it will
garbage collect old pods that weren't unmounted but if they did get
unmounted it will still fail.

Fixes #1322 