### PR TITLE
stage1/reaper: make reaper to reap when each exits.

### DIFF
--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -211,10 +211,10 @@ func (p *Pod) appToSystemd(ra *schema.RuntimeApp, interactive bool, flavor strin
 	opts := []*unit.UnitOption{
 		unit.NewUnitOption("Unit", "Description", fmt.Sprintf("Application=%v Image=%v", appName, imgName)),
 		unit.NewUnitOption("Unit", "DefaultDependencies", "false"),
-		unit.NewUnitOption("Unit", "OnFailure", "reaper.service"),
 		unit.NewUnitOption("Unit", "Wants", "exit-watcher.service"),
 		unit.NewUnitOption("Service", "Restart", "no"),
 		unit.NewUnitOption("Service", "ExecStart", execStart),
+		unit.NewUnitOption("Service", "ExecStop", fmt.Sprintf("/reaper.sh %s", appName)),
 		unit.NewUnitOption("Service", "User", "0"),
 		unit.NewUnitOption("Service", "Group", "0"),
 	}

--- a/stage1/reaper/reaper.sh
+++ b/stage1/reaper/reaper.sh
@@ -3,10 +3,6 @@ shopt -s nullglob
 
 SYSCTL=/usr/bin/systemctl
 
-cd /opt/stage2
-for app in *; do
-        status=$(${SYSCTL} show --property ExecMainStatus "${app}.service")
-        echo "${status#*=}" > "/rkt/status/$app"
-done
-
-${SYSCTL} halt --force
+app=$1
+status=$(${SYSCTL} show --property ExecMainStatus "${app}.service")
+echo "${status#*=}" > "/rkt/status/$app"

--- a/stage1/units/units.mk
+++ b/stage1/units/units.mk
@@ -7,7 +7,6 @@ LOCAL_UNIT_FILES := \
         $(MK_SRCDIR)/units/default.target \
         $(MK_SRCDIR)/units/exit-watcher.service \
         $(MK_SRCDIR)/units/local-fs.target \
-        $(MK_SRCDIR)/units/reaper.service \
         $(MK_SRCDIR)/units/sockets.target \
         $(MK_SRCDIR)/units/halt.target \
         $(MK_SRCDIR)/units/systemd-reboot.service \

--- a/stage1/units/units/exit-watcher.service
+++ b/stage1/units/units/exit-watcher.service
@@ -5,4 +5,4 @@ DefaultDependencies=false
 
 [Service]
 RemainAfterExit=yes
-ExecStop=/usr/bin/systemctl isolate reaper.service
+ExecStop=/usr/bin/systemctl halt --force

--- a/stage1/units/units/halt.target
+++ b/stage1/units/units/halt.target
@@ -1,6 +1,4 @@
 [Unit]
 Description=Halt
 DefaultDependencies=no
-Requires=reaper.service
-After=reaper.service
 AllowIsolate=yes

--- a/stage1/units/units/poweroff.target
+++ b/stage1/units/units/poweroff.target
@@ -1,6 +1,4 @@
 [Unit]
 Description=Poweroff
 DefaultDependencies=no
-Requires=reaper.service
-After=reaper.service
 AllowIsolate=yes

--- a/stage1/units/units/reaper.service
+++ b/stage1/units/units/reaper.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=rkt apps reaper
-AllowIsolate=true
-DefaultDependencies=false
-
-[Service]
-ExecStart=/reaper.sh


### PR DESCRIPTION
Previously, when an app exits with code == 0, its status will not
be written to file. Besides, if the exited app has non-zero exit code,
the whole pod will exit.

This PR changes the above behavior that when a app exits, its exit
code will be recorded no matter it's zero or not. Besides, the exit
of the app will not cause the whole pod to exit.