### PR TITLE
tests: add functional tests for rkt api service.

### DIFF
--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -597,6 +597,12 @@ func runAPIService(cmd *cobra.Command, args []string) (exit int) {
 
 	log.Printf("API service running on %v...", flagAPIServiceListenClientURL)
 
+	defer func() {
+		if r := recover(); r != nil {
+			log.Print("recovered", r)
+		}
+	}()
+
 	signal.Notify(exitCh, syscall.SIGINT, syscall.SIGTERM)
 	<-exitCh
 

--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -599,7 +599,7 @@ func runAPIService(cmd *cobra.Command, args []string) (exit int) {
 
 	defer func() {
 		if r := recover(); r != nil {
-			log.Print("recovered", r)
+			log.Print("recovered panic", r)
 		}
 	}()
 

--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -283,20 +283,6 @@ func getApplist(p *pod) ([]*v1alpha.App, error) {
 	return apps, nil
 }
 
-// getPodPid returns the pid of the pod if it's running, otherwise returns -1.
-func getPodPid(p *pod) (int32, error) {
-	var pid int32 = -1
-	if p.getState() == Running {
-		podpid, err := p.getPID()
-		if err != nil {
-			log.Printf("Failed to get PID for pod %q: %v", p.uuid, err)
-			return -1, err
-		}
-		pid = int32(podpid)
-	}
-	return pid, nil
-}
-
 // getNetworks returns the list of the info of the network that the pod belongs to.
 func getNetworks(p *pod) []*v1alpha.Network {
 	var networks []*v1alpha.Network
@@ -318,7 +304,7 @@ func getBasicPod(p *pod) (*v1alpha.Pod, *schema.PodManifest, error) {
 		return nil, nil, err
 	}
 
-	pid, err := getPodPid(p)
+	pid, err := p.getPID()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -330,7 +316,7 @@ func getBasicPod(p *pod) (*v1alpha.Pod, *schema.PodManifest, error) {
 
 	return &v1alpha.Pod{
 		Id:       p.uuid.String(),
-		Pid:      pid,
+		Pid:      int32(pid),
 		State:    getPodState(p), // Get pod's state.
 		Apps:     apps,
 		Manifest: data,

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -844,11 +844,11 @@ func discoverApp(app *discovery.App, insecure bool) (*discovery.Endpoints, error
 func getStoreKeyFromApp(s *store.Store, img string) (string, error) {
 	app, err := discovery.NewAppFromString(img)
 	if err != nil {
-		return "", fmt.Errorf("cannot parse the image name: %v", err)
+		return "", fmt.Errorf("cannot parse the image name %q: %v", img, err)
 	}
 	labels, err := types.LabelsFromMap(app.Labels)
 	if err != nil {
-		return "", fmt.Errorf("invalid labels in the name: %v", err)
+		return "", fmt.Errorf("invalid labels in the image %q: %v", img, err)
 	}
 	key, err := s.GetACI(app.Name, labels)
 	if err != nil {
@@ -856,7 +856,7 @@ func getStoreKeyFromApp(s *store.Store, img string) (string, error) {
 		case store.ACINotFoundError:
 			return "", err
 		default:
-			return "", fmt.Errorf("cannot find image: %v", err)
+			return "", fmt.Errorf("cannot find image %q: %v", img, err)
 		}
 	}
 	return key, nil

--- a/tests/rkt_api_service_test.go
+++ b/tests/rkt_api_service_test.go
@@ -1,0 +1,293 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"syscall"
+	"testing"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
+	"github.com/coreos/rkt/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/coreos/rkt/api/v1alpha"
+	"github.com/coreos/rkt/common"
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+func startAPIService(t *testing.T, ctx *testutils.RktRunCtx) *gexpect.ExpectSubprocess {
+	noGid := false
+	gid, err := common.LookupGid(common.RktGroup)
+	if err != nil {
+		t.Logf("no %q group, will run api service with root, ONLY DO THIS FOR TESTING!", common.RktGroup)
+		noGid = true
+	} else {
+		t.Logf("Running rkt install")
+		installCmd := fmt.Sprintf("%s install", ctx.Cmd())
+		runRktAndCheckOutput(t, installCmd, "rkt directory structure successfully created", false)
+	}
+
+	t.Logf("Running rkt api service")
+	apisvcCmd := fmt.Sprintf("%s api-service", ctx.Cmd())
+
+	if noGid {
+		return startRktAndCheckOutput(t, apisvcCmd, "API service running")
+	}
+	return startRktAsGidAndCheckOutput(t, apisvcCmd, "API service running", gid)
+}
+
+func stopAPIService(t *testing.T, svc *gexpect.ExpectSubprocess) {
+	if err := svc.Cmd.Process.Signal(syscall.SIGINT); err != nil {
+		t.Fatalf("Failed to stop the api service")
+	}
+	waitOrFail(t, svc, true)
+}
+
+func checkPodState(t *testing.T, rawState string, apiState v1alpha.PodState) {
+	switch rawState {
+	case "embryo":
+		if apiState == v1alpha.PodState_POD_STATE_EMBRYO {
+			return
+		}
+	case "preparing":
+		if apiState == v1alpha.PodState_POD_STATE_PREPARING {
+			return
+		}
+	case "aborted prepare":
+		if apiState == v1alpha.PodState_POD_STATE_ABORTED_PREPARE {
+			return
+		}
+	case "running":
+		if apiState == v1alpha.PodState_POD_STATE_RUNNING {
+			return
+		}
+	case "deleting":
+		if apiState == v1alpha.PodState_POD_STATE_DELETING {
+			return
+		}
+	case "exited":
+		if apiState == v1alpha.PodState_POD_STATE_EXITED {
+			return
+		}
+	case "garbage":
+		if apiState == v1alpha.PodState_POD_STATE_GARBAGE {
+			return
+		}
+	default:
+		t.Fatalf("Unexpected state: %v", rawState)
+	}
+	t.Errorf("Pod state returned by api-service (%q) is not equivalent to the state returned by 'rkt status' (%q)", apiState, rawState)
+}
+
+func checkPodApps(t *testing.T, rawApps map[string]*appInfo, apiApps []*v1alpha.App, hasAppState bool) {
+	if len(rawApps) != len(apiApps) {
+		t.Errorf("Expected %d apps, saw %d apps returned by api service %v", len(rawApps), len(apiApps), apiApps)
+	}
+
+	for _, app := range apiApps {
+		if appInfo, ok := rawApps[app.Name]; ok {
+			if hasAppState && appInfo.exitCode != int(app.ExitCode) {
+				t.Errorf("Expected %v, saw %v", appInfo.exitCode, app.ExitCode)
+			}
+			if appInfo.image.id != app.Image.Id {
+				t.Errorf("Expected %q, saw %q", appInfo.image.id, app.Image.Id)
+			}
+		} else {
+			t.Errorf("Expected app (name: %q) in the app list", appInfo.name)
+		}
+	}
+}
+
+func checkPodNetworks(t *testing.T, rawNets map[string]*networkInfo, apiNets []*v1alpha.Network) {
+	if len(rawNets) != len(apiNets) {
+		t.Errorf("Expected %d networks, saw %d networks returned by api service", len(rawNets), len(apiNets))
+	}
+
+	// Each network should have a unique name, so iteration over one list is enough given
+	// the lengths of the two lists are equal.
+	for _, net := range apiNets {
+		if netInfo, ok := rawNets[net.Name]; ok {
+			if netInfo.ipv4 != net.Ipv4 {
+				t.Errorf("Expected %q, saw %q", netInfo.ipv4, net.Ipv4)
+			}
+		} else {
+			t.Errorf("Expected network (name: %q, ipv4: %q) in networks", netInfo.name, netInfo.ipv4)
+		}
+	}
+}
+
+// Check the pod's information by 'rkt status'.
+func checkPod(t *testing.T, ctx *testutils.RktRunCtx, p *v1alpha.Pod, hasAppState, hasManifest bool) {
+	podInfo := getPodInfo(t, ctx, p.Id)
+	if podInfo.id != p.Id {
+		t.Errorf("Expected %q, saw %q", podInfo.id, p.Id)
+	}
+	if podInfo.pid != int(p.Pid) {
+		t.Errorf("Expected %d, saw %d", podInfo.pid, p.Pid)
+	}
+	checkPodState(t, podInfo.state, p.State)
+	checkPodApps(t, podInfo.apps, p.Apps, hasAppState)
+	checkPodNetworks(t, podInfo.networks, p.Networks)
+
+	if hasManifest && !bytes.Equal(podInfo.manifest, p.Manifest) {
+		t.Errorf("Expected %q, saw %q", string(podInfo.manifest), string(p.Manifest))
+	} else if !hasManifest && p.Manifest != nil {
+		t.Errorf("Expected nil manifest")
+	}
+}
+
+func checkPodBasics(t *testing.T, ctx *testutils.RktRunCtx, p *v1alpha.Pod) {
+	checkPod(t, ctx, p, false, false)
+}
+
+func checkPodDetails(t *testing.T, ctx *testutils.RktRunCtx, p *v1alpha.Pod) {
+	checkPod(t, ctx, p, true, true)
+}
+
+// Check the image's information by 'rkt image list'.
+func checkImage(t *testing.T, ctx *testutils.RktRunCtx, m *v1alpha.Image, hasManifest bool) {
+	imgInfo := getImageInfo(t, ctx, m.Id)
+	if imgInfo.id != m.Id {
+		t.Errorf("Expected %q, saw %q", imgInfo.id, m.Id)
+	}
+	if imgInfo.name != m.Name {
+		t.Errorf("Expected %q, saw %q", imgInfo.name, m.Name)
+	}
+	if imgInfo.version != m.Version {
+		t.Errorf("Expected %q, saw %q", imgInfo.version, m.Version)
+	}
+	if imgInfo.importTime != m.ImportTimestamp {
+		t.Errorf("Expected %q, saw %q", imgInfo.importTime, m.ImportTimestamp)
+	}
+
+	if hasManifest && !bytes.Equal(imgInfo.manifest, m.Manifest) {
+		t.Errorf("Expected %q, saw %q", string(imgInfo.manifest), string(m.Manifest))
+	} else if !hasManifest && m.Manifest != nil {
+		t.Errorf("Expected nil manifest")
+	}
+}
+
+func checkImageBasics(t *testing.T, ctx *testutils.RktRunCtx, m *v1alpha.Image) {
+	checkImage(t, ctx, m, false)
+}
+
+func checkImageDetails(t *testing.T, ctx *testutils.RktRunCtx, m *v1alpha.Image) {
+	checkImage(t, ctx, m, true)
+}
+
+func TestAPIServiceGetInfo(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	svc := startAPIService(t, ctx)
+	defer stopAPIService(t, svc)
+
+	c, conn := newAPIClientOrFail(t, "localhost:15441")
+	defer conn.Close()
+
+	resp, err := c.GetInfo(context.Background(), &v1alpha.GetInfoRequest{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	expectedAPIVersion := "1.0.0-alpha"
+	if resp.Info.ApiVersion != expectedAPIVersion {
+		t.Errorf("Expected api version to be %q, but saw %q", expectedAPIVersion, resp.Info.ApiVersion)
+	}
+}
+
+func TestAPIServiceListInspectPods(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	svc := startAPIService(t, ctx)
+	defer stopAPIService(t, svc)
+
+	c, conn := newAPIClientOrFail(t, "localhost:15441")
+	defer conn.Close()
+
+	resp, err := c.ListPods(context.Background(), &v1alpha.ListPodsRequest{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(resp.Pods) != 0 {
+		t.Errorf("Unexpected result: %v, should see zero pods", resp.Pods)
+	}
+
+	patchImportAndRun("rkt-inspect-print.aci", []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=42"}, t, ctx)
+
+	resp, err = c.ListPods(context.Background(), &v1alpha.ListPodsRequest{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(resp.Pods) == 0 {
+		t.Errorf("Unexpected result: %v, should see non-zero pods", resp.Pods)
+	}
+
+	for _, p := range resp.Pods {
+		checkPodBasics(t, ctx, p)
+
+		// Test InspectPod().
+		inspectResp, err := c.InspectPod(context.Background(), &v1alpha.InspectPodRequest{Id: p.Id})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		checkPodDetails(t, ctx, inspectResp.Pod)
+	}
+}
+
+func TestAPIServiceListInspectImages(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	svc := startAPIService(t, ctx)
+	defer stopAPIService(t, svc)
+
+	c, conn := newAPIClientOrFail(t, "localhost:15441")
+	defer conn.Close()
+
+	resp, err := c.ListImages(context.Background(), &v1alpha.ListImagesRequest{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(resp.Images) != 0 {
+		t.Errorf("Unexpected result: %v, should see zero images", resp.Images)
+	}
+
+	patchImportAndFetchHash("rkt-inspect-sleep.aci", []string{"--exec=/inspect"}, t, ctx)
+
+	resp, err = c.ListImages(context.Background(), &v1alpha.ListImagesRequest{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(resp.Images) == 0 {
+		t.Errorf("Unexpected result: %v, should see non-zero images", resp.Images)
+	}
+
+	for _, m := range resp.Images {
+		checkImageBasics(t, ctx, m)
+
+		// Test InspectImage().
+		inspectResp, err := c.InspectImage(context.Background(), &v1alpha.InspectImageRequest{Id: m.Id})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		checkImageDetails(t, ctx, inspectResp.Image)
+	}
+}

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -15,26 +15,35 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha512"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/steveeJ/gexpect"
+	"github.com/coreos/rkt/Godeps/_workspace/src/google.golang.org/grpc"
+	"github.com/coreos/rkt/api/v1alpha"
 	"github.com/coreos/rkt/tests/testutils"
 )
 
 const (
-	nobodyUid = uint32(65534)
+	defaultTimeLayout = "2006-01-02 15:04:05.999 -0700 MST"
+	nobodyUid         = uint32(65534)
 )
 
 func expectCommon(p *gexpect.ExpectSubprocess, searchString string, timeout time.Duration) error {
@@ -210,6 +219,14 @@ func patchImportAndFetchHash(image string, patches []string, t *testing.T, ctx *
 	return importImageAndFetchHash(t, ctx, imagePath)
 }
 
+func patchImportAndRun(image string, patches []string, t *testing.T, ctx *testutils.RktRunCtx) {
+	imagePath := patchTestACI(image, patches...)
+	defer os.Remove(imagePath)
+
+	cmd := fmt.Sprintf("%s --insecure-skip-verify run %s", ctx.Cmd(), imagePath)
+	spawnAndWaitOrFail(t, cmd, true)
+}
+
 func runGC(t *testing.T, ctx *testutils.RktRunCtx) {
 	cmd := fmt.Sprintf("%s gc --grace-period=0s", ctx.Cmd())
 	spawnAndWaitOrFail(t, cmd, true)
@@ -266,6 +283,28 @@ func runRktAsGidAndCheckOutput(t *testing.T, rktCmd, expectedLine string, expect
 	}
 }
 
+func startRktAsGidAndCheckOutput(t *testing.T, rktCmd, expectedLine string, gid int) *gexpect.ExpectSubprocess {
+	child, err := gexpect.Command(rktCmd)
+	if err != nil {
+		t.Fatalf("cannot exec rkt: %v", err)
+	}
+	if gid != 0 {
+		child.Cmd.SysProcAttr = &syscall.SysProcAttr{}
+		child.Cmd.SysProcAttr.Credential = &syscall.Credential{Uid: nobodyUid, Gid: uint32(gid)}
+	}
+
+	if err := child.Start(); err != nil {
+		t.Fatalf("cannot exec rkt: %v", err)
+	}
+
+	if expectedLine != "" {
+		if err := expectWithOutput(child, expectedLine); err != nil {
+			t.Fatalf("didn't receive expected output %q: %v", expectedLine, err)
+		}
+	}
+	return child
+}
+
 func runRktAndCheckRegexOutput(t *testing.T, rktCmd, match string) {
 	child := spawnOrFail(t, rktCmd)
 	defer child.Wait()
@@ -278,6 +317,10 @@ func runRktAndCheckRegexOutput(t *testing.T, rktCmd, match string) {
 
 func runRktAndCheckOutput(t *testing.T, rktCmd, expectedLine string, expectError bool) {
 	runRktAsGidAndCheckOutput(t, rktCmd, expectedLine, expectError, 0)
+}
+
+func startRktAndCheckOutput(t *testing.T, rktCmd, expectedLine string) *gexpect.ExpectSubprocess {
+	return startRktAsGidAndCheckOutput(t, rktCmd, expectedLine, 0)
 }
 
 func checkAppStatus(t *testing.T, ctx *testutils.RktRunCtx, multiApps bool, appName, expected string) {
@@ -316,4 +359,205 @@ func checkAppStatus(t *testing.T, ctx *testutils.RktRunCtx, multiApps bool, appN
 		t.Fatalf("Failed to get the status for app %s: expected: %s. %v",
 			appName, expected, err)
 	}
+}
+
+type imageInfo struct {
+	id         string
+	name       string
+	version    string
+	importTime int64
+	manifest   []byte
+}
+
+type appInfo struct {
+	name     string
+	exitCode int
+	image    *imageInfo
+	// TODO(yifan): Add app state.
+}
+
+type networkInfo struct {
+	name string
+	ipv4 string
+}
+
+type podInfo struct {
+	id       string
+	pid      int
+	state    string
+	apps     map[string]*appInfo
+	networks map[string]*networkInfo
+	manifest []byte
+}
+
+// parsePodInfo parses the 'rkt status $UUID' result into podInfo struct.
+// For example, the 'result' can be:
+// state=running
+// networks=default:ip4=172.16.28.103
+// pid=14352
+// exited=false
+func parsePodInfoOutput(t *testing.T, result string, p *podInfo) {
+	lines := strings.Split(strings.TrimSuffix(result, "\n"), "\n")
+	for _, line := range lines {
+		tuples := strings.SplitN(line, "=", 2)
+		if len(tuples) != 2 {
+			t.Fatalf("Unexpected line: %v", line)
+		}
+
+		switch tuples[0] {
+		case "state":
+			p.state = tuples[1]
+		case "networks":
+			networks := strings.Split(tuples[1], ",")
+			for _, n := range networks {
+				fields := strings.Split(n, ":")
+				if len(fields) != 2 {
+					t.Fatalf("Unexpected network info format: %v", n)
+				}
+
+				ip4 := strings.Split(fields[1], "=")
+				if len(ip4) != 2 {
+					t.Fatalf("Unexpected network info format: %v", n)
+				}
+
+				networkName := fields[0]
+				p.networks[networkName] = &networkInfo{
+					name: networkName,
+					ipv4: ip4[1],
+				}
+			}
+		case "pid":
+			pid, err := strconv.Atoi(tuples[1])
+			if err != nil {
+				t.Fatalf("Cannot parse the pod's pid %q: %v", tuples[1], err)
+			}
+			p.pid = pid
+		}
+		if strings.HasPrefix(tuples[0], "app-") {
+			exitCode, err := strconv.Atoi(tuples[1])
+			if err != nil {
+				t.Fatalf("cannot parse exit code from %q : %v", tuples[1], err)
+			}
+			appName := strings.TrimPrefix(tuples[0], "app-")
+
+			for _, app := range p.apps {
+				if app.name == appName {
+					app.exitCode = exitCode
+					break
+				}
+			}
+		}
+	}
+}
+
+func getPodDir(t *testing.T, ctx *testutils.RktRunCtx, podID string) string {
+	podsDir := path.Join(ctx.DataDir(), "pods")
+
+	dirs, err := ioutil.ReadDir(podsDir)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	for _, dir := range dirs {
+		podDir := path.Join(podsDir, dir.Name(), podID)
+		if _, err := os.Stat(podDir); err == nil {
+			return podDir
+		}
+	}
+	t.Fatalf("Failed to find pod directory for pod %q", podID)
+	return ""
+}
+
+// getPodInfo returns the pod info for the given pod ID.
+func getPodInfo(t *testing.T, ctx *testutils.RktRunCtx, podID string) *podInfo {
+	p := &podInfo{
+		id:       podID,
+		apps:     make(map[string]*appInfo),
+		networks: make(map[string]*networkInfo),
+	}
+
+	// Read pod manifest.
+	//
+	// TODO: run "rkt cat-manifest" instead of opening the manifest file manually.
+	// https://github.com/coreos/rkt/issues/1730
+	podManifestPath := path.Join(getPodDir(t, ctx, podID), "pod")
+	f, err := os.Open(podManifestPath)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	p.manifest, err = ioutil.ReadAll(f)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Fill app infos.
+	var manifest schema.PodManifest
+	if err := json.Unmarshal(p.manifest, &manifest); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	for _, app := range manifest.Apps {
+		appName := app.Name.String()
+		p.apps[appName] = &appInfo{
+			name: appName,
+			// TODO(yifan): Get the image's name.
+			image: &imageInfo{id: app.Image.ID.String()},
+		}
+	}
+
+	// Fill other infos.
+	output, err := exec.Command("/bin/bash", "-c", fmt.Sprintf("%s status %s", ctx.Cmd(), podID)).CombinedOutput()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	parsePodInfoOutput(t, string(output), p)
+
+	return p
+}
+
+// parseImageInfoOutput parses the 'rkt image list' result into imageInfo struct.
+// For example, the 'result' can be:
+// 'sha512-e9b77714dbbfda12cb9e136318b103a6f0ce082004d09d0224a620d2bbf38133 nginx:latest 2015-10-16 17:42:57.741 -0700 PDT true'
+func parseImageInfoOutput(t *testing.T, result string) *imageInfo {
+	fields := regexp.MustCompile("\t+").Split(result, 4)
+	nameVersion := strings.Split(fields[1], ":")
+	if len(nameVersion) != 2 {
+		t.Fatalf("Failed to parse name version string: %q", fields[1])
+	}
+	importTime, err := time.Parse(defaultTimeLayout, fields[2])
+	if err != nil {
+		t.Fatalf("Failed to parse time string: %q", fields[2])
+	}
+
+	return &imageInfo{
+		id:         fields[0],
+		name:       nameVersion[0],
+		version:    nameVersion[1],
+		importTime: importTime.Unix(),
+	}
+}
+
+// getImageInfo returns the image info for the given image ID.
+func getImageInfo(t *testing.T, ctx *testutils.RktRunCtx, imageID string) *imageInfo {
+	output, err := exec.Command("/bin/bash", "-c", fmt.Sprintf("%s image list --full | grep %s", ctx.Cmd(), imageID)).CombinedOutput()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	imgInfo := parseImageInfoOutput(t, string(output))
+
+	// Get manifest
+	output, err = exec.Command("/bin/bash", "-c", fmt.Sprintf("%s image cat-manifest %s", ctx.Cmd(), imageID)).CombinedOutput()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	imgInfo.manifest = bytes.TrimSuffix(output, []byte{'\n'})
+	return imgInfo
+}
+
+func newAPIClientOrFail(t *testing.T, address string) (v1alpha.PublicAPIClient, *grpc.ClientConn) {
+	conn, err := grpc.Dial(address, grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	c := v1alpha.NewPublicAPIClient(conn)
+	return c, conn
 }


### PR DESCRIPTION
Add tests for `GetInfo()`, `ListPods()`, `InspectPod()`
`ListImages()` and `InspectImage()`.

Fix https://github.com/coreos/rkt/issues/1668

Will be conflicted to https://github.com/coreos/rkt/pull/1688 which reduces the info returned by `ListPods()` and `ListImages()` 