### PR TITLE
lkvm: make sure $HOME is defined before running lkvm

### DIFF
--- a/Documentation/running-lkvm-stage1.md
+++ b/Documentation/running-lkvm-stage1.md
@@ -123,20 +123,3 @@ host OS
           └─ chroot
             └─ user-app1
 ```
-
-## Troubleshooting
-
-### Undefined $HOME
-
-Symptoms:
-
-```
-bind: No such file or directory
-  Error: Failed adding socket to epoll
-  Warning: Failed init: kvm_ipc__init
-```
-
-The LKVM stage1 currently requires $HOME to be defined
-(see [issue #1393](https://github.com/coreos/rkt/issues/1393)).
-When started from a systemd unit file, use `User=root`.
-When started from systemd-run, use `--uid=0`.

--- a/Documentation/using-rkt-with-systemd.md
+++ b/Documentation/using-rkt-with-systemd.md
@@ -15,11 +15,9 @@ Consequently, standard `systemd` idioms like `systemctl start` and `systemctl st
 To start a daemonized container from the command line, use [`systemd-run`](http://www.freedesktop.org/software/systemd/man/systemd-run.html):
 
 ```
-# systemd-run --uid=0 rkt run --mds-register=false coreos.com/etcd:v2.0.10
+# systemd-run rkt run --mds-register=false coreos.com/etcd:v2.0.10
 Running as unit run-29075.service.
 ```
-
-Note: `--uid=0` (or `User=root` below) is a workaround for [issue #1393](https://github.com/coreos/rkt/issues/1393).
 
 This creates a transient systemd unit on which you can use standard systemd tools:
 
@@ -65,7 +63,6 @@ Description=etcd
 ExecStart=/usr/bin/rkt --insecure-skip-verify run --mds-register=false coreos.com/etcd:v2.0.10
 KillMode=mixed
 Restart=always
-User=root
 ```
 
 This unit can now be managed using the standard `systemctl` commands:
@@ -114,7 +111,6 @@ ExecStartPre=/usr/bin/rkt fetch myapp.com/myapp-1.3.4
 ExecStart=/usr/bin/rkt run --inherit-env --private-net --port=http:8888 myapp.com/myapp-1.3.4
 KillMode=mixed
 Restart=always
-User=root
 ```
 
 ## Socket-activated service
@@ -155,7 +151,6 @@ Description=My socket-activated app
 [Service]
 ExecStart=/usr/bin/rkt run myapp.com/my-socket-activated-app:v1.0
 KillMode=mixed
-User=root
 ```
 
 ```

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -315,6 +315,12 @@ func getArgsEnv(p *Pod, flavor string, debug bool, n *networking.Networking) ([]
 		nsargs := kvm.VolumesToKvmDiskArgs(p.Manifest.Volumes)
 		args = append(args, nsargs...)
 
+		// lkvm requires $HOME to be defined,
+		// see https://github.com/coreos/rkt/issues/1393
+		if os.Getenv("HOME") == "" {
+			env = append(env, "HOME=/root")
+		}
+
 		return args, env, nil
 
 	case "coreos":


### PR DESCRIPTION
kvmtool currently does not work when $HOME is not defined. When started
by a systemd unit file (or by systemd-run), $HOME is typically
undefined, unless "User=" (or resp. "--uid=") is given.

Instead of asking users to work around the issue with "User=" or
"--uid=", just define that variable in rkt before calling lkvm.

This could be removed when this gets fixed in lkvm upstream.

Issue described in https://github.com/coreos/rkt/issues/1393

/cc @jellonek