### PR TITLE
stage0: make options output nicer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -187,7 +187,7 @@ AS_VAR_IF([RKT_STAGE1_IMAGE],[auto],
                            [RKT_STAGE1_IMAGE=""
                             AC_MSG_WARN([* It will be necessary to pass --stage1-image flag to run rkt])],
                    dnl other flavors
-                   [RKT_STAGE1_IMAGE="directory/with/rkt/binary/stage1-${RKT_STAGE1_USR_FROM}.aci"])])
+                   [RKT_STAGE1_IMAGE="path/stage1-${RKT_STAGE1_USR_FROM}.aci"])])
 
 RKT_STAGE1_IMAGE_LDFLAGS=`RKT_XF main.defaultStage1Image "${RKT_STAGE1_IMAGE}"`
 

--- a/rkt/help.go
+++ b/rkt/help.go
@@ -139,17 +139,13 @@ func usageFunc(cmd *cobra.Command) error {
 	subCommands := getSubCommands(cmd)
 	tabOut := getTabOutWithWriter(os.Stdout)
 	commandUsageTemplate.Execute(tabOut, struct {
-		Executable  string
 		Cmd         *cobra.Command
-		CmdFlags    *pflag.FlagSet
 		LocalFlags  string
 		GlobalFlags string
 		SubCommands []*cobra.Command
 		Version     string
 	}{
-		cliName,
 		cmd,
-		cmd.Flags(),
 		rktFlagUsages(cmd.LocalFlags()),
 		rktFlagUsages(cmd.InheritedFlags()),
 		subCommands,

--- a/rkt/help.go
+++ b/rkt/help.go
@@ -15,6 +15,8 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"strings"
 	"text/template"
@@ -79,16 +81,49 @@ DESCRIPTION:
 {{if .Cmd.HasLocalFlags}}\
 
 OPTIONS:
-{{.Cmd.LocalFlags.FlagUsages}}\
+{{.LocalFlags}}\
 {{end}}\
 {{if .Cmd.HasInheritedFlags}}\
 
 GLOBAL OPTIONS:
-{{.Cmd.InheritedFlags.FlagUsages}}\
+{{.GlobalFlags}}\
 {{end}}
 `[1:]
 
 	commandUsageTemplate = template.Must(template.New("command_usage").Funcs(templFuncs).Parse(strings.Replace(commandUsage, "\\\n", "", -1)))
+}
+
+func rktFlagUsages(flagSet *pflag.FlagSet) string {
+	x := new(bytes.Buffer)
+
+	flagSet.VisitAll(func(flag *pflag.Flag) {
+		if len(flag.Deprecated) > 0 {
+			return
+		}
+		format := ""
+		if len(flag.Shorthand) > 0 {
+			format = "  -%s, --%s"
+		} else {
+			format = "   %s   --%s"
+		}
+		if len(flag.NoOptDefVal) > 0 {
+			format = format + "["
+		}
+		if flag.Value.Type() == "string" {
+			// put quotes on the value
+			format = format + "=%q"
+		} else {
+			format = format + "=%s"
+		}
+		if len(flag.NoOptDefVal) > 0 {
+			format = format + "]"
+		}
+		format = format + "\t%s\n"
+		shorthand := flag.Shorthand
+		fmt.Fprintf(x, format, shorthand, flag.Name, flag.DefValue, flag.Usage)
+	})
+
+	return x.String()
 }
 
 func getSubCommands(cmd *cobra.Command) []*cobra.Command {
@@ -107,12 +142,16 @@ func usageFunc(cmd *cobra.Command) error {
 		Executable  string
 		Cmd         *cobra.Command
 		CmdFlags    *pflag.FlagSet
+		LocalFlags  string
+		GlobalFlags string
 		SubCommands []*cobra.Command
 		Version     string
 	}{
 		cliName,
 		cmd,
 		cmd.Flags(),
+		rktFlagUsages(cmd.LocalFlags()),
+		rktFlagUsages(cmd.InheritedFlags()),
 		subCommands,
 		version.Version,
 	})

--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -177,7 +177,7 @@ func init() {
 	cmdImageList.Flags().Var(&flagImagesSortFields, "sort", `sort the output according to the provided comma separated list of fields. Accepted values: "name", "importtime"`)
 	cmdImageList.Flags().Var(&flagImagesSortAsc, "order", `choose the sorting order if at least one sort field is provided (--sort). Accepted values: "asc", "desc"`)
 	cmdImageList.Flags().BoolVar(&flagNoLegend, "no-legend", false, "suppress a legend with the list")
-	cmdImageList.Flags().BoolVar(&flagFullOutput, "full", false, "Use long output format")
+	cmdImageList.Flags().BoolVar(&flagFullOutput, "full", false, "use long output format")
 }
 
 func runImages(cmd *cobra.Command, args []string) int {

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -54,7 +54,7 @@ func init() {
 	cmdPrepare.Flags().BoolVar(&flagQuiet, "quiet", false, "suppress superfluous output on stdout, print only the UUID on success")
 	cmdPrepare.Flags().BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	cmdPrepare.Flags().BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
-	cmdPrepare.Flags().BoolVar(&flagPrivateUsers, "private-users", false, "Run within user namespaces (experimental).")
+	cmdPrepare.Flags().BoolVar(&flagPrivateUsers, "private-users", false, "run within user namespaces (experimental).")
 	cmdPrepare.Flags().Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
 	cmdPrepare.Flags().BoolVar(&flagStoreOnly, "store-only", false, "use only available images in the store (do not discover or download from remote URLs)")
 	cmdPrepare.Flags().BoolVar(&flagNoStore, "no-store", false, "fetch images ignoring the local store")

--- a/rkt/rkt.go
+++ b/rkt/rkt.go
@@ -57,7 +57,7 @@ var cmdRkt = &cobra.Command{
 }
 
 func init() {
-	cmdRkt.PersistentFlags().BoolVar(&globalFlags.Debug, "debug", false, "Print out more debug information to stderr")
+	cmdRkt.PersistentFlags().BoolVar(&globalFlags.Debug, "debug", false, "print out more debug information to stderr")
 	cmdRkt.PersistentFlags().StringVar(&globalFlags.Dir, "dir", defaultDataDir, "rkt data directory")
 	cmdRkt.PersistentFlags().StringVar(&globalFlags.SystemConfigDir, "system-config", common.DefaultSystemConfigDir, "system configuration directory")
 	cmdRkt.PersistentFlags().StringVar(&globalFlags.LocalConfigDir, "local-config", common.DefaultLocalConfigDir, "local configuration directory")


### PR DESCRIPTION
While help output for the commands is nicely formatted with a gutter between the command name and the description, the options were not formatted so nicely. This change formats the options nicely as well.

This should close issue #1113.