### PR TITLE
rkt: Make run-prepared rerunnable when mds is missing

### DIFF
--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -98,6 +98,16 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
+	// Make sure we have a metadata service available before we move to
+	// run state so that the user can rerun the command without needing
+	// to prepare the image again.
+	if flagMDSRegister {
+		if err := stage0.CheckMdsAvailability(); err != nil {
+			stderr("prepare-run: %v", err)
+			return 1
+		}
+	}
+
 	if err := p.xToRun(); err != nil {
 		stderr("prepared-run: cannot transition to run: %v", err)
 		return 1

--- a/stage0/registration.go
+++ b/stage0/registration.go
@@ -191,3 +191,12 @@ func httpRequest(method, pth string, body io.Reader) error {
 
 	return err
 }
+
+func CheckMdsAvailability() error {
+	if conn, err := net.Dial("unix", common.MetadataServiceRegSock); err != nil {
+		return errUnreachable
+	} else {
+		conn.Close()
+		return nil
+	}
+}


### PR DESCRIPTION
When a user has no metadata service running and runs rkt run-prepared
without specifying mds-register=false, the pod is left in the run state
and the user needs to reprepare the pod again to rerun.

To avoid this scenario, this commit does an early check to see if the
metadata service is available before the pod is moved to the run state.

fixes https://github.com/coreos/rkt/issues/1434