### PR TITLE
Docs: Update docs with new rkt list --full flag

### DIFF
--- a/Documentation/subcommands/image.md
+++ b/Documentation/subcommands/image.md
@@ -6,7 +6,7 @@ You can get a list of images in the local store with their keys, names and impor
 
 ```
 # rkt image list
-KEY                      NAME                            IMPORT TIME            LATEST
+ID                       NAME                            IMPORT TIME            LATEST
 sha512-91e98d7f1679      coreos.com/etcd:v2.0.9          6 days ago             false
 sha512-a03f6bad952b      coreos.com/rkt/stage1:0.7.0     55 minutes ago         false
 ```
@@ -14,18 +14,18 @@ sha512-a03f6bad952b      coreos.com/rkt/stage1:0.7.0     55 minutes ago         
 A more detailed output can be had by adding the `--full` flag
 
 ```
-KEY                                                                       NAME               IMPORT TIME                          LATEST
+ID                                                                        NAME               IMPORT TIME                          LATEST
 sha512-b843248e28fa9132e23e1e763142049d17a61bab7873dff1e1ff105f9ddb2708   redis:latest       2015-09-17 13:27:04.24 +0200 CEST    true
 sha512-fb6b47cc9e7ee29f67422c6585c8f517c16e0e0ee9f4cf8b8cafd8e1c1d29233   redis:latest       2015-09-17 14:57:36.779 +0200 CEST   true
 ```
 
 ## rkt image rm
 
-Given an image key you can remove it from the local store.
+Given an image ID you can remove it from the local store.
 
 ```
 # rkt image rm sha512-a03f6bad952b
-rkt: successfully removed aci for imageID: "sha512-a03f6bad952b"
+rkt: successfully removed aci for image ID: "sha512-a03f6bad952b"
 rkt: 1 image(s) successfully remove
 ```
 

--- a/Documentation/subcommands/list.md
+++ b/Documentation/subcommands/list.md
@@ -2,11 +2,20 @@
 
 You can list all rkt pods.
 
-
 ```
 # rkt list
-UUID		APP	    ACI 		    STATE	NETWORKS
-5bc080ca	redis	redis		    running	default:ip4=172.16.28.7
-        	etcd	coreos.com/etcd
-3089337c	nginx	nginx		    exited
+UUID        APP     IMAGE NAME               STATE      NETWORKS
+5bc080ca    redis   redis                    running    default:ip4=172.16.28.7
+            etcd    coreos.com/etcd:v2.0.9
+3089337c    nginx   nginx                    exited
+```
+
+You can view the full UUID as well as the image's ID by using the `--full` flag
+
+```
+# rkt list --full
+UUID                                   APP     IMAGE NAME              IMAGE ID              STATE      NETWORKS
+5bc080cav-9e03-480d-b705-5928af396cc5  redis   redis                   sha512-91e98d7f1679   running    default:ip4=172.16.28.7
+                                       etcd    coreos.com/etcd:v2.0.9  sha512-a03f6bad952b
+3089337c4-8021-119b-5ea0-879a7c694de4  nginx   nginx                   sha512-32ad6892f21a   exited
 ```


### PR DESCRIPTION
Also updates the docs to use the term "image ID" instead of "key" where
appropriate.