### PR TITLE
Avoid allocating space for empty slice initialization

### DIFF
--- a/common/apps/apps.go
+++ b/common/apps/apps.go
@@ -75,7 +75,7 @@ func (al *Apps) Walk(f func(*App) error) error {
 // GetImages returns a list of the images in al, one per app.
 // The order reflects the app order in al.
 func (al *Apps) GetImages() []string {
-	il := []string{}
+	var il []string
 	for _, a := range al.apps {
 		il = append(il, a.Image)
 	}
@@ -85,7 +85,7 @@ func (al *Apps) GetImages() []string {
 // GetArgs returns a list of lists of arguments in al, one list of args per app.
 // The order reflects the app order in al.
 func (al *Apps) GetArgs() [][]string {
-	aal := [][]string{}
+	var aal [][]string
 	for _, a := range al.apps {
 		aal = append(aal, a.Args)
 	}
@@ -95,7 +95,7 @@ func (al *Apps) GetArgs() [][]string {
 // GetImageIDs returns a list of the imageIDs in al, one per app.
 // The order reflects the app order in al.
 func (al *Apps) GetImageIDs() []types.Hash {
-	hl := []types.Hash{}
+	var hl []types.Hash
 	for _, a := range al.apps {
 		hl = append(hl, a.ImageID)
 	}

--- a/networking/netinfo/netinfo.go
+++ b/networking/netinfo/netinfo.go
@@ -42,7 +42,7 @@ func LoadAt(cdirfd int) ([]NetInfo, error) {
 
 	f := os.NewFile(uintptr(fd), filename)
 
-	info := []NetInfo{}
+	var info []NetInfo
 	err = json.NewDecoder(f).Decode(&info)
 	return info, err
 }

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -135,7 +135,7 @@ func Load(podRoot string, podID *types.UUID) (*Networking, error) {
 		return nil, err
 	}
 
-	nets := []activeNet{}
+	var nets []activeNet
 	for _, ni := range nis {
 		n, err := loadNet(ni.ConfPath)
 		if err != nil {
@@ -230,7 +230,7 @@ func (n *Networking) enterHostNS() error {
 // Save writes out the info about active nets
 // for "rkt list" and friends to display
 func (e *Networking) Save() error {
-	nis := []netinfo.NetInfo{}
+	var nis []netinfo.NetInfo
 	for _, n := range e.nets {
 		nis = append(nis, *n.runtime)
 	}

--- a/networking/podenv.go
+++ b/networking/podenv.go
@@ -156,7 +156,7 @@ func listFiles(dir string) ([]string, error) {
 		return nil, err
 	}
 
-	files := []string{}
+	var files []string
 	for _, dent := range dirents {
 		if dent.IsDir() {
 			continue
@@ -276,7 +276,7 @@ func missingNets(defined common.NetList, loaded []activeNet) []string {
 		delete(diff, an.conf.Name)
 	}
 
-	missing := []string{}
+	var missing []string
 	for n, _ := range diff {
 		missing = append(missing, n)
 	}

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -45,7 +45,7 @@ func extractTar(tr *tar.Reader, overwrite bool, pwl PathWhitelistMap, uidRange *
 	um := syscall.Umask(0)
 	defer syscall.Umask(um)
 
-	dirhdrs := []*tar.Header{}
+	var dirhdrs []*tar.Header
 Tar:
 	for {
 		hdr, err := tr.Next()

--- a/rkt/help.go
+++ b/rkt/help.go
@@ -92,7 +92,7 @@ GLOBAL OPTIONS:
 }
 
 func getSubCommands(cmd *cobra.Command) []*cobra.Command {
-	subCommands := []*cobra.Command{}
+	var subCommands []*cobra.Command
 	for _, subCmd := range cmd.Commands() {
 		subCommands = append(subCommands, subCmd)
 		subCommands = append(subCommands, getSubCommands(subCmd)...)

--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -181,12 +181,12 @@ func init() {
 }
 
 func runImages(cmd *cobra.Command, args []string) int {
-	errors := []error{}
+	var errors []error
 	tabBuffer := new(bytes.Buffer)
 	tabOut := getTabOutWithWriter(tabBuffer)
 
 	if !flagNoLegend {
-		headerFields := []string{}
+		var headerFields []string
 		for _, f := range flagImagesFields {
 			headerFields = append(headerFields, ImagesFieldHeaderMap[f])
 		}
@@ -199,7 +199,7 @@ func runImages(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	sortAciinfoFields := []string{}
+	var sortAciinfoFields []string
 	for _, f := range flagImagesSortFields {
 		sortAciinfoFields = append(sortAciinfoFields, ImagesFieldAciInfoMap[f])
 	}
@@ -221,7 +221,7 @@ func runImages(cmd *cobra.Command, args []string) int {
 			continue
 		}
 		version, ok := im.Labels.Get("version")
-		fieldValues := []string{}
+		var fieldValues []string
 		for _, f := range flagImagesFields {
 			fieldValue := ""
 			switch f {
@@ -276,7 +276,7 @@ func runImages(cmd *cobra.Command, args []string) int {
 }
 
 func newImgListLoadError(err error, imj []byte, blobKey string) error {
-	lines := []string{}
+	var lines []string
 	im := lastditch.ImageManifest{}
 	imErr := im.UnmarshalJSON(imj)
 	if imErr == nil {

--- a/rkt/list.go
+++ b/rkt/list.go
@@ -53,7 +53,7 @@ func runList(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
-	errors := []error{}
+	var errors []error
 	tabBuffer := new(bytes.Buffer)
 	tabOut := getTabOutWithWriter(tabBuffer)
 
@@ -96,7 +96,7 @@ func runList(cmd *cobra.Command, args []string) int {
 			nets    string
 		}
 
-		appsToPrint := []printedApp{}
+		var appsToPrint []printedApp
 		uuid := p.uuid.String()
 		state := p.getState()
 		nets := fmtNets(p.nets)
@@ -267,7 +267,7 @@ func appLine(app lastditch.RuntimeApp) string {
 }
 
 func fmtNets(nis []netinfo.NetInfo) string {
-	parts := []string{}
+	var parts []string
 	for _, ni := range nis {
 		// there will be IPv6 support soon so distinguish between v4 and v6
 		parts = append(parts, fmt.Sprintf("%v:ip4=%v", ni.NetName, ni.IP))

--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -853,7 +853,7 @@ func (p *pod) getStage1TreeStoreID() (string, error) {
 // getAppTreeStoreIDs returns the treeStoreIDs of the apps images used in
 // this pod
 func (p *pod) getAppsTreeStoreIDs() ([]string, error) {
-	treeStoreIDs := []string{}
+	var treeStoreIDs []string
 	apps, err := p.getApps()
 	if err != nil {
 		return nil, err
@@ -883,7 +883,7 @@ func (p *pod) getAppsHashes() ([]types.Hash, error) {
 		return nil, err
 	}
 
-	hashes := []types.Hash{}
+	var hashes []types.Hash
 	for _, a := range apps {
 		hashes = append(hashes, a.Image.ID)
 	}

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -250,7 +250,7 @@ func installAssets() error {
 
 // getArgsEnv returns the nspawn or lkvm args and env according to the flavor used
 func getArgsEnv(p *Pod, flavor string, debug bool, n *networking.Networking) ([]string, []string, error) {
-	args := []string{}
+	var args []string
 	env := os.Environ()
 
 	// We store the pod's flavor so we can later garbage collect it correctly
@@ -467,7 +467,7 @@ func withClearedCloExec(lfd int, f func() error) error {
 }
 
 func forwardedPorts(pod *Pod) ([]networking.ForwardedPort, error) {
-	fps := []networking.ForwardedPort{}
+	var fps []networking.ForwardedPort
 
 	for _, ep := range pod.Manifest.Ports {
 		n := ""

--- a/stage1/init/kvm/mount.go
+++ b/stage1/init/kvm/mount.go
@@ -121,7 +121,7 @@ func PodToSystemdHostMountUnits(root string, volumes []types.Volume, appNames []
 		}
 
 		// serviceNames for ordering and requirements dependency for apps
-		serviceNames := []string{}
+		var serviceNames []string
 		for _, appName := range appNames {
 			serviceNames = append(serviceNames, serviceUnitName(appName))
 		}
@@ -201,7 +201,7 @@ func AppToSystemdMountUnits(root string, appName types.ACName, mountPoints []typ
 // shared volumes (only for "host" kind).
 // Example return is ["--9p,src/folder,9ptag"].
 func VolumesToKvmDiskArgs(volumes []types.Volume) []string {
-	args := []string{}
+	var args []string
 
 	for _, vol := range volumes {
 		mountTag := vol.Name.String() // tag/channel name for virtio

--- a/stage1/init/kvm/network.go
+++ b/stage1/init/kvm/network.go
@@ -24,7 +24,7 @@ import (
 // GetNetworkDescriptions explicitly convert slice of activeNets to slice of netDescribers
 // which is slice required by GetKVMNetArgs
 func GetNetworkDescriptions(n *networking.Networking) []netDescriber {
-	nds := []netDescriber{}
+	var nds []netDescriber
 	for _, an := range n.GetActiveNetworks() {
 		nds = append(nds, an)
 	}
@@ -46,8 +46,8 @@ type netDescriber interface {
 // and essentially from activeNets that expose netDescriber behavior
 func GetKVMNetArgs(nds []netDescriber) ([]string, []string, error) {
 
-	lkvmArgs := []string{}
-	kernelParams := []string{}
+	var lkvmArgs []string
+	var kernelParams []string
 
 	for i, nd := range nds {
 		// https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt

--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -312,7 +312,7 @@ func (p *Pod) appToSystemd(ra *schema.RuntimeApp, interactive bool, flavor strin
 	// Some pre-start jobs take a long time, set the timeout to 0
 	opts = append(opts, unit.NewUnitOption("Service", "TimeoutStartSec", "0"))
 
-	saPorts := []types.Port{}
+	var saPorts []types.Port
 	for _, p := range app.Ports {
 		if p.SocketActivated {
 			saPorts = append(saPorts, p)
@@ -447,7 +447,7 @@ func (p *Pod) PodToSystemd(interactive bool, flavor string, privateUsers string)
 	if flavor == "kvm" {
 		// prepare all applications names to become dependency for mount units
 		// all host-shared folder has to become available before applications starts
-		appNames := []types.ACName{}
+		var appNames []types.ACName
 		for _, runtimeApp := range p.Manifest.Apps {
 			appNames = append(appNames, runtimeApp.Name)
 		}
@@ -472,7 +472,7 @@ func (p *Pod) PodToSystemd(interactive bool, flavor string, privateUsers string)
 // appToNspawnArgs transforms the given app manifest, with the given associated
 // app name, into a subset of applicable systemd-nspawn argument
 func (p *Pod) appToNspawnArgs(ra *schema.RuntimeApp) ([]string, error) {
-	args := []string{}
+	var args []string
 	appName := ra.Name
 	id := ra.Image.ID
 	app := ra.App

--- a/store/aciinfo.go
+++ b/store/aciinfo.go
@@ -50,7 +50,7 @@ func aciinfoRowScan(rows *sql.Rows, aciinfo *ACIInfo) error {
 
 // GetAciInfosWithKeyPrefix returns all the ACIInfos with a blobkey starting with the given prefix.
 func GetACIInfosWithKeyPrefix(tx *sql.Tx, prefix string) ([]*ACIInfo, error) {
-	aciinfos := []*ACIInfo{}
+	var aciinfos []*ACIInfo
 	rows, err := tx.Query("SELECT * from aciinfo WHERE hasPrefix(blobkey, $1)", prefix)
 	if err != nil {
 		return nil, err
@@ -71,7 +71,7 @@ func GetACIInfosWithKeyPrefix(tx *sql.Tx, prefix string) ([]*ACIInfo, error) {
 // GetAciInfosWithName returns all the ACIInfos for a given name. found will be
 // false if no aciinfo exists.
 func GetACIInfosWithName(tx *sql.Tx, name string) ([]*ACIInfo, bool, error) {
-	aciinfos := []*ACIInfo{}
+	var aciinfos []*ACIInfo
 	found := false
 	rows, err := tx.Query("SELECT * from aciinfo WHERE name == $1", name)
 	if err != nil {
@@ -117,7 +117,7 @@ func GetACIInfoWithBlobKey(tx *sql.Tx, blobKey string) (*ACIInfo, bool, error) {
 // GetAllACIInfos returns all the ACIInfos sorted by optional sortfields and
 // with ascending or descending order.
 func GetAllACIInfos(tx *sql.Tx, sortfields []string, ascending bool) ([]*ACIInfo, error) {
-	aciinfos := []*ACIInfo{}
+	var aciinfos []*ACIInfo
 	query := "SELECT * from aciinfo"
 	if len(sortfields) > 0 {
 		query += fmt.Sprintf(" ORDER BY %s ", strings.Join(sortfields, ", "))

--- a/store/aciinfo_test.go
+++ b/store/aciinfo_test.go
@@ -48,7 +48,7 @@ func TestWriteACIInfo(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	aciinfos := []*ACIInfo{}
+	var aciinfos []*ACIInfo
 	ok := false
 	if err = s.db.Do(func(tx *sql.Tx) error {
 		aciinfos, ok, err = GetACIInfosWithName(tx, "name01")

--- a/store/migrate_test.go
+++ b/store/migrate_test.go
@@ -238,7 +238,7 @@ type ACIInfoV3 struct {
 }
 
 func getAllACIInfosV0_2(tx *sql.Tx) ([]*ACIInfoV0_2, error) {
-	aciinfos := []*ACIInfoV0_2{}
+	var aciinfos []*ACIInfoV0_2
 	rows, err := tx.Query("SELECT * from aciinfo")
 	if err != nil {
 		return nil, err
@@ -257,7 +257,7 @@ func getAllACIInfosV0_2(tx *sql.Tx) ([]*ACIInfoV0_2, error) {
 }
 
 func getAllACIInfosV3(tx *sql.Tx) ([]*ACIInfoV3, error) {
-	aciinfos := []*ACIInfoV3{}
+	var aciinfos []*ACIInfoV3
 	rows, err := tx.Query("SELECT * from aciinfo")
 	if err != nil {
 		return nil, err
@@ -283,7 +283,7 @@ type RemoteV0_1 struct {
 }
 
 func getAllRemoteV0_1(tx *sql.Tx) ([]*RemoteV0_1, error) {
-	remotes := []*RemoteV0_1{}
+	var remotes []*RemoteV0_1
 	rows, err := tx.Query("SELECT * from remote")
 	if err != nil {
 		return nil, err
@@ -311,7 +311,7 @@ type RemoteV2_3 struct {
 }
 
 func getAllRemoteV2_3(tx *sql.Tx) ([]*RemoteV2_3, error) {
-	remotes := []*RemoteV2_3{}
+	var remotes []*RemoteV2_3
 	rows, err := tx.Query("SELECT * from remote")
 	if err != nil {
 		return nil, err

--- a/store/store.go
+++ b/store/store.go
@@ -258,7 +258,7 @@ func (s Store) ResolveKey(key string) (string, error) {
 		key = key[:lenKey]
 	}
 
-	aciInfos := []*ACIInfo{}
+	var aciInfos []*ACIInfo
 	err := s.db.Do(func(tx *sql.Tx) error {
 		var err error
 		aciInfos, err = GetACIInfosWithKeyPrefix(tx, key)
@@ -424,7 +424,7 @@ func (ds Store) RemoveACI(key string) error {
 	// TODO(sgotti). Now that the ACIInfo is removed the image doesn't
 	// exists anymore, but errors removing non transactional entries can
 	// leave stale data that will require a cas GC to be implemented.
-	storeErrors := []error{}
+	var storeErrors []error
 	for _, s := range ds.stores {
 		if err := s.Erase(key); err != nil {
 			// If there's an error save it and continue with the other stores
@@ -451,7 +451,7 @@ func (s Store) GetTreeStoreID(key string) (string, error) {
 		return "", err
 	}
 
-	keys := []string{}
+	var keys []string
 	for _, image := range images {
 		keys = append(keys, image.Key)
 	}
@@ -543,7 +543,7 @@ func (ds Store) RemoveTreeStore(id string) error {
 // GetTreeStoreIDs returns a slice containing all the treeStore's IDs available
 // (both fully or partially rendered).
 func (ds Store) GetTreeStoreIDs() ([]string, error) {
-	treeStoreIDs := []string{}
+	var treeStoreIDs []string
 	ls, err := ioutil.ReadDir(ds.treestore.path)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -685,7 +685,7 @@ nextKey:
 }
 
 func (ds Store) GetAllACIInfos(sortfields []string, ascending bool) ([]*ACIInfo, error) {
-	aciInfos := []*ACIInfo{}
+	var aciInfos []*ACIInfo
 	err := ds.db.Do(func(tx *sql.Tx) error {
 		var err error
 		aciInfos, err = GetAllACIInfos(tx, sortfields, ascending)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -303,7 +303,7 @@ func TestGetAci(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		keys := []string{}
+		var keys []string
 		// Create ACIs
 		for _, ad := range tt.acidefs {
 			aci, err := aci.NewACI(dir, ad.imj, nil)

--- a/store/utils.go
+++ b/store/utils.go
@@ -71,7 +71,7 @@ func labelsToString(inLabels types.Labels) string {
 	labels := append(types.Labels(nil), inLabels...)
 	sort.Sort(labelsSlice(labels))
 
-	out := []string{}
+	var out []string
 	for _, l := range labels {
 		out = append(out, fmt.Sprintf("%q:%q", l.Name, l.Value))
 	}

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -40,7 +40,7 @@ func osArchTestRemoveImages(tests []osArchTest) {
 }
 
 func getMissingOrInvalidTests(t *testing.T, ctx *rktRunCtx) []osArchTest {
-	tests := []osArchTest{}
+	var tests []osArchTest
 
 	defer osArchTestRemoveImages(tests)
 	testImageName := "coreos.com/rkt-missing-os-arch-test"

--- a/tools/cleangen/main.go
+++ b/tools/cleangen/main.go
@@ -41,7 +41,7 @@ func main() {
 
 func getValidArgs() (string, []string) {
 	filename := ""
-	mapTo := []string{}
+	var mapTo []string
 	mapToWrapper := common.StringSliceWrapper{
 		Slice: &mapTo,
 	}

--- a/tools/depsgen/globcmd.go
+++ b/tools/depsgen/globcmd.go
@@ -74,7 +74,7 @@ func globGetArgs(args []string) globArgs {
 	suffix := f.String("suffix", "", "File suffix (example: .go)")
 	globbingMode := f.String("glob-mode", "all", "Which files to glob (normal, dot-files, all [default])")
 	filelist := f.String("filelist", "", "Read all the files from this file")
-	mapTo := []string{}
+	var mapTo []string
 	mapToWrapper := common.StringSliceWrapper{Slice: &mapTo}
 	f.Var(&mapToWrapper, "map-to", "Map contents of filelist to this directory, can be used multiple times")
 

--- a/tools/depsgen/gocmd.go
+++ b/tools/depsgen/gocmd.go
@@ -127,7 +127,7 @@ func goGetFiles(repo string, pkgs []string) []string {
 		"GoFiles",
 		"CgoFiles",
 	}
-	allFiles := []string{}
+	var allFiles []string
 	rawTuples := goRun(goList(params, pkgs))
 	for _, raw := range rawTuples {
 		tuple := goSliceRawTuple(raw)


### PR DESCRIPTION
In order to avoid unnecessarily allocating memory in the case where the
empty slice is never appended to, it's better to use the "var name
[]type" form than the "name := []type{}" form.

See:
https://github.com/golang/go/wiki/CodeReviewComments#declaring-empty-slices