### PR TITLE
semaphore: Update install-deps

### DIFF
--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -5,11 +5,8 @@
 if [ "${CI-}" == true ] ; then
 	# https://semaphoreci.com/
 	if [ "${SEMAPHORE-}" == true ] ; then
-		# In Semaphore's last platform update, the default gcc version is 4.6
-		# which breaks the systemd build.
-		# Set it to 4.8 manually.
-		# TODO: remove this when the issue is fixed in Semaphore
-		sudo update-alternatives --set gcc /usr/bin/gcc-4.8
+		# A colon to guard against an empty body error.
+		:
 
 		# Most dependencies are already installed on Semaphore.
 		# Here we can install any missing dependencies. Whenever
@@ -20,7 +17,6 @@ if [ "${CI-}" == true ] ; then
 		# uncomment the following line and add "sudo apt-get
 		# install -y <dep>" after it.
 
-		sudo apt-get update -qq || true
-		sudo apt-get install -y golang-go
+		#sudo apt-get update -qq || true
 	fi
 fi

--- a/tests/run-build.sh
+++ b/tests/run-build.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+# Setup go environment on semaphore
+if [ -f /opt/change-go-version.sh ]; then
+    . /opt/change-go-version.sh
+    change-go-version 1.4
+fi
+
 RKT_STAGE1_USR_FROM="${1}"
 RKT_STAGE1_SYSTEMD_VER="${2}"
 


### PR DESCRIPTION
We don't need to set gcc via alternatives to version 4.8 - it is
already fixed. Also, instead of installing go and gofmt with apt-get,
just use what semaphore provides with change-go-version script.

Maybe makes the builds a bit faster.