### PR TITLE
stage1: rework systemd service structure

### DIFF
--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -584,6 +584,11 @@ func stage1() int {
 		}
 	}
 
+	if err = p.WriteDefaultTarget(); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to write default.target: %v\n", err)
+		return 2
+	}
+
 	if err = p.WritePrepareAppTemplate(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to write prepare-app service template: %v\n", err)
 		return 2

--- a/stage1/reaper/reaper.sh
+++ b/stage1/reaper/reaper.sh
@@ -3,10 +3,9 @@ shopt -s nullglob
 
 SYSCTL=/usr/bin/systemctl
 
-cd /opt/stage2
-for app in *; do
-        status=$(${SYSCTL} show --property ExecMainStatus "${app}.service")
-        echo "${status#*=}" > "/rkt/status/$app"
-done
-
-${SYSCTL} halt --force
+if [ $# -eq 1 ]; then
+    app=$1
+    status=$(${SYSCTL} show --property ExecMainStatus "${app}.service")
+    echo "${status#*=}" > "/rkt/status/$app"
+    exit 0
+fi

--- a/stage1/units/units.mk
+++ b/stage1/units/units.mk
@@ -7,10 +7,8 @@ LOCAL_UNITDIR_RESTS := \
 LOCAL_UNITDIR := $(LOCAL_UNITDIR_BASE)/$(LOCAL_UNITDIR_REST)
 LOCAL_UNIT_DIRS := $(foreach d,$(LOCAL_UNITDIR_RESTS),$(LOCAL_UNITDIR_BASE)/$d)
 LOCAL_UNIT_FILES := \
-        $(MK_SRCDIR)/units/default-rkt.target \
-        $(MK_SRCDIR)/units/exit-watcher.service \
         $(MK_SRCDIR)/units/local-fs.target \
-        $(MK_SRCDIR)/units/reaper.service \
+        $(MK_SRCDIR)/units/shutdown.service \
         $(MK_SRCDIR)/units/sockets.target \
         $(MK_SRCDIR)/units/halt.target \
         $(MK_SRCDIR)/units/systemd-reboot.service \

--- a/stage1/units/units/default-rkt.target
+++ b/stage1/units/units/default-rkt.target
@@ -1,3 +1,0 @@
-[Unit]
-Description=rkt apps target
-DefaultDependencies=false

--- a/stage1/units/units/exit-watcher.service
+++ b/stage1/units/units/exit-watcher.service
@@ -1,8 +1,0 @@
-[Unit]
-Description=Graceful exit watcher
-StopWhenUnneeded=true
-DefaultDependencies=false
-
-[Service]
-RemainAfterExit=yes
-ExecStop=/usr/bin/systemctl isolate reaper.service

--- a/stage1/units/units/halt.target
+++ b/stage1/units/units/halt.target
@@ -1,6 +1,4 @@
 [Unit]
 Description=Halt
 DefaultDependencies=no
-Requires=reaper.service
-After=reaper.service
 AllowIsolate=yes

--- a/stage1/units/units/poweroff.target
+++ b/stage1/units/units/poweroff.target
@@ -1,6 +1,4 @@
 [Unit]
 Description=Poweroff
 DefaultDependencies=no
-Requires=reaper.service
-After=reaper.service
 AllowIsolate=yes

--- a/stage1/units/units/reaper.service
+++ b/stage1/units/units/reaper.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=rkt apps reaper
-AllowIsolate=true
-DefaultDependencies=false
-
-[Service]
-ExecStart=/reaper.sh

--- a/stage1/units/units/shutdown.service
+++ b/stage1/units/units/shutdown.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Pod shutdown
+AllowIsolate=true
+StopWhenUnneeded=yes
+DefaultDependencies=false
+
+[Service]
+RemainAfterExit=yes
+ExecStop=/usr/bin/systemctl halt --force


### PR DESCRIPTION
This changes the way rkt starts apps in a pod.

The default.target has a Wants and After dependency on each app, making
sure they all start. Each app has a Wants dependency on an associated
reaper service that deals with writing the app's status exit. Each
reaper service has a Wants and After dependency with a shutdown service
that simply shuts down the pod.

The reaper services and the shutdown service all start at the beginning
but do nothing and remain after exit (with the RemainAfterExit flag). By
using the StopWhenUnneeded flag, whenever they stop being referenced,
they'll do the actual work via the ExecStop command.

This means that when an app service is stopped, its associated reaper
will run and will write its exit status to /rkt/status/${app} without
having to wait until the pod exits. When all apps' services stop, their
associated reaper services will also stop and will cease referencing the
shutdown service. This will cause the pod to exit.

A Conflicts dependency was also added between each reaper service and
the halt and poweroff targets (they are triggered when the pod is
stopped from the outside). This will activate all the reaper services
when one of the targets is activated, causing the exit statuses to be
saved and the pod to finish like it was described in the previous
paragraph.

![rkt-systemd-nuclear](https://cloud.githubusercontent.com/assets/507354/9908897/062bd3f8-5c96-11e5-84fe-ed56f830ba73.png)
