### PR TITLE
doc: rkt with systemd: lkvm: workaround for missing $HOME

### DIFF
--- a/Documentation/using-rkt-with-systemd.md
+++ b/Documentation/using-rkt-with-systemd.md
@@ -15,9 +15,11 @@ Consequently, standard `systemd` idioms like `systemctl start` and `systemctl st
 To start a daemonized container from the command line, use [`systemd-run`](http://www.freedesktop.org/software/systemd/man/systemd-run.html):
 
 ```
-# systemd-run rkt run --mds-register=false coreos.com/etcd:v2.0.10
+# systemd-run --uid=0 rkt run --mds-register=false coreos.com/etcd:v2.0.10
 Running as unit run-29075.service.
 ```
+
+Note: `--uid=0` (or `User=root` below) is a workaround for [issue #1393](https://github.com/coreos/rkt/issues/1393).
 
 This creates a transient systemd unit on which you can use standard systemd tools:
 
@@ -63,6 +65,7 @@ Description=etcd
 ExecStart=/usr/bin/rkt --insecure-skip-verify run --mds-register=false coreos.com/etcd:v2.0.10
 KillMode=mixed
 Restart=always
+User=root
 ```
 
 This unit can now be managed using the standard `systemctl` commands:
@@ -111,6 +114,7 @@ ExecStartPre=/usr/bin/rkt fetch myapp.com/myapp-1.3.4
 ExecStart=/usr/bin/rkt run --inherit-env --private-net --port=http:8888 myapp.com/myapp-1.3.4
 KillMode=mixed
 Restart=always
+User=root
 ```
 
 ## Socket-activated service
@@ -151,6 +155,7 @@ Description=My socket-activated app
 [Service]
 ExecStart=/usr/bin/rkt run myapp.com/my-socket-activated-app:v1.0
 KillMode=mixed
+User=root
 ```
 
 ```


### PR DESCRIPTION
Running the lkvm flavor of rkt in systemd does not currently work if
$HOME is not defined: see https://github.com/coreos/rkt/issues/1393

It should be fixed in lkvm upstream, but meanwhile, mention the
workaround in the documentation.