### PR TITLE
common: change the port number

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -39,7 +39,7 @@ const (
 	OverlayPreparedFilename      = "overlay-prepared"
 	PrivateUsersPreparedFilename = "private-users-prepared"
 
-	MetadataServicePort    = 2375
+	MetadataServicePort    = 18112
 	MetadataServiceRegSock = "/run/rkt/metadata-svc.sock"
 
 	DefaultLocalConfigDir  = "/etc/rkt"


### PR DESCRIPTION
The previous port number was registered and reserved. Use a random high
port number in the non-dynamic range.