### PR TITLE
[WIP] stage1: support setting supplementaryGroups

### DIFF
--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -273,6 +273,16 @@ func (p *Pod) appToSystemd(ra *schema.RuntimeApp, interactive bool, flavor strin
 		unit.NewUnitOption("Service", "Group", "0"),
 	}
 
+	if len(app.SupplementaryGroups) > 0 {
+		var s bytes.Buffer
+		for _, gid := range app.SupplementaryGroups {
+			if _, err := s.WriteString(strconv.Itoa(gid) + " "); err != nil {
+				panic(fmt.Sprintf("error extending buffer: %v", err))
+			}
+		}
+		opts = append(opts, unit.NewUnitOption("Service", "SupplementaryGroups", strings.TrimSpace(s.String())))
+	}
+
 	if interactive {
 		opts = append(opts, unit.NewUnitOption("Service", "StandardInput", "tty"))
 		opts = append(opts, unit.NewUnitOption("Service", "StandardOutput", "tty"))


### PR DESCRIPTION
(eventually) fixes #1309.

Per https://github.com/appc/spec/pull/339, one of the nice things about
supplementary gids is that they can be applied without requiring any
nsswitch lookup. I thought it would be easy to achieve this using systemd.exec's
SupplementaryGroups setting:
http://www.freedesktop.org/software/systemd/man/systemd.exec.html#SupplementaryGroups=

Unfortunately, this somewhat unexpectedly tries to resolve the groups
given even if they are numeric gids (which isn't guaranteed to succeed),
instead of just calling setgroups() (which is) as I'd hoped:

https://github.com/systemd/systemd/blob/56c581598389739ba2a97baf896ea9277c278a1d/src/core/execute.c#L675

It looks like systemd is trying to be clever and reverse-lookup
gid->groupname, which is annoying:
https://github.com/systemd/systemd/blob/d11885c81419cac217ae132c1ef80733707ba650/src/basic/util.c#L3383

Throwing this up for feedback/ideas.