### PR TITLE
tests: functional test refactoring

### DIFF
--- a/tests/rkt_ace_validator_test.go
+++ b/tests/rkt_ace_validator_test.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 )
 
 var expectedResults = []string{
@@ -50,21 +48,12 @@ func TestAceValidator(t *testing.T) {
 		aceMain, aceSidekick)
 	rktCmd := fmt.Sprintf("%s %s", ctx.cmd(), rktArgs)
 
-	t.Logf("Command: %v", rktCmd)
-	child, err := gexpect.Spawn(rktCmd)
-	if err != nil {
-		t.Fatalf("Cannot exec rkt: %v", err)
-	}
+	child := spawnOrFail(t, rktCmd)
+	defer waitOrFail(t, child, true)
 
 	for _, e := range expectedResults {
-		err = expectWithOutput(child, e)
-		if err != nil {
+		if err := expectWithOutput(child, e); err != nil {
 			t.Fatalf("Expected %q but not found: %v", e, err)
 		}
-	}
-
-	err = child.Wait()
-	if err != nil {
-		t.Fatalf("rkt didn't terminate correctly: %v", err)
 	}
 }

--- a/tests/rkt_app_isolator_test.go
+++ b/tests/rkt_app_isolator_test.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 	"github.com/coreos/rkt/common/cgroup"
 )
 
@@ -69,20 +68,8 @@ func TestAppIsolatorMemory(t *testing.T) {
 	defer os.Remove(aciFileName)
 
 	rktCmd := fmt.Sprintf("%s --insecure-skip-verify run --mds-register=false %s", ctx.cmd(), aciFileName)
-	t.Logf("Command: %v", rktCmd)
-	child, err := gexpect.Spawn(rktCmd)
-	if err != nil {
-		t.Fatalf("Cannot exec rkt: %v", err)
-	}
 	expectedLine := "Memory Limit: " + strconv.Itoa(maxMemoryUsage)
-	if err := expectWithOutput(child, expectedLine); err != nil {
-		t.Fatalf("Didn't receive expected output %q: %v", expectedLine, err)
-	}
-
-	err = child.Wait()
-	if err != nil {
-		t.Fatalf("rkt didn't terminate correctly: %v", err)
-	}
+	runRktAndCheckOutput(t, rktCmd, expectedLine, false)
 }
 
 func TestAppIsolatorCPU(t *testing.T) {
@@ -100,20 +87,8 @@ func TestAppIsolatorCPU(t *testing.T) {
 	defer os.Remove(aciFileName)
 
 	rktCmd := fmt.Sprintf("%s --insecure-skip-verify run --mds-register=false %s", ctx.cmd(), aciFileName)
-	t.Logf("Command: %v", rktCmd)
-	child, err := gexpect.Spawn(rktCmd)
-	if err != nil {
-		t.Fatalf("Cannot exec rkt: %v", err)
-	}
 	expectedLine := "CPU Quota: " + strconv.Itoa(CPUQuota)
-	if err := expectWithOutput(child, expectedLine); err != nil {
-		t.Fatalf("Didn't receive expected output %q: %v", expectedLine, err)
-	}
-
-	err = child.Wait()
-	if err != nil {
-		t.Fatalf("rkt didn't terminate correctly: %v", err)
-	}
+	runRktAndCheckOutput(t, rktCmd, expectedLine, false)
 }
 
 func TestCgroups(t *testing.T) {
@@ -126,18 +101,6 @@ func TestCgroups(t *testing.T) {
 	defer os.Remove(aciFileName)
 
 	rktCmd := fmt.Sprintf("%s --insecure-skip-verify run --mds-register=false %s", ctx.cmd(), aciFileName)
-	t.Logf("Command: %v", rktCmd)
-	child, err := gexpect.Spawn(rktCmd)
-	if err != nil {
-		t.Fatalf("Cannot exec rkt: %v", err)
-	}
 	expectedLine := "check-cgroups: SUCCESS"
-	if err := expectWithOutput(child, expectedLine); err != nil {
-		t.Fatalf("Didn't receive expected output %q: %v", expectedLine, err)
-	}
-
-	err = child.Wait()
-	if err != nil {
-		t.Fatalf("rkt didn't terminate correctly: %v", err)
-	}
+	runRktAndCheckOutput(t, rktCmd, expectedLine, false)
 }

--- a/tests/rkt_auth_test.go
+++ b/tests/rkt_auth_test.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 	taas "github.com/coreos/rkt/tests/test-auth-server/aci"
 )
 
@@ -173,11 +172,7 @@ func expectedRunRkt(ctx *rktRunCtx, t *testing.T, host, dir, line string) {
 	// First, check that --insecure-skip-verify is required
 	// The server does not provide signatures for now.
 	cmd := fmt.Sprintf(`%s --debug run --mds-register=false %s/%s/prog.aci`, ctx.cmd(), host, dir)
-	t.Logf("Running rkt: %s", cmd)
-	child, err := gexpect.Spawn(cmd)
-	if err != nil {
-		t.Fatalf("Failed to run rkt: %v", err)
-	}
+	child := spawnOrFail(t, cmd)
 	defer child.Wait()
 	signatureErrorLine := "error downloading the signature file"
 	if err := expectWithOutput(child, signatureErrorLine); err != nil {
@@ -186,11 +181,7 @@ func expectedRunRkt(ctx *rktRunCtx, t *testing.T, host, dir, line string) {
 
 	// Then, run with --insecure-skip-verify
 	cmd = fmt.Sprintf(`%s --debug --insecure-skip-verify run --mds-register=false %s/%s/prog.aci`, ctx.cmd(), host, dir)
-	t.Logf("Running rkt: %s", cmd)
-	child, err = gexpect.Spawn(cmd)
-	if err != nil {
-		t.Fatalf("Failed to run rkt: %v", err)
-	}
+	child = spawnOrFail(t, cmd)
 	defer child.Wait()
 	if err := expectWithOutput(child, line); err != nil {
 		t.Fatalf("Didn't receive expected output %q: %v", line, err)

--- a/tests/rkt_cat_manifest_test.go
+++ b/tests/rkt_cat_manifest_test.go
@@ -20,8 +20,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 )
 
 const (
@@ -84,21 +82,7 @@ func TestCatManifest(t *testing.T) {
 
 	for i, tt := range tests {
 		runCmd := fmt.Sprintf("%s image cat-manifest %s", ctx.cmd(), tt.image)
-		t.Logf("Running 'run' test #%v: %v", i, runCmd)
-		child, err := gexpect.Spawn(runCmd)
-		if err != nil {
-			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
-		}
-
-		if tt.expect != "" {
-			if err := expectWithOutput(child, tt.expect); err != nil {
-				t.Fatalf("Expected %q but not found: %v", tt.expect, err)
-			}
-		}
-		if err := child.Wait(); err != nil {
-			if tt.shouldFind || err.Error() != "exit status 1" {
-				t.Fatalf("rkt didn't terminate correctly: %v", err)
-			}
-		}
+		t.Logf("Running test #%d", i)
+		runRktAndCheckOutput(t, runCmd, tt.expect, !tt.shouldFind)
 	}
 }

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -21,8 +21,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 )
 
 const (
@@ -93,17 +91,10 @@ func TestImageExport(t *testing.T) {
 		outputAciPath := filepath.Join(tmpDir, fmt.Sprintf("exported-%d.aci", i))
 		runCmd := fmt.Sprintf("%s image export %s %s", ctx.cmd(), tt.image, outputAciPath)
 		t.Logf("Running 'image export' test #%v: %v", i, runCmd)
-		child, err := gexpect.Spawn(runCmd)
-		if err != nil {
-			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
-		}
+		spawnAndWaitOrFail(t, runCmd, tt.shouldFind)
 
-		if err := child.Wait(); err != nil {
-			if !tt.shouldFind && err.Error() == "exit status 1" {
-				continue
-			} else if tt.shouldFind || err.Error() != "exit status 1" {
-				t.Fatalf("rkt didn't terminate correctly: %v", err)
-			}
+		if !tt.shouldFind {
+			continue
 		}
 
 		exportedHash, err := getHash(outputAciPath)

--- a/tests/rkt_image_extract_test.go
+++ b/tests/rkt_image_extract_test.go
@@ -19,8 +19,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 )
 
 // TestImageExtract tests 'rkt image extract', it will import some existing
@@ -72,17 +70,10 @@ func TestImageExtract(t *testing.T) {
 		outputPath := filepath.Join(tmpDir, fmt.Sprintf("extracted-%d", i))
 		runCmd := fmt.Sprintf("%s image extract --rootfs-only %s %s", ctx.cmd(), tt.image, outputPath)
 		t.Logf("Running 'image extract' test #%v: %v", i, runCmd)
-		child, err := gexpect.Spawn(runCmd)
-		if err != nil {
-			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
-		}
+		spawnAndWaitOrFail(t, runCmd, tt.shouldFind)
 
-		if err := child.Wait(); err != nil {
-			if !tt.shouldFind && err.Error() == "exit status 1" {
-				continue
-			} else if tt.shouldFind || err.Error() != "exit status 1" {
-				t.Fatalf("rkt didn't terminate correctly: %v", err)
-			}
+		if !tt.shouldFind {
+			continue
 		}
 
 		extractedInspectHash, err := getHash(filepath.Join(outputPath, "inspect"))

--- a/tests/rkt_image_list_test.go
+++ b/tests/rkt_image_list_test.go
@@ -19,8 +19,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 )
 
 type ImageId struct {
@@ -86,13 +84,7 @@ func TestShortHash(t *testing.T) {
 	for _, imageId := range imageIds {
 		cmd := fmt.Sprintf("%s --insecure-skip-verify fetch %s", ctx.cmd(), imageId.path)
 		t.Logf("Fetching %s: %v", imageId.path, cmd)
-		child, err := gexpect.Spawn(cmd)
-		if err != nil {
-			t.Fatalf("Cannot exec: %v", err)
-		}
-		if err := child.Wait(); err != nil {
-			t.Fatalf("rkt didn't terminate correctly: %v", err)
-		}
+		spawnAndWaitOrFail(t, cmd, true)
 	}
 
 	// Get hash from 'rkt image list'
@@ -100,18 +92,7 @@ func TestShortHash(t *testing.T) {
 	hash1 := fmt.Sprintf("sha512-%s", imageIds[1].hash[:12])
 	for _, hash := range []string{hash0, hash1} {
 		imageListCmd := fmt.Sprintf("%s image list --fields=id --no-legend", ctx.cmd())
-		child, err := gexpect.Spawn(imageListCmd)
-		if err != nil {
-			t.Fatal("Cannot exec rkt image list")
-		}
-
-		if err = expectWithOutput(child, hash); err != nil {
-			t.Fatalf("Couldn't find %s in: %v", hash, err)
-		}
-
-		if err := child.Wait(); err != nil {
-			t.Fatalf("rkt image list didn't terminate correctly: %v", err)
-		}
+		runRktAndCheckOutput(t, imageListCmd, hash, false)
 	}
 
 	tmpDir := createTempDirOrPanic("rkt_image_list_test")
@@ -182,28 +163,7 @@ func TestShortHash(t *testing.T) {
 	// Run tests
 	for i, tt := range tests {
 		runCmd := fmt.Sprintf("%s %s", ctx.cmd(), tt.cmd)
-		t.Logf("executing test #%d: %v", i, runCmd)
-		child, err := gexpect.Spawn(runCmd)
-		if err != nil {
-			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
-		}
-
-		if tt.expect != "" {
-			if err = expectWithOutput(child, tt.expect); err != nil {
-				t.Fatalf("Expected but didn't find %q in %v", tt.expect, err)
-			}
-		}
-
-		err = child.Wait()
-		const exit1 = "exit status 1"
-		switch {
-		case tt.shouldFail && err == nil:
-			t.Fatalf("Expected test #%d to fail but it didn't", i)
-		case !tt.shouldFail && err != nil:
-			t.Fatalf("rkt didn't terminate correctly: %v", err)
-		case err != nil && err.Error() != exit1:
-			t.Fatalf("rkt terminated with unexpected error: %v", err)
-		default:
-		}
+		t.Logf("Running test #%d", i)
+		runRktAndCheckOutput(t, runCmd, tt.expect, tt.shouldFail)
 	}
 }

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -21,8 +21,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 )
 
 const (
@@ -95,17 +93,10 @@ func TestImageRender(t *testing.T) {
 		outputPath := filepath.Join(tmpDir, fmt.Sprintf("rendered-%d", i))
 		runCmd := fmt.Sprintf("%s image render --rootfs-only %s %s", ctx.cmd(), tt.image, outputPath)
 		t.Logf("Running 'image render' test #%v: %v", i, runCmd)
-		child, err := gexpect.Spawn(runCmd)
-		if err != nil {
-			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
-		}
+		spawnAndWaitOrFail(t, runCmd, tt.shouldFind)
 
-		if err := child.Wait(); err != nil {
-			if !tt.shouldFind && err.Error() == "exit status 1" {
-				continue
-			} else if tt.shouldFind || err.Error() != "exit status 1" {
-				t.Fatalf("rkt didn't terminate correctly: %v", err)
-			}
+		if !tt.shouldFind {
+			continue
 		}
 
 		renderedInspectHash, err := getHash(filepath.Join(outputPath, "inspect"))

--- a/tests/rkt_image_rm_test.go
+++ b/tests/rkt_image_rm_test.go
@@ -45,25 +45,13 @@ func TestImageRunRm(t *testing.T) {
 
 	cmd := fmt.Sprintf("%s --insecure-skip-verify fetch %s", ctx.cmd(), imageFile)
 	t.Logf("Fetching %s: %v", imageFile, cmd)
-	child, err := gexpect.Spawn(cmd)
-	if err != nil {
-		t.Fatalf("Cannot exec: %v", err)
-	}
-	if err := child.Wait(); err != nil {
-		t.Fatalf("rkt didn't terminate correctly: %v", err)
-	}
+	spawnAndWaitOrFail(t, cmd, true)
 
 	// at this point we know that RKT_INSPECT_IMAGE env var is not empty
 	referencedACI := os.Getenv("RKT_INSPECT_IMAGE")
 	cmd = fmt.Sprintf("%s --insecure-skip-verify run --mds-register=false %s", ctx.cmd(), referencedACI)
 	t.Logf("Running %s: %v", referencedACI, cmd)
-	child, err = gexpect.Spawn(cmd)
-	if err != nil {
-		t.Fatalf("Cannot exec: %v", err)
-	}
-	if err := child.Wait(); err != nil {
-		t.Fatalf("rkt didn't terminate correctly: %v", err)
-	}
+	spawnAndWaitOrFail(t, cmd, true)
 
 	t.Logf("Retrieving stage1 image ID")
 	stage1ImageID, err := getImageId(ctx, stage1App)
@@ -107,13 +95,7 @@ func TestImagePrepareRmRun(t *testing.T) {
 
 	cmd := fmt.Sprintf("%s --insecure-skip-verify fetch %s", ctx.cmd(), imageFile)
 	t.Logf("Fetching %s: %v", imageFile, cmd)
-	child, err := gexpect.Spawn(cmd)
-	if err != nil {
-		t.Fatalf("Cannot exec: %v", err)
-	}
-	if err := child.Wait(); err != nil {
-		t.Fatalf("rkt didn't terminate correctly: %v", err)
-	}
+	spawnAndWaitOrFail(t, cmd, true)
 
 	// at this point we know that RKT_INSPECT_IMAGE env var is not empty
 	referencedACI := os.Getenv("RKT_INSPECT_IMAGE")
@@ -166,13 +148,7 @@ func TestImagePrepareRmRun(t *testing.T) {
 
 	cmd = fmt.Sprintf("%s run-prepared --mds-register=false %s", ctx.cmd(), podID.String())
 	t.Logf("Running %s: %v", referencedACI, cmd)
-	child, err = gexpect.Spawn(cmd)
-	if err != nil {
-		t.Fatalf("Cannot exec: %v", err)
-	}
-	if err := child.Wait(); err != nil {
-		t.Fatalf("rkt didn't terminate correctly: %v", err)
-	}
+	spawnAndWaitOrFail(t, cmd, true)
 }
 
 func getImageId(ctx *rktRunCtx, name string) (string, error) {

--- a/tests/rkt_interactive_test.go
+++ b/tests/rkt_interactive_test.go
@@ -20,8 +20,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 )
 
 var interactiveTests = []struct {
@@ -87,30 +85,22 @@ func TestInteractive(t *testing.T) {
 
 		rktCmd := fmt.Sprintf("%s %s", ctx.cmd(), tt.rktArgs)
 		rktCmd = strings.Replace(rktCmd, "^INTERACTIVE^", aciFileName, -1)
-		t.Logf("Command: %v", rktCmd)
-		child, err := gexpect.Spawn(rktCmd)
-		if err != nil {
-			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
-		}
+		child := spawnOrFail(t, rktCmd)
 		if tt.say != "" {
-			err = expectTimeoutWithOutput(child, "Enter text:", time.Minute)
-			if err != nil {
+			if err := expectTimeoutWithOutput(child, "Enter text:", time.Minute); err != nil {
 				t.Fatalf("Waited for the prompt but not found #%v: %v", i, err)
 			}
 
-			err = child.SendLine(tt.say)
-			if err != nil {
+			if err := child.SendLine(tt.say); err != nil {
 				t.Fatalf("Failed to send %q on the prompt #%v: %v", tt.say, i, err)
 			}
 		}
 
-		err = expectTimeoutWithOutput(child, tt.expect, time.Minute)
-		if err != nil {
+		if err := expectTimeoutWithOutput(child, tt.expect, time.Minute); err != nil {
 			t.Fatalf("Expected %q but not found #%v: %v", tt.expect, i, err)
 		}
 
-		err = child.Wait()
-		if err != nil {
+		if err := child.Wait(); err != nil {
 			t.Fatalf("rkt didn't terminate correctly: %v", err)
 		}
 	}

--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/syndtr/gocapability/capability"
 
 	"github.com/coreos/rkt/common/cgroup"
@@ -516,11 +515,8 @@ func TestPodManifest(t *testing.T) {
 
 		// 1. Test 'rkt run'.
 		runCmd := fmt.Sprintf("%s run --mds-register=false --pod-manifest=%s", ctx.cmd(), manifestFile)
-		t.Logf("Running 'run' test #%v: %v", i, runCmd)
-		child, err := gexpect.Spawn(runCmd)
-		if err != nil {
-			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
-		}
+		t.Logf("Running 'run' test #%v", i)
+		child := spawnOrFail(t, runCmd)
 
 		if tt.expectedResult != "" {
 			if err := expectWithOutput(child, tt.expectedResult); err != nil {
@@ -540,11 +536,8 @@ func TestPodManifest(t *testing.T) {
 		uuid := runRktAndGetUUID(t, rktCmd)
 
 		runPreparedCmd := fmt.Sprintf("%s run-prepared --mds-register=false %s", ctx.cmd(), uuid)
-		t.Logf("Running 'run-prepared' test #%v: %v", i, runPreparedCmd)
-		child, err = gexpect.Spawn(runPreparedCmd)
-		if err != nil {
-			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
-		}
+		t.Logf("Running 'run-prepared' test #%v", i)
+		child = spawnOrFail(t, runPreparedCmd)
 
 		if tt.expectedResult != "" {
 			if err := expectWithOutput(child, tt.expectedResult); err != nil {

--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -102,7 +102,7 @@ func TestPodManifest(t *testing.T) {
 		// [image name]:[image patches]
 		images         []imagePatch
 		podManifest    *schema.PodManifest
-		shouldSuccess  bool
+		shouldSucceed  bool
 		expectedResult string
 		cgroup         string
 	}{
@@ -528,7 +528,7 @@ func TestPodManifest(t *testing.T) {
 			}
 		}
 		if err := child.Wait(); err != nil {
-			if tt.shouldSuccess {
+			if tt.shouldSucceed {
 				t.Fatalf("rkt didn't terminate correctly: %v", err)
 			}
 		}
@@ -552,7 +552,7 @@ func TestPodManifest(t *testing.T) {
 			}
 		}
 		if err := child.Wait(); err != nil {
-			if tt.shouldSuccess {
+			if tt.shouldSucceed {
 				t.Fatalf("rkt didn't terminate correctly: %v", err)
 			}
 		}

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
 )
 
 var volTests = []struct {
@@ -99,22 +97,13 @@ func TestVolumes(t *testing.T) {
 		cmd = strings.Replace(cmd, "^VOL_RW_READ_FILE^", volRwReadFileImage, -1)
 		cmd = strings.Replace(cmd, "^VOL_RW_WRITE_FILE^", volRwWriteFileImage, -1)
 
-		t.Logf("Running test #%v: %v", i, cmd)
+		t.Logf("Running test #%v", i)
+		child := spawnOrFail(t, cmd)
+		defer waitOrFail(t, child, true)
 
-		child, err := gexpect.Spawn(cmd)
-		if err != nil {
-			t.Fatalf("Cannot exec rkt #%v: %v", i, err)
-		}
-
-		err = expectTimeoutWithOutput(child, tt.expect, time.Minute)
-		if err != nil {
+		if err := expectTimeoutWithOutput(child, tt.expect, time.Minute); err != nil {
 			fmt.Printf("Command: %s\n", cmd)
 			t.Fatalf("Expected %q but not found #%v: %v", tt.expect, i, err)
-		}
-
-		err = child.Wait()
-		if err != nil {
-			t.Fatalf("rkt didn't terminate correctly: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
Much of the code in the functional tests was copy and pasted around. This commit tries to reduce that a bit by providing functions for the common tasks of spawning, waiting, checking expected values, etc.

There is much more room for improvement, but this is a start.