### PR TITLE
lkvm: don't rely on $HOME

### DIFF
--- a/stage1/usr_from_kvm/lkvm/patches/lkvm-home-root.patch
+++ b/stage1/usr_from_kvm/lkvm/patches/lkvm-home-root.patch
@@ -1,0 +1,11 @@
+--- a/include/kvm/kvm.h	2015-09-14 19:35:53.382735385 +0200
++++ b/include/kvm/kvm.h	2015-09-14 19:35:22.692626754 +0200
+@@ -17,7 +17,7 @@
+ #define SIGKVMPAUSE		(SIGRTMIN + 1)
+ 
+ #define KVM_PID_FILE_PATH	"/.lkvm/"
+-#define HOME_DIR		getenv("HOME")
++#define HOME_DIR		"/root"
+ #define KVM_BINARY_NAME		"lkvm"
+ 
+ #ifndef PAGE_SIZE


### PR DESCRIPTION
When rkt is started via systemd-run, $HOME might not be defined.

Symptoms:
```
bind: No such file or directory
  Error: Failed adding socket to epoll
  Warning: Failed init: kvm_ipc__init

  Fatal: Initialisation failed
```

Fix https://github.com/coreos/rkt/issues/1393

/cc @yifan-gu @jellonek 

I am not sure what is the correct way to report this upstream in lkvm.
