### PR TITLE
stage1: common: mount also the host cgroup hierarchy

### DIFF
--- a/common/cgroup/cgroup.go
+++ b/common/cgroup/cgroup.go
@@ -215,6 +215,21 @@ func GetOwnCgroupPath(controller string) (string, error) {
 	return parts[2], nil
 }
 
+// JoinCgroup makes the calling process join the subcgroup hierarchy on a
+// particular controller
+func JoinSubcgroup(controller string, subcgroup string) error {
+	subcgroupPath := filepath.Join("/sys/fs/cgroup", controller, subcgroup)
+	if err := os.MkdirAll(subcgroupPath, 0600); err != nil {
+		return fmt.Errorf("error creating %q subcgroup: %v", subcgroup, err)
+	}
+	pidBytes := []byte(strconv.Itoa(os.Getpid()))
+	if err := ioutil.WriteFile(filepath.Join(subcgroupPath, "cgroup.procs"), pidBytes, 0600); err != nil {
+		return fmt.Errorf("error adding ourselves to the %q subcgroup: %v", subcgroup, err)
+	}
+
+	return nil
+}
+
 // If /system.slice does not exist in the cpuset controller, create it and
 // configure it.
 // Since this is a workaround, we ignore errors

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -758,6 +758,15 @@ func getContainerSubCgroup(machineID string) (string, error) {
 			if err != nil {
 				return "", fmt.Errorf("could not get own cgroup path: %v", err)
 			}
+			// systemd-nspawn won't work unless we're in a subcgroup. If we're
+			// in the root cgroup, we create a "rkt" subcgroup and we add
+			// ourselves to it
+			if ownCgroupPath == "/" {
+				ownCgroupPath = "/rkt"
+				if err := cgroup.JoinSubcgroup("systemd", ownCgroupPath); err != nil {
+					return "", fmt.Errorf("error joining %s subcgroup: %v", ownCgroupPath, err)
+				}
+			}
 			subcgroup = filepath.Join(ownCgroupPath, "system.slice")
 		}
 	}

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -637,8 +637,8 @@ func stage1() int {
 	machineID := p.GetMachineID()
 	subcgroup, err := getContainerSubCgroup(machineID)
 	if err == nil {
-		if err := cgroup.CreateCgroups(s1Root, subcgroup, serviceNames); err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating cgroups: %v\n", err)
+		if err := mountContainerCgroups(s1Root, subcgroup, serviceNames); err != nil {
+			fmt.Fprintf(os.Stderr, "Couldn't mount the container cgroups: %v\n", err)
 			return 5
 		}
 	} else {
@@ -659,6 +659,17 @@ func stage1() int {
 	}
 
 	return 0
+}
+
+func mountContainerCgroups(s1Root string, subcgroup string, serviceNames []string) error {
+	if err := cgroup.CreateCgroups(s1Root); err != nil {
+		return fmt.Errorf("error creating container cgroups: %v\n", err)
+	}
+	if err := cgroup.RemountCgroupsRO(s1Root, subcgroup, serviceNames); err != nil {
+		return fmt.Errorf("error restricting container cgroups: %v\n", err)
+	}
+
+	return nil
 }
 
 func getContainerSubCgroup(machineID string) (string, error) {

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -614,7 +614,7 @@ func stage1() int {
 	// create a separate mount namespace so the cgroup filesystems
 	// are unmounted when exiting the pod
 	if err := syscall.Unshare(syscall.CLONE_NEWNS); err != nil {
-		log.Fatalf("error unsharing: %v", err)
+		log.Fatalf("Error unsharing: %v", err)
 	}
 
 	// we recursively make / a "shared and slave" so mount events from the
@@ -623,10 +623,10 @@ func stage1() int {
 	// its peer group
 	// See https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt
 	if err := syscall.Mount("", "/", "none", syscall.MS_REC|syscall.MS_SLAVE, ""); err != nil {
-		log.Fatalf("error making / a slave mount: %v", err)
+		log.Fatalf("Error making / a slave mount: %v", err)
 	}
 	if err := syscall.Mount("", "/", "none", syscall.MS_REC|syscall.MS_SHARED, ""); err != nil {
-		log.Fatalf("error making / a shared and slave mount: %v", err)
+		log.Fatalf("Error making / a shared and slave mount: %v", err)
 	}
 
 	var serviceNames []string


### PR DESCRIPTION
To avoid problems on environments without a properly mounted cgroup
hierarchy and/or without the systemd hierarchy we also deal with
mounting the host cgroup hierarchy.

Since we're in a different mount namespace the host is not affected.

Fixes https://github.com/coreos/rkt/issues/1320
Fixes https://github.com/coreos/rkt/issues/1076
Fixes https://github.com/coreos/rkt/issues/1042