### PR TITLE
docs: fixed bad link to metadata service in run subcommand

### DIFF
--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -150,7 +150,7 @@ Now when the pod is running, the two apps will see the host's `/opt/tenant1/work
 
 ## Disabling metadata service registration
 
-By default, `rkt run` will register the pod with the [metadata service](https://github.com/coreos/rkt/blob/master/Documentation/metadata-service.md).
+By default, `rkt run` will register the pod with the [metadata service](https://github.com/coreos/rkt/blob/master/Documentation/subcommands/metadata-service.md).
 If the metadata service is not running, it is possible to disable this behavior with `--register-mds=false` command line option.
 
 ## Customize Networking


### PR DESCRIPTION
Same as the last docs fix I did, but in a different place. Metadata
service link returned a 404, updated to point to the new place.