### PR TITLE
stage1 usr_from_coresbump: bump pxe.img to 794

### DIFF
--- a/stage1/usr_from_coreos/manifest.d/systemd
+++ b/stage1/usr_from_coreos/manifest.d/systemd
@@ -25,6 +25,8 @@ lib64/ld-linux-x86-64.so.2
 lib64/libattr.so
 lib64/libattr.so.1
 lib64/libattr.so.1.1.0
+lib64/libaudit.so.1
+lib64/libaudit.so.1.0.0
 lib64/libblkid.so
 lib64/libblkid.so.1
 lib64/libblkid.so.1.1.0
@@ -56,6 +58,9 @@ lib64/liblzma.so.5.0.8
 lib64/libmount.so
 lib64/libmount.so.1
 lib64/libmount.so.1.1.0
+lib64/libpcre.so
+lib64/libpcre.so.1
+lib64/libpcre.so.1.2.4
 lib64/libpthread-2.20.so
 lib64/libpthread.so
 lib64/libpthread.so.0
@@ -65,6 +70,8 @@ lib64/librt.so.1
 lib64/libseccomp.so
 lib64/libseccomp.so.2
 lib64/libseccomp.so.2.1.1
+lib64/libselinux.so
+lib64/libselinux.so.1
 lib64/libuuid.so
 lib64/libuuid.so.1
 lib64/libuuid.so.1.3.0

--- a/stage1/usr_from_coreos/usr_from_coreos.mk
+++ b/stage1/usr_from_coreos/usr_from_coreos.mk
@@ -1,5 +1,5 @@
 UFC_SYSTEMD_VERSION := "v222"
-UFC_IMG_RELEASE := "738.1.0"
+UFC_IMG_RELEASE := "794.0.0"
 UFC_IMG_URL := "http://alpha.release.core-os.net/amd64-usr/$(UFC_IMG_RELEASE)/coreos_production_pxe_image.cpio.gz"
 
 UFC_ITMP := $(BUILDDIR)/tmp/usr_from_coreos


### PR DESCRIPTION
- Bump PXE image for coreos stage1 flavor
- Add new libraries to manifest

Fixes #1360