### PR TITLE
functional tests: Stop installing new libmount

### DIFF
--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -20,8 +20,8 @@ if [ "${CI-}" == true ] ; then
 		#sudo apt-get update -qq || true
 
 		# libmount: https://github.com/systemd/systemd/pull/986#issuecomment-138451264
-		sudo add-apt-repository --yes ppa:pitti/systemd-semaphore
-		sudo apt-get update -qq || true
-		sudo apt-get install -y libmount-dev libmount1
+		# sudo add-apt-repository --yes ppa:pitti/systemd-semaphore
+		# sudo apt-get update -qq || true
+		# sudo apt-get install -y libmount-dev libmount1
 	fi
 fi


### PR DESCRIPTION
This new version is required by systemd from master, but for now we
stopped building it in semaphore.