### PR TITLE
docs: stick to 80 character columns where possible

### DIFF
--- a/Documentation/app-container.md
+++ b/Documentation/app-container.md
@@ -6,7 +6,10 @@ rkt's native [image format](#aci) and [runtime environment](#pods) are those def
 
 ## ACI
 
-The image format defined by appc and used in rkt is the [_Application Container Image_][appc-aci], or ACI. An ACI is a simple tarball bundle of a rootfs (containing all the files needed to execute an application) and an _Image Manifest_, which defines things like default execution parameters and default resource constraints. ACIs can be built with tools like [`actool`](https://github.com/appc/spec#building-acis) or [`goaci`](https://github.com/appc/goaci). Docker images can be converted to ACI using [`docker2aci`](https://github.com/appc/docker2aci), although rkt will [do this automatically](https://github.com/coreos/rkt/blob/master/Documentation/running-docker-images.md).
+The image format defined by appc and used in rkt is the [_Application Container Image_][appc-aci], or ACI.
+An ACI is a simple tarball bundle of a rootfs (containing all the files needed to execute an application) and an _Image Manifest_, which defines things like default execution parameters and default resource constraints.
+ACIs can be built with tools like [`acbuild`](https://github.com/appc/acbuild), [`actool`](https://github.com/appc/spec#building-acis), or [`goaci`](https://github.com/appc/goaci).
+Docker images can be converted to ACI using [`docker2aci`](https://github.com/appc/docker2aci), although rkt will [do this automatically](https://github.com/coreos/rkt/blob/master/Documentation/running-docker-images.md).
 
 Most parameters defined in an image can be overridden at runtime by rkt. For example, the `rkt run` command allows users to supply custom exec arguments to an image.
 

--- a/Documentation/getting-started-guide.md
+++ b/Documentation/getting-started-guide.md
@@ -28,7 +28,7 @@ func main() {
 Next we need to build our application. We are going to statically link our app
 so we can ship an App Container Image with no external dependencies.
 
-With Go 1.3:
+With Go 1.3 or 1.5:
 
 ```
 $ CGO_ENABLED=0 GOOS=linux go build -o hello -a -tags netgo -ldflags '-w' .
@@ -49,87 +49,29 @@ $ ldd hello
 	not a dynamic executable
 ```
 
-## Create the image manifest
+## Create the image
 
-Edit: manifest.json
+To create the image, we can use `acbuild`, which can be downloaded via one of
+the [releases in the acbuild
+repository](https://github.com/appc/acbuild/releases)
 
-```json
-{
-    "acKind": "ImageManifest",
-    "acVersion": "0.7.0",
-    "name": "example.com/hello",
-    "labels": [
-        {
-            "name": "version",
-            "value": "0.0.1"
-        },
-        {
-            "name": "arch",
-            "value": "amd64"
-        },
-        {
-            "name": "os",
-            "value": "linux"
-        }
-    ],
-    "app": {
-        "user": "root",
-        "group": "root",
-        "exec": [
-            "/bin/hello"
-        ],
-        "ports": [
-            {
-                "name": "www",
-                "protocol": "tcp",
-                "port": 5000
-            }
-        ]
-    },
-    "annotations": [
-        {
-            "name": "authors",
-            "value": "Kelsey Hightower <kelsey.hightower@gmail.com>"
-        }
-    ]
-}
-```
+The following commands (run as root) will create an ACI containing our
+application and important metadata.
 
-### Validate the image manifest
+```bash
+acbuild begin
+acbuild set-name example.com/hello
+acbuild copy hello /bin/hello
+acbuild set-exec /bin/hello
+acbuild port add www tcp 5000
 
-To validate the manifest, we can use `actool`, which is currently provided in [releases in the App Container repository](https://github.com/appc/spec/releases).
+acbuild label add version 0.0.1
+acbuild label add arch amd64
+acbuild label add os linux
+acbuild annotation add authors "Kelsey Hightower <kelsey.hightower@gmail.com>"
 
-```
-$ actool --debug validate manifest.json
-manifest.json: valid ImageManifest
-```
-
-## Create the layout and the rootfs
-
-```
-$ mkdir hello-layout/
-$ mkdir hello-layout/rootfs
-$ mkdir hello-layout/rootfs/bin
-```
-
-Copy the image manifest and `hello` binary into the layout:
-
-```
-$ cp manifest.json hello-layout/manifest
-$ cp hello hello-layout/rootfs/bin/
-```
-
-## Build the application image
-
-```
-$ actool build hello-layout/ hello-0.0.1-linux-amd64.aci
-```
-
-### Validate the application image
-
-```
-$ actool --debug validate hello-0.0.1-linux-amd64.aci
-hello-0.0.1-linux-amd64.aci: valid app container image
+acbuild write hello-0.0.1-linux-amd64.aci
+acbuild end
 ```
 
 ## Run

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Keep in mind while running through the examples that right now `rkt` needs to be
 ### Building App Container Images (ACIs)
 
 rkt's native image format is ACI, defined in the [App Container spec](Documentation/app-container.md).
-To build ACIs, a simple way to get started is by using [`actool`](https://github.com/appc/spec/#working-with-the-spec).
+To build ACIs, a simple way to get started is by using [`acbuild`](https://github.com/appc/acbuild).
 Another good resource is the [appc build repository](https://github.com/appc/build-repository) which has resources for building ACIs from a number of popular projects and languages.
 There are also tools for converting [Docker images to ACIs](https://github.com/appc/docker2aci) (although note that rkt can [also run Docker images natively](Documentation/running-docker-images.md) directly from Docker repositories by using this library internally).
 


### PR DESCRIPTION
For those who read docs in the terminal, line wrapping can reduce the
readability of the docs. This commit reformats the docs to enforce 80
character columns where possible.