### PR TITLE
lkvm: fix stdio events pending race in interactive mode & lkvm update

### DIFF
--- a/stage1/usr_from_kvm/lkvm.mk
+++ b/stage1/usr_from_kvm/lkvm.mk
@@ -5,7 +5,7 @@ LKVM_BINARY := $(LKVM_SRCDIR)/lkvm-static
 LKVM_ACI_BINARY := $(ACIROOTFSDIR)/lkvm
 LKVM_GIT := https://kernel.googlesource.com/pub/scm/linux/kernel/git/will/kvmtool
 # just last published version (for reproducible builds), not for any other reason
-LKVM_VERSION := 4095fac878f618ae5e7384a1dc65ee34b6e05217
+LKVM_VERSION := efcf862611f2498d7b500e46a73d8a008e04325f
 
 LKVM_STUFFDIR := $(MK_SRCDIR)/lkvm
 LKVM_PATCHES := $(abspath $(LKVM_STUFFDIR)/patches/*.patch)

--- a/stage1/usr_from_kvm/lkvm/patches/terminal_late_fix.patch
+++ b/stage1/usr_from_kvm/lkvm/patches/terminal_late_fix.patch
@@ -1,0 +1,23 @@
+diff --git a/term.c b/term.c
+index 9763211..dec0d79 100644
+--- a/term.c
++++ b/term.c
+@@ -202,10 +202,16 @@ int term_init(struct kvm *kvm)
+ 
+ 	return 0;
+ }
+-dev_init(term_init);
++// temporary fix to delay term_init to prevent races between term-poll 
++// and threadpool console RX workers
++// TODO: refactor to synchronize these threads with global cdev.poll_cond/mutex/vq_ready
++// with poll_cond properly initialized earlier
++//dev_init(term_init);
++firmware_init(term_init);
+ 
+ int term_exit(struct kvm *kvm)
+ {
+ 	return 0;
+ }
+-dev_exit(term_exit);
++//dev_exit(term_exit);
++firmware_exit(term_exit);


### PR DESCRIPTION
There is a problem during console device initialization.
In case of some buffered stdio events, backend thread (host level) is
started before threadpool workers (threads that pass value to
frontend driver) while condition variable is no initialized properly yet.
This causes deadlock or segfault.

This temporary solution just delays initialization of mentioned backend thread to
firmware initialization phase.

Additionally this commit updates lkvm to the newest upstreamed version.

ps. I'm going to upstream this patch after refactoring and then we just updated lkvm to fixed version.