### PR TITLE
build: Fix useless rebuilds of stage1 images

### DIFF
--- a/stage1/makelib/aci_simple_go_bin.mk
+++ b/stage1/makelib/aci_simple_go_bin.mk
@@ -31,6 +31,7 @@ endif
 # 1.
 
 $(call setup-stamp-file,_ASGB_BUILD_STAMP_,binary-build)
+$(call generate-stamp-rule,$(_ASGB_BUILD_STAMP_))
 
 # variables for makelib/build_go_bin.mk
 BGB_STAMP := $(_ASGB_BUILD_STAMP_)


### PR DESCRIPTION
The stamp was not created at all, and that forced copying built go
tools into the ACI rootfs directory on every run, which in turn forced
rerunning actool to build the final stage1 image.