### PR TITLE
rkt,stage0: validate OS/arch during run (take 2)

### DIFF
--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -86,7 +86,7 @@ Examples
 ```
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.2.0",
+    "acVersion": "0.7.0",
     "name": "foo.com/rkt/stage1",
     "labels": [
         {   

--- a/Documentation/getting-started-guide.md
+++ b/Documentation/getting-started-guide.md
@@ -55,7 +55,7 @@ Edit: manifest.json
 ```
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.5.1",
+    "acVersion": "0.7.0",
     "name": "example.com/hello",
     "labels": [
         {

--- a/Documentation/subcommands/image.md
+++ b/Documentation/subcommands/image.md
@@ -82,7 +82,7 @@ For debugging or inspection you may want to extract an ACI manifest to stdout.
 ```
 # rkt image cat-manifest --pretty-print coreos.com/etcd
 {
-  "acVersion": "0.6.1",
+  "acVersion": "0.7.0",
   "acKind": "ImageManifest",
 ...
 ```

--- a/pkg/aci/aci.go
+++ b/pkg/aci/aci.go
@@ -106,7 +106,7 @@ func (aw *imageArchiveWriter) Close() error {
 // NewBasicACI creates a new ACI in the given directory with the given name.
 // Used for testing.
 func NewBasicACI(dir string, name string) (*os.File, error) {
-	manifest := fmt.Sprintf(`{"acKind":"ImageManifest","acVersion":"0.5.2","name":"%s"}`, name)
+	manifest := fmt.Sprintf(`{"acKind":"ImageManifest","acVersion":"0.7.0","name":"%s"}`, name)
 	return NewACI(dir, manifest, nil)
 }
 

--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -226,7 +226,7 @@ func TestDownloading(t *testing.T) {
 
 	imj := `{
 			"acKind": "ImageManifest",
-			"acVersion": "0.5.2",
+			"acVersion": "0.7.0",
 			"name": "example.com/test01"
 		}`
 

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -33,6 +33,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/rkt/common/apps"
+	"github.com/coreos/rkt/pkg/keystore"
+	"github.com/coreos/rkt/rkt/config"
+	"github.com/coreos/rkt/stage0"
+	"github.com/coreos/rkt/store"
+	"github.com/coreos/rkt/version"
+
 	docker2aci "github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/docker2aci/lib"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/docker2aci/lib/common"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/aci"
@@ -41,11 +48,6 @@ import (
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/coreos/ioprogress"
 	"github.com/coreos/rkt/Godeps/_workspace/src/golang.org/x/crypto/openpgp"
 	pgperrors "github.com/coreos/rkt/Godeps/_workspace/src/golang.org/x/crypto/openpgp/errors"
-	"github.com/coreos/rkt/common/apps"
-	"github.com/coreos/rkt/pkg/keystore"
-	"github.com/coreos/rkt/rkt/config"
-	"github.com/coreos/rkt/store"
-	"github.com/coreos/rkt/version"
 )
 
 type imageActionData struct {
@@ -224,6 +226,12 @@ func (f *fetcher) fetchSingleImage(img string, asc string) (string, error) {
 
 	switch u.Scheme {
 	case "":
+		// check if os and arch are valid early
+		if app := newDiscoveryApp(img); app != nil {
+			if err := types.IsValidOSArch(app.Labels, stage0.ValidOSArch); err != nil {
+				return "", err
+			}
+		}
 		return f.fetchImageByName(img, ascFile)
 	case "http", "https", "file", "docker":
 		return f.fetchImageByURL(u, ascFile)

--- a/stage0/arch.go
+++ b/stage0/arch.go
@@ -1,0 +1,19 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stage0
+
+var ValidOSArch = map[string][]string{
+	"linux": []string{"amd64"},
+}

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -406,10 +406,27 @@ func Run(cfg RunConfig, dir string) {
 func prepareAppImage(cfg PrepareConfig, appName types.ACName, img types.Hash, cdir string, useOverlay bool) error {
 	log.Println("Loading image", img.String())
 
+	am, err := cfg.Store.GetImageManifest(img.String())
+	if err != nil {
+		return fmt.Errorf("error getting the manifest: %v", err)
+	}
+
+	if _, hasOS := am.Labels.Get("os"); !hasOS {
+		return fmt.Errorf("missing os label in the image manifest")
+	}
+	if _, hasArch := am.Labels.Get("arch"); !hasArch {
+		return fmt.Errorf("missing arch label in the image manifest")
+	}
+
+	if err := types.IsValidOSArch(am.Labels.ToMap(), ValidOSArch); err != nil {
+		return err
+	}
+
 	appInfoDir := common.AppInfoPath(cdir, appName)
 	if err := os.MkdirAll(appInfoDir, 0755); err != nil {
 		return fmt.Errorf("error creating apps info directory: %v", err)
 	}
+
 	if useOverlay {
 		if cfg.PrivateUsers.Shift > 0 {
 			return fmt.Errorf("cannot use both overlay and user namespace: not implemented yet. (Try --no-overlay)")

--- a/stage1/aci/aci-manifest.in
+++ b/stage1/aci/aci-manifest.in
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.6.1",
+    "acVersion": "0.7.0",
     "name": "@RKT_STAGE1_DEFAULT_NAME@",
     "labels": [
         {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -162,7 +162,7 @@ func TestGetImageManifest(t *testing.T) {
 
 	imj := `{
 			"acKind": "ImageManifest",
-			"acVersion": "0.5.2",
+			"acVersion": "0.7.0",
 			"name": "example.com/test01"
 		}`
 
@@ -226,7 +226,7 @@ func TestGetAci(t *testing.T) {
 				{
 					`{
 						"acKind": "ImageManifest",
-						"acVersion": "0.1.1",
+						"acVersion": "0.7.0",
 						"name": "example.com/test01"
 					}`,
 					false,
@@ -234,7 +234,7 @@ func TestGetAci(t *testing.T) {
 				{
 					`{
 						"acKind": "ImageManifest",
-						"acVersion": "0.1.1",
+						"acVersion": "0.7.0",
 						"name": "example.com/test02",
 						"labels": [
 							{
@@ -248,7 +248,7 @@ func TestGetAci(t *testing.T) {
 				{
 					`{
 						"acKind": "ImageManifest",
-						"acVersion": "0.1.1",
+						"acVersion": "0.7.0",
 						"name": "example.com/test02",
 						"labels": [
 							{
@@ -360,7 +360,7 @@ func TestTreeStore(t *testing.T) {
 	imj := `
 		{
 		    "acKind": "ImageManifest",
-		    "acVersion": "0.5.2",
+		    "acVersion": "0.7.0",
 		    "name": "example.com/test01"
 		}
 	`
@@ -482,7 +482,7 @@ func TestRemoveACI(t *testing.T) {
 
 	imj := `{
                     "acKind": "ImageManifest",
-                    "acVersion": "0.4.0",
+                    "acVersion": "0.7.0",
                     "name": "example.com/test01"
                 }`
 
@@ -527,7 +527,7 @@ func TestRemoveACI(t *testing.T) {
 	// Simulate error removing from the
 	imj = `{
                    "acKind": "ImageManifest",
-                   "acVersion": "0.3.0",
+                   "acVersion": "0.7.0",
                    "name": "example.com/test01"
                }`
 

--- a/store/tree_test.go
+++ b/store/tree_test.go
@@ -28,7 +28,7 @@ func treeStoreWriteACI(dir string, s *Store) (string, error) {
 	imj := `
 		{
 		    "acKind": "ImageManifest",
-		    "acVersion": "0.5.2",
+		    "acVersion": "0.7.0",
 		    "name": "example.com/test01"
 		}
 	`

--- a/tests/empty-image/manifest
+++ b/tests/empty-image/manifest
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.6.1",
+    "acVersion": "0.7.0",
     "name": "coreos.com/rkt-empty",
     "labels": [
         {

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.5.1",
+    "acVersion": "0.7.0",
     "name": "coreos.com/rkt-inspect",
     "labels": [
         {

--- a/tests/rkt_cat_manifest_test.go
+++ b/tests/rkt_cat_manifest_test.go
@@ -27,7 +27,7 @@ import (
 const (
 
 	// The expected image manifest of the 'rkt-inspect-image-cat-manifest.aci'.
-	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.5.1","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.0","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestCatManifest tests 'rkt image cat-manifest', it will:

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.6.1","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
+	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.7.0","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
 )
 
 func TestRunOverrideExec(t *testing.T) {

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -19,8 +19,6 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
-
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 )
 
 const (
@@ -60,7 +58,7 @@ func TestRunOverrideExec(t *testing.T) {
 			expectedLine: "inspect execed as: /inspect",
 		},
 	} {
-		runRktAndCheckOutput(t, tt.rktCmd, tt.expectedLine)
+		runRktAndCheckOutput(t, tt.rktCmd, tt.expectedLine, false)
 	}
 }
 
@@ -78,7 +76,7 @@ func TestRunPreparedOverrideExec(t *testing.T) {
 
 	rktCmd = fmt.Sprintf("%s run-prepared --mds-register=false %s", ctx.cmd(), uuid)
 	expected = "inspect execed as: /inspect"
-	runRktAndCheckOutput(t, rktCmd, expected)
+	runRktAndCheckOutput(t, rktCmd, expected, false)
 
 	// Now test overriding the entrypoint (which is a symlink to /inspect so should behave identically)
 	rktCmd = fmt.Sprintf("%s prepare --insecure-skip-verify %s --exec /inspect-link -- --print-exec", ctx.cmd(), execImage)
@@ -86,20 +84,5 @@ func TestRunPreparedOverrideExec(t *testing.T) {
 
 	rktCmd = fmt.Sprintf("%s run-prepared --mds-register=false %s", ctx.cmd(), uuid)
 	expected = "inspect execed as: /inspect-link"
-	runRktAndCheckOutput(t, rktCmd, expected)
-}
-
-func runRktAndCheckOutput(t *testing.T, rktCmd, expectedLine string) {
-	child, err := gexpect.Spawn(rktCmd)
-	if err != nil {
-		t.Fatalf("cannot exec rkt: %v", err)
-	}
-
-	if err = expectWithOutput(child, expectedLine); err != nil {
-		t.Fatalf("didn't receive expected output %q: %v", expectedLine, err)
-	}
-
-	if err = child.Wait(); err != nil {
-		t.Fatalf("rkt didn't terminate correctly: %v", err)
-	}
+	runRktAndCheckOutput(t, rktCmd, expected, false)
 }

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.6.1","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.0","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageExport tests 'rkt image export', it will import some existing

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.6.1","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.0","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageRender tests 'rkt image render', it will import some existing empty

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -1,0 +1,158 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+const (
+	manifestOSArchTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.0","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"}ARCH_OS],"app":{"exec":["/inspect", "--print-msg=HelloWorld"],"user":"0","group":"0","workingDirectory":"/"}}`
+)
+
+type osArchTest struct {
+	image        string
+	rktCmd       string
+	expectedLine string
+	expectError  bool
+}
+
+func getMissingOrInvalidTests(t *testing.T, ctx *rktRunCtx) []osArchTest {
+	tests := []osArchTest{}
+
+	testImageName := "coreos.com/rkt-missing-os-arch-test"
+	manifest := strings.Replace(manifestOSArchTemplate, "IMG_NAME", testImageName, 1)
+
+	// Test a valid image as a sanity check
+	goodManifestStr := strings.Replace(manifest, "ARCH_OS", `,{"name":"os","value":"linux"},{"name":"arch","value":"amd64"}`, 1)
+	goodManifestFile := "good-manifest.json"
+	if err := ioutil.WriteFile(goodManifestFile, []byte(goodManifestStr), 0600); err != nil {
+		t.Fatalf("Cannot write good manifest: %v", err)
+	}
+	defer os.Remove(goodManifestFile)
+
+	goodImage := patchTestACI("rkt-good-image.aci", fmt.Sprintf("--manifest=%s", goodManifestFile))
+	goodTest := osArchTest{
+		image:        goodImage,
+		rktCmd:       fmt.Sprintf("%s --insecure-skip-verify run --mds-register=false %s", ctx.cmd(), goodImage),
+		expectedLine: "HelloWorld",
+		expectError:  false,
+	}
+	tests = append(tests, goodTest)
+
+	// Test an image with a missing os label
+	missingOSManifestStr := strings.Replace(manifest, "ARCH_OS", `,{"name":"arch","value":"amd64"}`, 1)
+	missingOSManifestFile := "missingOS-manifest.json"
+	if err := ioutil.WriteFile(missingOSManifestFile, []byte(missingOSManifestStr), 0600); err != nil {
+		t.Fatalf("Cannot write missing OS manifest: %v", err)
+	}
+	defer os.Remove(missingOSManifestFile)
+
+	missingOSImage := patchTestACI("rkt-missing-os.aci", fmt.Sprintf("--manifest=%s", missingOSManifestFile))
+	missingOSTest := osArchTest{
+		image:        missingOSImage,
+		rktCmd:       fmt.Sprintf("%s --insecure-skip-verify run %s", ctx.cmd(), missingOSImage),
+		expectedLine: "missing os label in the image manifest",
+		expectError:  true,
+	}
+	tests = append(tests, missingOSTest)
+
+	// Test an image with a missing arch label
+	missingArchManifestStr := strings.Replace(manifest, "ARCH_OS", `,{"name":"os","value":"linux"}`, 1)
+	missingArchManifestFile := "missingArch-manifest.json"
+	if err := ioutil.WriteFile(missingArchManifestFile, []byte(missingArchManifestStr), 0600); err != nil {
+		t.Fatalf("Cannot write missing Arch manifest: %v", err)
+	}
+	defer os.Remove(missingArchManifestFile)
+
+	missingArchImage := patchTestACI("rkt-missing-arch.aci", fmt.Sprintf("--manifest=%s", missingArchManifestFile))
+	missingArchTest := osArchTest{
+		image:        missingArchImage,
+		rktCmd:       fmt.Sprintf("%s --insecure-skip-verify run %s", ctx.cmd(), missingArchImage),
+		expectedLine: "missing arch label in the image manifest",
+		expectError:  true,
+	}
+	tests = append(tests, missingArchTest)
+
+	// Test an image with an invalid os
+	invalidOSManifestStr := strings.Replace(manifest, "ARCH_OS", `,{"name":"os","value":"freebsd"},{"name":"arch","value":"amd64"}`, 1)
+	invalidOSManifestFile := "invalid-os-manifest.json"
+	if err := ioutil.WriteFile(invalidOSManifestFile, []byte(invalidOSManifestStr), 0600); err != nil {
+		t.Fatalf("Cannot write invalid os manifest: %v", err)
+	}
+	defer os.Remove(invalidOSManifestFile)
+
+	invalidOSImage := patchTestACI("rkt-invalid-os.aci", fmt.Sprintf("--manifest=%s", invalidOSManifestFile))
+	invalidOSTest := osArchTest{
+		image:        invalidOSImage,
+		rktCmd:       fmt.Sprintf("%s --insecure-skip-verify run %s", ctx.cmd(), invalidOSImage),
+		expectedLine: `bad os "freebsd"`,
+		expectError:  true,
+	}
+	tests = append(tests, invalidOSTest)
+
+	// Test an image with an invalid arch
+	invalidArchManifestStr := strings.Replace(manifest, "ARCH_OS", `,{"name":"os","value":"linux"},{"name":"arch","value":"armv6l"}`, 1)
+	invalidArchManifestFile := "invalid-arch-manifest.json"
+	if err := ioutil.WriteFile(invalidArchManifestFile, []byte(invalidArchManifestStr), 0600); err != nil {
+		t.Fatalf("Cannot write invalid arch manifest: %v", err)
+	}
+	defer os.Remove(invalidArchManifestFile)
+
+	invalidArchImage := patchTestACI("rkt-invalid-arch.aci", fmt.Sprintf("--manifest=%s", invalidArchManifestFile))
+	invalidArchTest := osArchTest{
+		image:        invalidArchImage,
+		rktCmd:       fmt.Sprintf("%s --insecure-skip-verify run %s", ctx.cmd(), invalidArchImage),
+		expectedLine: `bad arch "armv6l"`,
+		expectError:  true,
+	}
+	tests = append(tests, invalidArchTest)
+
+	return tests
+}
+
+// TestMissingOrInvalidOSArchRun tests that rkt errors out when it tries to run
+// an image (not present in the store) with a missing or unsupported os/arch
+func TestMissingOrInvalidOSArchRun(t *testing.T) {
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
+	tests := getMissingOrInvalidTests(t, ctx)
+
+	for i, tt := range tests {
+		t.Logf("Running test #%v: %v", i, tt.rktCmd)
+		runRktAndCheckOutput(t, tt.rktCmd, tt.expectedLine, tt.expectError)
+		defer os.Remove(tt.image)
+	}
+}
+
+// TestMissingOrInvalidOSArchFetchRun tests that rkt errors out when it tries
+// to run an already fetched image with a missing or unsupported os/arch
+func TestMissingOrInvalidOSArchFetchRun(t *testing.T) {
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
+	tests := getMissingOrInvalidTests(t, ctx)
+
+	for i, tt := range tests {
+		imgHash := importImageAndFetchHash(t, ctx, tt.image)
+		rktCmd := fmt.Sprintf("%s run --mds-register=false %s", ctx.cmd(), imgHash)
+		t.Logf("Running test #%v: %v", i, rktCmd)
+		runRktAndCheckOutput(t, rktCmd, tt.expectedLine, tt.expectError)
+		defer os.Remove(tt.image)
+	}
+}

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -374,3 +374,18 @@ func runRktAndGetUUID(t *testing.T, rktCmd string) string {
 
 	return podID.String()
 }
+
+func runRktAndCheckOutput(t *testing.T, rktCmd, expectedLine string, expectError bool) {
+	child, err := gexpect.Spawn(rktCmd)
+	if err != nil {
+		t.Fatalf("cannot exec rkt: %v", err)
+	}
+
+	if err = expectWithOutput(child, expectedLine); err != nil {
+		t.Fatalf("didn't receive expected output %q: %v", expectedLine, err)
+	}
+
+	if err = child.Wait(); err != nil && !expectError {
+		t.Fatalf("rkt didn't terminate correctly: %v", err)
+	}
+}

--- a/tests/test-auth-server/aci/aci.go
+++ b/tests/test-auth-server/aci/aci.go
@@ -57,7 +57,7 @@ func (t *aciToolkit) prepareACI() ([]byte, error) {
 }
 
 const (
-	manifestStr    = `{"acKind":"ImageManifest","acVersion":"0.5.1+git","name":"testprog","app":{"exec":["/prog"],"user":"0","group":"0"}}`
+	manifestStr    = `{"acKind":"ImageManifest","acVersion":"0.7.0","name":"testprog","app":{"exec":["/prog"],"user":"0","group":"0"}}`
 	testProgSrcStr = `
 package main
 

--- a/tests/test-auth-server/aci/aci.go
+++ b/tests/test-auth-server/aci/aci.go
@@ -57,7 +57,7 @@ func (t *aciToolkit) prepareACI() ([]byte, error) {
 }
 
 const (
-	manifestStr    = `{"acKind":"ImageManifest","acVersion":"0.7.0","name":"testprog","app":{"exec":["/prog"],"user":"0","group":"0"}}`
+	manifestStr    = `{"acKind":"ImageManifest","acVersion":"0.7.0","name":"testprog","app":{"exec":["/prog"],"user":"0","group":"0"},"labels":[{"name":"os","value":"linux"},{"name":"arch","value":"amd64"}]}`
 	testProgSrcStr = `
 package main
 


### PR DESCRIPTION
We also check during fetchSingleImage so we don't start downloading an image
we know is not supported.

Fixes #271 

Take two. First take was #1472
