### PR TITLE
run: remove `--inject-volume`

### DIFF
--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -130,9 +130,9 @@ The volume is then mounted into each app running to the pod based on information
 
 ### Mounting Volumes without Mount Points
 
-If the ACI doesn't have any mount points defined in its manifest, you can still mount volumes using the `--mount` or `--inject-volume` flags.
+If the ACI doesn't have any mount points defined in its manifest, you can still mount volumes using the `--mount` flag.
 
-With `--mount` you define a mapping between volumes and a path in the app. This will override any mount points in the image manifest.
+With `--mount` you define a mapping between volumes and a path in the app. This will supplement and override any mount points in the image manifest.
 In the following example, the `--mount` option is positioned after the app name; it defines the mount only in that app:
 
 ```
@@ -148,12 +148,6 @@ It defines mounts on all apps: both app1 and app2 will have `/srv/logs` accessib
 # rkt run --volume logs,kind=host,source=/srv/logs \
        --mount volume=data,target=/var/log \
         example.com/app1 example.com/app2
-```
-
-`--inject-volume` is convenient when you don't want to share volumes between the apps in the pod. It simply maps a path in the host to a path in the app:
-
-```
-# rkt run example.com/app1 --inject-volume /srv/data:/var/data
 ```
 
 ### MapReduce Example

--- a/rkt/cli_apps.go
+++ b/rkt/cli_apps.go
@@ -155,42 +155,6 @@ func (ae *appExec) Set(s string) error {
 	return nil
 }
 
-// appInjectVolume is for --inject-volume flags in the form of: --inject-volume source=PATH,target=PATH
-type appInjectVolume apps.Apps
-
-func (aam *appInjectVolume) Set(s string) error {
-	app := (*apps.Apps)(aam).Last()
-	if app == nil {
-		return fmt.Errorf("--inject-volume must follow an image")
-	}
-
-	p := strings.SplitN(s, ":", 2)
-	if len(p) != 2 {
-		return fmt.Errorf("must be SOURCE_PATH:TARGET_PATH")
-	}
-
-	volName, err := types.SanitizeACName(p[1])
-	if err != nil {
-		return fmt.Errorf("empty target in volume")
-	}
-
-	rVol := types.Volume{Name: *types.MustACName(volName), Source: p[0], Kind: "host"}
-	mount := schema.Mount{Volume: rVol.Name, Path: p[1]}
-
-	(*apps.Apps)(aam).Volumes = append((*apps.Apps)(aam).Volumes, rVol)
-	app.Mounts = append(app.Mounts, mount)
-
-	return nil
-}
-
-func (aam *appInjectVolume) Type() string {
-	return "appInjectVolume"
-}
-
-func (aam *appInjectVolume) String() string {
-	return ""
-}
-
 // appMount is for --mount flags in the form of: --mount volume=VOLNAME,target=PATH
 type appMount apps.Apps
 

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -61,7 +61,7 @@ func init() {
 	// per-app flags
 	cmdPrepare.Flags().Var((*appExec)(&rktApps), "exec", "override the exec command for the preceding image")
 	cmdPrepare.Flags().Var((*appMount)(&rktApps), "mount", "mount point binding a volume to a path within an app")
-	cmdPrepare.Flags().Var((*appInjectVolume)(&rktApps), "inject-volume", "inject a volume into an app. Syntax: --inject-volume=SOURCE:TARGET")
+
 	// Disable interspersed flags to stop parsing after the first non flag
 	// argument. This is need to permit to correctly handle
 	// multiple "IMAGE -- imageargs ---"  options

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -86,7 +86,6 @@ func init() {
 	cmdRun.Flags().Var((*appAsc)(&rktApps), "signature", "local signature file to use in validating the preceding image")
 	cmdRun.Flags().Var((*appExec)(&rktApps), "exec", "override the exec command for the preceding image")
 	cmdRun.Flags().Var((*appMount)(&rktApps), "mount", "mount point binding a volume to a path within an app")
-	cmdRun.Flags().Var((*appInjectVolume)(&rktApps), "inject-volume", "inject a volume into an app. Syntax: --inject-volume=SOURCE:TARGET")
 
 	flagPorts = portList{}
 


### PR DESCRIPTION
The syntax of `--inject-volume` has been somewhat contentious [1][1] and
it seems pretty clear we do not want the flag to remain as-is.
Furthermore, there's actually no immediate need for it since the same
functionality can be achieved through a combination of the `--volume`
and `--mount` flags (which landed in the same PR as `--inject-volume`).
Hence, remove it for now, guide people towards the alternative, and we
can put further thought into re-adding something similar in future
(which would essentially just be a convenience).

[1]: https://github.com/coreos/rkt/issues/1656
[2]: https://github.com/coreos/rkt/pull/1582