### PR TITLE
doc: lkvm: troubleshooting for missing $HOME

### DIFF
--- a/Documentation/running-lkvm-stage1.md
+++ b/Documentation/running-lkvm-stage1.md
@@ -123,3 +123,20 @@ host OS
           └─ chroot
             └─ user-app1
 ```
+
+## Troubleshooting
+
+### Undefined $HOME
+
+Symptoms:
+
+```
+bind: No such file or directory
+  Error: Failed adding socket to epoll
+  Warning: Failed init: kvm_ipc__init
+```
+
+The LKVM stage1 currently requires $HOME to be defined
+(see [issue #1393](https://github.com/coreos/rkt/issues/1393)).
+When started from a systemd unit file, use `User=root`.
+When started from systemd-run, use `--uid=0`.


### PR DESCRIPTION
More documentation in addition to https://github.com/coreos/rkt/pull/1401

Running the lkvm flavor of rkt in systemd does not currently work if
$HOME is not defined: see https://github.com/coreos/rkt/issues/1393

It should be fixed in lkvm upstream, but meanwhile, mention the
workaround in the documentation.