### PR TITLE
stage0: check for valid name in PodManifest

### DIFF
--- a/rkt/list.go
+++ b/rkt/list.go
@@ -96,9 +96,12 @@ func runList(cmd *cobra.Command, args []string) int {
 			uuid = uuid[:8]
 		}
 		for _, app := range pm.Apps {
-			imageName := app.Image.Name.String()
-			if version, ok := app.Image.Labels.Get("version"); ok {
-				imageName = fmt.Sprintf("%s:%s", imageName, version)
+			imageName := "--"
+			if app.Image.Name != nil {
+				imageName = app.Image.Name.String()
+				if version, ok := app.Image.Labels.Get("version"); ok {
+					imageName = fmt.Sprintf("%s:%s", imageName, version)
+				}
 			}
 
 			var imageID string


### PR DESCRIPTION
Commit 65398a didn't take into consideration that the Name field in the
Image section of the PodManifest is options. Thus, in the case that it's
not there rkt list crashed. This is a temporary fix for this issue.

A more thorough fix is being tracked in ticket #1659.

Closes #1628