### PR TITLE
stage0: added exec flag to prepare statement

### DIFF
--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -59,6 +59,7 @@ func init() {
 	cmdPrepare.Flags().Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
 	cmdPrepare.Flags().BoolVar(&flagLocal, "local", false, "use only local images (do not discover or download from remote URLs)")
 	cmdPrepare.Flags().StringVar(&flagPodManifest, "pod-manifest", "", "the path to the pod manifest. If it's non-empty, then only '--quiet' and '--no-overlay' will have effects")
+	cmdPrepare.Flags().Var((*appExec)(&rktApps), "exec", "override the exec command for the preceding image")
 
 	// Disable interspersed flags to stop parsing after the first non flag
 	// argument. This is need to permit to correctly handle

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -17,10 +17,8 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 )
 
@@ -87,28 +85,4 @@ func runRktAndCheckOutput(t *testing.T, rktCmd, expectedLine string) {
 	if err = child.Wait(); err != nil {
 		t.Fatalf("rkt didn't terminate correctly: %v", err)
 	}
-}
-
-func runRktAndGetUUID(t *testing.T, rktCmd string) string {
-	child, err := gexpect.Spawn(rktCmd)
-	if err != nil {
-		t.Fatalf("cannot exec rkt: %v", err)
-	}
-
-	result, out, err := expectRegexWithOutput(child, "\n[0-9a-f-]{36}")
-	if err != nil || len(result) != 1 {
-		t.Fatalf("Error: %v\nOutput: %v", err, out)
-	}
-
-	if err = child.Wait(); err != nil {
-		t.Fatalf("rkt didn't terminate correctly: %v", err)
-	}
-
-	podIDStr := strings.TrimSpace(result[0])
-	podID, err := types.NewUUID(podIDStr)
-	if err != nil {
-		t.Fatalf("%q is not a valid UUID: %v", podIDStr, err)
-	}
-
-	return podID.String()
 }

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -17,8 +17,10 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 )
 
@@ -28,7 +30,7 @@ func TestRunOverrideExec(t *testing.T) {
 	ctx := newRktRunCtx()
 	defer ctx.cleanup()
 
-	for i, tt := range []struct {
+	for _, tt := range []struct {
 		rktCmd       string
 		expectedLine string
 	}{
@@ -43,17 +45,70 @@ func TestRunOverrideExec(t *testing.T) {
 			expectedLine: "inspect execed as: /inspect-link",
 		},
 	} {
-		child, err := gexpect.Spawn(tt.rktCmd)
-		if err != nil {
-			t.Fatalf("%d: cannot exec rkt: %v", i, err)
-		}
-
-		if err = expectWithOutput(child, tt.expectedLine); err != nil {
-			t.Fatalf("%d: didn't receive expected output %q: %v", i, tt.expectedLine, err)
-		}
-
-		if err = child.Wait(); err != nil {
-			t.Fatalf("%d: rkt didn't terminate correctly: %v", i, err)
-		}
+		runRktAndCheckOutput(t, tt.rktCmd, tt.expectedLine)
 	}
+}
+
+func TestRunPreparedOverrideExec(t *testing.T) {
+	execImage := patchTestACI("rkt-exec-override.aci", "--exec=/inspect")
+	defer os.Remove(execImage)
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
+
+	var rktCmd, uuid, expected string
+
+	// Sanity check - make sure no --exec override prints the expected exec invocation
+	rktCmd = fmt.Sprintf("%s prepare --insecure-skip-verify %s -- --print-exec", ctx.cmd(), execImage)
+	uuid = runRktAndGetUUID(t, rktCmd)
+
+	rktCmd = fmt.Sprintf("%s run-prepared --mds-register=false %s", ctx.cmd(), uuid)
+	expected = "inspect execed as: /inspect"
+	runRktAndCheckOutput(t, rktCmd, expected)
+
+	// Now test overriding the entrypoint (which is a symlink to /inspect so should behave identically)
+	rktCmd = fmt.Sprintf("%s prepare --insecure-skip-verify %s --exec /inspect-link -- --print-exec", ctx.cmd(), execImage)
+	uuid = runRktAndGetUUID(t, rktCmd)
+
+	rktCmd = fmt.Sprintf("%s run-prepared --mds-register=false %s", ctx.cmd(), uuid)
+	expected = "inspect execed as: /inspect-link"
+	runRktAndCheckOutput(t, rktCmd, expected)
+}
+
+func runRktAndCheckOutput(t *testing.T, rktCmd, expectedLine string) {
+	child, err := gexpect.Spawn(rktCmd)
+	if err != nil {
+		t.Fatalf("cannot exec rkt: %v", err)
+	}
+
+	if err = expectWithOutput(child, expectedLine); err != nil {
+		t.Fatalf("didn't receive expected output %q: %v", expectedLine, err)
+	}
+
+	if err = child.Wait(); err != nil {
+		t.Fatalf("rkt didn't terminate correctly: %v", err)
+	}
+}
+
+func runRktAndGetUUID(t *testing.T, rktCmd string) string {
+	child, err := gexpect.Spawn(rktCmd)
+	if err != nil {
+		t.Fatalf("cannot exec rkt: %v", err)
+	}
+
+	result, out, err := expectRegexWithOutput(child, "\n[0-9a-f-]{36}")
+	if err != nil || len(result) != 1 {
+		t.Fatalf("Error: %v\nOutput: %v", err, out)
+	}
+
+	if err = child.Wait(); err != nil {
+		t.Fatalf("rkt didn't terminate correctly: %v", err)
+	}
+
+	podIDStr := strings.TrimSpace(result[0])
+	podID, err := types.NewUUID(podIDStr)
+	if err != nil {
+		t.Fatalf("%q is not a valid UUID: %v", podIDStr, err)
+	}
+
+	return podID.String()
 }

--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -541,29 +541,11 @@ func TestPodManifest(t *testing.T) {
 		verifyHostFile(t, tmpdir, "file", i, tt.expectedResult)
 
 		// 2. Test 'rkt prepare' + 'rkt run-prepared'.
-		child, err = gexpect.Spawn(fmt.Sprintf("%s --insecure-skip-verify prepare --pod-manifest=%s",
-			ctx.cmd(), manifestFile))
-		if err != nil {
-			t.Fatalf("Cannot exec rkt: %v", err)
-		}
+		rktCmd := fmt.Sprintf("%s --insecure-skip-verify prepare --pod-manifest=%s",
+			ctx.cmd(), manifestFile)
+		uuid := runRktAndGetUUID(t, rktCmd)
 
-		// Read out the UUID.
-		result, out, err := expectRegexWithOutput(child, "\n[0-9a-f-]{36}")
-		if err != nil || len(result) != 1 {
-			t.Fatalf("Error: %v\nOutput: %v", err, out)
-		}
-
-		err = child.Wait()
-		if err != nil {
-			t.Fatalf("rkt didn't terminate correctly: %v", err)
-		}
-		podIDStr := strings.TrimSpace(result[0])
-		podID, err := types.NewUUID(podIDStr)
-		if err != nil {
-			t.Fatalf("%q is not a valid UUID: %v", podIDStr, err)
-		}
-
-		runPreparedCmd := fmt.Sprintf("%s run-prepared --mds-register=false %s", ctx.cmd(), podID.String())
+		runPreparedCmd := fmt.Sprintf("%s run-prepared --mds-register=false %s", ctx.cmd(), uuid)
 		t.Logf("Running 'run' test #%v: %v", i, runPreparedCmd)
 		child, err = gexpect.Spawn(runPreparedCmd)
 		if err != nil {

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 )
 
@@ -327,4 +328,28 @@ func removeFromCas(t *testing.T, ctx *rktRunCtx, hash string) {
 	if err != nil {
 		t.Fatalf("rkt didn't terminate correctly: %v", err)
 	}
+}
+
+func runRktAndGetUUID(t *testing.T, rktCmd string) string {
+	child, err := gexpect.Spawn(rktCmd)
+	if err != nil {
+		t.Fatalf("cannot exec rkt: %v", err)
+	}
+
+	result, out, err := expectRegexWithOutput(child, "\n[0-9a-f-]{36}")
+	if err != nil || len(result) != 1 {
+		t.Fatalf("Error: %v\nOutput: %v", err, out)
+	}
+
+	if err = child.Wait(); err != nil {
+		t.Fatalf("rkt didn't terminate correctly: %v", err)
+	}
+
+	podIDStr := strings.TrimSpace(result[0])
+	podID, err := types.NewUUID(podIDStr)
+	if err != nil {
+		t.Fatalf("%q is not a valid UUID: %v", podIDStr, err)
+	}
+
+	return podID.String()
 }


### PR DESCRIPTION
When preparing a container, the exec flag can be used to override the
default binary run inside the container. Behaves the same way as on the
run command.