### PR TITLE
stage1: set TimeoutStartSec to 0

### DIFF
--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -300,6 +300,9 @@ func (p *Pod) appToSystemd(ra *schema.RuntimeApp, interactive bool, flavor strin
 		opts = append(opts, unit.NewUnitOption("Service", typ, exec))
 	}
 
+	// Some pre-start jobs take a long time, set the timeout to 0
+	opts = append(opts, unit.NewUnitOption("Service", "TimeoutStartSec", "0"))
+
 	saPorts := []types.Port{}
 	for _, p := range app.Ports {
 		if p.SocketActivated {


### PR DESCRIPTION
Some pre-start jobs take a long time, set the timeout to 0 so they can
complete. If it takes too long, the user can just kill rkt.

Fixes #1515 