### PR TITLE
rkt: implement new image fetching behavior.

### DIFF
--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -436,13 +436,13 @@ func TestFetchImage(t *testing.T) {
 			ks: ks,
 		},
 	}
-	_, err = ft.fetchImage(fmt.Sprintf("%s/app.aci", ts.URL), "", true)
+	_, err = ft.fetchImage(fmt.Sprintf("%s/app.aci", ts.URL), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestFetchImageFromStore(t *testing.T) {
+func TestGetStoreKeyFromApp(t *testing.T) {
 	dir, err := ioutil.TempDir("", "fetch-image")
 	if err != nil {
 		t.Fatalf("error creating tempdir: %v", err)
@@ -469,12 +469,7 @@ func TestFetchImageFromStore(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 
-	ft := &fetcher{
-		imageActionData: imageActionData{
-			s: s,
-		},
-	}
-	_, err = ft.fetchImageFromStore("example.com/app")
+	_, err = getStoreKeyFromApp(s, "example.com/app")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -628,8 +623,10 @@ func TestFetchImageCache(t *testing.T) {
 				s:  s,
 				ks: ks,
 			},
+			// Skip local store
+			noStore: true,
 		}
-		_, err = ft.fetchImage(aciURL, "", true)
+		_, err = ft.fetchImage(aciURL, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -645,7 +642,7 @@ func TestFetchImageCache(t *testing.T) {
 		}
 
 		downloadTime := rem.DownloadTime
-		_, err = ft.fetchImage(aciURL, "", true)
+		_, err = ft.fetchImage(aciURL, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/rkt/stage1hash.go
+++ b/rkt/stage1hash.go
@@ -82,8 +82,9 @@ func getStage1Hash(s *store.Store, cmd *cobra.Command) (*types.Hash, error) {
 		imageActionData: imageActionData{
 			s: s,
 		},
-		local:    true,
-		withDeps: false,
+		storeOnly: true,
+		noStore:   false,
+		withDeps:  false,
 	}
 
 	imageFlag := cmd.Flags().Lookup(stage1ImageFlagName)
@@ -117,7 +118,7 @@ func getDefaultStage1HashFromStore(fn *finder) *types.Hash {
 	// otherwise we don't know if something changed
 	if !strings.HasSuffix(defaultStage1Version, "-dirty") {
 		stage1AppName := fmt.Sprintf("%s:%s", defaultStage1Name, url.QueryEscape(defaultStage1Version))
-		s1img, _ := fn.findImage(stage1AppName, "", true)
+		s1img, _ := fn.findImage(stage1AppName, "")
 		return s1img
 	}
 	return nil
@@ -151,7 +152,7 @@ func getLocalDefaultStage1Hash(fn *finder) (*types.Hash, error) {
 	// parameter to configure script, so it defaulted to desired
 	// filename like "stuff/yadda/stage1-lkvm.aci" (or something).
 	if filepath.IsAbs(defaultStage1Image) {
-		s1img, err := fn.findImage(defaultStage1Image, "", false)
+		s1img, err := fn.findImage(defaultStage1Image, "")
 		if s1img != nil {
 			return s1img, nil
 		}
@@ -170,7 +171,7 @@ func getLocalDefaultStage1Hash(fn *finder) (*types.Hash, error) {
 		}
 	}
 	fallbackPath := filepath.Join(filepath.Dir(exePath), imgBase)
-	s1img, err := fn.findImage(fallbackPath, "", false)
+	s1img, err := fn.findImage(fallbackPath, "")
 	if err != nil {
 		if firstErr != nil {
 			return nil, fmt.Errorf("error finding stage1 images %q and %q: %v and %v", defaultStage1Image, fallbackPath, firstErr, err)
@@ -182,7 +183,7 @@ func getLocalDefaultStage1Hash(fn *finder) (*types.Hash, error) {
 }
 
 func getCustomStage1Hash(fn *finder, path string) (*types.Hash, error) {
-	s1img, err := fn.findImage(path, "", false)
+	s1img, err := fn.findImage(path, "")
 	if err != nil {
 		return nil, fmt.Errorf("error finding stage1 image %q: %v", path, err)
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -65,6 +65,17 @@ var (
 	ErrKeyNotFound = errors.New("no keys found")
 )
 
+// ACINotFoundError is returned when an ACI cannot be found by GetACI
+// Useful to distinguish a generic error from an aci not found.
+type ACINotFoundError struct {
+	name   types.ACIdentifier
+	labels types.Labels
+}
+
+func (e ACINotFoundError) Error() string {
+	return fmt.Sprintf("cannot find aci satisfying name: %q and labels: %s in the local store", e.name, labelsToString(e.labels))
+}
+
 // StoreRemovalError defines an error removing a non transactional store (like
 // a diskv store or the tree store).
 // When this happen there's the possibility that the store is left in an
@@ -582,7 +593,7 @@ nextKey:
 	if curaciinfo != nil {
 		return curaciinfo.BlobKey, nil
 	}
-	return "", fmt.Errorf("cannot find aci satisfying name: %q and labels: %s in the local store", name, labelsToString(labels))
+	return "", ACINotFoundError{name: name, labels: labels}
 }
 
 func (ds Store) GetAllACIInfos(sortfields []string, ascending bool) ([]*ACIInfo, error) {


### PR DESCRIPTION
Implement fetching behavior as explained in the below table (see also https://github.com/coreos/rkt/issues/1196#issuecomment-127983674 for previous discussion).                  

For `fetch/run/prepare`.

--store-only | --no-store |  behavior          | description
 ----------- | ---------- | ------------------ | -------------------------------------------------------------------------------
1            | 0          | store              | Just check the store
0            | 1          | remote             | Do remote download (handling caching logic for http(s):// and docker://)
0            | 0          | store then remote  | Default Behavior. Does `store` and if it doesn't return an image calls `remote`

behavior details related to provided image:

behavior     | image              | detailed behavior
------------ | ------------------ | --------------------------------------------------------------------------------------------
store        | file://            | just use the file.
store        | http(s)://         | Search in the store remote table if the URL is available and use the saved BlobKey.
store        | docker://          | Search in the store remote table if the URL is available and use the saved BlobKey.
store        | image name         | Check store using GetACI(name, labels), if found use that image.
remote       | file://            | just use the file.
remote       | http(s)://         | Search in the store remote table if the URL is available. If it's available and the saved Cache-Control maxage > 0 determine if the image should be downloaded. If  it's not expired use the saved BlockKey. Otherwise download (sending if available the saved ETag). If download returns a `304 Not Modified` use the saved BlobKey.
remote       | docker://          | Fetch using docker2aci.
remote       | image name         | Do discovery. If discovery is successful use the discovered URL doing the above `remote` http(s):// image case.

Remote behavior doesn't mean that the image will always be downloaded. For
http(s):// images ETag and Cache-Control max-age are handled.
If someone really wants to bypass remote caching logic a future option
(something like `--no-cache`) should be implemented.

What's missing is an additional caching check for docker:// images. This will
mimic the caching done for http(s):// URLs and will avoid downloading an image
on remote behavior if a cached image is considered good.  This will come in a
later patch.

