### PR TITLE
stage0: added ability to resume interrupted downloads

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -239,6 +239,26 @@ func (s *Store) TmpFile() (*os.File, error) {
 	return ioutil.TempFile(dir, "")
 }
 
+// TmpNamedFile returns an *os.File with the specified name local to the same
+// filesystem as the Store, or any error encountered. If the file already
+// exists it will return the existing file in read/write mode with the cursor
+// at the end of the file.
+func (s Store) TmpNamedFile(name string) (*os.File, error) {
+	dir, err := s.TmpDir()
+	if err != nil {
+		return nil, err
+	}
+	fname := filepath.Join(dir, name)
+	_, err = os.Stat(fname)
+	if os.IsNotExist(err) {
+		return os.Create(fname)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return os.OpenFile(fname, os.O_RDWR|os.O_APPEND, 0644)
+}
+
 // TmpDir creates and returns dir local to the same filesystem as the Store,
 // or any error encountered
 func (s *Store) TmpDir() (string, error) {


### PR DESCRIPTION
Downloads for a given url are now saved to a file named after a sha512
hash of the url. If the file already exists for a requested download, a
check will be made to see if the server supports HTTP range requests. If
such requests are supported then only the missing part of the file will
be downloaded, otherwise the entire file will be downloaded as before.