### PR TITLE
rkt: exit with status 1 on image rm failure

### DIFF
--- a/rkt/image_rm.go
+++ b/rkt/image_rm.go
@@ -44,7 +44,6 @@ func runRmImage(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	//TODO(sgotti) Which return code to use when the removal fails only for some images?
 	done := 0
 	errors := 0
 	staleErrors := 0
@@ -82,11 +81,17 @@ func runRmImage(cmd *cobra.Command, args []string) (exit int) {
 	if done > 0 {
 		stderr("rkt: %d image(s) successfully removed", done)
 	}
-	if errors > 0 {
-		stderr("rkt: %d image(s) cannot be removed", errors)
+
+	// If anything didn't complete, return exit status of 1
+	if (errors + staleErrors) > 0 {
+		if staleErrors > 0 {
+			stderr("rkt: %d image(s) removed but left some stale files", staleErrors)
+		}
+		if errors > 0 {
+			stderr("rkt: %d image(s) cannot be removed", errors)
+		}
+		return 1
 	}
-	if staleErrors > 0 {
-		stderr("rkt: %d image(s) removed but left some stale files", staleErrors)
-	}
+
 	return 0
 }

--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -388,8 +388,8 @@ func TestPodManifest(t *testing.T) {
 			// Multiple apps (with same images) in the pod. The first app will read out the content
 			// written by the second app.
 			[]imagePatch{
-				{"rkt-test-run-pod-manifest-app.aci", []string{}},
-				{"rkt-test-run-pod-manifest-app.aci", []string{}},
+				{"rkt-test-run-pod-manifest-app.aci", []string{"--name=aci1"}},
+				{"rkt-test-run-pod-manifest-app.aci", []string{"--name=aci2"}},
 			},
 			&schema.PodManifest{
 				Apps: []schema.RuntimeApp{


### PR DESCRIPTION
When `rkt image rm` cannot remove one or more of the images that it is passed, it should return an exit status of 1. Up to now an exit status of 0 has been returned whether all, some or no images could be removed.

Closes #1483