### PR TITLE
docs: add syntax hints to code blocks

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -66,7 +66,7 @@ this type, define `type` as `basic` and the `credentials` field as a map
 with two keys - `user` and `password`. These fields must be specified and
 cannot be empty. For example:
 
-```
+```json
 {
 	"rktKind": "auth",
 	"rktVersion": "v1",
@@ -83,7 +83,7 @@ OAuth Bearer Token authentication requires only a token. To use this type,
 define `type` as `oauth` and the `credentials` field as a map with only one
 key - `token`. This field must be specified and cannot be empty. For example:
 
-```
+```json
 {
 	"rktKind": "auth",
 	"rktVersion": "v1",
@@ -103,7 +103,7 @@ consider this system configuration:
 
 `/usr/lib/rkt/auth.d/coreos.json`:
 
-```
+```json
 {
 	"rktKind": "auth",
 	"rktVersion": "v1",
@@ -125,7 +125,7 @@ configuration and the following local configurations:
 
 `/etc/rkt/auth.d/specific-coreos.json`:
 
-```
+```json
 {
 	"rktKind": "auth",
 	"rktVersion": "v1",
@@ -140,7 +140,7 @@ configuration and the following local configurations:
 
 `/etc/rkt/auth.d/specific-tectonic.json`:
 
-```
+```json
 {
 	"rktKind": "auth",
 	"rktVersion": "v1",
@@ -195,7 +195,7 @@ Some popular Docker registries:
 
 Example `dockerAuth` configuration:
 
-```
+```json
 {
 	"rktKind": "dockerAuth",
 	"rktVersion": "v1",
@@ -214,7 +214,7 @@ credentials used for each registry. For example, given this system configuration
 
 In `/usr/lib/rkt/auth.d/docker.json`:
 
-```
+```json
 {
 	"rktKind": "dockerAuth",
 	"rktVersion": "v1",
@@ -236,7 +236,7 @@ configuration and the following local configuration:
 
 `/etc/rkt/auth.d/specific-quay.json`:
 
-```
+```json
 {
 	"rktKind": "dockerAuth",
 	"rktVersion": "v1",
@@ -250,7 +250,7 @@ configuration and the following local configuration:
 
 `/etc/rkt/auth.d/specific-gcr.json`:
 
-```
+```json
 {
 	"rktKind": "dockerAuth",
 	"rktVersion": "v1",

--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -83,7 +83,7 @@ Examples
 
 ### Stage1 ACI manifest
 
-```
+```json
 {
     "acKind": "ImageManifest",
     "acVersion": "0.7.0",

--- a/Documentation/getting-started-guide.md
+++ b/Documentation/getting-started-guide.md
@@ -5,7 +5,7 @@ rkt, the reference implementation of the [App Container Specification](https://g
 
 ## Create a hello go application
 
-```
+```go
 package main
 
 import (
@@ -52,7 +52,7 @@ $ ldd hello
 
 Edit: manifest.json
 
-```
+```json
 {
     "acKind": "ImageManifest",
     "acVersion": "0.7.0",

--- a/Documentation/signing-and-verification-guide.md
+++ b/Documentation/signing-and-verification-guide.md
@@ -141,7 +141,7 @@ pubkeys.gpg
 
 Host an HTML page with the following meta tags:
 
-```
+```html
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -99,7 +99,7 @@ We also want this data to be available to a backup application that runs alongsi
 
 Below we show the abbreviated manifests for the respective applications (recall that the manifest is bundled into the application's ACI):
 
-```
+```json
 {
     "acKind": "ImageManifest",
     "name": "example.com/reduce-worker",
@@ -117,7 +117,7 @@ Below we show the abbreviated manifests for the respective applications (recall 
 }
 ```
 
-```
+```json
 {
     "acKind": "ImageManifest",
     "name": "example.com/worker-backup",

--- a/Documentation/subcommands/trust.md
+++ b/Documentation/subcommands/trust.md
@@ -24,7 +24,7 @@ To trust a key for an entire root domain, you must use the `--root` flag, with a
 
 The easiest way to trust a key is through meta discovery. rkt will find and download a public key that the creator has published on their website. This process is detailed in the [Application Container specification][appc-discovery]. The TL;DR is rkt will find a meta tag that looks like:
 
-```
+```html
 <meta name="ac-discovery-pubkeys" content="coreos.com/etcd https://coreos.com/dist/pubkeys/aci-pubkeys.gpg">
 ```
 

--- a/Documentation/using-rkt-with-systemd.md
+++ b/Documentation/using-rkt-with-systemd.md
@@ -121,7 +121,7 @@ Note that your application needs to be able to accept sockets from systemd's nat
 
 To make socket activation work, you need to add to your application manifest a [socket-activated port](https://github.com/appc/spec/blob/master/spec/aci.md#image-manifest-schema):
 
-```
+```json
 ...
 {
 ...


### PR DESCRIPTION
Just added some syntax highlighting hints to make the docs a bit shinier.