### PR TITLE
metadata svc: fix typo in the HTTP-POST options

### DIFF
--- a/rkt/metadata_service.go
+++ b/rkt/metadata_service.go
@@ -509,10 +509,10 @@ func handlePodSign(w http.ResponseWriter, r *http.Request) {
 func handlePodVerify(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
-	uuid, err := types.NewUUID(r.FormValue("uid"))
+	uuid, err := types.NewUUID(r.FormValue("uuid"))
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, "uid field missing or malformed: %v", err)
+		fmt.Fprintf(w, "uuid field missing or malformed: %v", err)
 		return
 	}
 


### PR DESCRIPTION
When requesting the metadata service to verify a signature from another pod,
the uuid of the pod needs to be passed as an HTTP-POST option. According to
the spec, the name of the option is "uuid" and not "uid".

Note: the same typo was done in the ACE validator: https://github.com/appc/spec/pull/485