### PR TITLE
build: Add a filelist generator tool

### DIFF
--- a/tools/common/filelist/filelist.go
+++ b/tools/common/filelist/filelist.go
@@ -1,0 +1,195 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filelist
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// Lists is a structure holding relative paths to files, symlinks and
+// directories. The members of this structure can be later combined
+// with common.MapFilesToDirectories to get some meaningful paths.
+type Lists struct {
+	Files    []string
+	Symlinks []string
+	Dirs     []string
+}
+
+type pair struct {
+	kind string
+	data *[]string
+}
+
+// ParseFilelist parses a given filelist. The filelist format is
+// rather simple:
+// <BLOCK>
+// <BLOCK>
+// ...
+//
+// Where "<BLOCK>" is as follows:
+// <HEADER>
+// <LIST>
+//
+// Where "<HEADER>" is as follows:
+// <KIND>
+// (<COUNT>)
+//
+// Where "<KIND>" is either "files", "symlinks" or "dirs" and
+// "<COUNT>" tells how many items are in the following list. "<LIST>"
+// is as follows:
+// <1st ITEM>
+// <2nd ITEM>
+// ...
+// <COUNTth ITEM>
+// <EMPTY LINE>
+func (list *Lists) ParseFilelist(filelist io.Reader) error {
+	scanner := bufio.NewScanner(filelist)
+	for {
+		kind, count, err := parseHeader(scanner)
+		if err != nil {
+			return fmt.Errorf("Failed to parse filelist: %v", err)
+		}
+		if kind == "" {
+			break
+		}
+		data := list.getDataForKind(kind)
+		if data == nil {
+			return fmt.Errorf("Failed to parse filelist: unknown kind %q, expected 'files', 'symlinks' or 'dirs'", kind)
+		}
+		items, err := parseList(scanner, count)
+		if err != nil {
+			return fmt.Errorf("Failed to parse filelist: %v", err)
+		}
+		*data = items
+	}
+	return nil
+}
+
+// parseList parses the list part of a block. It makes sure that there
+// is an exactly expected count of items.
+func parseList(scanner *bufio.Scanner, count int) ([]string, error) {
+	got := 0
+	items := make([]string, 0, count)
+	for {
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("expected either an empty line or a line with an item, unexpected EOF?")
+		}
+		line := scanner.Text()
+		if line == "" {
+			if got < count {
+				return nil, fmt.Errorf("too few items (declared %d, got %d)", count, got)
+			}
+			break
+		}
+		got++
+		if got > count {
+			return nil, fmt.Errorf("too many items (declared %d)", count)
+		}
+		items = append(items, line)
+	}
+	return items, nil
+}
+
+// parseHeader parses the first two lines of a block described in
+// ParseFilelist docs. So it returns a data kind (files, symlinks or
+// dirs) and a count of elements in the following list. If the
+// returned kind is empty then it means that there is no more entries
+// (provided that there is no error either).
+func parseHeader(scanner *bufio.Scanner) (string, int, error) {
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return "", 0, err
+		}
+		// no more entries in the file, just return empty kind
+		return "", 0, nil
+	}
+	kind := scanner.Text()
+	if kind == "" {
+		return "", 0, fmt.Errorf("got an empty kind, expected 'files', 'symlinks' or 'dirs'")
+	}
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return "", 0, err
+		} else {
+			return "", 0, fmt.Errorf("expected a line with a count, unexpected EOF?")
+		}
+	}
+	countReader := strings.NewReader(scanner.Text())
+	count := 0
+	n, err := fmt.Fscanf(countReader, "(%d)", &count)
+	if err != nil {
+		return "", 0, err
+	}
+	if n != 1 {
+		return "", 0, fmt.Errorf("incorrectly formatted line with number of %s", kind)
+	}
+	return kind, count, nil
+}
+
+func (list *Lists) getDataForKind(kind string) *[]string {
+	switch kind {
+	case "files":
+		return &list.Files
+	case "symlinks":
+		return &list.Symlinks
+	case "dirs":
+		return &list.Dirs
+	}
+	return nil
+}
+
+// GenerateFilelist generates a filelist, duh. And writes it to a
+// given writer. The format of generated file is described in
+// filelist.ParseFilelist.
+func (list *Lists) GenerateFilelist(out io.Writer) error {
+	w := bufio.NewWriter(out)
+	for _, pair := range list.getPairs() {
+		dLen := len(*pair.data)
+		toWrite := []string{
+			pair.kind,
+			"\n(",
+			strconv.Itoa(dLen),
+			")\n",
+		}
+		if dLen > 0 {
+			toWrite = append(toWrite,
+				strings.Join(*pair.data, "\n"),
+				"\n")
+		}
+		toWrite = append(toWrite, "\n")
+		for _, str := range toWrite {
+			if _, err := w.WriteString(str); err != nil {
+				return err
+			}
+		}
+	}
+	w.Flush()
+	return nil
+}
+
+func (list *Lists) getPairs() []pair {
+	return []pair{
+		{kind: "files", data: &list.Files},
+		{kind: "symlinks", data: &list.Symlinks},
+		{kind: "dirs", data: &list.Dirs},
+	}
+}

--- a/tools/common/util.go
+++ b/tools/common/util.go
@@ -1,0 +1,81 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// StringSliceWrapper is an implementation of flag.Value interface. It
+// is basically a proxy that appends strings to an already existing
+// strings slice.
+type StringSliceWrapper struct {
+	Slice *[]string
+}
+
+func (wrapper *StringSliceWrapper) String() string {
+	if len(*wrapper.Slice) > 0 {
+		return fmt.Sprintf(`["%s"]`, strings.Join(*wrapper.Slice, `" "`))
+	}
+	return "[]"
+}
+
+func (wrapper *StringSliceWrapper) Set(str string) error {
+	*wrapper.Slice = append(*wrapper.Slice, str)
+	return nil
+}
+
+// Warn is just a shorter version of a formatted printing to
+// stderr. It appends a newline for you.
+func Warn(format string, values ...interface{}) {
+	fmt.Fprintf(os.Stderr, fmt.Sprintf("%s%c", format, '\n'), values...)
+}
+
+// Die is the same as Warn, but it quits with exit status 1 after
+// printing a message.
+func Die(format string, values ...interface{}) {
+	Warn(format, values...)
+	os.Exit(1)
+}
+
+// MapFilesToDirectories creates one entry for each file and directory
+// passed. Result is a kind of cross-product. For files f1 and f2 and
+// directories d1 and d2, the returned list will contain d1/f1 d2/f1
+// d1/f2 d2/f2.
+//
+// The "files" part might be a bit misleading - you can pass a list of
+// symlinks or directories there as well.
+func MapFilesToDirectories(files, dirs []string) []string {
+	mapped := make([]string, 0, len(files)*len(dirs))
+	for _, f := range files {
+		for _, d := range dirs {
+			mapped = append(mapped, filepath.Join(d, f))
+		}
+	}
+	return mapped
+}
+
+// MustAbs returns an absolute path. It works like filepath.Abs, but
+// panics if it fails.
+func MustAbs(dir string) string {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to get absolute path of a directory %q: %v\n", dir, err))
+	}
+	return filepath.Clean(absDir)
+}

--- a/tools/filelistgen/main.go
+++ b/tools/filelistgen/main.go
@@ -1,0 +1,145 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/coreos/rkt/tools/common"
+	"github.com/coreos/rkt/tools/common/filelist"
+)
+
+type fsWalker struct {
+	dir  string
+	list *filelist.Lists
+}
+
+func main() {
+	dir := ""
+	suffix := ""
+	empty := false
+	flag.StringVar(&dir, "directory", "", "Directory path")
+	flag.StringVar(&suffix, "suffix", "", "Suffix for files in directory, when passed it basically does ${--dir}/*${suffix} (dotfiles are ignored)")
+	flag.BoolVar(&empty, "empty", false, "Generate empty filelist")
+
+	flag.Parse()
+	if !empty && dir == "" {
+		common.Die("No --directory parameter passed")
+	}
+
+	list := getListing(empty, dir, suffix)
+	if err := list.GenerateFilelist(os.Stdout); err != nil {
+		common.Die("Failed to generate a filelist: %v", err)
+	}
+}
+
+func getListing(empty bool, dir, suffix string) *filelist.Lists {
+	if empty {
+		return &filelist.Lists{}
+	}
+	if suffix == "" {
+		return getDeepListing(dir)
+	}
+	return getShallowListing(dir, suffix)
+}
+
+func getDeepListing(dir string) *filelist.Lists {
+	walker := newFsWalker(common.MustAbs(dir))
+	list, err := walker.getListing()
+	if err != nil {
+		common.Die("Error during getting listing from directory %q: %v", dir, err)
+	}
+	return list
+}
+
+func getShallowListing(dir, suffix string) *filelist.Lists {
+	list := &filelist.Lists{}
+	fiList, err := ioutil.ReadDir(dir)
+	if err != nil {
+		common.Die("Failed to read directory %q: %v", dir, err)
+	}
+	for _, fi := range fiList {
+		name := fi.Name()
+		if !strings.HasSuffix(name, suffix) {
+			continue
+		}
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		if err := categorizeEntry(name, fi.Mode(), list); err != nil {
+			common.Die("%v", err)
+		}
+	}
+	return list
+}
+
+func newFsWalker(dir string) *fsWalker {
+	return &fsWalker{
+		dir:  dir,
+		list: &filelist.Lists{},
+	}
+}
+
+func (w *fsWalker) getListing() (*filelist.Lists, error) {
+	src := w.dir
+	if err := filepath.Walk(src, w.getWalkFunc(src)); err != nil {
+		return nil, err
+	}
+	return w.list, nil
+}
+
+func (w *fsWalker) getWalkFunc(src string) filepath.WalkFunc {
+	return func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rootLess := filepath.Clean(path[len(src):])
+		// filepath.Clean guarantees that rootLess is never empty.
+		if rootLess[0] == filepath.Separator {
+			rootLess = rootLess[1:]
+		}
+		if rootLess == "." {
+			// skip the toplevel directory
+			return nil
+		}
+		if err := categorizeEntry(rootLess, info.Mode(), w.list); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func categorizeEntry(path string, mode os.FileMode, list *filelist.Lists) error {
+	switch {
+	case mode.IsDir():
+		list.Dirs = append(list.Dirs, path)
+	case mode.IsRegular():
+		list.Files = append(list.Files, path)
+	case isSymlink(mode):
+		list.Symlinks = append(list.Symlinks, path)
+	default:
+		return fmt.Errorf("unsupported file mode: %d (not a file, directory or symlink)", mode&os.ModeType)
+	}
+	return nil
+}
+
+func isSymlink(mode os.FileMode) bool {
+	return mode&os.ModeSymlink == os.ModeSymlink
+}

--- a/tools/filelistgentool.mk
+++ b/tools/filelistgentool.mk
@@ -1,0 +1,17 @@
+$(call setup-stamp-file,FILELISTGENTOOL_STAMP)
+
+# variables for makelib/build_go_bin.mk
+BGB_PKG_IN_REPO := tools/filelistgen
+BGB_BINARY := $(FILELISTGENTOOL)
+BGB_ADDITIONAL_GO_ENV := GOARCH=$(GOARCH_FOR_BUILD)
+
+CLEAN_FILES += $(FILELISTGENTOOL)
+
+$(FILELISTGENTOOL_STAMP): $(FILELISTGENTOOL)
+	touch "$@"
+
+$(FILELISTGENTOOL): $(MK_PATH) | $(TOOLSDIR)
+
+include makelib/build_go_bin.mk
+
+# FILELISTGENTOOL_STAMP deliberately not cleared

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -1,4 +1,4 @@
 # depsgentool is special (building other tools require it), so it has
 # to be included first
 $(call inc-one,depsgentool.mk)
-$(call inc-many,actool.mk)
+$(call inc-many,actool.mk filelistgentool.mk)


### PR DESCRIPTION
The filelist generator tool is currently not used by anything. But in
following commits it will be used by depsgen and by other new tool.

filelistgen is expected to be called like:
filelistgen <OPTIONS> >filelist

filelistgen has three modes of operation:

1. Generate empty filelist (zero directories, files and symlinks):

filelistgen --empty >empty.filelist

2. Generate shallow filelist of a directory with given suffix:

In this mode, the generator does not descend into subdirectories. The
generated filelist will contain only items that does not begin with a
dot and have a matching suffix.

filelist --directory=some/dir --suffix=.patch >patches.filelist

3. Generate deep filelist:

In this mode, the generator just gathers all files, directories and
symlinks from given directory and its subdirectories.

filelist --directory=some/dir >everything.filelist

The format of a filelist is described in
tools/common/filelist/filelist.go