### PR TITLE
docs: fixed bad link to metadata service in getting started

### DIFF
--- a/Documentation/getting-started-guide.md
+++ b/Documentation/getting-started-guide.md
@@ -141,7 +141,7 @@ Start the metadata service from your init system or simply from another terminal
 # rkt metadata-service
 ```
 
-rkt will register pods with the [metadata service](https://github.com/coreos/rkt/blob/master/Documentation/metadata-service.md) so they can introspect their environment.
+rkt will register pods with the [metadata service](https://github.com/coreos/rkt/blob/master/Documentation/subcommands/metadata-service.md) so they can introspect their environment.
 
 ### Launch a local application image
 


### PR DESCRIPTION
Looks like the page describing the metadata service was moved to the
subcommands folder. This commit moves the link on the getting started
page to point to it.