### PR TITLE
pkg/tar: rename extractTar to ExtractTarInsecure

### DIFF
--- a/pkg/tar/chroot.go
+++ b/pkg/tar/chroot.go
@@ -80,7 +80,11 @@ func extractTarCommand() error {
 	if err := json.NewDecoder(fileMapFile).Decode(&fileMap); err != nil {
 		return fmt.Errorf("error decoding fileMap: %v", err)
 	}
-	if err := extractTar(tar.NewReader(os.Stdin), overwrite, fileMap, uidRange); err != nil {
+	editor, err := NewUidShiftingFilePermEditor(uidRange)
+	if err != nil {
+		return fmt.Errorf("error determining current user: %v", err)
+	}
+	if err := ExtractTarInsecure(tar.NewReader(os.Stdin), "/", overwrite, fileMap, editor); err != nil {
 		return fmt.Errorf("error extracting tar: %v", err)
 	}
 


### PR DESCRIPTION
It would be useful in acbuild to be able to untar ACIs without
chrooting, so this commit makes the function that does the extracting of
the tar file exposed. With this change the tar package exposes an
ExtractTar function for extracting an ACI inside of a chroot, and an
ExtractTarInsecure function for extracting an ACI without any chroot
happening.