### PR TITLE
Use last-ditch manifest parser for error reporting

### DIFF
--- a/rkt/help.go
+++ b/rkt/help.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 	"text/template"
 
@@ -101,6 +102,7 @@ func getSubCommands(cmd *cobra.Command) []*cobra.Command {
 
 func usageFunc(cmd *cobra.Command) error {
 	subCommands := getSubCommands(cmd)
+	tabOut := getTabOutWithWriter(os.Stdout)
 	commandUsageTemplate.Execute(tabOut, struct {
 		Executable  string
 		Cmd         *cobra.Command

--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -176,7 +176,7 @@ func init() {
 	cmdImageList.Flags().BoolVar(&flagFullOutput, "full", false, "Use long output format")
 }
 
-func runImages(cmd *cobra.Command, args []string) (exit int) {
+func runImages(cmd *cobra.Command, args []string) int {
 	if !flagNoLegend {
 		headerFields := []string{}
 		for _, f := range flagImagesFields {
@@ -198,7 +198,7 @@ func runImages(cmd *cobra.Command, args []string) (exit int) {
 	aciInfos, err := s.GetAllACIInfos(sortAciinfoFields, bool(flagImagesSortAsc))
 	if err != nil {
 		stderr("images: unable to get aci infos: %v", err)
-		return
+		return 1
 	}
 
 	for _, aciInfo := range aciInfos {

--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -211,7 +211,9 @@ func runImages(cmd *cobra.Command, args []string) int {
 			continue
 		}
 		version, ok := im.Labels.Get("version")
+		fieldValues := []string{}
 		for _, f := range flagImagesFields {
+			fieldValue := ""
 			switch f {
 			case keyField:
 				hashKey := aciInfo.BlobKey
@@ -224,25 +226,25 @@ func runImages(cmd *cobra.Command, args []string) int {
 						hashKey = hashKey[:trimLength]
 					}
 				}
-				fmt.Fprintf(tabOut, "%s", hashKey)
+				fieldValue = hashKey
 			case nameField:
-				fmt.Fprintf(tabOut, "%s", aciInfo.Name)
+				fieldValue = aciInfo.Name
 				if ok {
-					fmt.Fprintf(tabOut, ":%s", version)
+					fieldValue = fmt.Sprintf("%s:%s", fieldValue, version)
 				}
 			case importTimeField:
 				if flagFullOutput {
-					fmt.Fprintf(tabOut, "%s", aciInfo.ImportTime.Format(defaultTimeLayout))
+					fieldValue = aciInfo.ImportTime.Format(defaultTimeLayout)
 				} else {
-					fmt.Fprintf(tabOut, "%s", humanize.Time(aciInfo.ImportTime))
+					fieldValue = humanize.Time(aciInfo.ImportTime)
 				}
 			case latestField:
-				fmt.Fprintf(tabOut, "%t", aciInfo.Latest)
+				fieldValue = fmt.Sprintf("%t", aciInfo.Latest)
 			}
-			fmt.Fprintf(tabOut, "\t")
+			fieldValues = append(fieldValues, fieldValue)
 
 		}
-		fmt.Fprintf(tabOut, "\n")
+		fmt.Fprintf(tabOut, "%s\n", strings.Join(fieldValues, "\t"))
 	}
 
 	tabOut.Flush()

--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -15,10 +15,13 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/dustin/go-humanize"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
 	"github.com/coreos/rkt/store"
@@ -178,7 +181,9 @@ func init() {
 }
 
 func runImages(cmd *cobra.Command, args []string) int {
-	tabOut := getTabOutWithWriter(os.Stdout)
+	errors := []error{}
+	tabBuffer := new(bytes.Buffer)
+	tabOut := getTabOutWithWriter(tabBuffer)
 
 	if !flagNoLegend {
 		headerFields := []string{}
@@ -205,9 +210,14 @@ func runImages(cmd *cobra.Command, args []string) int {
 	}
 
 	for _, aciInfo := range aciInfos {
-		im, err := s.GetImageManifest(aciInfo.BlobKey)
+		imj, err := s.GetImageManifestJSON(aciInfo.BlobKey)
 		if err != nil {
 			// ignore aciInfo with missing image manifest as it can be deleted in the meantime
+			continue
+		}
+		var im *schema.ImageManifest
+		if err = json.Unmarshal(imj, &im); err != nil {
+			errors = append(errors, newImgListLoadError(err, imj, aciInfo.BlobKey))
 			continue
 		}
 		version, ok := im.Labels.Get("version")
@@ -247,6 +257,38 @@ func runImages(cmd *cobra.Command, args []string) int {
 		fmt.Fprintf(tabOut, "%s\n", strings.Join(fieldValues, "\t"))
 	}
 
+	if len(errors) > 0 {
+		sep := "----------------------------------------"
+		stderr("%d error(s) encountered when listing images:", len(errors))
+		stderr("%s", sep)
+		for _, err := range errors {
+			stderr("%s", err.Error())
+			stderr("%s", sep)
+		}
+		stderr("Misc:")
+		stderr("  rkt's appc version: %s", schema.AppContainerVersion)
+		// make a visible break between errors and the listing
+		stderr("")
+	}
 	tabOut.Flush()
+	stdout("%s", tabBuffer.String())
 	return 0
+}
+
+func newImgListLoadError(err error, imj []byte, blobKey string) error {
+	lines := []string{}
+	im := lastditch.ImageManifest{}
+	imErr := im.UnmarshalJSON(imj)
+	if imErr == nil {
+		lines = append(lines, fmt.Sprintf("Unable to load manifest of image %s (spec version %s) because it is invalid:", im.Name, im.ACVersion))
+		lines = append(lines, fmt.Sprintf("  %v", err))
+	} else {
+		lines = append(lines, "Unable to load manifest of an image because it is invalid:")
+		lines = append(lines, fmt.Sprintf("  %v", err))
+		lines = append(lines, "  Also, failed to get any information about invalid image manifest:")
+		lines = append(lines, fmt.Sprintf("    %v", imErr))
+	}
+	lines = append(lines, "ID of the invalid image:")
+	lines = append(lines, fmt.Sprintf("  %s", blobKey))
+	return fmt.Errorf("%s", strings.Join(lines, "\n"))
 }

--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/dustin/go-humanize"
@@ -177,6 +178,8 @@ func init() {
 }
 
 func runImages(cmd *cobra.Command, args []string) int {
+	tabOut := getTabOutWithWriter(os.Stdout)
+
 	if !flagNoLegend {
 		headerFields := []string{}
 		for _, f := range flagImagesFields {

--- a/rkt/list.go
+++ b/rkt/list.go
@@ -43,7 +43,7 @@ func init() {
 	cmdList.Flags().BoolVar(&flagFullOutput, "full", false, "use long output format")
 }
 
-func runList(cmd *cobra.Command, args []string) (exit int) {
+func runList(cmd *cobra.Command, args []string) int {
 	s, err := store.NewStore(globalFlags.Dir)
 	if err != nil {
 		stderr("list: cannot open store: %v", err)

--- a/rkt/list.go
+++ b/rkt/list.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
@@ -49,6 +50,8 @@ func runList(cmd *cobra.Command, args []string) int {
 		stderr("list: cannot open store: %v", err)
 		return 1
 	}
+
+	tabOut := getTabOutWithWriter(os.Stdout)
 
 	if !flagNoLegend {
 		fmt.Fprintf(tabOut, "UUID\tAPP\tACI\tSTATE\tNETWORKS\n")

--- a/rkt/list.go
+++ b/rkt/list.go
@@ -17,11 +17,13 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/lastditch"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
 	common "github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/networking/netinfo"
@@ -51,7 +53,9 @@ func runList(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	tabOut := getTabOutWithWriter(os.Stdout)
+	errors := []error{}
+	tabBuffer := new(bytes.Buffer)
+	tabOut := getTabOutWithWriter(tabBuffer)
 
 	if !flagNoLegend {
 		fmt.Fprintf(tabOut, "UUID\tAPP\tACI\tSTATE\tNETWORKS\n")
@@ -64,40 +68,68 @@ func runList(cmd *cobra.Command, args []string) int {
 			// TODO(vc): we should really hold a shared lock here to prevent gc of the pod
 			pmf, err := p.readFile(common.PodManifestPath(""))
 			if err != nil {
-				stderr("Unable to read pod manifest: %v", err)
+				errors = append(errors, newPodListReadError(p, err))
 				return
 			}
 
 			if err := pm.UnmarshalJSON(pmf); err != nil {
-				stderr("Unable to load manifest: %v", err)
+				errors = append(errors, newPodListLoadError(p, err, pmf))
 				return
 			}
 
 			if len(pm.Apps) == 0 {
-				stderr("Pod contains zero apps")
+				errors = append(errors, newPodListZeroAppsError(p))
 				return
 			}
 		}
 
-		uuid := ""
-		if flagFullOutput {
-			uuid = p.uuid.String()
-		} else {
-			uuid = p.uuid.String()[:8]
+		type printedApp struct {
+			uuid    string
+			appName string
+			imgName string
+			state   string
+			nets    string
 		}
 
-		for i, app := range pm.Apps {
+		appsToPrint := []printedApp{}
+		uuid := p.uuid.String()
+		state := p.getState()
+		nets := fmtNets(p.nets)
+		if !flagFullOutput {
+			uuid = uuid[:8]
+		}
+		for _, app := range pm.Apps {
 			// Retrieve the image from the store.
-			im, err := s.GetImageManifest(app.Image.ID.String())
+			imj, err := s.GetImageManifestJSON(app.Image.ID.String())
 			if err != nil {
-				stderr("Unable to load image manifest: %v", err)
+				errors = append(errors, newPodListImageStoreFailure(p, err, &pm, app))
+				return
+			}
+			var im *schema.ImageManifest
+			if err = json.Unmarshal(imj, &im); err != nil {
+				errors = append(errors, newPodListImageLoadFailure(p, err, &pm, imj, app))
+				return
 			}
 
-			if i == 0 {
-				fmt.Fprintf(tabOut, "%s\t%s\t%s\t%s\t%s\n", uuid, app.Name.String(), im.Name.String(), p.getState(), fmtNets(p.nets))
-			} else {
-				fmt.Fprintf(tabOut, "\t%s\t%s\t\t\n", app.Name.String(), im.Name.String())
-			}
+			appsToPrint = append(appsToPrint, printedApp{
+				uuid:    uuid,
+				appName: app.Name.String(),
+				imgName: im.Name.String(),
+				state:   state,
+				nets:    nets,
+			})
+			// clear those variables so they won't be
+			// printed for another apps in the pod as they
+			// are actually describing a pod, not an app
+			uuid = ""
+			state = ""
+			nets = ""
+		}
+		// if we reached that point, then it means that the
+		// pod and all its apps are valid, so they can be
+		// printed
+		for _, app := range appsToPrint {
+			fmt.Fprintf(tabOut, "%s\t%s\t%s\t%s\t%s\n", app.uuid, app.appName, app.imgName, app.state, app.nets)
 		}
 
 	}); err != nil {
@@ -105,8 +137,113 @@ func runList(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
+	if len(errors) > 0 {
+		sep := "----------------------------------------"
+		stderr("%d error(s) encountered when listing pods:", len(errors))
+		stderr("%s", sep)
+		for _, err := range errors {
+			stderr("%s", err.Error())
+			stderr("%s", sep)
+		}
+		stderr("Misc:")
+		stderr("  rkt's appc version: %s", schema.AppContainerVersion)
+		stderr("%s", sep)
+		// make a visible break between errors and the listing
+		stderr("")
+	}
+
 	tabOut.Flush()
+	stdout("%s", tabBuffer.String())
 	return 0
+}
+
+func newPodListReadError(p *pod, err error) error {
+	lines := []string{
+		fmt.Sprintf("Unable to read pod %s manifest:", p.uuid.String()),
+		fmt.Sprintf("  %v", err),
+	}
+	return fmt.Errorf("%s", strings.Join(lines, "\n"))
+}
+
+func newPodListLoadError(p *pod, err error, pmj []byte) error {
+	lines := []string{
+		fmt.Sprintf("Unable to load pod %s manifest, because it is invalid:", p.uuid.String()),
+		fmt.Sprintf("  %v", err),
+	}
+	pm := lastditch.PodManifest{}
+	if err := pm.UnmarshalJSON(pmj); err != nil {
+		lines = append(lines, "  Also, failed to get any information about invalid pod manifest:")
+		lines = append(lines, fmt.Sprintf("    %v", err))
+	} else {
+		if len(pm.Apps) > 0 {
+			lines = append(lines, "Objects related to this error:")
+			for _, app := range pm.Apps {
+				lines = append(lines, fmt.Sprintf("  %s", appLine(app)))
+			}
+		} else {
+			lines = append(lines, "No other objects related to this error")
+		}
+	}
+	return fmt.Errorf("%s", strings.Join(lines, "\n"))
+}
+
+func newPodListZeroAppsError(p *pod) error {
+	return fmt.Errorf("Pod %s contains zero apps", p.uuid.String())
+}
+
+func newPodListImageStoreFailure(p *pod, err error, pm *schema.PodManifest, app schema.RuntimeApp) error {
+	lines := []string{
+		fmt.Sprintf("Unable to get image %s manifest from store:", app.Image.ID.String()),
+		fmt.Sprintf("  %v", err),
+		"Objects related to this error:",
+		fmt.Sprintf("  App: %q from failing image %q (%s)",
+			app.Name, app.Image.Name, app.Image.ID),
+		fmt.Sprintf("  Pod %s (spec version %s) with following apps:", p.uuid.String(), pm.ACVersion.String()),
+	}
+	for _, pApp := range pm.Apps {
+		lines = append(lines, fmt.Sprintf("    %s", appLine(degradeRuntimeApp(pApp))))
+	}
+	return fmt.Errorf("%s", strings.Join(lines, "\n"))
+}
+
+func newPodListImageLoadFailure(p *pod, err error, pm *schema.PodManifest, imj []byte, app schema.RuntimeApp) error {
+	im := lastditch.ImageManifest{}
+	imErr := im.UnmarshalJSON(imj)
+	acVersion := "unknown"
+	if imErr == nil {
+		acVersion = im.ACVersion
+	}
+	lines := []string{
+		fmt.Sprintf("Unable to load image %s manifest (spec version %s) because it is invalid:", app.Image.ID.String(), acVersion),
+		fmt.Sprintf("  %v", err),
+	}
+	if imErr != nil {
+		lines = append(lines, "  Also, failed to get any information about invalid image manifest:")
+		lines = append(lines, fmt.Sprintf("    %v", imErr))
+	}
+	lines = append(lines, "Objects related to this error:")
+	lines = append(lines, fmt.Sprintf("  App: %q from failing image %q (%s)",
+		app.Name, app.Image.Name, app.Image.ID))
+	lines = append(lines, fmt.Sprintf("  Pod %s (spec version %s) with following apps:", p.uuid.String(), pm.ACVersion.String()))
+	for _, pApp := range pm.Apps {
+		lines = append(lines, fmt.Sprintf("    %s", appLine(degradeRuntimeApp(pApp))))
+	}
+	return fmt.Errorf("%s", strings.Join(lines, "\n"))
+}
+
+func degradeRuntimeApp(app schema.RuntimeApp) lastditch.RuntimeApp {
+	return lastditch.RuntimeApp{
+		Name: app.Name.String(),
+		Image: lastditch.Image{
+			Name: app.Image.Name.String(),
+			ID:   app.Image.ID.String(),
+		},
+	}
+}
+
+func appLine(app lastditch.RuntimeApp) string {
+	return fmt.Sprintf("App: %q from image %q (%s)",
+		app.Name, app.Image.Name, app.Image.ID)
 }
 
 func fmtNets(nis []netinfo.NetInfo) string {

--- a/rkt/rkt.go
+++ b/rkt/rkt.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,10 +66,13 @@ func init() {
 }
 
 func init() {
-	tabOut = new(tabwriter.Writer)
-	tabOut.Init(os.Stdout, 0, 8, 1, '\t', 0)
-
 	cobra.EnablePrefixMatching = true
+}
+
+func getTabOutWithWriter(writer io.Writer) *tabwriter.Writer {
+	aTabOut := new(tabwriter.Writer)
+	aTabOut.Init(writer, 0, 8, 1, '\t', 0)
+	return aTabOut
 }
 
 // runWrapper return a func(cmd *cobra.Command, args []string) that internally

--- a/store/store.go
+++ b/store/store.go
@@ -531,8 +531,9 @@ func (s Store) WriteRemote(remote *Remote) error {
 	return err
 }
 
-// Get the ImageManifest with the specified key.
-func (s Store) GetImageManifest(key string) (*schema.ImageManifest, error) {
+// GetImageManifestJSON gets the ImageManifest JSON bytes with the
+// specified key.
+func (s Store) GetImageManifestJSON(key string) ([]byte, error) {
 	key, err := s.ResolveKey(key)
 	if err != nil {
 		return nil, fmt.Errorf("error resolving key: %v", err)
@@ -546,6 +547,15 @@ func (s Store) GetImageManifest(key string) (*schema.ImageManifest, error) {
 	imj, err := s.stores[imageManifestType].Read(key)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving image manifest: %v", err)
+	}
+	return imj, nil
+}
+
+// GetImageManifest gets the ImageManifest with the specified key.
+func (s Store) GetImageManifest(key string) (*schema.ImageManifest, error) {
+	imj, err := s.GetImageManifestJSON(key)
+	if err != nil {
+		return nil, err
 	}
 	var im *schema.ImageManifest
 	if err = json.Unmarshal(imj, &im); err != nil {


### PR DESCRIPTION
Text below copied from #1266.

Example output of `rkt list`:
```
Unable to load manifest of pod 1ad35d47-34a4-4800-ac34-088f7a8f75ee: ACName must contain only lower case alphanumeric characters plus "-"
Invalid pod manifest - version: 0.7.0+git
  App: "!redis" from image "redis" (sha512-afe588bd39c1e5b6e85743d0fbfde921cc895eeee9e64dac8c31b4647a12577c)
Unable to load manifest of pod 22fc87d3-9c53-4b35-b83d-d3d19a865f9c: ACName must contain only lower case alphanumeric characters plus "-"
Invalid pod manifest - version: 0.7.0+git
  App: "busybox~" from image "busybox" (sha512-bf885104dc06468d8458c43d3f7f66774da77c62c09574de22d1bce17fd14df4)
UUID		APP	ACI		STATE	NETWORKS
2f969bfd	redis	redis		exited	
70020f80	busybox	busybox		exited	
7b6c7615	busybox	busybox		exited	
85390bde	redis	redis		exited	
8a1549f5	busybox	busybox		exited	
952a459a	etcd	coreos.com/etcd	exited	
bf59d559	etcd	coreos.com/etcd	exited	
ebaae473	etcd	coreos.com/etcd	exited
``` 