### PR TITLE
common/cgroup: don't add isolators with nil limits

### DIFF
--- a/common/cgroup/cgroup.go
+++ b/common/cgroup/cgroup.go
@@ -58,8 +58,15 @@ func addMemoryLimit(opts []*unit.UnitOption, limit *resource.Quantity) ([]*unit.
 	return opts, nil
 }
 
+// MaybeAddIsolator considers the given isolator; if the type is known
+// (i.e. IsIsolatorSupported is true) and the limit is non-nil, the supplied
+// opts will be extended with an appropriate option implementing the desired
+// isolation.
 func MaybeAddIsolator(opts []*unit.UnitOption, isolator string, limit *resource.Quantity) ([]*unit.UnitOption, error) {
 	var err error
+	if limit == nil {
+		return opts, nil
+	}
 	if IsIsolatorSupported(isolator) {
 		opts, err = isolatorFuncs[isolator](opts, limit)
 		if err != nil {


### PR DESCRIPTION
If someone calls MaybeAddIsolator with a recognised isolator type but a
nil *resource.Limit, a kernel panic results when we try to call Value()
on the nil Limit. Rather than reaching this stage, just skip trying to
create an isolator when the supplied limit is nil.

Fixes #1377