### PR TITLE
rkt list fails to list pods whose image is removed

### DIFF
--- a/stage0/run.go
+++ b/stage0/run.go
@@ -185,8 +185,9 @@ func generatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
 			Name: *appName,
 			App:  am.App,
 			Image: schema.RuntimeImage{
-				Name: &am.Name,
-				ID:   img,
+				Name:   &am.Name,
+				ID:     img,
+				Labels: am.Labels,
 			},
 			Annotations: am.Annotations,
 		}


### PR DESCRIPTION
Since we are now able to remove an image without removing the pod, use
of the ImageManifest in the rkt list creates a dependency on an image
that may not be around, causing rkt list to fail.

This change removes that dependency and instead relies on the
PodManifest which will be available and should supply the needed
information.

Also found an issue in the PodManifest generation.

Fixes #1628