### PR TITLE
stage1: implement PodManifest.Mounts and --inject-volumes

### DIFF
--- a/common/apps/apps.go
+++ b/common/apps/apps.go
@@ -28,7 +28,7 @@ type App struct {
 	Args   []string       // any arguments the user supplied for this app
 	Asc    string         // signature file override for image verification (if fetching occurs)
 	Exec   string         // exec override for image
-	Mounts []schema.Mount // mounts for this app (superceding any mounts in rktApps.mounts of same MountPoint)
+	Mounts []schema.Mount // mounts for this app (superseding any mounts in rktApps.mounts of same MountPoint)
 
 	// TODO(jonboulle): These images are partially-populated hashes, this should be clarified.
 	ImageID types.Hash // resolved image identifier
@@ -74,7 +74,7 @@ func (al *Apps) Validate() error {
 		for _, m := range mnts {
 			_, ok := vs[m.Volume]
 			if !ok {
-				return fmt.Errorf("dangling mount point %q: volume %q not found", m.MountPoint, m.Volume)
+				return fmt.Errorf("dangling mount point %q: volume %q not found", m.Path, m.Volume)
 			}
 		}
 		return nil

--- a/common/apps/apps.go
+++ b/common/apps/apps.go
@@ -72,8 +72,7 @@ func (al *Apps) Validate() error {
 
 	f := func(mnts []schema.Mount) error {
 		for _, m := range mnts {
-			_, ok := vs[m.Volume]
-			if !ok {
+			if _, ok := vs[m.Volume]; !ok {
 				return fmt.Errorf("dangling mount point %q: volume %q not found", m.Path, m.Volume)
 			}
 		}

--- a/common/apps/apps.go
+++ b/common/apps/apps.go
@@ -17,21 +17,25 @@
 package apps
 
 import (
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
 type App struct {
-	Image string   // the image reference as supplied by the user on the cli
-	Args  []string // any arguments the user supplied for this app
-	Asc   string   // signature file override for image verification (if fetching occurs)
-	Exec  string   // exec override for image
+	Image  string         // the image reference as supplied by the user on the cli
+	Args   []string       // any arguments the user supplied for this app
+	Asc    string         // signature file override for image verification (if fetching occurs)
+	Exec   string         // exec override for image
+	Mounts []schema.Mount // mounts for this app (superceding any mounts in rktApps.mounts of same MountPoint)
 
 	// TODO(jonboulle): These images are partially-populated hashes, this should be clarified.
 	ImageID types.Hash // resolved image identifier
 }
 
 type Apps struct {
-	apps []App
+	apps    []App
+	Mounts  []schema.Mount // global mounts applied to all apps
+	Volumes []types.Volume // volumes available to all apps
 }
 
 // Reset creates a new slice for al.apps, needed by tests

--- a/rkt/cli_apps.go
+++ b/rkt/cli_apps.go
@@ -18,10 +18,15 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
+	"strings"
 
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/pflag"
 	"github.com/coreos/rkt/common/apps"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/pflag"
 )
 
 var (
@@ -146,6 +151,49 @@ func (ae *appExec) Set(s string) error {
 		return fmt.Errorf("--exec specified multiple times for the same image")
 	}
 	app.Exec = s
+}
+
+// appMount is for --mount flags in the form of: --mount volume=VOLNAME,target=MNTNAME
+type appMount apps.Apps
+
+func (al *appMount) Set(s string) error {
+	mount := schema.Mount{}
+
+	// this is intentionally made similar to types.VolumeFromString()
+	m, err := url.ParseQuery(strings.Replace(s, ",", "&", -1))
+	if err != nil {
+		return err
+	}
+
+	for key, val := range m {
+		if len(val) > 1 {
+			return fmt.Errorf("label %s with multiple values %q", key, val)
+		}
+		switch key {
+		// FIXME(vc): ACName seems a bit restrictive for naming volumes and mountpoints...
+		case "volume":
+			mv, err := types.NewACName(val[0])
+			if err != nil {
+				return err
+			}
+			mount.Volume = *mv
+		case "target":
+			mp, err := types.NewACName(val[0])
+			if err != nil {
+				return err
+			}
+			mount.MountPoint = *mp
+		default:
+			return fmt.Errorf("unknown mount parameter %q", key)
+		}
+	}
+
+	if (*apps.Apps)(al).Count() == 0 {
+		(*apps.Apps)(al).Mounts = append((*apps.Apps)(al).Mounts, mount)
+	} else {
+		app := (*apps.Apps)(al).Last()
+		app.Mounts = append(app.Mounts, mount)
+	}
 
 	return nil
 }
@@ -163,3 +211,31 @@ func (ae *appExec) Type() string {
 }
 
 // TODO(vc): --mount, --set-env, etc.
+func (al *appMount) String() string {
+	var ms []string
+	for _, m := range ((*apps.Apps)(al)).Mounts {
+		ms = append(ms, m.Volume.String(), ":", m.MountPoint.String())
+	}
+	return strings.Join(ms, " ")
+}
+
+// appsVolume is for --volume flags in the form name,kind=host,source=/tmp,readOnly=true (defined by appc)
+type appsVolume apps.Apps
+
+func (al *appsVolume) Set(s string) error {
+	vol, err := types.VolumeFromString(s)
+	if err != nil {
+		return err
+	}
+
+	(*apps.Apps)(al).Volumes = append((*apps.Apps)(al).Volumes, *vol)
+	return nil
+}
+
+func (al *appsVolume) String() string {
+	var vs []string
+	for _, v := range (*apps.Apps)(al).Volumes {
+		vs = append(vs, v.String())
+	}
+	return strings.Join(vs, " ")
+}

--- a/rkt/cli_apps.go
+++ b/rkt/cli_apps.go
@@ -103,7 +103,7 @@ func parseApps(al *apps.Apps, args []string, flags *pflag.FlagSet, allowAppArgs 
 		}
 	}
 
-	return nil
+	return al.Validate()
 }
 
 // Value interface implementations for the various per-app fields we provide flags for

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	cmdPrepare = &cobra.Command{
-		Use:   "prepare [--volume=name,kind=host,...] [--quiet] IMAGE [-- image-args...[---]]...",
+		Use:   "prepare [--volume=name,kind=host,...] [--mount volume=VOL,target=PATH] [--quiet] IMAGE [-- image-args...[---]]...",
 		Short: "Prepare to run image(s) in a pod in rkt",
 		Long: `IMAGE should be a string referencing an image; either a hash, local file on disk, or URL.
 They will be checked in that order and the first match will be used.
@@ -47,7 +47,6 @@ func init() {
 	cmdRkt.AddCommand(cmdPrepare)
 
 	addStage1ImageFlag(cmdPrepare.Flags())
-	cmdPrepare.Flags().Var(&flagVolumes, "volume", "volumes to mount into the pod")
 	cmdPrepare.Flags().Var(&flagPorts, "port", "ports to expose on the host (needs contained networking with NAT)")
 	cmdPrepare.Flags().BoolVar(&flagQuiet, "quiet", false, "suppress superfluous output on stdout, print only the UUID on success")
 	cmdPrepare.Flags().BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
@@ -58,8 +57,8 @@ func init() {
 	cmdPrepare.Flags().BoolVar(&flagNoStore, "no-store", false, "fetch images ignoring the local store")
 	cmdPrepare.Flags().StringVar(&flagPodManifest, "pod-manifest", "", "the path to the pod manifest. If it's non-empty, then only '--quiet' and '--no-overlay' will have effects")
 	cmdPrepare.Flags().Var((*appExec)(&rktApps), "exec", "override the exec command for the preceding image")
-	prepareFlags.Var((*appsVolume)(&rktApps), "volume", "volumes to make available in the pod")
-	prepareFlags.Var((*appMount)(&rktApps), "mount", "mount point binding a volume to a path within an app")
+	cmdPrepare.Flags().Var((*appsVolume)(&rktApps), "volume", "volumes to make available in the pod")
+	cmdPrepare.Flags().Var((*appMount)(&rktApps), "mount", "mount point binding a volume to a path within an app")
 
 	// Disable interspersed flags to stop parsing after the first non flag
 	// argument. This is need to permit to correctly handle
@@ -96,7 +95,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	if len(flagPodManifest) > 0 && (len(flagVolumes) > 0 || len(flagPorts) > 0 || flagInheritEnv || !flagExplicitEnv.IsEmpty() || flagStoreOnly || flagNoStore) {
+	if len(flagPodManifest) > 0 && (len(flagPorts) > 0 || flagInheritEnv || !flagExplicitEnv.IsEmpty() || flagStoreOnly || flagNoStore) {
 		stderr("prepare: conflicting flags set with --pod-manifest (see --help)")
 		return 1
 	}

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -58,6 +58,8 @@ func init() {
 	cmdPrepare.Flags().BoolVar(&flagNoStore, "no-store", false, "fetch images ignoring the local store")
 	cmdPrepare.Flags().StringVar(&flagPodManifest, "pod-manifest", "", "the path to the pod manifest. If it's non-empty, then only '--quiet' and '--no-overlay' will have effects")
 	cmdPrepare.Flags().Var((*appExec)(&rktApps), "exec", "override the exec command for the preceding image")
+	prepareFlags.Var((*appsVolume)(&rktApps), "volume", "volumes to make available in the pod")
+	prepareFlags.Var((*appMount)(&rktApps), "mount", "mount point binding a volume to a path within an app")
 
 	// Disable interspersed flags to stop parsing after the first non flag
 	// argument. This is need to permit to correctly handle
@@ -163,7 +165,6 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	if len(flagPodManifest) > 0 {
 		pcfg.PodManifest = flagPodManifest
 	} else {
-		pcfg.Volumes = []types.Volume(flagVolumes)
 		pcfg.Ports = []types.ExposedPort(flagPorts)
 		pcfg.InheritEnv = flagInheritEnv
 		pcfg.ExplicitEnv = flagExplicitEnv.Strings()

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -56,10 +56,12 @@ func init() {
 	cmdPrepare.Flags().BoolVar(&flagStoreOnly, "store-only", false, "use only available images in the store (do not discover or download from remote URLs)")
 	cmdPrepare.Flags().BoolVar(&flagNoStore, "no-store", false, "fetch images ignoring the local store")
 	cmdPrepare.Flags().StringVar(&flagPodManifest, "pod-manifest", "", "the path to the pod manifest. If it's non-empty, then only '--quiet' and '--no-overlay' will have effects")
-	cmdPrepare.Flags().Var((*appExec)(&rktApps), "exec", "override the exec command for the preceding image")
 	cmdPrepare.Flags().Var((*appsVolume)(&rktApps), "volume", "volumes to make available in the pod")
-	cmdPrepare.Flags().Var((*appMount)(&rktApps), "mount", "mount point binding a volume to a path within an app")
 
+	// per-app flags
+	cmdPrepare.Flags().Var((*appExec)(&rktApps), "exec", "override the exec command for the preceding image")
+	cmdPrepare.Flags().Var((*appMount)(&rktApps), "mount", "mount point binding a volume to a path within an app")
+	cmdPrepare.Flags().Var((*appInjectVolume)(&rktApps), "inject-volume", "inject a volume into an app. Syntax: --inject-volume=SOURCE:TARGET")
 	// Disable interspersed flags to stop parsing after the first non flag
 	// argument. This is need to permit to correctly handle
 	// multiple "IMAGE -- imageargs ---"  options

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -66,7 +66,6 @@ func init() {
 	cmdRkt.AddCommand(cmdRun)
 
 	addStage1ImageFlag(cmdRun.Flags())
-	cmdRun.Flags().Var(&flagVolumes, "volume", "volumes to mount into the pod")
 	cmdRun.Flags().Var(&flagPorts, "port", "ports to expose on the host (requires --net)")
 	cmdRun.Flags().Var(&flagNet, "net", "configure the pod's networking and optionally pass a list of user-configured networks to load and arguments to pass to them. syntax: --net[=n[:args], ...]")
 	cmdRun.Flags().Lookup("net").NoOptDefVal = "default"
@@ -81,12 +80,11 @@ func init() {
 	cmdRun.Flags().BoolVar(&flagMDSRegister, "mds-register", true, "register pod with metadata service")
 	cmdRun.Flags().StringVar(&flagUUIDFileSave, "uuid-file-save", "", "write out pod UUID to specified file")
 
-	runFlags.Var((*appsVolume)(&rktApps), "volume", "volumes to make available in the pod")
-	runFlags.Var((*appMount)(&rktApps), "mount", "mount point binding a volume to a path within an app")
-
 	// per-app flags
 	cmdRun.Flags().Var((*appAsc)(&rktApps), "signature", "local signature file to use in validating the preceding image")
 	cmdRun.Flags().Var((*appExec)(&rktApps), "exec", "override the exec command for the preceding image")
+	cmdRun.Flags().Var((*appsVolume)(&rktApps), "volume", "volumes to make available in the pod")
+	cmdRun.Flags().Var((*appMount)(&rktApps), "mount", "mount point binding a volume to a path within an app")
 
 	flagPorts = portList{}
 
@@ -122,7 +120,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	if len(flagPodManifest) > 0 && (len(flagVolumes) > 0 || len(flagPorts) > 0 || flagInheritEnv || !flagExplicitEnv.IsEmpty() || rktApps.Count() > 0 || flagStoreOnly || flagNoStore) {
+	if len(flagPodManifest) > 0 && (len(flagPorts) > 0 || flagInheritEnv || !flagExplicitEnv.IsEmpty() || rktApps.Count() > 0 || flagStoreOnly || flagNoStore) {
 		stderr("conflicting flags set with --pod-manifest (see --help)")
 		return 1
 	}

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -79,12 +79,13 @@ func init() {
 	cmdRun.Flags().StringVar(&flagPodManifest, "pod-manifest", "", "the path to the pod manifest. If it's non-empty, then only '--net', '--no-overlay' and '--interactive' will have effects")
 	cmdRun.Flags().BoolVar(&flagMDSRegister, "mds-register", true, "register pod with metadata service")
 	cmdRun.Flags().StringVar(&flagUUIDFileSave, "uuid-file-save", "", "write out pod UUID to specified file")
+	cmdRun.Flags().Var((*appsVolume)(&rktApps), "volume", "volumes to make available in the pod")
 
 	// per-app flags
 	cmdRun.Flags().Var((*appAsc)(&rktApps), "signature", "local signature file to use in validating the preceding image")
 	cmdRun.Flags().Var((*appExec)(&rktApps), "exec", "override the exec command for the preceding image")
-	cmdRun.Flags().Var((*appsVolume)(&rktApps), "volume", "volumes to make available in the pod")
 	cmdRun.Flags().Var((*appMount)(&rktApps), "mount", "mount point binding a volume to a path within an app")
+	cmdRun.Flags().Var((*appInjectVolume)(&rktApps), "inject-volume", "inject a volume into an app. Syntax: --inject-volume=SOURCE:TARGET")
 
 	flagPorts = portList{}
 

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -41,7 +41,8 @@ They will be checked in that order and the first match will be used.
 Volumes are made available to the container via --volume.
 Mounts bind volumes into each image's root within the container via --mount.
 --mount is position-sensitive; occuring before any images applies to all images,
-occuring after any images applies only to the nearest preceding image.
+occuring after any images applies only to the nearest preceding image. Per-app
+mounts take precedence over global ones if they have the same path.
 
 An "--" may be used to inhibit rkt run's parsing of subsequent arguments,
 which will instead be appended to the preceding image app's exec arguments.

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -144,8 +144,8 @@ func imageNameToAppName(name types.ACIdentifier) (*types.ACName, error) {
 	return types.MustACName(sn), nil
 }
 
-// deduplicateMPs removes mounts with duplicated paths. If there's more than
-// one mount with the same path, it keeps the first one encountered.
+// deduplicateMPs removes Mounts with duplicated paths. If there's more than
+// one Mount with the same path, it keeps the first one encountered.
 func deduplicateMPs(mounts []schema.Mount) []schema.Mount {
 	var res []schema.Mount
 	seen := make(map[string]struct{})
@@ -160,8 +160,7 @@ func deduplicateMPs(mounts []schema.Mount) []schema.Mount {
 
 // MergeMounts combines the global and per-app mount slices
 func MergeMounts(mounts []schema.Mount, appMounts []schema.Mount) []schema.Mount {
-	ml := mounts
-	ml = append(appMounts, ml...)
+	ml := append(appMounts, mounts...)
 	return deduplicateMPs(ml)
 }
 

--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -516,9 +516,8 @@ func (p *Pod) appToNspawnArgs(ra *schema.RuntimeApp) ([]string, error) {
 	}
 
 	for _, mp := range app.MountPoints {
-		_, ok := mounts[mp.Path]
 		// there's already an injected mount for this target path, skip
-		if ok {
+		if _, ok := mounts[mp.Path]; ok {
 			continue
 		}
 		vol, ok := vols[mp.Name]

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -39,7 +39,8 @@ var volTests = []struct {
 		`<<<host>>>`,
 	},
 	{
-		`/bin/sh -c "export FILE=/dir1/file ; ^RKT_BIN^ --debug --insecure-skip-verify run --mds-register=false --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ --mount=volume=dir1,target=dir1^VOL_RO_READ_FILE^"`,
+		`/bin/sh -c "export FILE=/dir1/file ; ^RKT_BIN^ --debug --insecure-skip-verify run --mds-register=false --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ --mount=volume=dir1,target=dir1 ^VOL_RO_READ_FILE^"`,
+		`<<<host>>>`,
 	},
 	// Check that we can write to files in the ACI
 	{

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -35,12 +35,11 @@ var volTests = []struct {
 	},
 	// Check that we can read files from a volume (both ro and rw)
 	{
-		`/bin/sh -c "export FILE=/dir1/file ; ^RKT_BIN^ --debug --insecure-skip-verify run --mds-register=false --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ ^VOL_RW_READ_FILE^"`,
+		`/bin/sh -c "export FILE=/dir1/file ; ^RKT_BIN^ --debug --insecure-skip-verify run --mds-register=false --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ --mount=volume=dir1,target=dir1 ^VOL_RW_READ_FILE^"`,
 		`<<<host>>>`,
 	},
 	{
-		`/bin/sh -c "export FILE=/dir1/file ; ^RKT_BIN^ --debug --insecure-skip-verify run --mds-register=false --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ ^VOL_RO_READ_FILE^"`,
-		`<<<host>>>`,
+		`/bin/sh -c "export FILE=/dir1/file ; ^RKT_BIN^ --debug --insecure-skip-verify run --mds-register=false --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ --mount=volume=dir1,target=dir1^VOL_RO_READ_FILE^"`,
 	},
 	// Check that we can write to files in the ACI
 	{
@@ -49,16 +48,16 @@ var volTests = []struct {
 	},
 	// Check that we can write files to a volume (both ro and rw)
 	{
-		`/bin/sh -c "export FILE=/dir1/file CONTENT=2 ; ^RKT_BIN^ --debug --insecure-skip-verify run --mds-register=false --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ ^VOL_RW_WRITE_FILE^"`,
+		`/bin/sh -c "export FILE=/dir1/file CONTENT=2 ; ^RKT_BIN^ --debug --insecure-skip-verify run --mds-register=false --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ --mount=volume=dir1,target=dir1 ^VOL_RW_WRITE_FILE^"`,
 		`<<<2>>>`,
 	},
 	{
-		`/bin/sh -c "export FILE=/dir1/file CONTENT=3 ; ^RKT_BIN^ --debug --insecure-skip-verify run --mds-register=false --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ ^VOL_RO_WRITE_FILE^"`,
+		`/bin/sh -c "export FILE=/dir1/file CONTENT=3 ; ^RKT_BIN^ --debug --insecure-skip-verify run --mds-register=false --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ --mount=volume=dir1,target=dir1 ^VOL_RO_WRITE_FILE^"`,
 		`Cannot write to file "/dir1/file": open /dir1/file: read-only file system`,
 	},
 	// Check that the volume still contain the file previously written
 	{
-		`/bin/sh -c "export FILE=/dir1/file ; ^RKT_BIN^ --debug --insecure-skip-verify run --mds-register=false --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ ^VOL_RO_READ_FILE^"`,
+		`/bin/sh -c "export FILE=/dir1/file ; ^RKT_BIN^ --debug --insecure-skip-verify run --mds-register=false --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^ --mount=volume=dir1,target=dir1 ^VOL_RO_READ_FILE^"`,
 		`<<<2>>>`,
 	},
 }


### PR DESCRIPTION
Based on #770

#### Implement positional --mount
--mount flags preceding any apps apply globally to all apps,
--mount flags succeeding any apps apply only to the nearest preceding app.

#### Add --inject-volume flag
This flag allows injecting volumes into apps using source and target
paths.

Example:

```
rkt run app.aci --inject-volume /data:/var/lib/data
```

Fixes #1467
Fixes #761