### PR TITLE
provide more info in rkt list

### DIFF
--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -30,7 +30,7 @@ import (
 const (
 	defaultTimeLayout = "2006-01-02 15:04:05.999 -0700 MST"
 
-	keyField        = "key"
+	idField         = "id"
 	nameField       = "name"
 	importTimeField = "importtime"
 	latestField     = "latest"
@@ -39,7 +39,7 @@ const (
 var (
 	// map of valid fields and related flag value
 	imagesAllFields = map[string]struct{}{
-		keyField:        struct{}{},
+		idField:         struct{}{},
 		nameField:       struct{}{},
 		importTimeField: struct{}{},
 		latestField:     struct{}{},
@@ -47,7 +47,7 @@ var (
 
 	// map of valid fields and related header name
 	ImagesFieldHeaderMap = map[string]string{
-		keyField:        "KEY",
+		idField:         "ID",
 		nameField:       "NAME",
 		importTimeField: "IMPORT TIME",
 		latestField:     "LATEST",
@@ -56,7 +56,7 @@ var (
 	// map of valid sort fields containing the mapping between the provided field name
 	// and the related aciinfo's field name.
 	ImagesFieldAciInfoMap = map[string]string{
-		keyField:        "blobkey",
+		idField:         "blobkey",
 		nameField:       "name",
 		importTimeField: "importtime",
 		latestField:     "latest",
@@ -168,12 +168,12 @@ var (
 
 func init() {
 	// Set defaults
-	flagImagesFields = []string{keyField, nameField, importTimeField, latestField}
+	flagImagesFields = []string{idField, nameField, importTimeField, latestField}
 	flagImagesSortFields = []string{importTimeField}
 	flagImagesSortAsc = true
 
 	cmdImage.AddCommand(cmdImageList)
-	cmdImageList.Flags().Var(&flagImagesFields, "fields", `comma separated list of fields to display. Accepted values: "key", "name", "importtime", "latest"`)
+	cmdImageList.Flags().Var(&flagImagesFields, "fields", `comma separated list of fields to display. Accepted values: "id", "name", "importtime", "latest"`)
 	cmdImageList.Flags().Var(&flagImagesSortFields, "sort", `sort the output according to the provided comma separated list of fields. Accepted values: "name", "importtime"`)
 	cmdImageList.Flags().Var(&flagImagesSortAsc, "order", `choose the sorting order if at least one sort field is provided (--sort). Accepted values: "asc", "desc"`)
 	cmdImageList.Flags().BoolVar(&flagNoLegend, "no-legend", false, "suppress a legend with the list")
@@ -225,7 +225,7 @@ func runImages(cmd *cobra.Command, args []string) int {
 		for _, f := range flagImagesFields {
 			fieldValue := ""
 			switch f {
-			case keyField:
+			case idField:
 				hashKey := aciInfo.BlobKey
 				if !flagFullOutput {
 					// The short hash form is [HASH_ALGO]-[FIRST 12 CHAR]

--- a/rkt/image_rm.go
+++ b/rkt/image_rm.go
@@ -23,7 +23,7 @@ import (
 var (
 	cmdImageRm = &cobra.Command{
 		Use:   "rm IMAGEID...",
-		Short: "Remove image(s) with the given key(s) from the local store",
+		Short: "Remove image(s) with the given ID(s) from the local store",
 		Run:   runWrapper(runRmImage),
 	}
 )
@@ -34,7 +34,7 @@ func init() {
 
 func runRmImage(cmd *cobra.Command, args []string) (exit int) {
 	if len(args) < 1 {
-		stderr("rkt: Must provide at least one image key")
+		stderr("rkt: Must provide at least one image ID")
 		return 1
 	}
 
@@ -51,29 +51,29 @@ func runRmImage(cmd *cobra.Command, args []string) (exit int) {
 		errors++
 		h, err := types.NewHash(pkey)
 		if err != nil {
-			stderr("rkt: wrong imageID %q: %v", pkey, err)
+			stderr("rkt: wrong image ID %q: %v", pkey, err)
 			continue
 		}
 		key, err := s.ResolveKey(h.String())
 		if err != nil {
-			stderr("rkt: imageID %q not valid: %v", pkey, err)
+			stderr("rkt: image ID %q not valid: %v", pkey, err)
 			continue
 		}
 		if key == "" {
-			stderr("rkt: imageID %q doesn't exist", pkey)
+			stderr("rkt: image ID %q doesn't exist", pkey)
 			continue
 		}
 
 		if err = s.RemoveACI(key); err != nil {
 			if serr, ok := err.(*store.StoreRemovalError); ok {
 				staleErrors++
-				stderr("rkt: some files cannot be removed for imageID %q: %v", pkey, serr)
+				stderr("rkt: some files cannot be removed for image ID %q: %v", pkey, serr)
 			} else {
-				stderr("rkt: error removing aci for imageID %q: %v", pkey, err)
+				stderr("rkt: error removing aci for image ID %q: %v", pkey, err)
 				continue
 			}
 		}
-		stdout("rkt: successfully removed aci for imageID: %q", pkey)
+		stdout("rkt: successfully removed aci for image ID: %q", pkey)
 		errors--
 		done++
 	}

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -86,7 +86,7 @@ func (f *finder) findImage(img string, asc string) (*types.Hash, error) {
 	if err == nil {
 		fullKey, err := f.s.ResolveKey(img)
 		if err != nil {
-			return nil, fmt.Errorf("could not resolve key: %v", err)
+			return nil, fmt.Errorf("could not resolve image ID: %v", err)
 		}
 		h, err = types.NewHash(fullKey)
 		if err != nil {
@@ -167,7 +167,7 @@ func (f *fetcher) addImageDeps(hash string, imgsl *list.List, seen map[string]st
 		}
 		imgsl.PushBack(app.String())
 		if _, ok := seen[app.String()]; ok {
-			return fmt.Errorf("dependency %s specified multiple times in the dependency tree for imageID: %s", app.String(), hash)
+			return fmt.Errorf("dependency %s specified multiple times in the dependency tree for image ID: %s", app.String(), hash)
 		}
 		seen[app.String()] = struct{}{}
 	}
@@ -762,7 +762,7 @@ func getStoreKeyFromAppOrHash(s *store.Store, input string) (string, error) {
 	if _, err := types.NewHash(input); err == nil {
 		key, err = s.ResolveKey(input)
 		if err != nil {
-			return "", fmt.Errorf("cannot resolve key: %v", err)
+			return "", fmt.Errorf("cannot resolve image ID: %v", err)
 		}
 	} else {
 		key, err = getStoreKeyFromApp(s, input)

--- a/store/store.go
+++ b/store/store.go
@@ -64,7 +64,7 @@ var diskvStores = [...]string{
 }
 
 var (
-	ErrKeyNotFound = errors.New("no keys found")
+	ErrKeyNotFound = errors.New("no image IDs found")
 )
 
 // ACINotFoundError is returned when an ACI cannot be found by GetACI
@@ -245,7 +245,7 @@ func (s Store) ResolveKey(key string) (string, error) {
 		return "", fmt.Errorf("wrong key prefix")
 	}
 	if len(key) < minlenKey {
-		return "", fmt.Errorf("key too short")
+		return "", fmt.Errorf("image ID too short")
 	}
 	if len(key) > lenKey {
 		key = key[:lenKey]
@@ -266,7 +266,7 @@ func (s Store) ResolveKey(key string) (string, error) {
 		return "", ErrKeyNotFound
 	}
 	if keyCount != 1 {
-		return "", fmt.Errorf("ambiguous key: %q", key)
+		return "", fmt.Errorf("ambiguous image ID: %q", key)
 	}
 	return aciInfos[0].BlobKey, nil
 }
@@ -274,7 +274,7 @@ func (s Store) ResolveKey(key string) (string, error) {
 func (s Store) ReadStream(key string) (io.ReadCloser, error) {
 	key, err := s.ResolveKey(key)
 	if err != nil {
-		return nil, fmt.Errorf("error resolving key: %v", err)
+		return nil, fmt.Errorf("error resolving image ID: %v", err)
 	}
 	keyLock, err := lock.SharedKeyLock(s.imageLockDir, key)
 	if err != nil {
@@ -404,7 +404,7 @@ func (ds Store) RemoveACI(key string) error {
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("cannot remove image with key: %s from db: %v", key, err)
+		return fmt.Errorf("cannot remove image with ID: %s from db: %v", key, err)
 	}
 
 	// Then remove non transactional entries from the blob, imageManifest
@@ -574,7 +574,7 @@ func (s Store) WriteRemote(remote *Remote) error {
 func (s Store) GetImageManifestJSON(key string) ([]byte, error) {
 	key, err := s.ResolveKey(key)
 	if err != nil {
-		return nil, fmt.Errorf("error resolving key: %v", err)
+		return nil, fmt.Errorf("error resolving image ID: %v", err)
 	}
 	keyLock, err := lock.SharedKeyLock(s.imageLockDir, key)
 	if err != nil {
@@ -700,7 +700,7 @@ func (s Store) Dump(hex bool) {
 			fmt.Printf("%s/%s: %s\n", s.BasePath, key, out)
 			keyCount++
 		}
-		fmt.Printf("%d total keys\n", keyCount)
+		fmt.Printf("%d total image ID(s)\n", keyCount)
 	}
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -138,9 +138,9 @@ func TestResolveKey(t *testing.T) {
 		t.Errorf("expected err=%q, got %q", expectedErr, err)
 	}
 
-	// key too short
+	// image ID too short
 	k, err = s.ResolveKey("sha512-1")
-	expectedErr = "key too short"
+	expectedErr = "image ID too short"
 	if err == nil {
 		t.Errorf("expected non-nil error!")
 	}

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -55,7 +55,7 @@ func TestImageExport(t *testing.T) {
 	ctx := newRktRunCtx()
 	defer ctx.cleanup()
 
-	testImageKey := importImageAndFetchHash(t, ctx, testImage)
+	testImageId := importImageAndFetchHash(t, ctx, testImage)
 
 	testImageHash, err := getHash(testImage)
 	if err != nil {
@@ -73,7 +73,7 @@ func TestImageExport(t *testing.T) {
 			testImageHash,
 		},
 		{
-			testImageKey,
+			testImageId,
 			true,
 			testImageHash,
 		},

--- a/tests/rkt_image_list_test.go
+++ b/tests/rkt_image_list_test.go
@@ -99,7 +99,7 @@ func TestShortHash(t *testing.T) {
 	hash0 := fmt.Sprintf("sha512-%s", imageIds[0].hash[:12])
 	hash1 := fmt.Sprintf("sha512-%s", imageIds[1].hash[:12])
 	for _, hash := range []string{hash0, hash1} {
-		imageListCmd := fmt.Sprintf("%s image list --fields=key --no-legend", ctx.cmd())
+		imageListCmd := fmt.Sprintf("%s image list --fields=id --no-legend", ctx.cmd())
 		child, err := gexpect.Spawn(imageListCmd)
 		if err != nil {
 			t.Fatal("Cannot exec rkt image list")
@@ -123,23 +123,23 @@ func TestShortHash(t *testing.T) {
 		shouldFail bool
 		expect     string
 	}{
-		// Try invalid key
+		// Try invalid ID
 		{
 			"image cat-manifest sha512-12341234",
 			true,
-			"no keys found",
+			"no image IDs found",
 		},
 		// Try using one char hash
 		{
 			fmt.Sprintf("image cat-manifest %s", hash0[:len("sha512-")+1]),
 			true,
-			"key too short",
+			"image ID too short",
 		},
 		// Try short hash that collides
 		{
 			fmt.Sprintf("image cat-manifest %s", hash0[:len("sha512-")+2]),
 			true,
-			"ambiguous key",
+			"ambiguous image ID",
 		},
 		// Test that 12-char hash works with image cat-manifest
 		{

--- a/tests/rkt_image_rm_test.go
+++ b/tests/rkt_image_rm_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	rmImageReferenced = `rkt: imageID %q is referenced by some containers, cannot remove.`
-	rmImageOk         = "rkt: successfully removed aci for imageID:"
+	rmImageReferenced = `rkt: image ID %q is referenced by some containers, cannot remove.`
+	rmImageOk         = "rkt: successfully removed aci for image ID:"
 
 	unreferencedACI = "rkt-unreferencedACI.aci"
 	unreferencedApp = "coreos.com/rkt-unreferenced"
@@ -65,19 +65,19 @@ func TestImageRunRm(t *testing.T) {
 		t.Fatalf("rkt didn't terminate correctly: %v", err)
 	}
 
-	t.Logf("Retrieving stage1 imageID")
+	t.Logf("Retrieving stage1 image ID")
 	stage1ImageID, err := getImageId(ctx, stage1App)
 	if err != nil {
 		t.Fatalf("rkt didn't terminate correctly: %v", err)
 	}
 
-	t.Logf("Retrieving %s imageID", referencedApp)
+	t.Logf("Retrieving %s image ID", referencedApp)
 	referencedImageID, err := getImageId(ctx, referencedApp)
 	if err != nil {
 		t.Fatalf("rkt didn't terminate correctly: %v", err)
 	}
 
-	t.Logf("Retrieving %s imageID", unreferencedApp)
+	t.Logf("Retrieving %s image ID", unreferencedApp)
 	unreferencedImageID, err := getImageId(ctx, unreferencedApp)
 	if err != nil {
 		t.Fatalf("rkt didn't terminate correctly: %v", err)
@@ -137,13 +137,13 @@ func TestImagePrepareRmRun(t *testing.T) {
 		t.Fatalf("rkt didn't terminate correctly: %v", err)
 	}
 
-	t.Logf("Retrieving %s imageID", referencedApp)
+	t.Logf("Retrieving %s image ID", referencedApp)
 	referencedImageID, err := getImageId(ctx, referencedApp)
 	if err != nil {
 		t.Fatalf("rkt didn't terminate correctly: %v", err)
 	}
 
-	t.Logf("Retrieving %s imageID", unreferencedApp)
+	t.Logf("Retrieving %s image ID", unreferencedApp)
 	unreferencedImageID, err := getImageId(ctx, unreferencedApp)
 	if err != nil {
 		t.Fatalf("rkt didn't terminate correctly: %v", err)
@@ -176,7 +176,7 @@ func TestImagePrepareRmRun(t *testing.T) {
 }
 
 func getImageId(ctx *rktRunCtx, name string) (string, error) {
-	cmd := fmt.Sprintf(`/bin/sh -c "%s image list --fields=key,name --no-legend | grep %s | awk '{print $1}'"`, ctx.cmd(), name)
+	cmd := fmt.Sprintf(`/bin/sh -c "%s image list --fields=id,name --no-legend | grep %s | awk '{print $1}'"`, ctx.cmd(), name)
 	child, err := gexpect.Spawn(cmd)
 	if err != nil {
 		return "", fmt.Errorf("Cannot exec rkt: %v", err)


### PR DESCRIPTION
The `rkt list` command currently shows an inadequate amount of information to determine which image an app is associated with. For example, one could have fetched multiple versions of an image and it's possible for images to have the same name but different hashes. However, these details are not shown in the output.

This change adds the version information to the default `rkt list` output and adds the 12-char ID of the image to the output when the '--full' flag is used.

It also changes the 'ACI' field header to 'IMAGE NAME'.

Lastly, this PR change tries to make the term used for the image's hash value more consistent by changing the user-facing reference to "Image ID" instead of "key". "Key" is already used more adequately  in the trust context.

Closes #1492