### PR TITLE
appc/spec: use version 0.7.1

### DIFF
--- a/Documentation/app-container.md
+++ b/Documentation/app-container.md
@@ -30,8 +30,8 @@ To validate that `rkt` successfully implements the ACE part of the spec, use the
 # rkt --insecure-skip-verify run \
 	--mds-register \
 	--volume=database,kind=host,source=/tmp \
-	https://github.com/appc/spec/releases/download/v0.7.0/ace-validator-main.aci \
-	https://github.com/appc/spec/releases/download/v0.7.0/ace-validator-sidekick.aci
+	https://github.com/appc/spec/releases/download/v0.7.1/ace-validator-main.aci \
+	https://github.com/appc/spec/releases/download/v0.7.1/ace-validator-sidekick.aci
 ```
 
 [appc-repo]: https://github.com/appc/spec/

--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -86,7 +86,7 @@ Examples
 ```json
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.7.0",
+    "acVersion": "0.7.1",
     "name": "foo.com/rkt/stage1",
     "labels": [
         {   

--- a/pkg/aci/aci.go
+++ b/pkg/aci/aci.go
@@ -106,7 +106,7 @@ func (aw *imageArchiveWriter) Close() error {
 // NewBasicACI creates a new ACI in the given directory with the given name.
 // Used for testing.
 func NewBasicACI(dir string, name string) (*os.File, error) {
-	manifest := fmt.Sprintf(`{"acKind":"ImageManifest","acVersion":"0.7.0","name":"%s"}`, name)
+	manifest := fmt.Sprintf(`{"acKind":"ImageManifest","acVersion":"0.7.1","name":"%s"}`, name)
 	return NewACI(dir, manifest, nil)
 }
 

--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -226,7 +226,7 @@ func TestDownloading(t *testing.T) {
 
 	imj := `{
 			"acKind": "ImageManifest",
-			"acVersion": "0.7.0",
+			"acVersion": "0.7.1",
 			"name": "example.com/test01"
 		}`
 

--- a/stage1/aci/aci-manifest.in
+++ b/stage1/aci/aci-manifest.in
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.7.0",
+    "acVersion": "0.7.1",
     "name": "@RKT_STAGE1_NAME@",
     "labels": [
         {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -162,7 +162,7 @@ func TestGetImageManifest(t *testing.T) {
 
 	imj := `{
 			"acKind": "ImageManifest",
-			"acVersion": "0.7.0",
+			"acVersion": "0.7.1",
 			"name": "example.com/test01"
 		}`
 
@@ -226,7 +226,7 @@ func TestGetAci(t *testing.T) {
 				{
 					`{
 						"acKind": "ImageManifest",
-						"acVersion": "0.7.0",
+						"acVersion": "0.7.1",
 						"name": "example.com/test01"
 					}`,
 					false,
@@ -234,7 +234,7 @@ func TestGetAci(t *testing.T) {
 				{
 					`{
 						"acKind": "ImageManifest",
-						"acVersion": "0.7.0",
+						"acVersion": "0.7.1",
 						"name": "example.com/test02",
 						"labels": [
 							{
@@ -248,7 +248,7 @@ func TestGetAci(t *testing.T) {
 				{
 					`{
 						"acKind": "ImageManifest",
-						"acVersion": "0.7.0",
+						"acVersion": "0.7.1",
 						"name": "example.com/test02",
 						"labels": [
 							{
@@ -360,7 +360,7 @@ func TestTreeStore(t *testing.T) {
 	imj := `
 		{
 		    "acKind": "ImageManifest",
-		    "acVersion": "0.7.0",
+		    "acVersion": "0.7.1",
 		    "name": "example.com/test01"
 		}
 	`
@@ -482,7 +482,7 @@ func TestRemoveACI(t *testing.T) {
 
 	imj := `{
                     "acKind": "ImageManifest",
-                    "acVersion": "0.7.0",
+                    "acVersion": "0.7.1",
                     "name": "example.com/test01"
                 }`
 
@@ -527,7 +527,7 @@ func TestRemoveACI(t *testing.T) {
 	// Simulate error removing from the
 	imj = `{
                    "acKind": "ImageManifest",
-                   "acVersion": "0.7.0",
+                   "acVersion": "0.7.1",
                    "name": "example.com/test01"
                }`
 

--- a/store/tree_test.go
+++ b/store/tree_test.go
@@ -28,7 +28,7 @@ func treeStoreWriteACI(dir string, s *Store) (string, error) {
 	imj := `
 		{
 		    "acKind": "ImageManifest",
-		    "acVersion": "0.7.0",
+		    "acVersion": "0.7.1",
 		    "name": "example.com/test01"
 		}
 	`

--- a/tests/empty-image/manifest
+++ b/tests/empty-image/manifest
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.7.0",
+    "acVersion": "0.7.1",
     "name": "coreos.com/rkt-empty",
     "labels": [
         {

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.7.0",
+    "acVersion": "0.7.1",
     "name": "coreos.com/rkt-inspect",
     "labels": [
         {

--- a/tests/rkt_cat_manifest_test.go
+++ b/tests/rkt_cat_manifest_test.go
@@ -25,7 +25,7 @@ import (
 const (
 
 	// The expected image manifest of the 'rkt-inspect-image-cat-manifest.aci'.
-	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.0","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.1","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestCatManifest tests 'rkt image cat-manifest', it will:

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.7.0","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
+	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.7.1","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
 )
 
 func TestRunOverrideExec(t *testing.T) {

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.0","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.1","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageExport tests 'rkt image export', it will import some existing

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.0","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.1","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageRender tests 'rkt image render', it will import some existing empty

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	manifestOSArchTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.0","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"}ARCH_OS],"app":{"exec":["/inspect", "--print-msg=HelloWorld"],"user":"0","group":"0","workingDirectory":"/"}}`
+	manifestOSArchTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.1","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"}ARCH_OS],"app":{"exec":["/inspect", "--print-msg=HelloWorld"],"user":"0","group":"0","workingDirectory":"/"}}`
 )
 
 type osArchTest struct {

--- a/tests/test-auth-server/aci/aci.go
+++ b/tests/test-auth-server/aci/aci.go
@@ -57,7 +57,7 @@ func (t *aciToolkit) prepareACI() ([]byte, error) {
 }
 
 const (
-	manifestStr    = `{"acKind":"ImageManifest","acVersion":"0.7.0","name":"testprog","app":{"exec":["/prog"],"user":"0","group":"0"},"labels":[{"name":"os","value":"linux"},{"name":"arch","value":"amd64"}]}`
+	manifestStr    = `{"acKind":"ImageManifest","acVersion":"0.7.1","name":"testprog","app":{"exec":["/prog"],"user":"0","group":"0"},"labels":[{"name":"os","value":"linux"},{"name":"arch","value":"amd64"}]}`
 	testProgSrcStr = `
 package main
 


### PR DESCRIPTION
rkt uses appc/spec 0.7.1 since https://github.com/coreos/rkt/pull/1543