### PR TITLE
stage1: add empty /proc directory in the archive

### DIFF
--- a/stage1/usr_from_coreos/usr_from_coreos.mk
+++ b/stage1/usr_from_coreos/usr_from_coreos.mk
@@ -58,6 +58,7 @@ CLEAN_SYMLINKS += \
 	$(ACIROOTFSDIR)/lib \
 	$(ACIROOTFSDIR)/bin
 CLEAN_DIRS += \
+	$(ACIROOTFSDIR)/proc \
 	$(UFC_ROOTFS)
 
 $(UFC_STAMP): $(UFC_ACI_ROOTFS_STAMP) $(UFC_ACIROOTFS_DEPS_STAMP) $(UFC_ACIROOTFS_CLEAN_STAMP) $(UFC_ROOTFS_CLEAN_STAMP)
@@ -74,6 +75,7 @@ $(UFC_ACI_ROOTFS_STAMP): $(UFC_MKBASE_STAMP) $(UFC_FILELIST)
 	ln -sf 'usr/lib64' "$(ACIROOTFSDIR)/lib64"; \
 	ln -sf 'usr/lib' "$(ACIROOTFSDIR)/lib"; \
 	ln -sf 'usr/bin' "$(ACIROOTFSDIR)/bin"; \
+	mkdir -p "$(ACIROOTFSDIR)/proc"; \
 	echo "$(UFC_SYSTEMD_VERSION)" >"$(ACIROOTFSDIR)/systemd-version"; \
 	touch "$@"
 

--- a/stage1/usr_from_host/usr_from_host.mk
+++ b/stage1/usr_from_host/usr_from_host.mk
@@ -6,8 +6,11 @@ $(call forward-vars,$(UFH_STAMP), \
 	ACIROOTFSDIR)
 $(UFH_STAMP): | $(ACIROOTFSDIR)
 	ln -sf 'host' "$(ACIROOTFSDIR)/flavor"
+	mkdir -p "$(ACIROOTFSDIR)/proc"; \
 	touch "$@"
 
 CLEAN_SYMLINKS += $(ACIROOTFSDIR)/flavor
+CLEAN_DIRS += $(ACIROOTFSDIR)/proc
+
 
 $(call undefine-namespaces,UFH)

--- a/stage1/usr_from_src/usr_from_src.mk
+++ b/stage1/usr_from_src/usr_from_src.mk
@@ -53,6 +53,7 @@ CREATE_DIRS += \
 CLEAN_FILES += \
 	$(ACIROOTFSDIR)/systemd-version
 CLEAN_DIRS += \
+	$(ACIROOTFSDIR)/proc \
 	$(UFS_SYSTEMD_SRCDIR) \
 	$(UFS_SYSTEMD_BUILDDIR) \
 	$(UFS_ROOTFSDIR)
@@ -71,6 +72,7 @@ $(UFS_ROOTFS_STAMP): $(UFS_SYSTEMD_INSTALL_STAMP) | $(ACIROOTFSDIR)
 	cp -af "$(UFS_ROOTFSDIR)/." "$(ACIROOTFSDIR)"; \
 	ln -sf 'src' "$(ACIROOTFSDIR)/flavor"; \
 	echo "$(RKT_STAGE1_SYSTEMD_VER)" >"$(ACIROOTFSDIR)/systemd-version"; \
+	mkdir -p "$(ACIROOTFSDIR)/proc"; \
 	touch "$@"
 
 $(call forward-vars,$(UFS_SYSTEMD_INSTALL_STAMP), \


### PR DESCRIPTION
If an empty /proc directory is in the archive, systemd-nspawn does not
have to create it. It should help with the following issue:
https://github.com/coreos/rkt/pull/1452#issuecomment-142243571

@krnowak : is it the correct way to add an empty directory in the stage1.aci archive?

/cc @yifan-gu 