### PR TITLE
functional tests: fix noapp exec test

### DIFF
--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -56,7 +56,7 @@ func TestRunOverrideExec(t *testing.T) {
 		},
 		{
 			// Test overriding the entrypoint with a missing app section
-			rktCmd:       fmt.Sprintf("%s --insecure-skip-verify run --mds-register=false %s --exec /inspect -- --print-exec", ctx.cmd(), execImage),
+			rktCmd:       fmt.Sprintf("%s --insecure-skip-verify run --mds-register=false %s --exec /inspect -- --print-exec", ctx.cmd(), noappImage),
 			expectedLine: "inspect execed as: /inspect",
 		},
 	} {


### PR DESCRIPTION
It wasn't using the right image :$