### PR TITLE
directory parameters: allow relative paths

### DIFF
--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -17,8 +17,6 @@
 package main
 
 import (
-	"io/ioutil"
-	"log"
 	"os"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
@@ -104,15 +102,6 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	if rktApps.Count() < 1 && len(flagPodManifest) == 0 {
 		stderr("prepare: must provide at least one image or specify the pod manifest")
 		return 1
-	}
-
-	if globalFlags.Dir == "" {
-		log.Printf("dir unset - using temporary directory")
-		globalFlags.Dir, err = ioutil.TempDir("", "rkt")
-		if err != nil {
-			stderr("prepare: error creating temporary directory: %v", err)
-			return 1
-		}
 	}
 
 	s, err := store.NewStore(globalFlags.Dir)

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -18,8 +18,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
-	"log"
 	"strconv"
 	"strings"
 
@@ -121,16 +119,6 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 	if len(flagPodManifest) > 0 && (len(flagVolumes) > 0 || len(flagPorts) > 0 || flagInheritEnv || !flagExplicitEnv.IsEmpty() || rktApps.Count() > 0 || flagStoreOnly || flagNoStore) {
 		stderr("conflicting flags set with --pod-manifest (see --help)")
 		return 1
-	}
-
-	if globalFlags.Dir == "" {
-		log.Printf("dir unset - using temporary directory")
-		var err error
-		globalFlags.Dir, err = ioutil.TempDir("", "rkt")
-		if err != nil {
-			stderr("error creating temporary directory: %v", err)
-			return 1
-		}
 	}
 
 	if flagInteractive && rktApps.Count() > 1 {

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -17,9 +17,6 @@
 package main
 
 import (
-	"io/ioutil"
-	"log"
-
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/stage0"
@@ -58,16 +55,6 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 	if err != nil {
 		stderr("Unable to resolve UUID: %v", err)
 		return 1
-	}
-
-	if globalFlags.Dir == "" {
-		log.Printf("dir unset - using temporary directory")
-		var err error
-		globalFlags.Dir, err = ioutil.TempDir("", "rkt")
-		if err != nil {
-			stderr("error creating temporary directory: %v", err)
-			return 1
-		}
 	}
 
 	s, err := store.NewStore(globalFlags.Dir)


### PR DESCRIPTION
The parameters --dir=, --system-config= and --local-config= used to only
accept absolute paths. This patch changes the type of the parameters
from string to absDir. When the flag is parsed, the potentially relative
path is converted to an absolute path automatically.

The parameters still have the same defaults. It is no longer allowed to
pass an empty string (e.g. --dir="" is not allowed).

Fixes https://github.com/coreos/rkt/issues/1605