### PR TITLE
semaphore: install the last libmount

### DIFF
--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -18,5 +18,10 @@ if [ "${CI-}" == true ] ; then
 		# install -y <dep>" after it.
 
 		#sudo apt-get update -qq || true
+
+		# libmount: https://github.com/systemd/systemd/pull/986#issuecomment-138451264
+		sudo add-apt-repository --yes ppa:pitti/systemd-semaphore
+		sudo apt-get update -qq || true
+		sudo apt-get install -y libmount-dev libmount1
 	fi
 fi


### PR DESCRIPTION
The src flavor with systemd from git master requires the last version of
libmount.

Symptoms:
> configure: error: *** libmount support required but libraries not found

Semaphore does not have the correct version. This patch installs the
last version as explained on https://github.com/systemd/systemd/pull/986

-----

Let's see how long it takes to run this on Semaphore.