### PR TITLE
net: revendor go-iptables for --wait

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -123,7 +123,7 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/go-iptables/iptables",
-			"Rev": "83dfad0f13fd7310fb3c1cb8563248d8d604b95b"
+			"Rev": "74b0926558061d3a23824e9c18c9cf9c1b9c11f4"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-semver/semver",

--- a/Godeps/_workspace/src/github.com/coreos/go-iptables/iptables/iptables.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-iptables/iptables/iptables.go
@@ -53,7 +53,7 @@ func New() (*IPTables, error) {
 }
 
 // Exists checks if given rulespec in specified table/chain exists
-func (ipt *IPTables) Exists(table, chain string, rulespec...string) (bool, error) {
+func (ipt *IPTables) Exists(table, chain string, rulespec ...string) (bool, error) {
 	checkPresent, err := getIptablesHasCheckCommand()
 	if err != nil {
 		log.Printf("Error checking iptables version, assuming version at least 1.4.11: %v", err)
@@ -114,8 +114,8 @@ func (ipt *IPTables) Delete(table, chain string, rulespec ...string) error {
 func (ipt *IPTables) List(table, chain string) ([]string, error) {
 	var stdout, stderr bytes.Buffer
 	cmd := exec.Cmd{
-		Path: ipt.path,
-		Args: []string{ipt.path, "-t", table, "-S", chain},
+		Path:   ipt.path,
+		Args:   []string{ipt.path, "--wait", "-t", table, "-S", chain},
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}
@@ -158,11 +158,12 @@ func (ipt *IPTables) DeleteChain(table, chain string) error {
 	return ipt.run("-t", table, "-X", chain)
 }
 
-func (ipt *IPTables) run(args... string) error {
+func (ipt *IPTables) run(args ...string) error {
 	var stderr bytes.Buffer
+	args = append([]string{"--wait"}, args...)
 	cmd := exec.Cmd{
-		Path: ipt.path,
-		Args: append([]string{ipt.path}, args...),
+		Path:   ipt.path,
+		Args:   append([]string{ipt.path}, args...),
 		Stderr: &stderr,
 	}
 


### PR DESCRIPTION
Revendor go-iptables to pick up addition
of --wait flag so that multiple containers
starting won't cause failure.