### PR TITLE
ci: allow skipping ci runs via keyword in commit msg

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,10 @@ The tests run on the [Semaphore](https://semaphoreci.com/) CI system through the
 This user is authorized against the corresponding [`rktbot`](https://github.com/rktbot) GitHub account.
 The credentials for `rktbot` are currently managed by CoreOS.
 
+The tests are executed on Semaphore at each Pull Request (PR). Each GitHub PR page should have a link to the [test results on Semaphore](https://semaphoreci.com/coreos/rkt).
+
+Developers can disable the tests by adding `[skip ci]` in the last commit message of the PR.
+
 ### Build settings
 
 Use "Other" language and the following build commands:

--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -2,6 +2,16 @@
 
 # Helper script for Continuous Integration Services
 
+# Check if the last commit message requests the CI to skip the build.
+git log HEAD~..HEAD > last-commit
+if grep -qE '[ci skip]|[skip ci]' last-commit ; then
+    cat last-commit
+    echo
+    echo "Build skipped as requested in the last commit."
+    touch ci-skip
+    exit 0
+fi
+
 if [ "${CI-}" == true ] ; then
 	# https://semaphoreci.com/
 	if [ "${SEMAPHORE-}" == true ] ; then

--- a/tests/run-build.sh
+++ b/tests/run-build.sh
@@ -2,6 +2,14 @@
 
 set -e
 
+# Skip build if requested
+if test -e ci-skip ; then
+    cat last-commit
+    echo
+    echo "Build skipped as requested in the last commit."
+    exit 0
+fi
+
 # Setup go environment on semaphore
 if [ -f /opt/change-go-version.sh ]; then
     . /opt/change-go-version.sh


### PR DESCRIPTION
Just add "[skip ci]" somewhere in the commit message to skip the build in CI.
