### PR TITLE
tests: new test for user namespaces

### DIFF
--- a/tests/functional.mk
+++ b/tests/functional.mk
@@ -47,7 +47,7 @@ $(FTST_IMAGE): $(FTST_IMAGE_MANIFEST) $(FTST_ACI_INSPECT) $(FTST_ACI_ECHO_SERVER
 	echo -n dir1 >$(FTST_IMAGE_ROOTFSDIR)/dir1/file
 	echo -n dir2 >$(FTST_IMAGE_ROOTFSDIR)/dir2/file
 	ln -sf /inspect $(FTST_IMAGE_ROOTFSDIR)/inspect-link
-	"$(ACTOOL)" build --overwrite "$(FTST_IMAGE_DIR)" "$@"
+	"$(ACTOOL)" build --overwrite --owner-root "$(FTST_IMAGE_DIR)" "$@"
 
 # variables for makelib/build_go_bin.mk
 BGB_STAMP := $(FTST_FUNCTIONAL_TESTS_STAMP)

--- a/tests/inspect/inspect.go
+++ b/tests/inspect/inspect.go
@@ -49,6 +49,7 @@ var (
 		ExitCode          int
 		ReadFile          bool
 		WriteFile         bool
+		StatFile          bool
 		Sleep             int
 		PreSleep          int
 		PrintMemoryLimit  bool
@@ -82,6 +83,7 @@ func init() {
 	globalFlagset.IntVar(&globalFlags.ExitCode, "exit-code", 0, "Return this exit code")
 	globalFlagset.BoolVar(&globalFlags.ReadFile, "read-file", false, "Print the content of the file $FILE")
 	globalFlagset.BoolVar(&globalFlags.WriteFile, "write-file", false, "Write $CONTENT in the file $FILE")
+	globalFlagset.BoolVar(&globalFlags.StatFile, "stat-file", false, "Print the ownership and mode of the file $FILE")
 	globalFlagset.IntVar(&globalFlags.Sleep, "sleep", -1, "Sleep before exiting (in seconds)")
 	globalFlagset.IntVar(&globalFlags.PreSleep, "pre-sleep", -1, "Sleep before executing (in seconds)")
 	globalFlagset.BoolVar(&globalFlags.PrintMemoryLimit, "print-memorylimit", false, "Print cgroup memory limit")
@@ -243,6 +245,22 @@ func main() {
 		fmt.Print("<<<")
 		fmt.Print(string(dat))
 		fmt.Print(">>>\n")
+	}
+
+	if globalFlags.StatFile {
+		fileName := os.Getenv("FILE")
+		if globalFlags.FileName != "" {
+			fileName = globalFlags.FileName
+		}
+
+		fi, err := os.Stat(fileName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Cannot stat file %q: %v\n", fileName, err)
+			os.Exit(1)
+		}
+		fmt.Printf("%s: mode: %s\n", fileName, fi.Mode().String())
+		fmt.Printf("%s: user: %v\n", fileName, fi.Sys().(*syscall.Stat_t).Uid)
+		fmt.Printf("%s: group: %v\n", fileName, fi.Sys().(*syscall.Stat_t).Gid)
 	}
 
 	if globalFlags.CheckCwd != "" {

--- a/tests/rkt_userns_test.go
+++ b/tests/rkt_userns_test.go
@@ -1,0 +1,89 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
+)
+
+var usernsTests = []struct {
+	runCmd     string
+	file       string
+	expectMode string
+	expectUid  string
+	expectGid  string
+}{
+	{
+		`^RKT_BIN^ --debug --insecure-skip-verify run ^USERNS^ --no-overlay --set-env=FILE=^FILE^ --mds-register=false ^IMAGE^`,
+		"/",    // stage2 rootfs ($POD/stage1/rootfs/opt/stage2/rkt-inspect)
+		"drwx", // TODO: revisit the permissions with #1581
+		"0",
+		"0",
+	},
+	{
+		`^RKT_BIN^ --debug --insecure-skip-verify run ^USERNS^ --no-overlay --set-env=FILE=^FILE^ --mds-register=false ^IMAGE^`,
+		"/proc/1/root/", // stage1 rootfs ($POD/stage1/rootfs)
+		"drwx",          // TODO: revisit the permissions with #1581
+		"0",
+		"", // no check: it could be 0 but also the gid of 'rkt', see https://github.com/coreos/rkt/pull/1452
+	},
+}
+
+func TestUserns(t *testing.T) {
+	image := patchTestACI("rkt-inspect-stat.aci", "--exec=/inspect --stat-file")
+	defer os.Remove(image)
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
+
+	for i, tt := range usernsTests {
+		for _, userNsOpt := range []string{"", "--private-users"} {
+			runCmd := tt.runCmd
+			runCmd = strings.Replace(runCmd, "^IMAGE^", image, -1)
+			runCmd = strings.Replace(runCmd, "^RKT_BIN^", ctx.cmd(), -1)
+			runCmd = strings.Replace(runCmd, "^FILE^", tt.file, -1)
+			runCmd = strings.Replace(runCmd, "^USERNS^", userNsOpt, -1)
+
+			t.Logf("Running 'run' test #%v: %v", i, runCmd)
+			child, err := gexpect.Spawn(runCmd)
+			if err != nil {
+				t.Fatalf("Cannot exec rkt #%v: %v", i, err)
+			}
+
+			err = expectWithOutput(child, tt.file+": mode: "+tt.expectMode)
+			if err != nil {
+				t.Fatalf("Expected %q but not found: %v", tt.expectMode, err)
+			}
+			err = expectWithOutput(child, tt.file+": user: "+tt.expectUid)
+			if err != nil {
+				t.Fatalf("Expected %q but not found: %v", tt.expectUid, err)
+			}
+			err = expectWithOutput(child, tt.file+": group: "+tt.expectGid)
+			if err != nil {
+				t.Fatalf("Expected %q but not found: %v", tt.expectGid, err)
+			}
+
+			err = child.Wait()
+			if err != nil {
+				t.Fatalf("rkt didn't terminate correctly: %v", err)
+			}
+
+			ctx.reset()
+		}
+	}
+}


### PR DESCRIPTION
Check if "/" in the container belongs to root as it should.

Fixes #1531

-----

WIP: the test does not work yet: first, mkdir /proc failed. I added the patch from #1454 to have `/proc` in stage1.aci for testing, and then systemd-nspawn fails to mount it:

```
mount("proc", "/proc", "proc", MS_NOSUID|MS_NODEV|MS_NOEXEC, NULL) = -1 EPERM (Operation not permitted)
```

I need to check whether the regression comes from #1452 or if it is something else...