### PR TITLE
Documentation: Add 'file' to lkvm build-time requirements

### DIFF
--- a/Documentation/hacking.md
+++ b/Documentation/hacking.md
@@ -84,6 +84,7 @@ Additional build dependencies for the stage1 kvm follow. If building with docker
 * xz-utils
 * patch
 * bc
+* file
 
 ### Alternative stage1 paths
 


### PR DESCRIPTION
Turns out this wasn't on the fedora image I was using (coreos toolbox), so it's nice to note this.