### PR TITLE
directory parameters: allow relative paths

### DIFF
--- a/rkt/enter.go
+++ b/rkt/enter.go
@@ -93,7 +93,7 @@ func runEnter(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(globalFlags.Dir.String())
 	if err != nil {
 		stderr("Cannot open store: %v", err)
 		return 1

--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -65,7 +65,7 @@ func runFetch(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(globalFlags.Dir.String())
 	if err != nil {
 		stderr("fetch: cannot open store: %v", err)
 		return 1

--- a/rkt/gc.go
+++ b/rkt/gc.go
@@ -185,7 +185,7 @@ func deletePod(p *pod) {
 	}
 
 	if p.isExitedGarbage {
-		s, err := store.NewStore(globalFlags.Dir)
+		s, err := store.NewStore(globalFlags.Dir.String())
 		if err != nil {
 			stderr("Cannot open store: %v", err)
 			return

--- a/rkt/image_cat_manifest.go
+++ b/rkt/image_cat_manifest.go
@@ -43,7 +43,7 @@ func runImageCatManifest(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(globalFlags.Dir.String())
 	if err != nil {
 		stderr("image cat-manifest: cannot open store: %v", err)
 		return 1

--- a/rkt/image_export.go
+++ b/rkt/image_export.go
@@ -44,7 +44,7 @@ func runImageExport(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(globalFlags.Dir.String())
 	if err != nil {
 		stderr("image export: cannot open store: %v", err)
 		return 1

--- a/rkt/image_extract.go
+++ b/rkt/image_extract.go
@@ -52,7 +52,7 @@ func runImageExtract(cmd *cobra.Command, args []string) (exit int) {
 	}
 	outputDir := args[1]
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(globalFlags.Dir.String())
 	if err != nil {
 		stderr("image extract: cannot open store: %v", err)
 		return 1

--- a/rkt/image_gc.go
+++ b/rkt/image_gc.go
@@ -36,7 +36,7 @@ func init() {
 }
 
 func runGcImage(cmd *cobra.Command, args []string) (exit int) {
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(globalFlags.Dir.String())
 	if err != nil {
 		stderr("rkt: cannot open store: %v", err)
 		return 1

--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -193,7 +193,7 @@ func runImages(cmd *cobra.Command, args []string) int {
 		fmt.Fprintf(tabOut, "%s\n", strings.Join(headerFields, "\t"))
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(globalFlags.Dir.String())
 	if err != nil {
 		stderr("images: cannot open store: %v\n", err)
 		return 1

--- a/rkt/image_render.go
+++ b/rkt/image_render.go
@@ -51,7 +51,7 @@ func runImageRender(cmd *cobra.Command, args []string) (exit int) {
 	}
 	outputDir := args[1]
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(globalFlags.Dir.String())
 	if err != nil {
 		stderr("image render: cannot open store: %v", err)
 		return 1

--- a/rkt/image_rm.go
+++ b/rkt/image_rm.go
@@ -38,7 +38,7 @@ func runRmImage(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(globalFlags.Dir.String())
 	if err != nil {
 		stderr("rkt: cannot open store: %v", err)
 		return 1

--- a/rkt/install.go
+++ b/rkt/install.go
@@ -94,7 +94,7 @@ func setPermissions(path string, uid int, gid int, perm os.FileMode) error {
 
 func createDirStructure(gid int) error {
 	for dir, perm := range dirs {
-		path := filepath.Join(globalFlags.Dir, dir)
+		path := filepath.Join(globalFlags.Dir.String(), dir)
 
 		if err := os.MkdirAll(path, perm); err != nil {
 			return fmt.Errorf("error creating %q directory: %v", path, err)
@@ -160,7 +160,7 @@ func runInstall(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	casDbPath := filepath.Join(globalFlags.Dir, "cas", "db")
+	casDbPath := filepath.Join(globalFlags.Dir.String(), "cas", "db")
 	if err := setCasDbFilesPermissions(casDbPath, gid, casDbPerm); err != nil {
 		stderr("install: error setting cas db permissions: %v", err)
 		return 1

--- a/rkt/list.go
+++ b/rkt/list.go
@@ -47,7 +47,7 @@ func init() {
 }
 
 func runList(cmd *cobra.Command, args []string) int {
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(globalFlags.Dir.String())
 	if err != nil {
 		stderr("list: cannot open store: %v", err)
 		return 1

--- a/rkt/pods_test.go
+++ b/rkt/pods_test.go
@@ -119,7 +119,7 @@ func TestWalkPods(t *testing.T) {
 		}
 		defer os.RemoveAll(d)
 
-		globalFlags.Dir = d
+		globalFlags.Dir = absDir{d}
 		if err := initPods(); err != nil {
 			t.Fatalf("error initializing pods: %v", err)
 		}

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -17,8 +17,6 @@
 package main
 
 import (
-	"io/ioutil"
-	"log"
 	"os"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
@@ -106,16 +104,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	if globalFlags.Dir == "" {
-		log.Printf("dir unset - using temporary directory")
-		globalFlags.Dir, err = ioutil.TempDir("", "rkt")
-		if err != nil {
-			stderr("prepare: error creating temporary directory: %v", err)
-			return 1
-		}
-	}
-
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(globalFlags.Dir.String())
 	if err != nil {
 		stderr("prepare: cannot open store: %v", err)
 		return 1

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -18,8 +18,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
-	"log"
 	"strconv"
 	"strings"
 
@@ -123,16 +121,6 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	if globalFlags.Dir == "" {
-		log.Printf("dir unset - using temporary directory")
-		var err error
-		globalFlags.Dir, err = ioutil.TempDir("", "rkt")
-		if err != nil {
-			stderr("error creating temporary directory: %v", err)
-			return 1
-		}
-	}
-
 	if flagInteractive && rktApps.Count() > 1 {
 		stderr("run: interactive option only supports one image")
 		return 1
@@ -143,7 +131,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(globalFlags.Dir.String())
 	if err != nil {
 		stderr("run: cannot open store: %v", err)
 		return 1
@@ -268,7 +256,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		LockFd:       lfd,
 		Interactive:  flagInteractive,
 		MDSRegister:  flagMDSRegister,
-		LocalConfig:  globalFlags.LocalConfigDir,
+		LocalConfig:  globalFlags.LocalConfigDir.String(),
 		RktGid:       rktgid,
 	}
 
@@ -278,7 +266,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 	rcfg.Apps = apps
-	stage0.Run(rcfg, p.path(), globalFlags.Dir) // execs, never returns
+	stage0.Run(rcfg, p.path(), globalFlags.Dir.String()) // execs, never returns
 
 	return 1
 }

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -17,9 +17,6 @@
 package main
 
 import (
-	"io/ioutil"
-	"log"
-
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/stage0"
@@ -60,17 +57,7 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	if globalFlags.Dir == "" {
-		log.Printf("dir unset - using temporary directory")
-		var err error
-		globalFlags.Dir, err = ioutil.TempDir("", "rkt")
-		if err != nil {
-			stderr("error creating temporary directory: %v", err)
-			return 1
-		}
-	}
-
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(globalFlags.Dir.String())
 	if err != nil {
 		stderr("prepared-run: cannot open store: %v", err)
 		return 1
@@ -148,6 +135,6 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 	if globalFlags.Debug {
 		stage0.InitDebug()
 	}
-	stage0.Run(rcfg, p.path(), globalFlags.Dir) // execs, never returns
+	stage0.Run(rcfg, p.path(), globalFlags.Dir.String()) // execs, never returns
 	return 1
 }


### PR DESCRIPTION
The parameters --dir=, --system-config= and --local-config= used to only
accept absolute paths. This patch changes the type of the parameters
from string to absDir. When the flag is parsed, the potentially relative
path is converted to an absolute path automatically.

The parameters still have the same defaults. It is no longer allowed to
pass an empty string (e.g. --dir="" is not allowed).

The value can be accessed using "globalFlags.Dir.String()". This makes
this patch big because I had to add the ".String()" suffix each time the
values are accessed.

Fixes https://github.com/coreos/rkt/issues/1605

-----

- Is there a better way than adding the `.String()` suffix in a lot of places?
- The new type `absDir` is defined in `rkt/rkt.go`. Any better place?