### PR TITLE
Send human consumable messages to stderr

### DIFF
--- a/rkt/images.go
+++ b/rkt/images.go
@@ -624,7 +624,7 @@ func (f *fetcher) downloadHTTP(url, label string, out writeSyncer, etag string) 
 	reader := &ioprogress.Reader{
 		Reader:       res.Body,
 		Size:         res.ContentLength,
-		DrawFunc:     ioprogress.DrawTerminalf(os.Stdout, fmtfunc),
+		DrawFunc:     ioprogress.DrawTerminalf(os.Stderr, fmtfunc),
 		DrawInterval: time.Second,
 	}
 


### PR DESCRIPTION
Right now the progress bar for downloading an image will be send to
stderr for docker images, and stdout for aci images. This should send it
to stderr in both cases.