### PR TITLE
rkt: implement initial image gc for the tree store.

### DIFF
--- a/Documentation/subcommands/image.md
+++ b/Documentation/subcommands/image.md
@@ -29,6 +29,16 @@ rkt: successfully removed aci for imageID: "sha512-a03f6bad952b"
 rkt: 1 image(s) successfully remove
 ```
 
+## rkt image gc
+
+You can garbage collect the rkt store to cleanup unused internal data and remove old images (this one to be implemented).
+
+```
+# rkt image gc
+rkt: removed treestore "deps-sha512-120e20cf5c4588b9ed9727e9963f87cc587bec8f23e26fb607cb6adf6d3953f2"
+```
+
+
 ## rkt image export
 
 There are cases where you might want to export the ACI from the store to copy to another machine, file server, etc.

--- a/common/common.go
+++ b/common/common.go
@@ -33,7 +33,7 @@ import (
 const (
 	stage1Dir   = "/stage1"
 	stage2Dir   = "/opt/stage2"
-	appsInfoDir = "/appsinfo"
+	AppsInfoDir = "/appsinfo"
 
 	EnvLockFd                    = "RKT_LOCK_FD"
 	SELinuxContext               = "RKT_SELINUX_CONTEXT"
@@ -41,6 +41,8 @@ const (
 	AppTreeStoreIDFilename       = "treeStoreID"
 	OverlayPreparedFilename      = "overlay-prepared"
 	PrivateUsersPreparedFilename = "private-users-prepared"
+
+	PrepareLock = "prepareLock"
 
 	MetadataServicePort    = 18112
 	MetadataServiceRegSock = "/run/rkt/metadata-svc.sock"
@@ -102,7 +104,7 @@ func ImageManifestPath(root string, appName types.ACName) string {
 
 // AppsInfoPath returns the path to the appsinfo directory inside a pod.
 func AppsInfoPath(root string) string {
-	return filepath.Join(root, appsInfoDir)
+	return filepath.Join(root, AppsInfoDir)
 }
 
 // AppInfoPath returns the path to the app's appsinfo directory inside a pod.

--- a/rkt/image_gc.go
+++ b/rkt/image_gc.go
@@ -1,0 +1,111 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
+	"github.com/coreos/rkt/common"
+	"github.com/coreos/rkt/pkg/lock"
+	"github.com/coreos/rkt/store"
+)
+
+var (
+	cmdImageGc = &cobra.Command{
+		Use:   "gc",
+		Short: "Garbage collect local store",
+		Run:   runWrapper(runGcImage),
+	}
+)
+
+func init() {
+	cmdImage.AddCommand(cmdImageGc)
+}
+
+func runGcImage(cmd *cobra.Command, args []string) (exit int) {
+	s, err := store.NewStore(globalFlags.Dir)
+	if err != nil {
+		stderr("rkt: cannot open store: %v", err)
+		return 1
+	}
+
+	if err := gcTreeStore(s); err != nil {
+		stderr("rkt: failed to remove unreferenced treestores: %v", err)
+		return 1
+	}
+	return 0
+}
+
+// gcTreeStore removes all treeStoreIDs not referenced by any non garbage
+// collected pod from the store.
+func gcTreeStore(s *store.Store) error {
+	// Take an exclusive lock to block other pods being created.
+	// This is needed to avoid races between the below steps (getting the
+	// list of referenced treeStoreIDs, getting the list of treeStoreIDs
+	// from the store, removal of unreferenced treeStoreIDs) and new
+	// pods/treeStores being created/referenced
+	keyLock, err := lock.ExclusiveKeyLock(lockDir(), common.PrepareLock)
+	if err != nil {
+		return fmt.Errorf("cannot get exclusive prepare lock: %v", err)
+	}
+	defer keyLock.Close()
+	referencedTreeStoreIDs, err := getReferencedTreeStoreIDs()
+	if err != nil {
+		return fmt.Errorf("cannot get referenced treestoreIDs: %v", err)
+	}
+	treeStoreIDs, err := s.GetTreeStoreIDs()
+	if err != nil {
+		return fmt.Errorf("cannot get treestoreIDs from the store: %v", err)
+	}
+	for _, treeStoreID := range treeStoreIDs {
+		if _, ok := referencedTreeStoreIDs[treeStoreID]; !ok {
+			if err := s.RemoveTreeStore(treeStoreID); err != nil {
+				stderr("rkt: error removing treestore %q: %v", treeStoreID, err)
+			}
+			stderr("rkt: removed treestore %q", treeStoreID)
+		}
+	}
+	return nil
+}
+
+func getReferencedTreeStoreIDs() (map[string]struct{}, error) {
+	treeStoreIDs := map[string]struct{}{}
+	var walkErr error
+	// Consider pods in preparing, prepared, run, exitedgarbage state
+	if err := walkPods(includeMostDirs, func(p *pod) {
+		stage1TreeStoreID, err := p.getStage1TreeStoreID()
+		if err != nil {
+			walkErr = fmt.Errorf("cannot get stage1 treestoreID for pod %s: %v", p.uuid, err)
+			return
+		}
+		appsTreeStoreIDs, err := p.getAppsTreeStoreIDs()
+		if err != nil {
+			walkErr = fmt.Errorf("cannot get apps treestoreIDs for pod %s: %v", p.uuid, err)
+			return
+		}
+		allTreeStoreIDs := append(appsTreeStoreIDs, stage1TreeStoreID)
+
+		for _, treeStoreID := range allTreeStoreIDs {
+			treeStoreIDs[treeStoreID] = struct{}{}
+		}
+	}); err != nil {
+		return nil, fmt.Errorf("failed to get pod handles: %v", err)
+	}
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return treeStoreIDs, nil
+}

--- a/rkt/install.go
+++ b/rkt/install.go
@@ -46,6 +46,7 @@ var (
 		".":                        os.FileMode(0755),
 		"tmp":                      os.FileMode(0775),
 		"pods":                     os.FileMode(0700),
+		"locks":                    os.FileMode(0700),
 		"cas":                      os.FileMode(0775),
 		"cas/db":                   os.FileMode(0775),
 		"cas/imagelocks":           os.FileMode(0775),

--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -850,6 +850,32 @@ func (p *pod) getStage1TreeStoreID() (string, error) {
 	return string(s1IDb), nil
 }
 
+// getAppTreeStoreIDs returns the treeStoreIDs of the apps images used in
+// this pod
+func (p *pod) getAppsTreeStoreIDs() ([]string, error) {
+	treeStoreIDs := []string{}
+	apps, err := p.getApps()
+	if err != nil {
+		return nil, err
+	}
+	for _, a := range apps {
+		path, err := filepath.Rel("/", filepath.Join(common.AppsInfoDir, a.Name.String(), common.AppTreeStoreIDFilename))
+		if err != nil {
+			return nil, err
+		}
+		treeStoreID, err := p.readFile(path)
+		if err != nil {
+			// When not using overlayfs, apps don't have a treeStoreID file
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		treeStoreIDs = append(treeStoreIDs, string(treeStoreID))
+	}
+	return treeStoreIDs, nil
+}
+
 // getAppsHashes returns a list of the app hashes in the pod
 func (p *pod) getAppsHashes() ([]types.Hash, error) {
 	apps, err := p.getApps()

--- a/rkt/rkt.go
+++ b/rkt/rkt.go
@@ -144,3 +144,7 @@ func getKeystore() *keystore.Keystore {
 func getConfig() (*config.Config, error) {
 	return config.GetConfigFrom(globalFlags.SystemConfigDir, globalFlags.LocalConfigDir)
 }
+
+func lockDir() string {
+	return filepath.Join(globalFlags.Dir, "locks")
+}

--- a/store/store.go
+++ b/store/store.go
@@ -510,6 +510,26 @@ func (ds Store) RemoveTreeStore(id string) error {
 	return nil
 }
 
+// GetTreeStoreIDs returns a slice containing all the treeStore's IDs available
+// (both fully or partially rendered).
+func (ds Store) GetTreeStoreIDs() ([]string, error) {
+	treeStoreIDs := []string{}
+	ls, err := ioutil.ReadDir(ds.treestore.path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("cannot read treestore directory: %v", err)
+		}
+	}
+
+	for _, p := range ls {
+		if p.IsDir() {
+			id := filepath.Base(p.Name())
+			treeStoreIDs = append(treeStoreIDs, id)
+		}
+	}
+	return treeStoreIDs, nil
+}
+
 // GetRemote tries to retrieve a remote with the given ACIURL. found will be
 // false if remote doesn't exist.
 func (s Store) GetRemote(aciURL string) (*Remote, bool, error) {

--- a/tests/rkt_image_gc_test.go
+++ b/tests/rkt_image_gc_test.go
@@ -1,0 +1,99 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
+	"github.com/coreos/rkt/common"
+)
+
+func TestImageGCTreeStore(t *testing.T) {
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
+
+	expectedTreeStores := 2
+	// If overlayfs is not supported only the stage1 image is rendered in the treeStore
+	if !common.SupportsOverlay() {
+		expectedTreeStores = 1
+	}
+
+	// at this point we know that RKT_INSPECT_IMAGE env var is not empty
+	referencedACI := os.Getenv("RKT_INSPECT_IMAGE")
+	cmd := fmt.Sprintf("%s --insecure-skip-verify run --mds-register=false %s", ctx.cmd(), referencedACI)
+	t.Logf("Running %s: %v", referencedACI, cmd)
+	child, err := gexpect.Spawn(cmd)
+	if err != nil {
+		t.Fatalf("Cannot exec: %v", err)
+	}
+	if err := child.Wait(); err != nil {
+		t.Fatalf("rkt didn't terminate correctly: %v", err)
+	}
+
+	treeStoreIDs, err := getTreeStoreIDs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// We expect 2 treeStoreIDs for stage1 and app (only 1 if overlay is not supported/enabled)
+	if len(treeStoreIDs) != expectedTreeStores {
+		t.Fatalf("expected %d entries in the treestore but found %d entries", expectedTreeStores, len(treeStoreIDs))
+	}
+
+	runImageGC(t, ctx)
+
+	treeStoreIDs, err = getTreeStoreIDs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// We expect 1/2 treeStoreIDs again as no pod gc has been executed
+	if len(treeStoreIDs) != expectedTreeStores {
+		t.Fatalf("expected %d entries in the treestore but found %d entries", expectedTreeStores, len(treeStoreIDs))
+	}
+
+	runGC(t, ctx)
+	runImageGC(t, ctx)
+
+	treeStoreIDs, err = getTreeStoreIDs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(treeStoreIDs) != 0 {
+		t.Fatalf("expected empty treestore but found %d entries", len(treeStoreIDs))
+	}
+}
+
+func getTreeStoreIDs(ctx *rktRunCtx) (map[string]struct{}, error) {
+	treeStoreIDs := map[string]struct{}{}
+	ls, err := ioutil.ReadDir(filepath.Join(ctx.dataDir(), "cas", "tree"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return treeStoreIDs, nil
+		}
+		return nil, fmt.Errorf("cannot read treestore directory: %v", err)
+	}
+
+	for _, p := range ls {
+		if p.IsDir() {
+			id := filepath.Base(p.Name())
+			treeStoreIDs[id] = struct{}{}
+		}
+	}
+	return treeStoreIDs, nil
+}

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -338,6 +338,19 @@ func runGC(t *testing.T, ctx *rktRunCtx) {
 	}
 }
 
+func runImageGC(t *testing.T, ctx *rktRunCtx) {
+	cmd := fmt.Sprintf("%s image gc", ctx.cmd())
+	child, err := gexpect.Spawn(cmd)
+	if err != nil {
+		t.Fatalf("Cannot exec rkt: %v", err)
+	}
+
+	err = child.Wait()
+	if err != nil {
+		t.Fatalf("rkt didn't terminate correctly: %v", err)
+	}
+}
+
 func removeFromCas(t *testing.T, ctx *rktRunCtx, hash string) {
 	cmd := fmt.Sprintf("%s image rm %s", ctx.cmd(), hash)
 	child, err := gexpect.Spawn(cmd)


### PR DESCRIPTION
This is on top of #1240. The last patch is the interesting one.

rkt: implement initial image gc for the tree store.

This patch adds an initial image gc command.

Image gc can be thought in multiple ways:

* Remove treeStores not referenced by any non GCed pod
* Remove images not used for some time (#1205)
* ~~Cleanup the store from other garbage:~~
 * ~~Entries removed from the aciinfo tables but failed to remove for any reason from the diskv stores during `rkt image rm`~~
 * ~~Cleanup store's treestorelocks directory~~
 * ~~Cleanup store's tmpdir directory~~

This patch implements the removal of treeStores not referenced by any non GCed pod.
A "preparelock" is added to avoid races between getting the list of referenced treeStoreIDs and new pods/treeStores being created/referenced in the meantime.