### PR TITLE
Allow loopback only networking

### DIFF
--- a/Documentation/app-container.md
+++ b/Documentation/app-container.md
@@ -25,9 +25,10 @@ To validate that `rkt` successfully implements the ACE part of the spec, use the
 ```
 # rkt metadata-service &  # Make sure metadata service is running
 # rkt --insecure-skip-verify run \
+	--mds-register \
 	--volume=database,kind=host,source=/tmp \
-	https://github.com/appc/spec/releases/download/v0.5.1/ace-validator-main.aci \
-	https://github.com/appc/spec/releases/download/v0.5.1/ace-validator-sidekick.aci
+	https://github.com/appc/spec/releases/download/v0.7.0/ace-validator-main.aci \
+	https://github.com/appc/spec/releases/download/v0.7.0/ace-validator-sidekick.aci
 ```
 
 [appc-repo]: https://github.com/appc/spec/

--- a/Documentation/networking.md
+++ b/Documentation/networking.md
@@ -47,8 +47,10 @@ The *default-restricted* network does not set up the default route and IP masque
 It only allows communication with the host via the veth interface and thus enables the pod to communicate with the metadata service which runs on the host.
 If *default* is not among the specified networks, the *default-restricted* network will be added to the list of networks automatically.
 It can also be loaded directly by explicitly passing `--net=default-restricted`.
-The special alias network name ***none*** (`--net=none`) will effectively load the *default-restricted* network to always guarantee access to the metadata service that runs on the host.
 
+### No (loopback only) networking
+The passing of `--net=none` will put the pod in a network namespace with only the loopback networking.
+This can be used to completely isolate the pods network.
 
 ### Setting up additional networks
 In addition to the default network (veth) described in the previous sections, rkt pods can be configured to join additional networks.

--- a/networking/podenv.go
+++ b/networking/podenv.go
@@ -64,6 +64,10 @@ func (e *podEnv) loadNets() ([]activeNet, error) {
 		return nil, err
 	}
 
+	if e.netsLoadList.None() {
+		return nets, nil
+	}
+
 	if !netExists(nets, "default") && !netExists(nets, "default-restricted") {
 		var defaultNet string
 		if e.netsLoadList.Specific("default") || e.netsLoadList.All() {
@@ -218,16 +222,19 @@ func copyFileToDir(src, dstdir string) (string, error) {
 }
 
 func loadUserNets(localConfig string, netsLoadList common.NetList) ([]activeNet, error) {
+	if netsLoadList.None() {
+		log.Printf("Networking namespace with loopback only")
+		return nil, nil
+	}
+
 	userNetPath := filepath.Join(localConfig, UserNetPathSuffix)
-	log.Printf("Loading networks from %v\n", userNetPath)
+	log.Printf("Loading networks from %v", userNetPath)
 
 	files, err := listFiles(userNetPath)
 	if err != nil {
 		return nil, err
 	}
-
 	sort.Strings(files)
-
 	nets := make([]activeNet, 0, len(files))
 
 	for _, filename := range files {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -117,8 +117,17 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		privateUsers.SetRandomUidRange(uid.DefaultRangeCount)
 	}
 
-	if len(flagPorts) > 0 && !flagNet.Any() {
-		stderr("--port flag requires --net")
+	if len(flagPorts) > 0 && flagNet.None() {
+		stderr("--port flag does not work with 'none' networking")
+		return 1
+	}
+	if len(flagPorts) > 0 && flagNet.Host() {
+		stderr("--port flag does not work with 'host' networking")
+		return 1
+	}
+
+	if flagMDSRegister && flagNet.None() {
+		stderr("--mds-register flag does not work with --net=none. Please use 'host', 'default' or an equivalent network")
 		return 1
 	}
 

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -78,7 +78,7 @@ func init() {
 	cmdRun.Flags().BoolVar(&flagStoreOnly, "store-only", false, "use only available images in the store (do not discover or download from remote URLs)")
 	cmdRun.Flags().BoolVar(&flagNoStore, "no-store", false, "fetch images ignoring the local store")
 	cmdRun.Flags().StringVar(&flagPodManifest, "pod-manifest", "", "the path to the pod manifest. If it's non-empty, then only '--net', '--no-overlay' and '--interactive' will have effects")
-	cmdRun.Flags().BoolVar(&flagMDSRegister, "mds-register", true, "register pod with metadata service")
+	cmdRun.Flags().BoolVar(&flagMDSRegister, "mds-register", false, "register pod with metadata service. needs network connectivity to the host (--net=(default|default-restricted|host)")
 	cmdRun.Flags().StringVar(&flagUUIDFileSave, "uuid-file-save", "", "write out pod UUID to specified file")
 	cmdRun.Flags().Var((*appsVolume)(&rktApps), "volume", "volumes to make available in the pod")
 

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -42,7 +42,7 @@ func init() {
 	cmdRunPrepared.Flags().Var(&flagNet, "net", "configure the pod's networking. optionally pass a list of user-configured networks to load and arguments to pass to them. syntax: --net[=n[:args]][,]")
 	cmdRunPrepared.Flags().Lookup("net").NoOptDefVal = "default"
 	cmdRunPrepared.Flags().BoolVar(&flagInteractive, "interactive", false, "the pod is interactive")
-	cmdRunPrepared.Flags().BoolVar(&flagMDSRegister, "mds-register", true, "register pod with metadata service")
+	cmdRunPrepared.Flags().BoolVar(&flagMDSRegister, "mds-register", false, "register pod with metadata service")
 }
 
 func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -552,7 +552,7 @@ func stage1() int {
 	}
 
 	var n *networking.Networking
-	if netList.Any() {
+	if netList.Contained() {
 		fps, err := forwardedPorts(p)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())

--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -248,7 +248,9 @@ func (p *Pod) appToSystemd(ra *schema.RuntimeApp, interactive bool, flavor strin
 	env := app.Environment
 
 	env.Set("AC_APP_NAME", appName.String())
-	env.Set("AC_METADATA_URL", p.MetadataServiceURL)
+	if p.MetadataServiceURL != "" {
+		env.Set("AC_METADATA_URL", p.MetadataServiceURL)
+	}
 
 	if err := p.writeEnvFile(env, appName, privateUsers); err != nil {
 		return fmt.Errorf("unable to write environment file: %v", err)

--- a/tests/inspect/inspect.go
+++ b/tests/inspect/inspect.go
@@ -67,6 +67,7 @@ var (
 		GetHttp           string
 		ServeHttp         string
 		ServeHttpTimeout  int
+		PrintIfaceCount   bool
 	}{}
 )
 
@@ -101,6 +102,7 @@ func init() {
 	globalFlagset.StringVar(&globalFlags.GetHttp, "get-http", "", "HTTP-Get from the given address")
 	globalFlagset.StringVar(&globalFlags.ServeHttp, "serve-http", "", "Serve the hostname via HTTP on the given address:port")
 	globalFlagset.IntVar(&globalFlags.ServeHttpTimeout, "serve-http-timeout", 30, "HTTP Timeout to wait for a client connection")
+	globalFlagset.BoolVar(&globalFlags.PrintIfaceCount, "print-iface-count", false, "Print the interface count")
 }
 
 func in(list []int, el int) bool {
@@ -426,6 +428,15 @@ func main() {
 			os.Exit(1)
 		}
 		fmt.Printf("HTTP-Get received: %s\n", body)
+	}
+
+	if globalFlags.PrintIfaceCount {
+		ifaceCount, err := testutils.GetIfaceCount()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Interface count: %d\n", ifaceCount)
 	}
 
 	os.Exit(globalFlags.ExitCode)

--- a/tests/rkt_ace_validator_test.go
+++ b/tests/rkt_ace_validator_test.go
@@ -44,7 +44,7 @@ func TestAceValidator(t *testing.T) {
 		panic("empty RKT_ACE_SIDEKICK_IMAGE env var")
 	}
 
-	rktArgs := fmt.Sprintf("--debug --insecure-skip-verify run --volume database,kind=empty %s %s",
+	rktArgs := fmt.Sprintf("--debug --insecure-skip-verify run --mds-register --volume database,kind=empty %s %s",
 		aceMain, aceSidekick)
 	rktCmd := fmt.Sprintf("%s %s", ctx.cmd(), rktArgs)
 

--- a/tests/testutils/iputils.go
+++ b/tests/testutils/iputils.go
@@ -173,3 +173,11 @@ func GetNextFreePort4() (int, error) {
 	}
 	return 0, fmt.Errorf("No available ports")
 }
+
+func GetIfaceCount() (int, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return 0, err
+	}
+	return len(ifaces), nil
+}


### PR DESCRIPTION
* default to mds-register=false
* net=none will only load loopback interface

Fixes #1574.
Fixes #1566.