### PR TITLE
stage0/run: use store.GetImageManifestJSON() instead

### DIFF
--- a/stage0/run.go
+++ b/stage0/run.go
@@ -623,14 +623,9 @@ func setupStage1Image(cfg RunConfig, cdir string, useOverlay bool) error {
 
 // writeManifest takes an img ID and writes the corresponding manifest in dest
 func writeManifest(cfg CommonConfig, img types.Hash, dest string) error {
-	manifest, err := cfg.Store.GetImageManifest(img.String())
+	mb, err := cfg.Store.GetImageManifestJSON(img.String())
 	if err != nil {
 		return err
-	}
-
-	mb, err := json.Marshal(manifest)
-	if err != nil {
-		return fmt.Errorf("error marshalling image manifest: %v", err)
 	}
 
 	debug("Writing image manifest")


### PR DESCRIPTION
This way we don't need to re-marshal the manifest into a []byte, just
trust the manifest coming from the store.  If the manifests need
validating we should do that before putting them in the store.  This is
in the hot path of starting pods since we write manifests for the app
and stage1 acis.