### PR TITLE
store: close aci.NewCompressedReader

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -282,6 +282,7 @@ func (s Store) WriteACI(r io.ReadSeeker, latest bool) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error decompressing image: %v", err)
 	}
+	defer dr.Close()
 
 	// Write the decompressed image (tar) to a temporary file on disk, and
 	// tee so we can generate the hash


### PR DESCRIPTION
The interface for aci.NewCompressedReader changed in the upstream appc
code (https://github.com/appc/spec/pull/462) to return a ReadCloser
instead of a Reader. Hence it's now our responsibility to close the
returned ACI.

Fixes #1224

/cc @sgotti