### PR TITLE
rkt/run: don't check treestore if insecure

### DIFF
--- a/rkt/run.go
+++ b/rkt/run.go
@@ -213,9 +213,10 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	pcfg := stage0.PrepareConfig{
-		CommonConfig: cfg,
-		UseOverlay:   !flagNoOverlay && common.SupportsOverlay(),
-		PrivateUsers: privateUsers,
+		CommonConfig:       cfg,
+		UseOverlay:         !flagNoOverlay && common.SupportsOverlay(),
+		PrivateUsers:       privateUsers,
+		SkipTreeStoreCheck: globalFlags.InsecureSkipVerify,
 	}
 
 	if len(flagPodManifest) > 0 {


### PR DESCRIPTION
Disable checking the treestore when using --insecure-skip-verify.

This reduces the start-up time of big images dramatically.

For example, with docker://jenkins.

docker://jenkins

real	0m7.200s
user	0m6.740s
sys	0m0.550s

docker://jenkins --insecure-skip-verify

real	0m0.384s
user	0m0.100s
sys	0m0.030s