### PR TITLE
rkt: removePod: fix switch order

### DIFF
--- a/rkt/rm.go
+++ b/rkt/rm.go
@@ -116,13 +116,15 @@ func removePod(p *pod) bool {
 			return false
 		}
 
+	// p.isExitedGarbage and p.isExited can be true at the same time. Test
+	// the most specific case first.
+	case p.isExitedGarbage, p.isGarbage:
+
 	case p.isExited:
 		if err := p.xToExitedGarbage(); err != nil && err != os.ErrNotExist {
 			stderr("Rename error: %v", err)
 			return false
 		}
-
-	case p.isExitedGarbage, p.isGarbage:
 	}
 
 	if err := p.ExclusiveLock(); err != nil {


### PR DESCRIPTION
p.isExitedGarbage and p.isExited can both be true at the same time. Fix
the tests order in the switch, so we don't move a pod to garbage if it
is already in garbage.

Fixes https://github.com/coreos/rkt/issues/1620

-----

/cc @vcaputo 