### PR TITLE
rkt/prepare: find default stage1 image in init().

### DIFF
--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -45,9 +45,11 @@ End the image arguments with a lone "---" to resume argument parsing.`,
 )
 
 func init() {
+	setDefaultStage1Image()
+
 	cmdRkt.AddCommand(cmdPrepare)
 
-	cmdPrepare.Flags().StringVar(&flagStage1Image, "stage1-image", defaultStage1Image, `image to use as stage1. Local paths and http/https URLs are supported. If empty, rkt will look for a file called "stage1.aci" in the same directory as rkt itself`)
+	cmdPrepare.Flags().StringVar(&flagStage1Image, "stage1-image", defaultStage1Image, `image to use as stage1. Local paths and http/https URLs are supported. By default, rkt will look for a file called "stage1.aci" in the same directory as rkt itself`)
 	cmdPrepare.Flags().Var(&flagVolumes, "volume", "volumes to mount into the pod")
 	cmdPrepare.Flags().Var(&flagPorts, "port", "ports to expose on the host (requires --private-net)")
 	cmdPrepare.Flags().BoolVar(&flagQuiet, "quiet", false, "suppress superfluous output on stdout, print only the UUID on success")

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -66,9 +66,7 @@ End the image arguments with a lone "---" to resume argument parsing.`,
 	flagUUIDFileSave string
 )
 
-func init() {
-	cmdRkt.AddCommand(cmdRun)
-
+func setDefaultStage1Image() {
 	// if not set by linker, try discover the directory rkt is running
 	// from, and assume the default stage1.aci is stored alongside it.
 	if defaultStage1Image == "" {
@@ -76,8 +74,14 @@ func init() {
 			defaultStage1Image = filepath.Join(filepath.Dir(exePath), "stage1.aci")
 		}
 	}
+}
 
-	cmdRun.Flags().StringVar(&flagStage1Image, "stage1-image", defaultStage1Image, `image to use as stage1. Local paths and http/https URLs are supported. If empty, rkt will look for a file called "stage1.aci" in the same directory as rkt itself`)
+func init() {
+	setDefaultStage1Image()
+
+	cmdRkt.AddCommand(cmdRun)
+
+	cmdRun.Flags().StringVar(&flagStage1Image, "stage1-image", defaultStage1Image, `image to use as stage1. Local paths and http/https URLs are supported. By default, rkt will look for a file called "stage1.aci" in the same directory as rkt itself`)
 	cmdRun.Flags().Var(&flagVolumes, "volume", "volumes to mount into the pod")
 	cmdRun.Flags().Var(&flagPorts, "port", "ports to expose on the host (requires --private-net)")
 	cmdRun.Flags().Var(&flagPrivateNet, "private-net", "give pod a private network that defaults to the default network plus all user-configured networks. Can be limited to a comma-separated list of network names")


### PR DESCRIPTION
Before this, 'rkt help prepare' will show default stage1image="",
(although it doesn't affect the real prepare work).
