### PR TITLE
build: Fix ACI Go tools not being rebuilt on the source file changes

### DIFF
--- a/stage1/makelib/aci_install_bin.mk
+++ b/stage1/makelib/aci_install_bin.mk
@@ -4,6 +4,9 @@
 # installed in their ACI rootfs
 #
 # AIB_BINARY - a binary to install
+#
+# AIB_BUILD_STAMP - a stamp used to build the go binary and generate
+# the deps file in the meantime
 
 # In detail for each flavor - generate a stamp which depends on a
 # binary in the ACI rootfs directory. The binary will be copied to the
@@ -21,7 +24,7 @@ $(foreach flavor,$(AIB_FLAVORS), \
 	$(eval _AIB_ACI_BINARY_ := $(STAGE1_ACIROOTFSDIR_$(flavor))/$(_AIB_NAME_)) \
 	$(eval STAGE1_SECONDARY_STAMPS_$(flavor) += $(_AIB_STAMP_)) \
 	$(eval STAGE1_INSTALL_FILES_$(flavor) += $(AIB_BINARY):$(_AIB_ACI_BINARY_):-) \
-	$(call add-dependency,$(_AIB_ACI_BINARY_),$(MK_PATH) $(_AIB_PATH_)) \
+	$(call add-dependency,$(_AIB_ACI_BINARY_),$(MK_PATH) $(_AIB_PATH_) $(AIB_BUILD_STAMP)) \
 	$(call generate-stamp-rule,$(_AIB_STAMP_),$(_AIB_ACI_BINARY_),,,))
 
 $(call undefine-namespaces,AIB _AIB)

--- a/stage1/makelib/aci_simple_go_bin.mk
+++ b/stage1/makelib/aci_simple_go_bin.mk
@@ -46,6 +46,7 @@ $(_ASGB_BINARY_): $(_ASGB_PATH_) $(MK_PATH) | $(TOOLSDIR)
 # 2.
 
 AIB_FLAVORS := $(ASGB_FLAVORS)
+AIB_BUILD_STAMP := $(_ASGB_BUILD_STAMP_)
 AIB_BINARY := $(_ASGB_BINARY_)
 include stage1/makelib/aci_install_bin.mk
 


### PR DESCRIPTION
stage1 ACI image had an indirect dependency on a tool (init or gc)
inside the ACI rootfs directory, but it didn't have any dependency on
the stamp which, besides making sure that the binary was built, is
making sure that the deps file are generated. Those deps file are
adding dependencies to built binary on its source files.

Make the binary in the ACI rootfs directory to depend on the stamp
too, so the missing files are generated.