### PR TITLE
DOT NOT MERGE: install/stage0: change file mode bits to several fils/dirs.

### DIFF
--- a/common/group.go
+++ b/common/group.go
@@ -1,0 +1,115 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	groupFilePath = "/etc/group"
+	RktGroup      = "rkt"
+)
+
+// Group represents an entry in the group file.
+type Group struct {
+	Name  string
+	Pass  string
+	Gid   int
+	Users []string
+}
+
+// LookupGid reads the group file and returns the gid of the group
+// specified by groupName.
+func LookupGid(groupName string) (gid int, err error) {
+	groups, err := parseGroupFile(groupFilePath)
+	if err != nil {
+		return -1, fmt.Errorf("error parsing %q file: %v", groupFilePath, err)
+	}
+
+	group, ok := groups[groupName]
+	if !ok {
+		return -1, fmt.Errorf("%q group not found", groupName)
+	}
+
+	return group.Gid, nil
+}
+
+func parseGroupFile(path string) (group map[string]Group, err error) {
+	groupFile, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer groupFile.Close()
+
+	return parseGroups(groupFile)
+}
+
+func parseGroups(r io.Reader) (group map[string]Group, err error) {
+	s := bufio.NewScanner(r)
+	out := make(map[string]Group)
+
+	for s.Scan() {
+		if err := s.Err(); err != nil {
+			return nil, err
+		}
+
+		text := s.Text()
+		if text == "" {
+			continue
+		}
+
+		p := Group{}
+		parseGroupLine(text, &p)
+
+		out[p.Name] = p
+	}
+
+	return out, nil
+}
+
+func parseGroupLine(line string, group *Group) {
+	const (
+		NameIdx = iota
+		PassIdx
+		GidIdx
+		UsersIdx
+	)
+
+	if line == "" {
+		return
+	}
+
+	splits := strings.Split(line, ":")
+	if len(splits) < 4 {
+		return
+	}
+
+	group.Name = splits[NameIdx]
+	group.Pass = splits[PassIdx]
+	group.Gid, _ = strconv.Atoi(splits[GidIdx])
+
+	u := splits[UsersIdx]
+	if u != "" {
+		group.Users = strings.Split(u, ",")
+	} else {
+		group.Users = []string{}
+	}
+}

--- a/common/group_test.go
+++ b/common/group_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 The rkt Authors
+// Copyright 2015 The rkt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package common
 
 import (
 	"reflect"

--- a/rkt/image_gc.go
+++ b/rkt/image_gc.go
@@ -74,8 +74,9 @@ func gcTreeStore(s *store.Store) error {
 		if _, ok := referencedTreeStoreIDs[treeStoreID]; !ok {
 			if err := s.RemoveTreeStore(treeStoreID); err != nil {
 				stderr("rkt: error removing treestore %q: %v", treeStoreID, err)
+			} else {
+				stderr("rkt: removed treestore %q", treeStoreID)
 			}
-			stderr("rkt: removed treestore %q", treeStoreID)
 		}
 	}
 	return nil

--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -93,7 +93,7 @@ func initPods() error {
 	if !podsInitialized {
 		dirs := []string{embryoDir(), prepareDir(), preparedDir(), runDir(), exitedGarbageDir(), garbageDir()}
 		for _, d := range dirs {
-			if err := os.MkdirAll(d, 0700); err != nil {
+			if err := os.MkdirAll(d, 0750); err != nil {
 				return fmt.Errorf("error creating directory: %v", err)
 			}
 		}
@@ -166,7 +166,7 @@ func newPod() (*pod, error) {
 		return nil, fmt.Errorf("error creating UUID: %v", err)
 	}
 
-	err = os.Mkdir(p.embryoPath(), 0700)
+	err = os.Mkdir(p.embryoPath(), 0750)
 	if err != nil {
 		return nil, err
 	}

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -252,7 +252,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	rktgid, err := lookupGid(rktGroup)
+	rktgid, err := common.LookupGid(common.RktGroup)
 	if err != nil {
 		stderr("run: group %q not found, will use default gid when rendering images")
 		rktgid = -1

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -252,6 +252,12 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	rktgid, err := lookupGid(rktGroup)
+	if err != nil {
+		stderr("run: group %q not found, will use default gid when rendering images")
+		rktgid = -1
+	}
+
 	rcfg := stage0.RunConfig{
 		CommonConfig: cfg,
 		PrivateNet:   flagPrivateNet,
@@ -259,6 +265,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		Interactive:  flagInteractive,
 		MDSRegister:  flagMDSRegister,
 		LocalConfig:  globalFlags.LocalConfigDir,
+		RktGid:       rktgid,
 	}
 
 	apps, err := p.getApps()

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -21,6 +21,7 @@ import (
 	"log"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
+	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/stage0"
 	"github.com/coreos/rkt/store"
 )
@@ -125,7 +126,7 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	rktgid, err := lookupGid(rktGroup)
+	rktgid, err := common.LookupGid(common.RktGroup)
 	if err != nil {
 		stderr("prepared-run: group %q not found, will use default gid when rendering images")
 		rktgid = -1

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -125,6 +125,12 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	rktgid, err := lookupGid(rktGroup)
+	if err != nil {
+		stderr("prepared-run: group %q not found, will use default gid when rendering images")
+		rktgid = -1
+	}
+
 	rcfg := stage0.RunConfig{
 		CommonConfig: stage0.CommonConfig{
 			Store: s,
@@ -136,6 +142,7 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		Interactive: flagInteractive,
 		MDSRegister: flagMDSRegister,
 		Apps:        apps,
+		RktGid:      rktgid,
 	}
 	stage0.Run(rcfg, p.path()) // execs, never returns
 	return 1

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -50,6 +50,17 @@ import (
 	"github.com/coreos/rkt/version"
 )
 
+const (
+	// Default perm bits for the regular files
+	// within the stage1 directory. (e.g. image manifest,
+	// pod manifest, stage1ID, etc).
+	defaultRegularFilePerm = os.FileMode(0640)
+
+	// Default perm bits for the regular directories
+	// within the stage1 directory.
+	defaultRegularDirPerm = os.FileMode(0750)
+)
+
 // configuration parameters required by Prepare
 type PrepareConfig struct {
 	CommonConfig
@@ -72,6 +83,7 @@ type RunConfig struct {
 	MDSRegister bool                  // whether to register with metadata service or not
 	Apps        schema.AppList        // applications (prepare gets them via Apps)
 	LocalConfig string                // Path to local configuration
+	RktGid      int                   // group id of the 'rkt' group, -1 if there's no rkt group.
 }
 
 // configuration shared by both Run and Prepare
@@ -244,7 +256,7 @@ func validatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
 
 // Prepare sets up a pod based on the given config.
 func Prepare(cfg PrepareConfig, dir string, uuid *types.UUID) error {
-	if err := os.MkdirAll(common.AppsInfoPath(dir), 0755); err != nil {
+	if err := os.MkdirAll(common.AppsInfoPath(dir), defaultRegularDirPerm); err != nil {
 		return fmt.Errorf("error creating apps info directory: %v", err)
 	}
 	log.Printf("Preparing stage1")
@@ -265,7 +277,7 @@ func Prepare(cfg PrepareConfig, dir string, uuid *types.UUID) error {
 
 	log.Printf("Writing pod manifest")
 	fn := common.PodManifestPath(dir)
-	if err := ioutil.WriteFile(fn, pmb, 0700); err != nil {
+	if err := ioutil.WriteFile(fn, pmb, defaultRegularFilePerm); err != nil {
 		return fmt.Errorf("error writing pod manifest: %v", err)
 	}
 
@@ -282,7 +294,7 @@ func Prepare(cfg PrepareConfig, dir string, uuid *types.UUID) error {
 		// mark the pod as prepared for user namespaces
 		uidrangeBytes := cfg.PrivateUsers.Serialize()
 
-		if err := ioutil.WriteFile(filepath.Join(dir, common.PrivateUsersPreparedFilename), uidrangeBytes, 0700); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(dir, common.PrivateUsersPreparedFilename), uidrangeBytes, defaultRegularFilePerm); err != nil {
 			return fmt.Errorf("error writing userns marker file: %v", err)
 		}
 	}
@@ -423,7 +435,7 @@ func prepareAppImage(cfg PrepareConfig, appName types.ACName, img types.Hash, cd
 	}
 
 	appInfoDir := common.AppInfoPath(cdir, appName)
-	if err := os.MkdirAll(appInfoDir, 0755); err != nil {
+	if err := os.MkdirAll(appInfoDir, defaultRegularDirPerm); err != nil {
 		return fmt.Errorf("error creating apps info directory: %v", err)
 	}
 
@@ -443,14 +455,23 @@ func prepareAppImage(cfg PrepareConfig, appName types.ACName, img types.Hash, cd
 			}
 		}
 
-		if err := ioutil.WriteFile(common.AppTreeStoreIDPath(cdir, appName), []byte(treeStoreID), 0700); err != nil {
+		if err := ioutil.WriteFile(common.AppTreeStoreIDPath(cdir, appName), []byte(treeStoreID), defaultRegularFilePerm); err != nil {
 			return fmt.Errorf("error writing app treeStoreID: %v", err)
 		}
 	} else {
 		ad := common.AppPath(cdir, appName)
-		err := os.MkdirAll(ad, 0755)
+		err := os.MkdirAll(ad, defaultRegularDirPerm)
 		if err != nil {
 			return fmt.Errorf("error creating image directory: %v", err)
+		}
+
+		shiftedUid, shiftedGid, err := cfg.PrivateUsers.ShiftRange(uint32(os.Getuid()), uint32(os.Getgid()))
+		if err != nil {
+			return fmt.Errorf("error getting uid, gid: %v", err)
+		}
+
+		if err := os.Chown(ad, int(shiftedUid), int(shiftedGid)); err != nil {
+			return fmt.Errorf("error shifting app %q's stage2 dir: %v", appName, err)
 		}
 
 		if err := aci.RenderACIWithImageID(img, ad, cfg.Store, cfg.PrivateUsers); err != nil {
@@ -469,7 +490,7 @@ func prepareAppImage(cfg PrepareConfig, appName types.ACName, img types.Hash, cd
 func setupAppImage(cfg RunConfig, appName types.ACName, img types.Hash, cdir string, useOverlay bool) error {
 	ad := common.AppPath(cdir, appName)
 	if useOverlay {
-		err := os.MkdirAll(ad, 0776)
+		err := os.MkdirAll(ad, defaultRegularDirPerm)
 		if err != nil {
 			return fmt.Errorf("error creating image directory: %v", err)
 		}
@@ -493,7 +514,7 @@ func setupAppImage(cfg RunConfig, appName types.ACName, img types.Hash, cdir str
 // When useOverlay is false, it attempts to render and expand the stage1.
 func prepareStage1Image(cfg PrepareConfig, img types.Hash, cdir string, useOverlay bool) error {
 	s1 := common.Stage1ImagePath(cdir)
-	if err := os.MkdirAll(s1, 0755); err != nil {
+	if err := os.MkdirAll(s1, defaultRegularDirPerm); err != nil {
 		return fmt.Errorf("error creating stage1 directory: %v", err)
 	}
 
@@ -522,7 +543,7 @@ func prepareStage1Image(cfg PrepareConfig, img types.Hash, cdir string, useOverl
 	}
 
 	fn := path.Join(cdir, common.Stage1TreeStoreIDFilename)
-	if err := ioutil.WriteFile(fn, []byte(treeStoreID), 0700); err != nil {
+	if err := ioutil.WriteFile(fn, []byte(treeStoreID), defaultRegularFilePerm); err != nil {
 		return fmt.Errorf("error writing stage1 treeStoreID: %v", err)
 	}
 	return nil
@@ -531,12 +552,13 @@ func prepareStage1Image(cfg PrepareConfig, img types.Hash, cdir string, useOverl
 // setupStage1Image mounts the overlay filesystem for stage1.
 // When useOverlay is false it is a noop
 func setupStage1Image(cfg RunConfig, cdir string, useOverlay bool) error {
+	s1 := common.Stage1ImagePath(cdir)
 	if useOverlay {
 		treeStoreID, err := ioutil.ReadFile(filepath.Join(cdir, common.Stage1TreeStoreIDFilename))
 		if err != nil {
 			return err
 		}
-		s1 := common.Stage1ImagePath(cdir)
+
 		// pass an empty appName: make sure it remains consistent with
 		// overlayStatusDirTemplate
 		if err := overlayRender(cfg, string(treeStoreID), cdir, s1, ""); err != nil {
@@ -551,7 +573,29 @@ func setupStage1Image(cfg RunConfig, cdir string, useOverlay bool) error {
 		}
 	}
 
-	return nil
+	// Chown the 'rootfs' directory, so that rkt list/rkt status can access it.
+	if err := os.Chown(filepath.Join(s1, "rootfs"), -1, cfg.RktGid); err != nil {
+		return err
+	}
+
+	// Chown the 'rootfs/rkt' and its sub-directory, so that rkt list/rkt status can
+	// access it.
+	// Also set 'S_ISGID' bit on the mode so that when the app writes exit status to
+	// 'rootfs/rkt/status/$app', the file has the group ID set to 'rkt'.
+	chownWalker := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if err := os.Chown(path, -1, cfg.RktGid); err != nil {
+			return err
+		}
+		if err := os.Chmod(path, info.Mode()|os.ModeSetgid); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	return filepath.Walk(filepath.Join(s1, "rootfs", "rkt"), chownWalker)
 }
 
 // writeManifest takes an img ID and writes the corresponding manifest in dest
@@ -567,7 +611,7 @@ func writeManifest(cfg CommonConfig, img types.Hash, dest string) error {
 	}
 
 	log.Printf("Writing image manifest")
-	if err := ioutil.WriteFile(filepath.Join(dest, "manifest"), mb, 0700); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(dest, "manifest"), mb, defaultRegularFilePerm); err != nil {
 		return fmt.Errorf("error writing image manifest: %v", err)
 	}
 
@@ -591,27 +635,48 @@ func copyAppManifest(cdir string, appName types.ACName, dest string) error {
 // It mounts an overlay filesystem from the cached tree of the image as rootfs.
 func overlayRender(cfg RunConfig, treeStoreID string, cdir string, dest string, appName string) error {
 	destRootfs := path.Join(dest, "rootfs")
-	if err := os.MkdirAll(destRootfs, 0755); err != nil {
+	if err := os.MkdirAll(destRootfs, defaultRegularDirPerm); err != nil {
 		return err
 	}
 
 	cachedTreePath := cfg.Store.GetTreeStoreRootFS(treeStoreID)
 
-	overlayDir := path.Join(cdir, "overlay", treeStoreID)
-	if err := os.MkdirAll(overlayDir, 0755); err != nil {
+	overlayDir := path.Join(cdir, "overlay")
+	if err := os.MkdirAll(overlayDir, defaultRegularDirPerm); err != nil {
 		return err
 	}
 
-	upperDir := path.Join(overlayDir, "upper", appName)
-	if err := os.MkdirAll(upperDir, 0755); err != nil {
+	// Since the parent directory (rkt/pods/$STATE/$POD_UUID) has the 'S_ISGID' bit, here
+	// we need to explicitly turn the bit off when creating this overlay
+	// directory so that it won't inherit the bit. Otherwise the files
+	// created by users within the pod will inherit the 'S_ISGID' bit
+	// as well.
+	if err := os.Chmod(overlayDir, defaultRegularDirPerm); err != nil {
+		return err
+	}
+
+	imgDir := path.Join(overlayDir, treeStoreID)
+	if err := os.MkdirAll(imgDir, defaultRegularDirPerm); err != nil {
+		return err
+	}
+
+	// Also make 'rkt/pods/$STATE/$POD_UUID/overlay/$IMAGE_ID' to be readable by 'rkt' group
+	// As 'rkt' status will read the 'rkt/pods/$STATE/$POD_UUID/overlay/$IMAGE_ID/upper/rkt/status/$APP'
+	// to get exit status.
+	if err := os.Chown(imgDir, -1, cfg.RktGid); err != nil {
+		return err
+	}
+
+	upperDir := path.Join(imgDir, "upper", appName)
+	if err := os.MkdirAll(upperDir, defaultRegularDirPerm); err != nil {
 		return err
 	}
 	if err := label.SetFileLabel(upperDir, cfg.MountLabel); err != nil {
 		return err
 	}
 
-	workDir := path.Join(overlayDir, "work", appName)
-	if err := os.MkdirAll(workDir, 0755); err != nil {
+	workDir := path.Join(imgDir, "work", appName)
+	if err := os.MkdirAll(workDir, defaultRegularDirPerm); err != nil {
 		return err
 	}
 	if err := label.SetFileLabel(workDir, cfg.MountLabel); err != nil {

--- a/tests/rkt_exit_test.go
+++ b/tests/rkt_exit_test.go
@@ -17,50 +17,11 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
 	"time"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 )
-
-func checkStatus(t *testing.T, ctx *rktRunCtx, appName, expected string) {
-	cmd := fmt.Sprintf(`/bin/sh -c "`+
-		`UUID=$(%s list --full|grep '^[a-f0-9]'|awk '{print $1}') ;`+
-		`echo -n 'status=' ;`+
-		`%s status $UUID|grep '^app-%s.*=[0-9]*$'|cut -d= -f2"`,
-		ctx.cmd(), ctx.cmd(), appName)
-
-	t.Logf("Get status for app %s: %s\n", appName, cmd)
-	child, err := gexpect.Spawn(cmd)
-	if err != nil {
-		t.Fatalf("Cannot exec rkt")
-	}
-
-	err = expectWithOutput(child, expected)
-	if err != nil {
-		// For debugging purpose, print the full output of
-		// "rkt list" and "rkt status"
-		cmd := fmt.Sprintf(`%s list --full ;`+
-			`UUID=$(%s list --full|grep  '^[a-f0-9]'|awk '{print $1}') ;`+
-			`%s status $UUID`,
-			ctx.cmd(), ctx.cmd(), ctx.cmd())
-		out, err2 := exec.Command("/bin/sh", "-c", cmd).CombinedOutput()
-		if err2 != nil {
-			t.Logf("Could not run rkt status: %v. %s", err2, out)
-		} else {
-			t.Logf("%s\n", out)
-		}
-
-		t.Fatalf("Failed to get the status for app %s: expected: %s. %v",
-			appName, expected, err)
-	}
-
-	err = child.Wait()
-	if err != nil {
-		t.Fatalf("rkt didn't terminate correctly: %v", err)
-	}
-}
 
 // TestExitCodeSimple is testing a few exit codes on 1 pod containing just 1 app
 func TestExitCodeSimple(t *testing.T) {
@@ -83,7 +44,7 @@ func TestExitCodeSimple(t *testing.T) {
 			t.Fatalf("rkt didn't terminate correctly: %v", err)
 		}
 
-		checkStatus(t, ctx, "rkt-inspect", fmt.Sprintf("status=%d", i))
+		checkAppStatus(t, ctx, false, "rkt-inspect", fmt.Sprintf("status=%d", i))
 	}
 }
 
@@ -128,12 +89,12 @@ func TestExitCodeWithSeveralApps(t *testing.T) {
 	// terminate soon because they already printed their HelloWorld message.
 	time.Sleep(100 * time.Millisecond)
 
-	checkStatus(t, ctx, "hello0", "status=0")
-	checkStatus(t, ctx, "hello1", "status=1")
+	checkAppStatus(t, ctx, true, "hello0", "status=0")
+	checkAppStatus(t, ctx, true, "hello1", "status=1")
 	// Currently, hello2 should be stop correctly (exit code 0) when hello1
 	// failed, so it cannot return its exit code 2. This might change with
 	// https://github.com/coreos/rkt/issues/1461
-	checkStatus(t, ctx, "hello2", "status=0")
+	checkAppStatus(t, ctx, true, "hello2", "status=0")
 
 	t.Logf("Waiting pod termination\n")
 	err = child.Wait()
@@ -143,10 +104,10 @@ func TestExitCodeWithSeveralApps(t *testing.T) {
 
 	t.Logf("Check final status\n")
 
-	checkStatus(t, ctx, "hello0", "status=0")
-	checkStatus(t, ctx, "hello1", "status=1")
+	checkAppStatus(t, ctx, true, "hello0", "status=0")
+	checkAppStatus(t, ctx, true, "hello1", "status=1")
 	// Currently, hello2 should be stop correctly (exit code 0) when hello1
 	// failed, so it cannot return its exit code 2. This might change with
 	// https://github.com/coreos/rkt/issues/1461
-	checkStatus(t, ctx, "hello2", "status=0")
+	checkAppStatus(t, ctx, true, "hello2", "status=0")
 }

--- a/tests/rkt_non_root_test.go
+++ b/tests/rkt_non_root_test.go
@@ -1,0 +1,198 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"syscall"
+	"testing"
+
+	"github.com/coreos/rkt/common"
+)
+
+// TestNonRootReadInfo tests that non-root users that can do rkt list, rkt image list.
+func TestNonRootReadInfo(t *testing.T) {
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
+
+	gid, err := common.LookupGid(common.RktGroup)
+	if err != nil {
+		t.Skipf("Skipping the test because there's no %q group", common.RktGroup)
+	}
+
+	// Do 'rkt install. and launch some pods in root'.
+	cmd := fmt.Sprintf("%s install", ctx.cmd())
+	t.Logf("Running rkt install")
+	runRktAndCheckOutput(t, cmd, "rkt directory structure successfully created", false)
+
+	// Launch some pods, this creates the environment for later testing,
+	// also it exercises 'rkt install'.
+	imgs := []struct {
+		name     string
+		msg      string
+		exitCode string
+		imgFile  string
+	}{
+		{name: "inspect-1", msg: "foo-1", exitCode: "1"},
+		{name: "inspect-2", msg: "foo-2", exitCode: "2"},
+		//{name: "inspect-3", msg: "foo-3", exitCode: "3"}, // Waiting for #1453 #1503.
+	}
+
+	for i, img := range imgs {
+		imgName := fmt.Sprintf("rkt-%s.aci", img.name)
+		imgs[i].imgFile = patchTestACI(imgName, fmt.Sprintf("--name=%s", img.name), fmt.Sprintf("--exec=/inspect --print-msg=%s --exit-code=%s", img.msg, img.exitCode))
+		defer os.Remove(imgs[i].imgFile)
+	}
+
+	runCmds := []string{
+		// Run with overlay, no private-users.
+		fmt.Sprintf("%s --insecure-skip-verify run --mds-register=false %s", ctx.cmd(), imgs[0].imgFile),
+
+		// Run without overlay, no private-users.
+		fmt.Sprintf("%s --insecure-skip-verify run --no-overlay --mds-register=false %s", ctx.cmd(), imgs[1].imgFile),
+
+		// Run without overlay and private-users.
+		//fmt.Sprintf("%s --insecure-skip-verify run --no-overlay --private-users --mds-register=false %s", ctx.cmd(), imgs[2].imgFile),
+	}
+
+	for i, cmd := range runCmds {
+		t.Logf("#%d: Running %s", i, cmd)
+		runRktAndCheckOutput(t, cmd, imgs[i].msg, false)
+	}
+
+	done := make(chan struct{})
+
+	// Go disables setuid/setgid because of its runtime model makes
+	// these syscall not effactive in most cases because:
+	// 1. setuid/setgid syscalls only affects the calling (kernel) thread.
+	// 2. Kernel thread is not binded to goroutine.
+	//
+	// Here we use LockOSThread() and Syscall() to work around this.
+	// Also we need to run in a groutine and destroy the kernel thread on exit
+	// so we are able to clean up the context in root.
+	// For more details, see: https://code.google.com/p/go/issues/detail?id=1435
+	go func() {
+		runtime.LockOSThread()
+		defer func() {
+			close(done)
+			// Destroy the thread so that other goroutines will not run in non-root.
+			syscall.Syscall(syscall.SYS_EXIT, uintptr(0), 0, 0)
+		}()
+
+		// Force runtime to create kernel thread for other goroutines if necessary.
+		// This reduces the chance that the runtime clones this thread after we setuid/setgid.
+		// (Hopefully, if no other goroutines are created during the execution of this goroutine,
+		// then no more kernel threads will be created).
+		runtime.Gosched()
+
+		// Setgid to 'rkt'.
+		_, _, e := syscall.Syscall(syscall.SYS_SETGID, uintptr(gid), 0, 0)
+		if e != 0 {
+			t.Fatalf("Cannot setgid: %v", e.Error())
+		}
+
+		// Setuid to 'nobody' (65534).
+		_, _, e = syscall.Syscall(syscall.SYS_SETUID, uintptr(65534), 0, 0)
+		if e != 0 {
+			t.Fatalf("Cannot setuid: %v", e.Error())
+		}
+
+		// Run rkt list/status to check status.
+		for _, img := range imgs {
+			checkAppStatus(t, ctx, false, img.name, fmt.Sprintf("status=%s", img.exitCode))
+		}
+
+		// Run rkt image list to check images.
+		imgListCmd := fmt.Sprintf("%s image list", ctx.cmd())
+		t.Logf("Running %s", imgListCmd)
+		runRktAndCheckOutput(t, imgListCmd, "inspect-", false)
+	}()
+
+	<-done
+}
+
+// TestNonRootFetchRmGcImage tests that non-root users can remove images fetched by themselves but
+// can not remove images fetched by root, or gc any images.
+func TestNonRootFetchRmGcImage(t *testing.T) {
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
+
+	gid, err := common.LookupGid(common.RktGroup)
+	if err != nil {
+		t.Skipf("Skipping the test because there's no %q group", common.RktGroup)
+	}
+
+	// Do 'rkt install and fetch an image with root.
+	cmd := fmt.Sprintf("%s install", ctx.cmd())
+	t.Logf("Running rkt install")
+	runRktAndCheckOutput(t, cmd, "rkt directory structure successfully created", false)
+
+	rootImg := patchTestACI("rkt-inspect-root-rm.aci", "--exec=/inspect --print-msg=foobar")
+	defer os.Remove(rootImg)
+	rootImgHash := importImageAndFetchHash(t, ctx, rootImg)
+
+	// Launch/gc a pod so we can test non-root image gc.
+	runCmd := fmt.Sprintf("%s --insecure-skip-verify run --mds-register=false %s", ctx.cmd(), rootImg)
+	runRktAndCheckOutput(t, runCmd, "foobar", false)
+
+	ctx.runGC()
+
+	done := make(chan struct{})
+
+	go func() {
+		runtime.LockOSThread()
+		defer func() {
+			close(done)
+			syscall.Syscall(syscall.SYS_EXIT, uintptr(0), 0, 0)
+		}()
+
+		runtime.Gosched()
+
+		// Setgid to 'rkt'.
+		_, _, e := syscall.Syscall(syscall.SYS_SETGID, uintptr(gid), 0, 0)
+		if e != 0 {
+			t.Fatalf("Cannot setgid: %v", e.Error())
+		}
+
+		// Setuid to 'nobody' (65534).
+		_, _, e = syscall.Syscall(syscall.SYS_SETUID, uintptr(65534), 0, 0)
+		if e != 0 {
+			t.Fatalf("Cannot setuid: %v", e.Error())
+		}
+
+		// Should not be able to do image gc.
+		imgGcCmd := fmt.Sprintf("%s image gc", ctx.cmd())
+		t.Logf("Running %s", imgGcCmd)
+		runRktAndCheckOutput(t, imgGcCmd, "permission denied", true)
+
+		// Should not be able to remove the image fetched by root.
+		imgRmCmd := fmt.Sprintf("%s image rm %s", ctx.cmd(), rootImgHash)
+		t.Logf("Running %s", imgRmCmd)
+		runRktAndCheckOutput(t, imgRmCmd, "permission denied", true)
+
+		// Should be able to remove the image fetched by ourselves.
+		nonrootImg := patchTestACI("rkt-inspect-non-root-rm.aci", "--exec=/inspect")
+		defer os.Remove(nonrootImg)
+		nonrootImgHash := importImageAndFetchHash(t, ctx, nonrootImg)
+
+		imgRmCmd = fmt.Sprintf("%s image rm %s", ctx.cmd(), nonrootImgHash)
+		t.Logf("Running %s", imgRmCmd)
+		runRktAndCheckOutput(t, imgRmCmd, "successfully removed", false)
+	}()
+
+	<-done
+}


### PR DESCRIPTION
Changes made:
Add `set-group-ID` bit to the directorys installed by `rkt install`
so that later the files created in those directory can be read by
users in the `rkt` group if the group exits. All the directories are
read-only by `rkt` group except for the `cas` which enables `rkt`
group to fetch images.

Change the permission bits of ppid, pod manifest, image manifest,
dropped the execution bit.

Change the gid of `stage1/rootfs` to the gid of `rkt` group if the
group exits.

Change the gid of `stage1/rootfs/rkt` directory and all its sub-directories
(`rootfs/rkt/status`, `rootfs/rkt/env` currently) to the gid of `rkt`
group if the group exits. Also add `set-group-ID` bit to them so that
files created by the pod in these directories later can be read by
process in `rkt` group. (e.g. exit code of the apps)

Change the gid of `overlay/$IMAGE_ID` to the gid of `rkt` group so
`rkt status` can access the status via the overlay directory.
(the underlying `rkt/status` directory's perm will also be modified
as described previously).