### PR TITLE
Give different names to different flavors of stage1 images

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,12 +49,11 @@ AC_CANONICAL_HOST
 AC_CANONICAL_BUILD
 
 ## STAGE1:type
-m4_define([DEFAULT_FLAVOR], [coreos])
 AC_ARG_WITH([stage1],
-            AS_HELP_STRING([--with-stage1=type],
-                           [type of stage1 build one of 'src', 'coreos', 'host', 'none', 'kvm' (default: 'DEFAULT_FLAVOR')]),
+            [AS_HELP_STRING([--with-stage1],
+                            [type of stage1 build one of 'src', 'coreos', 'host', 'none', 'kvm' (default: 'coreos')])],
             [RKT_STAGE1_USR_FROM="${withval}"],
-            [RKT_STAGE1_USR_FROM="DEFAULT_FLAVOR"])
+            [RKT_STAGE1_USR_FROM="coreos"])
 
 AS_CASE([${RKT_STAGE1_USR_FROM}],
         [none],
@@ -82,16 +81,15 @@ AS_CASE([${RKT_STAGE1_USR_FROM}],
 
 AC_SUBST(RKT_STAGE1_USR_FROM)
 
-m4_define(DEFAULT_STAGE1_NAME,coreos.com/rkt/stage1)
 AC_ARG_WITH(stage1-default-name,
-            AS_HELP_STRING([--with-stage1-default-name=stage1_name],
-                           [default name of stage1, default: DEFAULT_STAGE1_NAME]),
+            [AS_HELP_STRING([--with-stage1-default-name],
+                            [default name of stage1, default: 'coreos.com/rkt/stage1'])],
             [RKT_STAGE1_DEFAULT_NAME="${withval}"],
             [RKT_STAGE1_DEFAULT_NAME=auto])
 
 AC_ARG_WITH(stage1-default-version,
-            AS_HELP_STRING([--with-stage1-default-version=stage1_version],
-                           [default version of stage1, default: same as rkt version]),
+            [AS_HELP_STRING([--with-stage1-default-version],
+                            [default version of stage1, default: same as rkt version])],
             [RKT_STAGE1_DEFAULT_VERSION="${withval}"],
             [RKT_STAGE1_DEFAULT_VERSION=auto])
 
@@ -114,7 +112,7 @@ AS_VAR_IF([RKT_STAGE1_USR_FROM], [none],
                       RKT_STAGE1_DEFAULT_VERSION=auto])])
 
 AS_VAR_IF([RKT_STAGE1_DEFAULT_NAME], [auto],
-          [RKT_STAGE1_DEFAULT_NAME=DEFAULT_STAGE1_NAME])
+          [RKT_STAGE1_DEFAULT_NAME='coreos.com/rkt/stage1'])
 AS_VAR_IF([RKT_STAGE1_DEFAULT_VERSION], [auto],
           [RKT_STAGE1_DEFAULT_VERSION=${RKT_VERSION}])
 
@@ -126,17 +124,15 @@ AC_SUBST(RKT_STAGE1_DEFAULT_ACI_LDFLAGS)
 
 ## STAGE1: Systemd git path and version for src flavor
 
-m4_define([DEFAULT_STAGE1_SYSTEMD_SRC], [https://github.com/systemd/systemd.git])
 AC_ARG_WITH([stage1-systemd-src],
-            AS_HELP_STRING([--with-stage1-systemd-src=git-path],
-                           [address to git repository of systemd, used in 'src' stage1 flavor (default: 'DEFAULT_STAGE1_SYSTEMD_SRC')]),
+            [AS_HELP_STRING([--with-stage1-systemd-src],
+                            [address to git repository of systemd, used in 'src' stage1 flavor (default: 'https://github.com/systemd/systemd.git')])],
             [RKT_STAGE1_SYSTEMD_SRC="${withval}"],
             [RKT_STAGE1_SYSTEMD_SRC='auto'])
 
-m4_define([DEFAULT_STAGE1_SYSTEMD_VER], [v222])
 AC_ARG_WITH([stage1-systemd-version],
-            AS_HELP_STRING([--with-stage1-systemd-version=version],
-                           [systemd version to build, used in 'src' stage1 flavor (default: 'DEFAULT_STAGE1_SYSTEMD_VER', should be in format 'v<number>', like v222)]),
+            [AS_HELP_STRING([--with-stage1-systemd-version],
+                            [systemd version to build, used in 'src' stage1 flavor (default: 'v222', should be in format 'v<number>', like v222)])],
             [RKT_STAGE1_SYSTEMD_VER="${withval}"],
             [RKT_STAGE1_SYSTEMD_VER='auto'])
 
@@ -144,12 +140,12 @@ AS_CASE([$RKT_STAGE1_USR_FROM],
         [src],
                 [AS_VAR_IF([RKT_STAGE1_SYSTEMD_SRC], [auto],
                            dnl systemd source not specified, use default
-                           [RKT_STAGE1_SYSTEMD_SRC=DEFAULT_STAGE1_SYSTEMD_SRC],
+                           [RKT_STAGE1_SYSTEMD_SRC='https://github.com/systemd/systemd.git'],
                            dnl systemd source specified, use it
                            [])
                  AS_VAR_IF([RKT_STAGE1_SYSTEMD_VER], [auto],
                            dnl systemd version not specified, use default
-                           [RKT_STAGE1_SYSTEMD_VER=DEFAULT_STAGE1_SYSTEMD_VER],
+                           [RKT_STAGE1_SYSTEMD_VER='v222'],
                            dnl systemd version specified, use it
                            [])],
         dnl other flavors
@@ -174,10 +170,9 @@ AC_SUBST(RKT_STAGE1_SYSTEMD_SRC)
 AC_SUBST(RKT_STAGE1_SYSTEMD_VER)
 
 ## STAGE1: linker-defined custom STAGE1 image path, default is unset
-m4_define([DEFAULT_STAGE1_IMAGE], [])
 AC_ARG_WITH([stage1-image-path],
-            AS_HELP_STRING([--with-stage1-image-path],
-                           [custom stage1 image path (default: 'DEFAULT_STAGE1_IMAGE')]),
+            [AS_HELP_STRING([--with-stage1-image-path],
+                            [custom stage1 image path (default: empty)])],
             [RKT_STAGE1_IMAGE="${withval}"],
             [RKT_STAGE1_IMAGE=""])
 
@@ -191,16 +186,15 @@ AC_SUBST(RKT_STAGE1_IMAGE_LDFLAGS)
 
 ## STAGE1: path to coreos pxe and its systemd version
 
-m4_define([DEFAULT_LOCAL_COREOS_PXE_IMAGE_PATH], [])
 AC_ARG_WITH([coreos-local-pxe-image-path],
-            AS_HELP_STRING([--with-coreos-local-pxe-image-path],
-                           [path to local CoreOS PXE image, used in 'coreos' and 'kvm' stage1 flavors (default: 'DEFAULT_LOCAL_COREOS_PXE_IMAGE_PATH') (the GPG signature of this file will not be checked!)]),
+            [AS_HELP_STRING([--with-coreos-local-pxe-image-path],
+                            [path to local CoreOS PXE image, used in 'coreos' and 'kvm' stage1 flavors (default: empty) (the GPG signature of this file will not be checked!)])],
             [RKT_LOCAL_COREOS_PXE_IMAGE_PATH="${withval}"],
             [RKT_LOCAL_COREOS_PXE_IMAGE_PATH=""])
 
 AC_ARG_WITH([coreos-local-pxe-image-systemd-version],
-            AS_HELP_STRING([--with-coreos-local-pxe-image-systemd-version],
-                           [version of systemd in local CoreOS PXE image, used in 'coreos' and 'kvm' stage1 flavors (should be in format 'v<number>', like v222)]),
+            [AS_HELP_STRING([--with-coreos-local-pxe-image-systemd-version],
+                            [version of systemd in local CoreOS PXE image, used in 'coreos' and 'kvm' stage1 flavors (should be in format 'v<number>', like v222)])],
             [RKT_LOCAL_COREOS_PXE_IMAGE_SYSTEMD_VER="${withval}"],
             [RKT_LOCAL_COREOS_PXE_IMAGE_SYSTEMD_VER=])
 
@@ -242,8 +236,8 @@ AC_SUBST(RKT_LOCAL_COREOS_PXE_IMAGE_SYSTEMD_VER)
 ## Functional tests
 
 AC_ARG_ENABLE([functional-tests],
-              AS_HELP_STRING([--enable-functional-tests],
-                             [enable functional tests on make check (linux only, uses sudo, default: no, use auto to enable if possible, for host stage1 flavor systemd version 220 or higher on host is required)]),
+              [AS_HELP_STRING([--enable-functional-tests],
+                              [enable functional tests on make check (linux only, uses sudo, default: 'no', use 'auto' to enable if possible, for host stage1 flavor systemd version 220 or higher on host is required)])],
               [RKT_RUN_FUNCTIONAL_TESTS="${enableval}"],
               [RKT_RUN_FUNCTIONAL_TESTS="no"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -159,7 +159,12 @@ AS_VAR_IF([RKT_STAGE1_USR_FROM], [none],
                       RKT_STAGE1_DEFAULT_VERSION=auto])])
 
 AS_VAR_IF([RKT_STAGE1_DEFAULT_NAME], [auto],
-          [RKT_STAGE1_DEFAULT_NAME="coreos.com/rkt/stage1-${RKT_STAGE1_USR_FROM}"])
+          [AS_CASE([$RKT_STAGE1_USR_FROM],
+	           dnl for src flavor, we also append systemd version to stage1 name
+	           [src],
+		           [RKT_STAGE1_DEFAULT_NAME="coreos.com/rkt/stage1-${RKT_STAGE1_USR_FROM}-${RKT_STAGE1_SYSTEMD_VER}"],
+		   dnl other flavors get only flavor name
+                   [RKT_STAGE1_DEFAULT_NAME="coreos.com/rkt/stage1-${RKT_STAGE1_USR_FROM}"])])
 AS_VAR_IF([RKT_STAGE1_DEFAULT_VERSION], [auto],
           [RKT_STAGE1_DEFAULT_VERSION=${RKT_VERSION}])
 

--- a/configure.ac
+++ b/configure.ac
@@ -81,47 +81,6 @@ AS_CASE([${RKT_STAGE1_USR_FROM}],
 
 AC_SUBST(RKT_STAGE1_USR_FROM)
 
-AC_ARG_WITH(stage1-default-name,
-            [AS_HELP_STRING([--with-stage1-default-name],
-                            [default name of stage1, default: 'coreos.com/rkt/stage1-${flavor}'])],
-            [RKT_STAGE1_DEFAULT_NAME="${withval}"],
-            [RKT_STAGE1_DEFAULT_NAME=auto])
-
-AC_ARG_WITH(stage1-default-version,
-            [AS_HELP_STRING([--with-stage1-default-version],
-                            [default version of stage1, default: same as rkt version])],
-            [RKT_STAGE1_DEFAULT_VERSION="${withval}"],
-            [RKT_STAGE1_DEFAULT_VERSION=auto])
-
-dnl warn if we specified above flags for other flavors than none
-AS_VAR_IF([RKT_STAGE1_USR_FROM], [none],
-          dnl none flavor
-          [],
-          dnl not none flavor
-          [AS_VAR_IF([RKT_STAGE1_DEFAULT_NAME], [auto],
-                     dnl default
-                     [],
-                     dnl not default
-                     [AC_MSG_WARN([* --with-stage1-default-name is ignored by ${RKT_STAGE1_USR_FROM} stage1 flavor])
-                      RKT_STAGE1_DEFAULT_NAME=auto])
-           AS_VAR_IF([RKT_STAGE1_DEFAULT_VERSION], [auto],
-                     dnl default
-                     [],
-                     dnl not default
-                     [AC_MSG_WARN([* --with-stage1-default-version is ignored by ${RKT_STAGE1_USR_FROM} stage1 flavor])
-                      RKT_STAGE1_DEFAULT_VERSION=auto])])
-
-AS_VAR_IF([RKT_STAGE1_DEFAULT_NAME], [auto],
-          [RKT_STAGE1_DEFAULT_NAME="coreos.com/rkt/stage1-${RKT_STAGE1_USR_FROM}"])
-AS_VAR_IF([RKT_STAGE1_DEFAULT_VERSION], [auto],
-          [RKT_STAGE1_DEFAULT_VERSION=${RKT_VERSION}])
-
-RKT_STAGE1_DEFAULT_ACI_LDFLAGS="`RKT_XF main.defaultStage1Name "${RKT_STAGE1_DEFAULT_NAME}"` `RKT_XF main.defaultStage1Version "${RKT_STAGE1_DEFAULT_VERSION}"`"
-
-AC_SUBST(RKT_STAGE1_DEFAULT_NAME)
-AC_SUBST(RKT_STAGE1_DEFAULT_VERSION)
-AC_SUBST(RKT_STAGE1_DEFAULT_ACI_LDFLAGS)
-
 ## STAGE1: Systemd git path and version for src flavor
 
 AC_ARG_WITH([stage1-systemd-src],
@@ -168,6 +127,47 @@ AS_VAR_IF([RKT_STAGE1_SYSTEMD_VER], [HEAD],
 
 AC_SUBST(RKT_STAGE1_SYSTEMD_SRC)
 AC_SUBST(RKT_STAGE1_SYSTEMD_VER)
+
+AC_ARG_WITH(stage1-default-name,
+            [AS_HELP_STRING([--with-stage1-default-name],
+                            [default name of stage1, default: 'coreos.com/rkt/stage1-${flavor}'])],
+            [RKT_STAGE1_DEFAULT_NAME="${withval}"],
+            [RKT_STAGE1_DEFAULT_NAME=auto])
+
+AC_ARG_WITH(stage1-default-version,
+            [AS_HELP_STRING([--with-stage1-default-version],
+                            [default version of stage1, default: same as rkt version])],
+            [RKT_STAGE1_DEFAULT_VERSION="${withval}"],
+            [RKT_STAGE1_DEFAULT_VERSION=auto])
+
+dnl warn if we specified above flags for other flavors than none
+AS_VAR_IF([RKT_STAGE1_USR_FROM], [none],
+          dnl none flavor
+          [],
+          dnl not none flavor
+          [AS_VAR_IF([RKT_STAGE1_DEFAULT_NAME], [auto],
+                     dnl default
+                     [],
+                     dnl not default
+                     [AC_MSG_WARN([* --with-stage1-default-name is ignored by ${RKT_STAGE1_USR_FROM} stage1 flavor])
+                      RKT_STAGE1_DEFAULT_NAME=auto])
+           AS_VAR_IF([RKT_STAGE1_DEFAULT_VERSION], [auto],
+                     dnl default
+                     [],
+                     dnl not default
+                     [AC_MSG_WARN([* --with-stage1-default-version is ignored by ${RKT_STAGE1_USR_FROM} stage1 flavor])
+                      RKT_STAGE1_DEFAULT_VERSION=auto])])
+
+AS_VAR_IF([RKT_STAGE1_DEFAULT_NAME], [auto],
+          [RKT_STAGE1_DEFAULT_NAME="coreos.com/rkt/stage1-${RKT_STAGE1_USR_FROM}"])
+AS_VAR_IF([RKT_STAGE1_DEFAULT_VERSION], [auto],
+          [RKT_STAGE1_DEFAULT_VERSION=${RKT_VERSION}])
+
+RKT_STAGE1_DEFAULT_ACI_LDFLAGS="`RKT_XF main.defaultStage1Name "${RKT_STAGE1_DEFAULT_NAME}"` `RKT_XF main.defaultStage1Version "${RKT_STAGE1_DEFAULT_VERSION}"`"
+
+AC_SUBST(RKT_STAGE1_DEFAULT_NAME)
+AC_SUBST(RKT_STAGE1_DEFAULT_VERSION)
+AC_SUBST(RKT_STAGE1_DEFAULT_ACI_LDFLAGS)
 
 ## STAGE1: linker-defined custom STAGE1 image path
 AC_ARG_WITH([stage1-image-path],

--- a/configure.ac
+++ b/configure.ac
@@ -83,7 +83,7 @@ AC_SUBST(RKT_STAGE1_USR_FROM)
 
 AC_ARG_WITH(stage1-default-name,
             [AS_HELP_STRING([--with-stage1-default-name],
-                            [default name of stage1, default: 'coreos.com/rkt/stage1'])],
+                            [default name of stage1, default: 'coreos.com/rkt/stage1-${flavor}'])],
             [RKT_STAGE1_DEFAULT_NAME="${withval}"],
             [RKT_STAGE1_DEFAULT_NAME=auto])
 
@@ -112,7 +112,7 @@ AS_VAR_IF([RKT_STAGE1_USR_FROM], [none],
                       RKT_STAGE1_DEFAULT_VERSION=auto])])
 
 AS_VAR_IF([RKT_STAGE1_DEFAULT_NAME], [auto],
-          [RKT_STAGE1_DEFAULT_NAME='coreos.com/rkt/stage1'])
+          [RKT_STAGE1_DEFAULT_NAME="coreos.com/rkt/stage1-${RKT_STAGE1_USR_FROM}"])
 AS_VAR_IF([RKT_STAGE1_DEFAULT_VERSION], [auto],
           [RKT_STAGE1_DEFAULT_VERSION=${RKT_VERSION}])
 
@@ -169,18 +169,22 @@ AS_VAR_IF([RKT_STAGE1_SYSTEMD_VER], [HEAD],
 AC_SUBST(RKT_STAGE1_SYSTEMD_SRC)
 AC_SUBST(RKT_STAGE1_SYSTEMD_VER)
 
-## STAGE1: linker-defined custom STAGE1 image path, default is unset
+## STAGE1: linker-defined custom STAGE1 image path
 AC_ARG_WITH([stage1-image-path],
             [AS_HELP_STRING([--with-stage1-image-path],
-                            [custom stage1 image path (default: empty)])],
+                            [custom stage1 image path (default for all flavors but 'none': 'stage1-${flavor}', for 'none' - empty); the path has to be absolute, otherwise rkt will search for the image in the same directory as rkt using the basename of passed value])],
             [RKT_STAGE1_IMAGE="${withval}"],
-            [RKT_STAGE1_IMAGE=""])
+            [RKT_STAGE1_IMAGE="auto"])
 
-RKT_STAGE1_IMAGE_LDFLAGS=
-# if stage1 image variable is set, add a linker flag to rkt defining the variable
-AS_VAR_IF([RKT_STAGE1_IMAGE], [],
-          [],
-          [RKT_STAGE1_IMAGE_LDFLAGS=`RKT_XF main.defaultStage1Image "${RKT_STAGE1_IMAGE}"`])
+AS_VAR_IF([RKT_STAGE1_IMAGE],[auto],
+          [AS_CASE([$RKT_STAGE1_USR_FROM],
+                   [none],
+                           [RKT_STAGE1_IMAGE=""
+                            AC_MSG_WARN([* It will be necessary to pass --stage1-image flag to run rkt])],
+                   dnl other flavors
+                   [RKT_STAGE1_IMAGE="directory/with/rkt/binary/stage1-${RKT_STAGE1_USR_FROM}.aci"])])
+
+RKT_STAGE1_IMAGE_LDFLAGS=`RKT_XF main.defaultStage1Image "${RKT_STAGE1_IMAGE}"`
 
 AC_SUBST(RKT_STAGE1_IMAGE_LDFLAGS)
 

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -45,8 +45,6 @@ End the image arguments with a lone "---" to resume argument parsing.`,
 )
 
 func init() {
-	setDefaultStage1Image()
-
 	cmdRkt.AddCommand(cmdPrepare)
 
 	addStage1ImageFlag(cmdPrepare.Flags())
@@ -132,7 +130,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		withDeps: false,
 	}
 
-	s1img, err := getStage1Hash(s, flagStage1Image)
+	s1img, err := getStage1Hash(s, cmd)
 	if err != nil {
 		stderr("prepare: %v", err)
 		return 1

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -49,7 +49,7 @@ func init() {
 
 	cmdRkt.AddCommand(cmdPrepare)
 
-	cmdPrepare.Flags().StringVar(&flagStage1Image, "stage1-image", defaultStage1Image, `image to use as stage1. Local paths and http/https URLs are supported. By default, rkt will look for a file called "stage1.aci" in the same directory as rkt itself`)
+	addStage1ImageFlag(cmdPrepare.Flags())
 	cmdPrepare.Flags().Var(&flagVolumes, "volume", "volumes to mount into the pod")
 	cmdPrepare.Flags().Var(&flagPorts, "port", "ports to expose on the host (requires --private-net)")
 	cmdPrepare.Flags().BoolVar(&flagQuiet, "quiet", false, "suppress superfluous output on stdout, print only the UUID on success")

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -59,8 +59,6 @@ End the image arguments with a lone "---" to resume argument parsing.`,
 )
 
 func init() {
-	setDefaultStage1Image()
-
 	cmdRkt.AddCommand(cmdRun)
 
 	addStage1ImageFlag(cmdRun.Flags())
@@ -160,7 +158,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		withDeps: false,
 	}
 
-	s1img, err := getStage1Hash(s, flagStage1Image)
+	s1img, err := getStage1Hash(s, cmd)
 	if err != nil {
 		stderr("%v", err)
 		return 1

--- a/rkt/stage1hash.go
+++ b/rkt/stage1hash.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/pflag"
 	"github.com/coreos/rkt/store"
 )
@@ -33,38 +34,50 @@ const (
 )
 
 var (
-	defaultStage1Image   string // either set by linker, or guessed in init()
+	defaultStage1Image   string // set by linker
 	defaultStage1Name    string // set by linker
 	defaultStage1Version string // set by linker
-
-	flagStage1Image  string
 )
-
-func setDefaultStage1Image() {
-	// if not set by linker, try discover the directory rkt is running
-	// from, and assume the default stage1.aci is stored alongside it.
-	if defaultStage1Image == "" {
-		if exePath, err := os.Readlink("/proc/self/exe"); err == nil {
-			defaultStage1Image = filepath.Join(filepath.Dir(exePath), "stage1.aci")
-		}
-	}
-}
 
 // addStage1ImageFlag adds a flag for specifying custom stage1 image
 // path
 func addStage1ImageFlag(flags *pflag.FlagSet) {
-	flags.StringVar(&flagStage1Image, stage1ImageFlagName, defaultStage1Image, stage1ImageFlagHelp())
+	flags.String(stage1ImageFlagName, defaultStage1Image, stage1ImageFlagHelp())
 }
 
 func stage1ImageFlagHelp() string {
+	u, err := url.Parse(defaultStage1Image)
+	if err != nil {
+		panic(fmt.Sprintf("defaultStage1Image %q is not a valid URL: %v", defaultStage1Image, err))
+	}
+	imgDir := filepath.Dir(defaultStage1Image)
+	imgBase := filepath.Base(defaultStage1Image)
 	firstPart := "image to use as stage1. Local paths and http/https URLs are supported"
-	return fmt.Sprintf(`%s. By default, rkt will look for a file called "stage1.aci" in the same directory as rkt itself`, firstPart)
+
+	if len(defaultStage1Image) < 1 {
+		return fmt.Sprintf(`%s. There is no default stage1 image to use`, firstPart)
+	}
+	if u.Scheme != "" {
+		return fmt.Sprintf(`%s. By default, rkt will look for a file %q`, firstPart, defaultStage1Image)
+	}
+	if filepath.IsAbs(imgDir) {
+		return fmt.Sprintf(`%s. By default, rkt will look for a file called %q first in %q directory, then in the same directory as rkt itself`, firstPart, imgBase, imgDir)
+	}
+	return fmt.Sprintf(`%s. By default, rkt will look for a file called %q in the same directory as rkt itself`, firstPart, imgBase)
 }
 
 // getStage1Hash will try to fetch stage1 from store if it is a
 // default one. If that fails it will try to get via usual fetching
 // from disk or network.
-func getStage1Hash(s *store.Store, stage1ImagePath string) (*types.Hash, error) {
+//
+// As a special case, if stage1 image path is a default and not
+// overriden by --stage1-image flag and it is has no scheme, it will
+// try to fetch it from two places on disk - from the path directly if
+// it is absolute and then from the same directory where rkt binary
+// resides.
+//
+// The passed command must have "stage1-image" string flag registered.
+func getStage1Hash(s *store.Store, cmd *cobra.Command) (*types.Hash, error) {
 	fn := &finder{
 		imageActionData: imageActionData{
 			s: s,
@@ -72,30 +85,106 @@ func getStage1Hash(s *store.Store, stage1ImagePath string) (*types.Hash, error) 
 		local:    true,
 		withDeps: false,
 	}
-	isDefault := stage1ImagePath == defaultStage1Image
 
-	var (
-		s1img *types.Hash
-		err   error
-	)
-	// with a default stage1, first try to get the image from the store
-	if isDefault {
-		// we make sure we've built rkt with a clean git tree, otherwise we
-		// don't know if something changed
-		if !strings.HasSuffix(defaultStage1Version, "-dirty") {
-			stage1AppName := fmt.Sprintf("%s:%s", defaultStage1Name, url.QueryEscape(defaultStage1Version))
-			s1img, err = fn.findImage(stage1AppName, "", true)
-		}
+	imageFlag := cmd.Flags().Lookup(stage1ImageFlagName)
+	if imageFlag == nil {
+		panic(fmt.Sprintf("Expected flag --%s to be registered in command %s", stage1ImageFlagName, cmd.Name()))
+	}
+	path := imageFlag.Value.String()
+	if path == defaultStage1Image {
+		return getDefaultStage1Hash(fn, imageFlag.Changed)
+	}
+	return getCustomStage1Hash(fn, path)
+}
+
+func getDefaultStage1Hash(fn *finder, overridden bool) (*types.Hash, error) {
+	// just fail if default stage1 image path is empty - might
+	// happen for none flavor
+	if defaultStage1Image == "" {
+		return nil, fmt.Errorf("no default stage1 image is set, use --%s flag", stage1ImageFlagName)
 	}
 
-	// we couldn't find a proper stage1 image in the store, fall back to using
-	// a stage1 ACI file (slow)
-	if s1img == nil {
-		s1img, err = fn.findImage(stage1ImagePath, "", false)
-		if err != nil {
-			return nil, fmt.Errorf("error finding stage1 image %q: %v", stage1ImagePath, err)
+	if s1img := getDefaultStage1HashFromStore(fn); s1img != nil {
+		return s1img, nil
+	}
+	// we couldn't find a proper stage1 image in the store, fall
+	// back to using a stage1 ACI file (slow)
+	return getDefaultStage1HashFromUrl(fn, overridden)
+}
+
+func getDefaultStage1HashFromStore(fn *finder) *types.Hash {
+	// we make sure we've built rkt with a clean git tree,
+	// otherwise we don't know if something changed
+	if !strings.HasSuffix(defaultStage1Version, "-dirty") {
+		stage1AppName := fmt.Sprintf("%s:%s", defaultStage1Name, url.QueryEscape(defaultStage1Version))
+		s1img, _ := fn.findImage(stage1AppName, "", true)
+		return s1img
+	}
+	return nil
+}
+
+func getDefaultStage1HashFromUrl(fn *finder, overridden bool) (*types.Hash, error) {
+	if overridden {
+		// we specified --stage1-image parameter explicitly,
+		// so just try to get it without further or more ado
+		return getCustomStage1Hash(fn, defaultStage1Image)
+	}
+	if url, err := url.Parse(defaultStage1Image); err != nil {
+		return nil, fmt.Errorf("failed ot parse %q as URL: %v", defaultStage1Image, err)
+	} else if url.Scheme != "" {
+		// default stage1 image path is some schemed path,
+		// just try to get it
+		getCustomStage1Hash(fn, defaultStage1Image)
+	}
+	// default scheme path is a relative or absolute path to a
+	// file
+	return getLocalDefaultStage1Hash(fn)
+}
+
+func getLocalDefaultStage1Hash(fn *finder) (*types.Hash, error) {
+	var firstErr error = nil
+	// Guard against relative path to default stage1 image. It
+	// could be fine for some custom stage1 path passed via
+	// --stage1-image parameter, but not for default, not
+	// overridden ones. Usually, if the path is relative, then it
+	// means we simply didn't pass --with-stage1-image-path
+	// parameter to configure script, so it defaulted to desired
+	// filename like "stuff/yadda/stage1-lkvm.aci" (or something).
+	if filepath.IsAbs(defaultStage1Image) {
+		s1img, err := fn.findImage(defaultStage1Image, "", false)
+		if s1img != nil {
+			return s1img, nil
+		}
+		firstErr = err
+	}
+	// could not find default stage1 image in a given path
+	// (or we ignored it), lets try to load one in the
+	// same directory as rkt itself
+	imgBase := filepath.Base(defaultStage1Image)
+	exePath, err := os.Readlink("/proc/self/exe")
+	if err != nil {
+		if firstErr != nil {
+			return nil, fmt.Errorf("error finding stage1 images %q and %q in rkt binary directory: %v and %v", defaultStage1Image, imgBase, firstErr, err)
+		} else {
+			return nil, fmt.Errorf("error finding stage1 image %q in rkt binary directory: %v", imgBase, err)
 		}
 	}
+	fallbackPath := filepath.Join(filepath.Dir(exePath), imgBase)
+	s1img, err := fn.findImage(fallbackPath, "", false)
+	if err != nil {
+		if firstErr != nil {
+			return nil, fmt.Errorf("error finding stage1 images %q and %q: %v and %v", defaultStage1Image, fallbackPath, firstErr, err)
+		} else {
+			return nil, fmt.Errorf("error finding stage1 image %q: %v", fallbackPath, err)
+		}
+	}
+	return s1img, nil
+}
 
+func getCustomStage1Hash(fn *finder, path string) (*types.Hash, error) {
+	s1img, err := fn.findImage(path, "", false)
+	if err != nil {
+		return nil, fmt.Errorf("error finding stage1 image %q: %v", path, err)
+	}
 	return s1img, nil
 }

--- a/rkt/stage1hash.go
+++ b/rkt/stage1hash.go
@@ -1,0 +1,101 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/pflag"
+	"github.com/coreos/rkt/store"
+)
+
+const (
+	stage1ImageFlagName string = "stage1-image"
+)
+
+var (
+	defaultStage1Image   string // either set by linker, or guessed in init()
+	defaultStage1Name    string // set by linker
+	defaultStage1Version string // set by linker
+
+	flagStage1Image  string
+)
+
+func setDefaultStage1Image() {
+	// if not set by linker, try discover the directory rkt is running
+	// from, and assume the default stage1.aci is stored alongside it.
+	if defaultStage1Image == "" {
+		if exePath, err := os.Readlink("/proc/self/exe"); err == nil {
+			defaultStage1Image = filepath.Join(filepath.Dir(exePath), "stage1.aci")
+		}
+	}
+}
+
+// addStage1ImageFlag adds a flag for specifying custom stage1 image
+// path
+func addStage1ImageFlag(flags *pflag.FlagSet) {
+	flags.StringVar(&flagStage1Image, stage1ImageFlagName, defaultStage1Image, stage1ImageFlagHelp())
+}
+
+func stage1ImageFlagHelp() string {
+	firstPart := "image to use as stage1. Local paths and http/https URLs are supported"
+	return fmt.Sprintf(`%s. By default, rkt will look for a file called "stage1.aci" in the same directory as rkt itself`, firstPart)
+}
+
+// getStage1Hash will try to fetch stage1 from store if it is a
+// default one. If that fails it will try to get via usual fetching
+// from disk or network.
+func getStage1Hash(s *store.Store, stage1ImagePath string) (*types.Hash, error) {
+	fn := &finder{
+		imageActionData: imageActionData{
+			s: s,
+		},
+		local:    true,
+		withDeps: false,
+	}
+	isDefault := stage1ImagePath == defaultStage1Image
+
+	var (
+		s1img *types.Hash
+		err   error
+	)
+	// with a default stage1, first try to get the image from the store
+	if isDefault {
+		// we make sure we've built rkt with a clean git tree, otherwise we
+		// don't know if something changed
+		if !strings.HasSuffix(defaultStage1Version, "-dirty") {
+			stage1AppName := fmt.Sprintf("%s:%s", defaultStage1Name, url.QueryEscape(defaultStage1Version))
+			s1img, err = fn.findImage(stage1AppName, "", true)
+		}
+	}
+
+	// we couldn't find a proper stage1 image in the store, fall back to using
+	// a stage1 ACI file (slow)
+	if s1img == nil {
+		s1img, err = fn.findImage(stage1ImagePath, "", false)
+		if err != nil {
+			return nil, fmt.Errorf("error finding stage1 image %q: %v", stage1ImagePath, err)
+		}
+	}
+
+	return s1img, nil
+}

--- a/stage1/stage1.mk
+++ b/stage1/stage1.mk
@@ -22,7 +22,7 @@
 STAGE1_STAMPS :=
 STAGE1_USR_STAMPS :=
 _STAGE1_SUBDIRS_ := diagexec prepare-app enter net-plugins net init gc reaper units aci usr_from_$(RKT_STAGE1_USR_FROM)
-_STAGE1_ACI_ := $(BINDIR)/stage1.aci
+_STAGE1_ACI_ := $(BINDIR)/stage1-$(RKT_STAGE1_USR_FROM).aci
 STAGE1_COPY_SO_DEPS :=
 STAGE1_INSTALL_FILES :=
 STAGE1_INSTALL_SYMLINKS :=


### PR DESCRIPTION
This PR makes some small changes in rkt's behavior. Hopefully commit messages are quite clear about the changes.

In short - we do not default to `stage1.aci` in the same directory as rkt if default stage1 image path was not set; we always set the path. But the code tries to load the stage1 image from the same directory as rkt if loading stage1 image from default path fails.

This PR fixes #1292.  