### PR TITLE
build: Split the building of CoreOS ACI rootfs into separate file

### DIFF
--- a/stage1/usr_from_coreos/build-usr.mk
+++ b/stage1/usr_from_coreos/build-usr.mk
@@ -1,0 +1,204 @@
+# This file takes the following inputs and prepares the initial
+# contents in a given ACI rootfs directory based on manifests in a
+# given manifest directory.
+#
+# INPUTS:
+#
+# CBU_MANIFESTS_DIR - a directory with .manifest files for
+# unsquashfs. These files are simply a list of files to be extracted
+# from squashfs image.
+#
+# CBU_TMPDIR - a path to directory, which this Makefile can use for
+# its own purposes.
+#
+# CBU_DIFF - a differentiator for stamps, filelists, etc. Required
+# because this Makefile can be used by several flavors to build ACI
+# rootfs (coreos, kvm). So it is used to differentiate build system
+# files from each user/flavor. Needs to be unique across the entire
+# build system.
+#
+# CBU_STAMP - a stamp which will tell that the basic contents of ACI
+# rootfs are prepared.
+#
+# CBU_ACIROOTFSDIR - a directory of an ACI rootfs.
+#
+# CBU_FLAVOR - used for the flavor symlink in ACI rootfs.
+
+$(call inc-one,coreos-common.mk)
+
+# This will hold all the files taken from the squashfs file according
+# to given manifests.
+CBU_ROOTFS := $(CBU_TMPDIR)/rootfs
+# This is just all manifests in CBU_MANIFESTS_DIR concatenated, sorted
+# and uniquefied.
+CBU_COMPLETE_MANIFEST := $(CBU_TMPDIR)/manifest.txt
+# All manifest in the CBU_MANIFESTS_DIR
+CBU_MANIFESTS := $(wildcard $(CBU_MANIFESTS_DIR)/*)
+
+# Stamp telling when ACI rootfs was prepared.
+$(call setup-stamp-file,CBU_ACI_ROOTFS_STAMP,$(CBU_DIFF)-acirootfs)
+# Stamp telling when tmp rootfs was copied to ACI rootfs.
+$(call setup-stamp-file,CBU_ROOTFS_COPY_STAMP,$(CBU_DIFF)-rootfs-copy)
+# Stamp telling when squashfs file was unpacked using the complete
+# manifest.
+$(call setup-stamp-file,CBU_MKBASE_STAMP,$(CBU_DIFF)-mkbase)
+
+# Stamp and dep file for generating dependencies on manifest files.
+$(call setup-stamp-file,CBU_MANIFEST_DEPS_STAMP,$(CBU_DIFF)-manifest-deps)
+$(call setup-dep-file,CBU_MANIFEST_DEPMK,$(CBU_DIFF)-manifest)
+
+# Stamp and dep file for generating dependencies on tmp rootfs.
+$(call setup-stamp-file,CBU_TMPROOTFS_DEPMK_STAMP,$(CBU_DIFF)-tmprootfs-deps)
+$(call setup-dep-file,CBU_TMPROOTFS_DEPMK,$(CBU_DIFF)-tmprootfs)
+
+# Stamp and clean file for cleaning partially ACI rootfs and whole tmp
+# rootfs.
+$(call setup-stamp-file,CBU_ROOTFS_CLEAN_STAMP,$(CBU_DIFF)-rootfs-clean)
+$(call setup-clean-file,CBU_ROOTFSDIR_CLEANMK,$(CBU_DIFF)-rootfs)
+
+# Filelist for stuff taken from squashfs - it is more detailed when
+# compared to complete manifest.
+$(call setup-filelist-file,CBU_DETAILED_FILELIST,$(CBU_DIFF)-acirootfs)
+# Filelist for all manifest files.
+$(call setup-filelist-file,CBU_ALL_MANIFESTS_FILELIST,$(CBU_DIFF)-manifests)
+
+# Stamps for removing outdated contents of either ACI rootfs or tmp
+# rootfs.
+$(call setup-stamp-file,CBU_REMOVE_ACIROOTFSDIR_STAMP,$(CBU_DIFF)-remove-acirootfs)
+$(call setup-stamp-file,CBU_REMOVE_TMPROOTFSDIR_STAMP,$(CBU_DIFF)-remove-tmprootfs)
+
+# Stamp and dep file for generating dependencies on a list of
+# symlinks.
+$(call setup-stamp-file,CBU_ACIROOTFS_SYMLINKS_KV_DEPMK_STAMP,$(CBU_DIFF)-acirootfs-symlinks)
+$(call setup-dep-file,CBU_ACIROOTFS_SYMLINKS_KV_DEPMK,$(CBU_DIFF)-acirootfs-symlinks-kv)
+
+# Stamp and dep file for generating dependencies on a systemd version.
+$(call setup-stamp-file,CBU_ACIROOTFS_SYSTEMD_VERSION_KV_DEPMK_STAMP,$(CBU_DIFF)-systemd-version)
+$(call setup-dep-file,CBU_ACIROOTFS_SYSTEMD_VERSION_KV_DEPMK,$(CBU_DIFF)-systemd-version-kv)
+
+# All stamps in this file that generate deps or clean files
+CBU_DEPS_AND_CLEAN_STAMPS := \
+	$(CBU_TMPROOTFS_DEPMK_STAMP) \
+	$(CBU_MANIFEST_DEPS_STAMP) \
+	$(CBU_ROOTFS_CLEAN_STAMP) \
+	$(CBU_ACIROOTFS_SYMLINKS_KV_DEPMK_STAMP) \
+	$(CBU_ACIROOTFS_SYSTEMD_VERSION_KV_DEPMK_STAMP)
+
+# All symlinks to be created in ACI rootfs
+CBU_ACIROOTFS_SYMLINKS := \
+	$(CBU_ACIROOTFSDIR)/flavor \
+	$(CBU_ACIROOTFSDIR)/lib64 \
+	$(CBU_ACIROOTFSDIR)/lib \
+	$(CBU_ACIROOTFSDIR)/bin
+CBU_SYSTEMD_VERSION_FILE := $(CBU_ACIROOTFSDIR)/systemd-version
+
+CLEAN_FILES += \
+	$(CBU_COMPLETE_MANIFEST) \
+	$(CBU_SYSTEMD_VERSION_FILE)
+INSTALL_DIRS += \
+	$(CBU_ROOTFS):0755
+INSTALL_SYMLINKS += \
+	$(CBU_FLAVOR):$(CBU_ACIROOTFSDIR)/flavor \
+	usr/lib64:$(CBU_ACIROOTFSDIR)/lib64 \
+	usr/lib:$(CBU_ACIROOTFSDIR)/lib \
+	usr/bin:$(CBU_ACIROOTFSDIR)/bin
+
+
+# The main stamp - makes sure that ACI rootfs directory is prepared
+# with initial contents and all deps/clean files are generated.
+$(CBU_STAMP): $(CBU_ACI_ROOTFS_STAMP) $(CBU_DEPS_AND_CLEAN_STAMPS)
+	touch "$@"
+
+# This stamp makes sure that ACI rootfs is fully populated - stuff is
+# copied, symlinks and systemd-version file are created.
+$(CBU_ACI_ROOTFS_STAMP): $(CBU_ROOTFS_COPY_STAMP) $(CBU_SYSTEMD_VERSION_FILE) | $(CBU_ACIROOTFS_SYMLINKS)
+	touch "$@"
+
+# This generates the systemd-version file in ACI rootfs.
+$(call forward-vars,$(CBU_SYSTEMD_VERSION_FILE), \
+	CCN_SYSTEMD_VERSION CBU_SYSTEMD_VERSION_FILE)
+$(CBU_SYSTEMD_VERSION_FILE): $(CBU_ROOTFS_COPY_STAMP)
+	echo "$(CCN_SYSTEMD_VERSION)" >"$(CBU_SYSTEMD_VERSION_FILE)"
+
+# This depmk forces systemd-version file recreation if systemd version
+# (in CCN_SYSTEMD_VERSION variable) changes.
+$(call generate-kv-deps,$(CBU_ACIROOTFS_SYSTEMD_VERSION_KV_DEPMK_STAMP),$(CBU_SYSTEMD_VERSION_FILE),$(CBU_ACIROOTFS_SYSTEMD_VERSION_KV_DEPMK),CCN_SYSTEMD_VERSION)
+
+# Create the symlinks after the tmp rootfs was copied to ACI rootfs
+$(CBU_ACIROOTFS_SYMLINKS): $(CBU_ROOTFS_COPY_STAMP)
+
+# This copies tmp rootfs to ACI rootfs
+$(call forward-vars,$(CBU_ROOTFS_COPY_STAMP), \
+	CBU_ROOTFS CBU_ACIROOTFSDIR)
+$(CBU_ROOTFS_COPY_STAMP): $(CBU_MKBASE_STAMP) | $(CBU_ACIROOTFSDIR)
+	set -e; \
+	cp -af "$(CBU_ROOTFS)/." "$(CBU_ACIROOTFSDIR)"; \
+	touch "$@"
+
+# The ACI rootfs directory might be removed with its contents are
+# outdated.
+$(CBU_ACIROOTFSDIR): $(CBU_REMOVE_ACIROOTFSDIR_STAMP)
+
+# This removes the ACI rootfs directory if it holds outdated initial
+# contents (mostly happens when squashfs changes).
+$(call forward-vars,$(CBU_REMOVE_ACIROOTFSDIR_STAMP), \
+	CBU_ACIROOTFSDIR)
+$(CBU_REMOVE_ACIROOTFSDIR_STAMP): $(CBU_MKBASE_STAMP)
+	set -e; rm -rf "$(CBU_ACIROOTFSDIR)"; touch "$@"
+
+# This depmk forces the removal of ACI rootfs dir and its repopulation
+# if any of the symlinks to be created by the stamp populating ACI
+# rootfs dir changes.
+$(call generate-kv-deps,$(CBU_ACIROOTFS_SYMLINKS_KV_DEPMK_STAMP),$(CBU_REMOVE_ACIROOTFSDIR_STAMP) $(CBU_ROOTFS_COPY_STAMP),$(CBU_ACIROOTFS_SYMLINKS_KV_DEPMK),CBU_ACIROOTFS_SYMLINKS)
+
+# This depmk can be created only when detailed filelist is
+# generated. It will invalidate ACI rootfs creation if contents of
+# temporary rootfs change.
+$(call generate-glob-deps,$(CBU_TMPROOTFS_DEPMK_STAMP),$(CBU_REMOVE_ACIROOTFSDIR_STAMP),$(CBU_TMPROOTFS_DEPMK),,$(CBU_DETAILED_FILELIST),$(CBU_ROOTFS))
+
+# This cleanmk can be generated only after the detailed filelist was
+# generated.
+$(call generate-clean-mk,$(CBU_ROOTFS_CLEAN_STAMP),$(CBU_ROOTFSDIR_CLEANMK),$(CBU_DETAILED_FILELIST),$(CBU_ACIROOTFSDIR) $(CBU_ROOTFS))
+
+# This unpacks squashfs image to a temporary rootfs.
+$(call forward-vars,$(CBU_MKBASE_STAMP), \
+	CBU_ROOTFS CBU_COMPLETE_MANIFEST CCN_SQUASHFS)
+$(CBU_MKBASE_STAMP): $(CCN_SQUASHFS) $(CBU_COMPLETE_MANIFEST) | $(CBU_ROOTFS)
+	set -e; \
+	unsquashfs -d "$(CBU_ROOTFS)/usr" -ef "$(CBU_COMPLETE_MANIFEST)" "$(CCN_SQUASHFS)"; \
+	touch "$@"
+
+# The temporary rootfs directory might be removed before its creation
+# if it has outdated contents.
+$(CBU_ROOTFS): $(CBU_REMOVE_TMPROOTFSDIR_STAMP)
+
+# If either squashfs file or the concatenated manifest file changes we
+# need to unpack the squashfs file again. Clean the directory holding
+# the old contents beforehand.
+$(call forward-vars,$(CBU_REMOVE_TMPROOTFSDIR_STAMP), \
+	CBU_ROOTFS)
+$(CBU_REMOVE_TMPROOTFSDIR_STAMP): $(CCN_SQUASHFS) $(CBU_COMPLETE_MANIFEST)
+	set -e; rm -rf "$(CBU_ROOTFS)"; touch "$@"
+
+# This filelist can be generated only after the pxe image was
+# unsquashed to a temporary rootfs.
+$(CBU_DETAILED_FILELIST): $(CBU_MKBASE_STAMP)
+$(call generate-deep-filelist,$(CBU_DETAILED_FILELIST),$(CBU_ROOTFS))
+
+# This concatenates all manifests into one file.
+$(CBU_COMPLETE_MANIFEST): $(CBU_MANIFESTS) | $(CBU_TMPDIR)
+	set -e; \
+	cat $^ | sort -u > "$@.tmp"; \
+	$(call bash-cond-rename,$@.tmp,$@)
+
+# This filelist can be generated anytime.
+$(call generate-shallow-filelist,$(CBU_ALL_MANIFESTS_FILELIST),$(CBU_MANIFESTS_DIR),.manifest)
+
+# This depmk can be created only when filelist of manifests is
+# generated. If any of the file changes or is deleted or new one is
+# added, it will invalidate CBU_COMPLETE_MANIFEST, which in turn will
+# invalidate squashfs unpacking, which in turn will invalidate aci
+# rootfs directory creation.
+$(call generate-glob-deps,$(CBU_MANIFEST_DEPS_STAMP),$(CBU_COMPLETE_MANIFEST),$(CBU_MANIFEST_DEPMK),.manifest,$(CBU_ALL_MANIFESTS_FILELIST),$(CBU_MANIFESTS_DIR),normal)
+
+$(call undefine-namespaces,CBU)

--- a/stage1/usr_from_coreos/usr_from_coreos.mk
+++ b/stage1/usr_from_coreos/usr_from_coreos.mk
@@ -1,84 +1,22 @@
-$(call inc-one,coreos-common.mk)
-
 $(call setup-tmp-dir,UFC_TMPDIR)
 
-UFC_ROOTFS := $(UFC_TMPDIR)/rootfs
-UFC_FILELIST := $(UFC_TMPDIR)/manifest.txt
-UFC_MANIFESTS_DIR ?= $(MK_SRCDIR)/manifest.d
-UFC_MANIFESTS := $(wildcard $(UFC_MANIFESTS_DIR)/*.manifest)
+# This directory will be used by the build-usr.mk
+UFC_CBUDIR := $(UFC_TMPDIR)/cbu
 
-$(call setup-dep-file,UFC_DEPMK,manifests)
-$(call setup-clean-file,UFC_ROOTFSDIR_CLEANMK,/rootfs)
-$(call setup-clean-file,UFC_ACIROOTFSDIR_CLEANMK,/acirootfs)
-$(call setup-stamp-file,UFC_STAMP)
-$(call setup-stamp-file,UFC_MKBASE_STAMP,/mkbase)
-$(call setup-stamp-file,UFC_ACI_ROOTFS_STAMP,/acirootfs)
-$(call setup-stamp-file,UFC_ACIROOTFS_DEPS_STAMP,/acirootfs-deps)
-$(call setup-stamp-file,UFC_ROOTFS_CLEAN_STAMP,/rootfs-clean)
-$(call setup-stamp-file,UFC_ACIROOTFS_CLEAN_STAMP,/acirootfs-clean)
+$(call setup-stamp-file,UFC_CBU_STAMP,cbu)
 
-$(call setup-filelist-file,UFC_DETAILED_FILELIST)
+INSTALL_DIRS += $(UFC_CBUDIR):-
+S1_RF_USR_STAMPS += $(UFC_CBU_STAMP)
 
-INSTALL_DIRS += $(UFC_ITMP):-
-S1_RF_USR_STAMPS += $(UFC_STAMP)
-CLEAN_FILES += \
-	$(UFC_FILELIST) \
-	$(S1_RF_ACIROOTFSDIR)/systemd-version
-CLEAN_SYMLINKS += \
-	$(S1_RF_ACIROOTFSDIR)/flavor \
-	$(S1_RF_ACIROOTFSDIR)/lib64 \
-	$(S1_RF_ACIROOTFSDIR)/lib \
-	$(S1_RF_ACIROOTFSDIR)/bin
-CLEAN_DIRS += \
-	$(UFC_ROOTFS)
+# Input variables for building the ACI rootfs from CoreOS image
+# (build-usr.mk).
+CBU_MANIFESTS_DIR := $(MK_SRCDIR)/manifest.d
+CBU_TMPDIR := $(UFC_CBUDIR)
+CBU_DIFF := for-usr-from-coreos-mk
+CBU_STAMP := $(UFC_CBU_STAMP)
+CBU_ACIROOTFSDIR := $(S1_RF_ACIROOTFSDIR)
+CBU_FLAVOR := coreos
 
-$(UFC_STAMP): $(UFC_ACI_ROOTFS_STAMP) $(UFC_ACIROOTFS_DEPS_STAMP) $(UFC_ACIROOTFS_CLEAN_STAMP) $(UFC_ROOTFS_CLEAN_STAMP)
-	touch "$@"
-
-$(call forward-vars,$(UFC_ACI_ROOTFS_STAMP), \
-	S1_RF_ACIROOTFSDIR UFC_ROOTFS CCN_SYSTEMD_VERSION)
-$(UFC_ACI_ROOTFS_STAMP): $(UFC_MKBASE_STAMP) $(UFC_FILELIST)
-	set -e; \
-	rm -rf "$(S1_RF_ACIROOTFSDIR)"; \
-	cp -af "$(UFC_ROOTFS)/." "$(S1_RF_ACIROOTFSDIR)"; \
-	 \
-	ln -sf 'coreos' "$(S1_RF_ACIROOTFSDIR)/flavor"; \
-	ln -sf 'usr/lib64' "$(S1_RF_ACIROOTFSDIR)/lib64"; \
-	ln -sf 'usr/lib' "$(S1_RF_ACIROOTFSDIR)/lib"; \
-	ln -sf 'usr/bin' "$(S1_RF_ACIROOTFSDIR)/bin"; \
-	echo "$(CCN_SYSTEMD_VERSION)" >"$(S1_RF_ACIROOTFSDIR)/systemd-version"; \
-	touch "$@"
-
-# This depmk can be created only when detailed filelist is generated
-$(UFC_ACIROOTFS_DEPS_STAMP): $(UFC_DETAILED_FILELIST)
-$(call generate-glob-deps,$(UFC_ACIROOTFS_DEPS_STAMP),$(UFC_ACI_ROOTFS_STAMP),$(UFC_DEPMK),,$(UFC_DETAILED_FILELIST),$(UFC_ROOTFS))
-
-# This cleanmk can be created only when detailed filelist is generated
-$(UFC_ACIROOTFS_CLEAN_STAMP): $(UFC_DETAILED_FILELIST)
-$(call generate-clean-mk,$(UFC_ACIROOTFS_CLEAN_STAMP),$(UFC_ACIROOTFSDIR_CLEANMK),$(UFC_DETAILED_FILELIST),$(S1_RF_ACIROOTFSDIR))
-
-$(call forward-vars,$(UFC_MKBASE_STAMP), \
-	UFC_ROOTFS UFC_FILELIST CCN_SQUASHFS)
-$(UFC_MKBASE_STAMP): $(CCN_SQUASHFS) $(UFC_FILELIST)
-	set -e; \
-	rm -rf "$(UFC_ROOTFS)"; \
-	install -m 0755 -d "$(UFC_ROOTFS)"; \
-	unsquashfs -d "$(UFC_ROOTFS)/usr" -ef "$(UFC_FILELIST)" "$(CCN_SQUASHFS)"; \
-	touch "$@"
-
-# This filelist can be generated only after the pxe image was
-# unpackaged and unsquashed
-$(UFC_DETAILED_FILELIST): $(UFC_MKBASE_STAMP)
-$(call generate-deep-filelist,$(UFC_DETAILED_FILELIST),$(UFC_ROOTFS))
-
-# This cleanmk can be generated only after the detailed filelist was
-# generated.
-$(UFC_ROOTFS_CLEAN_STAMP): $(UFC_DETAILED_FILELIST)
-$(call generate-clean-mk,$(UFC_ROOTFS_CLEAN_STAMP),$(UFC_ROOTFSDIR_CLEANMK),$(UFC_DETAILED_FILELIST),$(UFC_ROOTFS))
-
-$(UFC_FILELIST): $(UFC_MANIFESTS) | $(UFC_TMPDIR)
-	cat $^ | sort -u > "$@.tmp"
-	cmp "$@.tmp" "$@" || mv "$@.tmp" "$@"
-	rm -f "$@.tmp"
+$(call inc-one,build-usr.mk)
 
 $(call undefine-namespaces,UFC)

--- a/stage1/usr_from_kvm/usr_from_kvm.mk
+++ b/stage1/usr_from_kvm/usr_from_kvm.mk
@@ -1,21 +1,27 @@
+$(call setup-stamp-file,UFK_CBU_STAMP,cbu)
+$(call setup-tmp-dir,UFK_TMPDIR)
+
 UFK_INCLUDES := \
-	../usr_from_coreos/usr_from_coreos.mk \
 	kernel.mk \
 	files.mk \
 	lkvm.mk
-$(call setup-stamp-file,UFK_REPLACE_FLAVOR_STAMP)
-$(call setup-tmp-dir,UFK_TMPDIR)
+# This directory will be used by the build-usr.mk
+UFK_CBUDIR := $(UFK_TMPDIR)/cbu
 
-UFC_MANIFESTS_DIR := $(MK_SRCDIR)/manifest.d
+S1_RF_USR_STAMPS += $(UFK_CBU_STAMP)
+INSTALL_DIRS += $(UFK_CBUDIR):-
+
 $(call inc-many,$(UFK_INCLUDES))
 
-S1_RF_SECONDARY_STAMPS += $(UFK_REPLACE_FLAVOR_STAMP)
+# Some input variables for building the ACI rootfs from CoreOS image
+# (build-usr.mk).
+CBU_MANIFESTS_DIR := $(MK_SRCDIR)/manifest.d
+CBU_TMPDIR := $(UFK_CBUDIR)
+CBU_DIFF := for-usr-from-kvm-mk
+CBU_STAMP := $(UFK_CBU_STAMP)
+CBU_ACIROOTFSDIR := $(S1_RF_ACIROOTFSDIR)
+CBU_FLAVOR := kvm
 
-$(call forward-vars,$(UFK_REPLACE_FLAVOR_STAMP), \
-	S1_RF_ACIROOTFSDIR)
-$(UFK_REPLACE_FLAVOR_STAMP):
-	rm -f "$(S1_RF_ACIROOTFSDIR)/flavor"
-	ln -sf 'kvm' "$(S1_RF_ACIROOTFSDIR)/flavor"
-	touch "$@"
+$(call inc-one,../usr_from_coreos/build-usr.mk)
 
 $(call undefine-namespaces,UFK)


### PR DESCRIPTION
All the rules for preparing the initial contents of ACI rootfs from
CoreOS image are placed in build-usr.mk. Both usr_from_kvm and
usr_from_coreos use this file to get their rootfs prepared.

This commit includes also a bunch of tweaks and fixes.

- properly customizable flavor symlink creation (so kvm flavor does
  not need a hack replacing the flavor symlink with its own)

- proper creation and dependencies on symlinks directly in ACI rootfs
  directory (symlinks are created via INSTALL_SYMLINKS variable and
  adding a new one to both CBU_ACIROOTFS_SYMLINKS and INSTALL_SYMLINKS
  will recreate the ACI rootfs)

- proper dependencies for file manifests (not ACI manifest; modifying
  a manifest or removing one or adding a new one will recreate the ACI
  rootfs)

- documented it a bit

- the ACI rootfs directory is removed when its contents are outdated
  (it is done by adding a dependency on directory-removing stamp to
  the ACI rootfs directory; the directory-removing stamp may get
  invalidated, thus removing the ACI rootfs)