### PR TITLE
functional tests: Return from a goroutine when the ACI server closes

### DIFF
--- a/tests/rkt_auth_test.go
+++ b/tests/rkt_auth_test.go
@@ -160,6 +160,8 @@ func serverHandler(t *testing.T, server *taas.Server) {
 			if ok {
 				t.Logf("server: %v", msg)
 			}
+		case <-server.Stop:
+			return
 		}
 	}
 }

--- a/tests/testutils/goroutineassistant.go
+++ b/tests/testutils/goroutineassistant.go
@@ -21,20 +21,20 @@ import (
 )
 
 type GoroutineAssistant struct {
-	s  chan string
+	s  chan error
 	wg sync.WaitGroup
 	t  *testing.T
 }
 
 func NewGoroutineAssistant(t *testing.T) *GoroutineAssistant {
 	return &GoroutineAssistant{
-		s: make(chan string),
+		s: make(chan error),
 		t: t,
 	}
 }
 
 func (a *GoroutineAssistant) Fatalf(s string, args ...interface{}) {
-	a.s <- fmt.Sprintf(s, args...)
+	a.s <- fmt.Errorf(s, args...)
 }
 
 func (a *GoroutineAssistant) Add(n int) {
@@ -49,11 +49,10 @@ func (a *GoroutineAssistant) Wait() {
 	done := make(chan struct{})
 	go func() {
 		a.wg.Wait()
-		done <- struct{}{}
+		a.s <- nil
 	}()
-	select {
-	case s := <-a.s:
+	err := <-a.s
+	if err != nil {
 		a.t.Fatalf(s)
-	case <-done:
 	}
 }

--- a/tests/testutils/goroutineassistant.go
+++ b/tests/testutils/goroutineassistant.go
@@ -46,13 +46,12 @@ func (a *GoroutineAssistant) Done() {
 }
 
 func (a *GoroutineAssistant) Wait() {
-	done := make(chan struct{})
 	go func() {
 		a.wg.Wait()
 		a.s <- nil
 	}()
 	err := <-a.s
 	if err != nil {
-		a.t.Fatalf(s)
+		a.t.Fatalf("%v", err)
 	}
 }

--- a/tests/testutils/httputils.go
+++ b/tests/testutils/httputils.go
@@ -75,12 +75,12 @@ func HttpGet(addr string) (string, error) {
 	log.Printf("Connecting to %v", addr)
 	res, err := http.Get(fmt.Sprintf("%v", addr))
 	if err != nil {
-		log.Fatal(err)
+		return "", err
 	}
 	text, err := ioutil.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
-		log.Fatal(err)
+		return "", err
 	}
-	return string(text), err
+	return string(text), nil
 }


### PR DESCRIPTION
The test ACI server closes both Msg and Stop channels on Close(). The
Stop channel never receives any messages - it is only used to listen
for service shutdown. The channel listening is done in serverHandler,
which is run in its own goroutine. The Stop channel was used shortly
before, but I wrongly removed it during review process. Because of
that, the function never returned and the goroutine was unnecessarily
kept alive.