### PR TITLE
stage0: don't change the group ownership of rootfs

### DIFF
--- a/stage0/run.go
+++ b/stage0/run.go
@@ -597,29 +597,7 @@ func setupStage1Image(cfg RunConfig, cdir string, useOverlay bool) error {
 		}
 	}
 
-	// Chown the 'rootfs' directory, so that rkt list/rkt status can access it.
-	if err := os.Chown(filepath.Join(s1, "rootfs"), -1, cfg.RktGid); err != nil {
-		return err
-	}
-
-	// Chown the 'rootfs/rkt' and its sub-directory, so that rkt list/rkt status can
-	// access it.
-	// Also set 'S_ISGID' bit on the mode so that when the app writes exit status to
-	// 'rootfs/rkt/status/$app', the file has the group ID set to 'rkt'.
-	chownWalker := func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if err := os.Chown(path, -1, cfg.RktGid); err != nil {
-			return err
-		}
-		if err := os.Chmod(path, info.Mode()|os.ModeSetgid); err != nil {
-			return err
-		}
-		return nil
-	}
-
-	return filepath.Walk(filepath.Join(s1, "rootfs", "rkt"), chownWalker)
+	return nil
 }
 
 // writeManifest takes an img ID and writes the corresponding manifest in dest

--- a/stage1/rootfs.mk
+++ b/stage1/rootfs.mk
@@ -12,7 +12,7 @@ _S1_RF_NAME_ := usr_from_$(S1_RF_FLAVOR)
 
 INSTALL_DIRS += \
 	$(S1_RF_ACIDIR):- \
-	$(S1_RF_ACIROOTFSDIR):0750
+	$(S1_RF_ACIROOTFSDIR):0755
 
 $(call inc-one,$(_S1_RF_NAME_)/$(_S1_RF_NAME_).mk)
 

--- a/stage1/usr_from_coreos/usr_from_coreos.mk
+++ b/stage1/usr_from_coreos/usr_from_coreos.mk
@@ -62,7 +62,7 @@ $(call forward-vars,$(UFC_MKBASE_STAMP), \
 $(UFC_MKBASE_STAMP): $(CCN_SQUASHFS) $(UFC_FILELIST)
 	set -e; \
 	rm -rf "$(UFC_ROOTFS)"; \
-	install -m 0750 -d "$(UFC_ROOTFS)"; \
+	install -m 0755 -d "$(UFC_ROOTFS)"; \
 	unsquashfs -d "$(UFC_ROOTFS)/usr" -ef "$(UFC_FILELIST)" "$(CCN_SQUASHFS)"; \
 	touch "$@"
 

--- a/stage1/usr_from_src/usr_from_src.mk
+++ b/stage1/usr_from_src/usr_from_src.mk
@@ -78,7 +78,7 @@ $(call forward-vars,$(UFS_SYSTEMD_INSTALL_STAMP), \
 $(UFS_SYSTEMD_INSTALL_STAMP): $(UFS_SYSTEMD_BUILD_STAMP)
 	set -e; \
 	DESTDIR="$(abspath $(UFS_ROOTFSDIR))" $(MAKE) -C "$(UFS_SYSTEMD_BUILDDIR)" install-strip; \
-	chmod 0750 "$(UFS_ROOTFSDIR)"; \
+	chmod 0755 "$(UFS_ROOTFSDIR)"; \
 	touch "$@"
 
 # This filelist can be generated only after the installation of

--- a/tests/rkt_userns_test.go
+++ b/tests/rkt_userns_test.go
@@ -39,7 +39,7 @@ var usernsTests = []struct {
 	{
 		`^RKT_BIN^ --debug --insecure-skip-verify run ^USERNS^ --no-overlay --set-env=FILE=^FILE^ --mds-register=false ^IMAGE^`,
 		"/proc/1/root/", // stage1 rootfs ($POD/stage1/rootfs)
-		"drwxr-x---",
+		"drwxr-xr-x",
 		"0",
 		"", // no check: it could be 0 but also the gid of 'rkt', see https://github.com/coreos/rkt/pull/1452
 	},


### PR DESCRIPTION
Setting the group of the rootfs to 'rkt' causes problems with user
namespaces when the group is not mapped in the user namespace. It
prevents the container from doing a 'mkdir' or a 'lstat' on /proc. See
https://github.com/systemd/systemd/issues/1585

Setting the group ownership of the rootfs to 'rkt' was done in
https://github.com/coreos/rkt/pull/1452 so that the command 'rkt status'
could work as non-root. However, if the rootfs is r-x for others, setting
the group should not be necessary. r-x for others was removed by
https://github.com/coreos/rkt/pull/1607 but I am adding it back.

This patch reverts a part of https://github.com/coreos/rkt/issues/1602,
therefore fixing the regression with user namespaces. 'rkt status' as
non-root still works.

Fixes https://github.com/coreos/rkt/issues/1602

-----

/cc @yifan-gu @krnowak 