### PR TITLE
functional tests: Semaphore is broken

### DIFF
--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -29,6 +29,12 @@ if [ "${CI-}" == true ] ; then
 
 		#sudo apt-get update -qq || true
 
+		# Fix for go 1.4.3: see https://github.com/coreos/rkt/issues
+		# GOPATH is only needed to allow go to work; the actual
+		# binaries are installed in GOROOT for these commands
+		sudo -E GOPATH=/tmp go get golang.org/x/tools/cmd/vet
+		sudo -E GOPATH=/tmp go get golang.org/x/tools/cmd/cover
+
 		# libmount: https://github.com/systemd/systemd/pull/986#issuecomment-138451264
 		# sudo add-apt-repository --yes ppa:pitti/systemd-semaphore
 		# sudo apt-get update -qq || true


### PR DESCRIPTION
We're having some problems with building coreos/rkt after Semaphore's platform update today. Here's [an example](https://semaphoreci.com/coreos/rkt/branches/pull-request-1582/builds/10)

```
go tool: no such tool "vet"; to install:
	go get golang.org/x/tools/cmd/vet
```

I opened an ssh session and it seems that not all the go executables are installed for go1.4.3. For example, "vet" and "cover" should be in "/usr/local/golang/1.4.3/go/pkg/tool/linux_amd64" but they're not. In the go1.5.1 installation they are there.

I checked the go1.4.3 release and they're not included there either while they are in go1.4.2. ~~It seems they did that unintendedly since go1.4.3 is supposed to be a bugfix release.~~
Here's an upstream issue: https://github.com/golang/go/issues/12883

I guess we can `go get` the missing commands.