### PR TITLE
stage1: quote exec[0]

### DIFF
--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -107,6 +107,14 @@ func LoadPod(root string, uuid *types.UUID) (*Pod, error) {
 	return p, nil
 }
 
+func simpleEscape(str string) string {
+	esc := strings.Replace(str, `\`, `\\`, -1)
+	esc = strings.Replace(esc, `"`, `\"`, -1)
+	esc = strings.Replace(esc, `'`, `\'`, -1)
+
+	return esc
+}
+
 // quoteExec returns an array of quoted strings appropriate for systemd execStart usage
 func quoteExec(exec []string) string {
 	if len(exec) == 0 {
@@ -115,15 +123,12 @@ func quoteExec(exec []string) string {
 	}
 
 	var qexec []string
-	qexec = append(qexec, exec[0])
-	// FIXME(vc): systemd gets angry if qexec[0] is quoted
-	// https://bugs.freedesktop.org/show_bug.cgi?id=86171
+	escExec := simpleEscape(exec[0])
+	qexec = append(qexec, `"`+escExec+`"`)
 
 	if len(exec) > 1 {
 		for _, arg := range exec[1:] {
-			escArg := strings.Replace(arg, `\`, `\\`, -1)
-			escArg = strings.Replace(escArg, `"`, `\"`, -1)
-			escArg = strings.Replace(escArg, `'`, `\'`, -1)
+			escArg := simpleEscape(arg)
 			escArg = strings.Replace(escArg, `$`, `$$`, -1)
 			qexec = append(qexec, `"`+escArg+`"`)
 		}

--- a/stage1/init/pod_test.go
+++ b/stage1/init/pod_test.go
@@ -25,16 +25,25 @@ func TestQuoteExec(t *testing.T) {
 	}{
 		{
 			input:  []string{`path`, `"arg1"`, `"'arg2'"`, `'arg3'`},
-			output: `path "\"arg1\"" "\"\'arg2\'\"" "\'arg3\'"`,
+			output: `"path" "\"arg1\"" "\"\'arg2\'\"" "\'arg3\'"`,
 		}, {
 			input:  []string{`path`},
-			output: `path`,
+			output: `"path"`,
 		}, {
 			input:  []string{`path`, ``, `arg2`},
-			output: `path "" "arg2"`,
+			output: `"path" "" "arg2"`,
 		}, {
 			input:  []string{`path`, `"foo\bar"`, `\`},
-			output: `path "\"foo\\bar\"" "\\"`,
+			output: `"path" "\"foo\\bar\"" "\\"`,
+		}, {
+			input:  []string{`path with spaces`, `"foo\bar"`, `\`},
+			output: `"path with spaces" "\"foo\\bar\"" "\\"`,
+		}, {
+			input:  []string{`path with "quo't'es" and \slashes`, `"arg"`, `\`},
+			output: `"path with \"quo\'t\'es\" and \\slashes" "\"arg\"" "\\"`,
+		}, {
+			input:  []string{`$path$`},
+			output: `"$path$"`,
 		},
 	}
 


### PR DESCRIPTION
Now that we use systemd v222 in stage1 we can quote the executable path.
This allows it to contain spaces.

Fixes #1466