### PR TITLE
stage1: use PodManifest.Mounts in the kvm flavor

### DIFF
--- a/stage1/common/mount.go
+++ b/stage1/common/mount.go
@@ -1,0 +1,80 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+func isMPReadOnly(mountPoints []types.MountPoint, name types.ACName) bool {
+	for _, mp := range mountPoints {
+		if mp.Name == name {
+			return mp.ReadOnly
+		}
+	}
+
+	return false
+}
+
+// IsMountReadOnly returns if a mount should be readOnly.
+// If the readOnly flag in the pod manifest is not nil, it overrides the
+// readOnly flag in the image manifest.
+func IsMountReadOnly(vol types.Volume, mountPoints []types.MountPoint) bool {
+	var readOnly bool
+	if vol.ReadOnly != nil {
+		readOnly = *vol.ReadOnly
+	} else {
+		readOnly = isMPReadOnly(mountPoints, vol.Name)
+	}
+
+	return readOnly
+}
+
+func GenerateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume) ([]schema.Mount, error) {
+	appName := ra.Name
+	id := ra.Image.ID
+	app := ra.App
+
+	mnts := make(map[string]schema.Mount)
+	for _, m := range ra.Mounts {
+		mnts[m.Path] = m
+	}
+
+	for _, mp := range app.MountPoints {
+		// there's already an injected mount for this target path, skip
+		if _, ok := mnts[mp.Path]; ok {
+			continue
+		}
+		vol, ok := volumes[mp.Name]
+		if !ok {
+			catCmd := fmt.Sprintf("sudo rkt image cat-manifest --pretty-print %v", id)
+			volumeCmd := ""
+			for _, mp := range app.MountPoints {
+				volumeCmd += fmt.Sprintf("--volume %s,kind=host,source=/some/path ", mp.Name)
+			}
+
+			return nil, fmt.Errorf("no volume for mountpoint %q:%q in app %q.\n"+
+				"You can inspect the volumes with:\n\t%v\n"+
+				"App %q requires the following volumes:\n\t%v",
+				mp.Name, mp.Path, appName, catCmd, appName, volumeCmd)
+		}
+		ra.Mounts = append(ra.Mounts, schema.Mount{Volume: vol.Name, Path: mp.Path})
+	}
+
+	return ra.Mounts, nil
+}

--- a/stage1/init/kvm/mount.go
+++ b/stage1/init/kvm/mount.go
@@ -63,14 +63,13 @@ func serviceUnitName(appName types.ACName) string {
 	return appName.String() + ".service"
 }
 
-// installNewMountUnit creates and installs new mount unit in default
-// systemd location (/usr/lib/systemd/system) in pod stage1 filesystem.
-// root is a stage1 relative to pod filesystem path like /var/lib/uuid/rootfs/
-// (from Pod.Root).
-// beforeAndrequiredBy creates systemd unit dependency (can be space separated
+// installNewMountUnit creates and installs a new mount unit in the default
+// systemd location (/usr/lib/systemd/system) inside the pod stage1 filesystem.
+// root is pod's absolute stage1 path (from Pod.Root).
+// beforeAndrequiredBy creates a systemd unit dependency (can be space separated
 // for multi).
-func installNewMountUnit(root, what, where, fsType, options, beforeAndrequiredBy, unitsDir string) error {
-
+// It returns the name of the generated unit.
+func installNewMountUnit(root, what, where, fsType, options, beforeAndrequiredBy, unitsDir string) (string, error) {
 	opts := []*unit.UnitOption{
 		unit.NewUnitOption("Unit", "Description", fmt.Sprintf("Mount unit for %s", where)),
 		unit.NewUnitOption("Unit", "DefaultDependencies", "false"),
@@ -84,17 +83,26 @@ func installNewMountUnit(root, what, where, fsType, options, beforeAndrequiredBy
 
 	unitsPath := filepath.Join(root, unitsDir)
 	unitName := unit.UnitNamePathEscape(where + ".mount")
+
+	if err := writeUnit(opts, filepath.Join(unitsPath, unitName)); err != nil {
+		return "", err
+	}
+	log.Printf("mount unit created: %q in %q (what=%q, where=%q)", unitName, unitsPath, what, where)
+
+	return unitName, nil
+}
+
+func writeUnit(opts []*unit.UnitOption, unitPath string) error {
 	unitBytes, err := ioutil.ReadAll(unit.Serialize(opts))
 	if err != nil {
-		return fmt.Errorf("failed to serialize mount unit file to bytes %q: %v", unitName, err)
+		return fmt.Errorf("failed to serialize mount unit file to bytes %q: %v", unitPath, err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(unitsPath, unitName), unitBytes, 0644)
+	err = ioutil.WriteFile(unitPath, unitBytes, 0644)
 	if err != nil {
-		return fmt.Errorf("failed to create mount unit file %q: %v", unitName, err)
+		return fmt.Errorf("failed to create mount unit file %q: %v", unitPath, err)
 	}
 
-	log.Printf("mount unit created: %q in %q (what=%q, where=%q)", unitName, unitsPath, what, where)
 	return nil
 }
 
@@ -106,7 +114,6 @@ func installNewMountUnit(root, what, where, fsType, options, beforeAndrequiredBy
 // appNames are used to create before/required dependency between mount unit and
 // app service units.
 func PodToSystemdHostMountUnits(root string, volumes []types.Volume, appNames []types.ACName, unitsDir string) error {
-
 	// pod volumes need to mount p9 qemu mount_tags
 	for _, vol := range volumes {
 		// only host shared volumes
@@ -130,7 +137,7 @@ func PodToSystemdHostMountUnits(root string, volumes []types.Volume, appNames []
 
 		// for host kind we create a mount unit to mount host shared folder
 		if vol.Kind == "host" {
-			err = installNewMountUnit(root,
+			_, err = installNewMountUnit(root,
 				name, // what (source) in 9p it is a channel tag which equals to volume.Name/mountPoint.name
 				filepath.Join(stage1MntDir, name), // where - destination
 				"9p",                            // fsType
@@ -173,18 +180,6 @@ func AppToSystemdMountUnits(root string, appName types.ACName, volumes []types.V
 		wherePath := filepath.Join(common.RelAppRootfsPath(appName), m.Path)
 		whereFullPath := filepath.Join(root, wherePath)
 
-		mountOptions := "bind"
-		var readOnly bool
-		if vol.ReadOnly != nil {
-			readOnly = *vol.ReadOnly
-		} else {
-			readOnly = s1common.IsMPReadOnly(app.MountPoints, vol.Name)
-		}
-
-		if readOnly {
-			mountOptions += ",ro"
-		}
-
 		// assertion to make sure that "what" exists (created earlier by PodToSystemdHostMountUnits)
 		log.Printf("checking required source path: %q", whatFullPath)
 		if _, err := os.Stat(whatFullPath); os.IsNotExist(err) {
@@ -199,12 +194,12 @@ func AppToSystemdMountUnits(root string, appName types.ACName, volumes []types.V
 		}
 
 		// install new mount unit for bind mount /mnt/volumeName -> /opt/stage2/{app-id}/rootfs/{{mountPoint.Path}}
-		err = installNewMountUnit(
+		mu, err := installNewMountUnit(
 			root,      // where put a mount unit
 			whatPath,  // what - stage1 rootfs /mnt/VolumeName
 			wherePath, // where - inside chroot app filesystem
 			"bind",    // fstype
-			mountOptions,
+			"bind",    // options
 			serviceUnitName(appName),
 			unitsDir,
 		)
@@ -212,6 +207,25 @@ func AppToSystemdMountUnits(root string, appName types.ACName, volumes []types.V
 			return fmt.Errorf("cannot install new mount unit for app %q: %v", appName.String(), err)
 		}
 
+		readOnly := s1common.IsMountReadOnly(vol, app.MountPoints)
+		// TODO(iaguis) when we update util-linux to 2.27, this code can go
+		// away and we can bind-mount RO with one unit file.
+		// http://ftp.kernel.org/pub/linux/utils/util-linux/v2.27/v2.27-ReleaseNotes
+		if readOnly {
+			opts := []*unit.UnitOption{
+				unit.NewUnitOption("Unit", "Description", fmt.Sprintf("Remount read-only unit for %s", wherePath)),
+				unit.NewUnitOption("Unit", "DefaultDependencies", "false"),
+				unit.NewUnitOption("Unit", "After", mu),
+				unit.NewUnitOption("Unit", "Wants", mu),
+				unit.NewUnitOption("Service", "ExecStart", fmt.Sprintf("/usr/bin/mount -o remount,ro %s", wherePath)),
+				unit.NewUnitOption("Install", "RequiredBy", mu),
+			}
+
+			remountUnitPath := filepath.Join(root, unitsDir, unit.UnitNamePathEscape(wherePath+"-remount.service"))
+			if err := writeUnit(opts, remountUnitPath); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
In https://github.com/coreos/rkt/pull/1582 we added support for
PodManifest.Mounts but we didn't consider the kvm flavor.

This commit adds support for the kvm flavor and refactors the code a
bit.

Fixes #1663