### PR TITLE
Documentation: typo in metadata-service.md

### DIFF
--- a/Documentation/subcommands/metadata-service.md
+++ b/Documentation/subcommands/metadata-service.md
@@ -3,7 +3,7 @@
 ## Overview
 
 The metadata service is designed to help running apps introspect their execution environment and assert their pod identity.
-In particular, the metadata service exposes the contents of the pod and image manifests and well as a convenient method of looking up annotations.
+In particular, the metadata service exposes the contents of the pod and image manifests as well as a convenient method of looking up annotations.
 Finally, the metadata service provides a pod with cryptographically verifiable identity.
 
 ## Running the metadata service
@@ -16,7 +16,7 @@ If using socket activation, ensure the socket is named `/run/rkt/metadata-svc.so
 Please note that when started under socket activation, the metadata service will not remove the socket on exit.
 Use the `RemoveOnStop` directive in the relevant `.socket` file to clean up.
 
-Example systemd unit files for running the metadata service are available in [dist](https://github.com/coreos/rkt/tree/master/dist/init/systemd)
+Example systemd unit files for running the metadata service are available in [dist](https://github.com/coreos/rkt/tree/master/dist/init/systemd).
 
 In addition to listening on a Unix socket, the metadata service will also listen on a TCP port 2375.
 When contacting the metadata service, the apps utilize this port.


### PR DESCRIPTION
Possibly typo? If I am wrong, please feel free to drop this.
And added missing punctuation.

Thanks!