### PR TITLE
kvm: resource isolators

### DIFF
--- a/Documentation/running-lkvm-stage1.md
+++ b/Documentation/running-lkvm-stage1.md
@@ -68,8 +68,12 @@ If you want to see the kernel and boot messages, run rkt with the `--debug` flag
 
 You can exit pressing `<Ctrl-a x>`.
 
-Notes-cpus: By default containers start working on all cpus if at least one app does not have specfied cpus. In the other case, container will be working on aggregate amount of cpus. 
-Notes-memory: Container memory is a sum of memory required by each app in pod and additional 128MB required by system. If memory of some app is not specified, app memory will be set on default value (128MB).
+#### CPU usage
+By default, processes will start working on all CPUs if at least one app does not have specfied CPUs. 
+In the other case, container will be working on aggregate amount of CPUs. 
+
+#### Memory
+Currently, the memory allocated to the virtual machine is a sum of memory required by each app in pod and additional 128MB required by system. If memory of some app is not specified, app memory will be set on default value (128MB).
 
 ### Selecting stage1 at runtime
 

--- a/Documentation/running-lkvm-stage1.md
+++ b/Documentation/running-lkvm-stage1.md
@@ -68,6 +68,8 @@ If you want to see the kernel and boot messages, run rkt with the `--debug` flag
 
 You can exit pressing `<Ctrl-a x>`.
 
+Notes: By default containers start working on all cpus and with 1GB. If user specify parameters via pod-manifest, memory will be increased by 128MB. Additional memory is required by system process.
+
 ### Selecting stage1 at runtime
 
 If you want to run software that requires hypervisor isolation along with trusted software that only needs container isolation, you can [choose which stage1.aci to use at runtime](https://github.com/coreos/rkt/blob/master/Documentation/commands.md#use-a-custom-stage-1).

--- a/Documentation/running-lkvm-stage1.md
+++ b/Documentation/running-lkvm-stage1.md
@@ -68,7 +68,8 @@ If you want to see the kernel and boot messages, run rkt with the `--debug` flag
 
 You can exit pressing `<Ctrl-a x>`.
 
-Notes: By default containers start working on all cpus and with 1GB. If user specify parameters via pod-manifest, memory will be increased by 128MB. Additional memory is required by system process.
+Notes-cpus: By default containers start working on all cpus if at least one app does not have specfied cpus. In the other case, container will be working on aggregate amount of cpus. 
+Notes-memory: Container memory is a sum of memory required by each app in pod and additional 128MB required by system. If memory of some app is not specified, app memory will be set on default value (128MB).
 
 ### Selecting stage1 at runtime
 

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -280,9 +280,22 @@ func getArgsEnv(p *Pod, flavor string, debug bool, n *networking.Networking) ([]
 			return nil, nil, err
 		}
 
-		// TODO: base on resource isolators
-		cpu := 1
-		mem := 128
+		cpu, mem := kvm.GetAppsResources(p.Manifest.Apps)
+
+		// if user doesn't specify amount of cpus we set no limit.
+		if cpu == 0 {
+			cpu = int64(runtime.NumCPU())
+		}
+		// Convert bytes into megabytes
+		mem /= 1024 * 1024
+
+		// If user doesn't specify amount of mem we set 1GB.
+		// else add additional 128MB for system process.
+		if mem == 0 {
+			mem = int64(1024)
+		} else {
+			mem += 128
+		}
 
 		kernelParams := []string{
 			"console=hvc0",
@@ -312,8 +325,8 @@ func getArgsEnv(p *Pod, flavor string, debug bool, n *networking.Networking) ([]
 			"run",
 			"--name", "rkt-" + p.UUID.String(),
 			"--no-dhcp", // speed bootup
-			"--cpu", strconv.Itoa(cpu),
-			"--mem", strconv.Itoa(mem),
+			"--cpu", strconv.FormatInt(cpu, 10),
+			"--mem", strconv.FormatInt(mem, 10),
 			"--console=virtio",
 			"--kernel", kernelPath,
 			"--disk", "stage1/rootfs", // relative to run/pods/uuid dir this is a place where systemd resides

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -282,21 +282,6 @@ func getArgsEnv(p *Pod, flavor string, debug bool, n *networking.Networking) ([]
 
 		cpu, mem := kvm.GetAppsResources(p.Manifest.Apps)
 
-		// if user doesn't specify amount of cpus we set no limit.
-		if cpu == 0 {
-			cpu = int64(runtime.NumCPU())
-		}
-		// Convert bytes into megabytes
-		mem /= 1024 * 1024
-
-		// If user doesn't specify amount of mem we set 1GB.
-		// else add additional 128MB for system process.
-		if mem == 0 {
-			mem = int64(1024)
-		} else {
-			mem += 128
-		}
-
 		kernelParams := []string{
 			"console=hvc0",
 			"init=/usr/lib/systemd/systemd",

--- a/stage1/init/kvm/resources.go
+++ b/stage1/init/kvm/resources.go
@@ -1,0 +1,50 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvm
+
+import (
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+// findResources find value of last isolator for particular type.
+func findResources(isolators types.Isolators) (mem, cpus int64) {
+	for _, i := range isolators {
+		switch v := i.Value().(type) {
+		case *types.ResourceMemory:
+			memQuantity := v.Limit()
+			mem = memQuantity.Value()
+		case *types.ResourceCPU:
+			cpusQuantity := v.Limit()
+			cpus = cpusQuantity.Value()
+		}
+	}
+
+	return mem, cpus
+}
+
+// GetAppsResources return values specfied by user in pod-manifest.
+// Function expects a podmanifest apps.
+// Return aggregate quantity of mem[B] and cpus.
+func GetAppsResources(apps schema.AppList) (total_cpus, total_mem int64) {
+	for i := range apps {
+		ra := &apps[i]
+		app := ra.App
+		mem, cpus := findResources(app.Isolators)
+		total_cpus += cpus
+		total_mem += mem
+	}
+	return total_cpus, total_mem
+}

--- a/stage1/init/kvm/resources.go
+++ b/stage1/init/kvm/resources.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
+
 const (
 	defaultMem        = 128 // MB
 	systemMemOverhead = 128 // MB
@@ -44,7 +45,7 @@ func findResources(isolators types.Isolators) (mem, cpus int64) {
 // Function expects a podmanifest apps.
 // Return aggregate quantity of mem (in MB) and cpus.
 func GetAppsResources(apps schema.AppList) (totalCpus, totalMem int64) {
-	cpusSpecified  := false
+	cpusSpecified := false
 	for i := range apps {
 		ra := &apps[i]
 		app := ra.App

--- a/stage1/init/kvm/resources.go
+++ b/stage1/init/kvm/resources.go
@@ -40,6 +40,8 @@ func findResources(isolators types.Isolators) (mem, cpus int64) {
 			// cpus = cpusQuantity
 		}
 	}
+	return mem, cpus
+}
 
 // GetAppsResources returns values specfied by user in pod-manifest.
 // Function expects a podmanifest apps.
@@ -50,13 +52,13 @@ func GetAppsResources(apps schema.AppList) (totalCpus, totalMem int64) {
 		ra := &apps[i]
 		app := ra.App
 		mem, cpus := findResources(app.Isolators)
-		cpusSpecified = cpusSpecified && cpus != 0
+		cpusSpecified = cpusSpecified || cpus != 0
 		totalCpus += cpus
 		totalMem += mem
 	}
 	// If user doesn't specify cpus for at least one app, we set no limit for
 	// whole pod.
-	if cpusSpecified {
+	if !cpusSpecified {
 		totalCpus = int64(runtime.NumCPU())
 	}
 

--- a/stage1/init/kvm/resources_test.go
+++ b/stage1/init/kvm/resources_test.go
@@ -1,0 +1,70 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvm
+
+import (
+	"testing"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+func TestFindResources(t *testing.T) {
+	tests := []struct {
+		in types.Isolators
+
+		wmem int64
+		wcpu int64
+	}{
+		{
+			types.Isolators{},
+
+			defaultMem,
+			0,
+		},
+		{
+			types.Isolators([]types.Isolator{
+				newIsolator(`
+				{
+					"name":     "resource/cpu",
+					"value": {
+						"limit": 100,
+						"request": 100
+						}
+				}`),
+			}),
+
+			defaultMem,
+			100,
+		},
+	}
+
+	for i, tt := range tests {
+		gmem, gcpu := findResources(tt.in)
+		if gmem != tt.wmem {
+			t.Errorf("#%d: got mem=%d, want %d", i, gmem, tt.wmem)
+		}
+		if gcpu != tt.wcpu {
+			t.Errorf("#%d: got cpu=%d, want %d", i, gcpu, tt.wcpu)
+		}
+	}
+}
+
+func newIsolator(body string) (i types.Isolator) {
+	err := i.UnmarshalJSON([]byte(body))
+	if err != nil {
+		panic(err)
+	}
+	return
+}


### PR DESCRIPTION
KVM Added: new functionality to read cpus and mem from resource isolators. Currently kvm uses hard-coded values.
Notes-cpus: By default containers start working on all cpus if at least one app does not have specfied cpus. In the other case, container will be working on aggregate amount of cpus. 
Notes-memory: Container memory is a sum of memory required by each app in pod and additional 128MB required by system. If memory of some app is not specified, app memory will be set on default value (128MB).