### PR TITLE
rkt: image gc: garbage-collect images from the store

### DIFF
--- a/Documentation/subcommands/image.md
+++ b/Documentation/subcommands/image.md
@@ -31,13 +31,18 @@ rkt: 1 image(s) successfully remove
 
 ## rkt image gc
 
-You can garbage collect the rkt store to clean up unused internal data and remove old images (this one to be implemented).
+You can garbage collect the rkt store to clean up unused internal data and remove old images.
+
+By default, images not used in the last 24h will be removed. This can be configured with the `--grace-period` flag.
 
 ```
-# rkt image gc
-rkt: removed treestore "deps-sha512-120e20cf5c4588b9ed9727e9963f87cc587bec8f23e26fb607cb6adf6d3953f2"
+# rkt image gc --grace-period 48h
+rkt: removed treestore "deps-sha512-219204dd54481154aec8f6eafc0f2064d973c8a2c0537eab827b7414f0a36248"
+rkt: removed treestore "deps-sha512-3f2a1ad0e9739d977278f0019b6d7d9024a10a2b1166f6c9fdc98f77a357856d"
+rkt: successfully removed aci for image ID: "sha512-e39d4089a224718c41e6bef4c1ac692a6c1832c8c69cf28123e1f205a9355444"
+rkt: successfully removed aci for image ID: "sha512-0648aa44a37a8200147d41d1a9eff0757d0ac113a22411f27e4e03cbd1e84d0d"
+rkt: 2 image(s) successfully removed
 ```
-
 
 ## rkt image export
 

--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -30,41 +30,46 @@ import (
 const (
 	defaultTimeLayout = "2006-01-02 15:04:05.999 -0700 MST"
 
-	idField         = "id"
-	nameField       = "name"
-	importTimeField = "importtime"
-	latestField     = "latest"
+	idField           = "id"
+	nameField         = "name"
+	importTimeField   = "importtime"
+	lastUsedTimeField = "lastusedtime"
+	latestField       = "latest"
 )
 
 var (
 	// map of valid fields and related flag value
 	imagesAllFields = map[string]struct{}{
-		idField:         struct{}{},
-		nameField:       struct{}{},
-		importTimeField: struct{}{},
-		latestField:     struct{}{},
+		idField:           struct{}{},
+		nameField:         struct{}{},
+		importTimeField:   struct{}{},
+		lastUsedTimeField: struct{}{},
+		latestField:       struct{}{},
 	}
 
 	// map of valid fields and related header name
 	ImagesFieldHeaderMap = map[string]string{
-		idField:         "ID",
-		nameField:       "NAME",
-		importTimeField: "IMPORT TIME",
-		latestField:     "LATEST",
+		idField:           "ID",
+		nameField:         "NAME",
+		importTimeField:   "IMPORT TIME",
+		lastUsedTimeField: "LAST USED",
+		latestField:       "LATEST",
 	}
 
 	// map of valid sort fields containing the mapping between the provided field name
 	// and the related aciinfo's field name.
 	ImagesFieldAciInfoMap = map[string]string{
-		idField:         "blobkey",
-		nameField:       "name",
-		importTimeField: "importtime",
-		latestField:     "latest",
+		idField:           "blobkey",
+		nameField:         "name",
+		importTimeField:   "importtime",
+		lastUsedTimeField: "lastusedtime",
+		latestField:       "latest",
 	}
 
 	ImagesSortableFields = map[string]struct{}{
-		nameField:       struct{}{},
-		importTimeField: struct{}{},
+		nameField:         struct{}{},
+		importTimeField:   struct{}{},
+		lastUsedTimeField: struct{}{},
 	}
 )
 
@@ -168,13 +173,13 @@ var (
 
 func init() {
 	// Set defaults
-	flagImagesFields = []string{idField, nameField, importTimeField, latestField}
+	flagImagesFields = []string{idField, nameField, importTimeField, lastUsedTimeField, latestField}
 	flagImagesSortFields = []string{importTimeField}
 	flagImagesSortAsc = true
 
 	cmdImage.AddCommand(cmdImageList)
-	cmdImageList.Flags().Var(&flagImagesFields, "fields", `comma separated list of fields to display. Accepted values: "id", "name", "importtime", "latest"`)
-	cmdImageList.Flags().Var(&flagImagesSortFields, "sort", `sort the output according to the provided comma separated list of fields. Accepted values: "name", "importtime"`)
+	cmdImageList.Flags().Var(&flagImagesFields, "fields", `comma separated list of fields to display. Accepted values: "id", "name", "importtime", "lastusedtime", "latest"`)
+	cmdImageList.Flags().Var(&flagImagesSortFields, "sort", `sort the output according to the provided comma separated list of fields. Accepted values: "name", "importtime", "lastusedtime"`)
 	cmdImageList.Flags().Var(&flagImagesSortAsc, "order", `choose the sorting order if at least one sort field is provided (--sort). Accepted values: "asc", "desc"`)
 	cmdImageList.Flags().BoolVar(&flagNoLegend, "no-legend", false, "suppress a legend with the list")
 	cmdImageList.Flags().BoolVar(&flagFullOutput, "full", false, "use long output format")
@@ -248,6 +253,13 @@ func runImages(cmd *cobra.Command, args []string) int {
 				} else {
 					fieldValue = humanize.Time(aciInfo.ImportTime)
 				}
+			case lastUsedTimeField:
+				if flagFullOutput {
+					fieldValue = aciInfo.LastUsedTime.Format(defaultTimeLayout)
+				} else {
+					fieldValue = humanize.Time(aciInfo.LastUsedTime)
+				}
+
 			case latestField:
 				fieldValue = fmt.Sprintf("%t", aciInfo.Latest)
 			}

--- a/store/aciinfo.go
+++ b/store/aciinfo.go
@@ -30,6 +30,8 @@ type ACIInfo struct {
 	Name string
 	// ImportTime is the time this ACI was imported in the store.
 	ImportTime time.Time
+	// LastUsedTime is the last time this image was read
+	LastUsedTime time.Time
 	// Latest defines if the ACI was imported using the latest pattern (no
 	// version label was provided on ACI discovery)
 	Latest bool
@@ -37,15 +39,16 @@ type ACIInfo struct {
 
 func NewACIInfo(blobKey string, latest bool, t time.Time) *ACIInfo {
 	return &ACIInfo{
-		BlobKey:    blobKey,
-		Latest:     latest,
-		ImportTime: t,
+		BlobKey:      blobKey,
+		Latest:       latest,
+		ImportTime:   t,
+		LastUsedTime: time.Now(),
 	}
 }
 
 func aciinfoRowScan(rows *sql.Rows, aciinfo *ACIInfo) error {
 	// This ordering MUST match that in schema.go
-	return rows.Scan(&aciinfo.BlobKey, &aciinfo.Name, &aciinfo.ImportTime, &aciinfo.Latest)
+	return rows.Scan(&aciinfo.BlobKey, &aciinfo.Name, &aciinfo.ImportTime, &aciinfo.LastUsedTime, &aciinfo.Latest)
 }
 
 // GetAciInfosWithKeyPrefix returns all the ACIInfos with a blobkey starting with the given prefix.
@@ -152,7 +155,7 @@ func WriteACIInfo(tx *sql.Tx, aciinfo *ACIInfo) error {
 	if err != nil {
 		return err
 	}
-	_, err = tx.Exec("INSERT into aciinfo (blobkey, name, importtime, latest) VALUES ($1, $2, $3, $4)", aciinfo.BlobKey, aciinfo.Name, aciinfo.ImportTime, aciinfo.Latest)
+	_, err = tx.Exec("INSERT into aciinfo (blobkey, name, importtime, lastusedtime, latest) VALUES ($1, $2, $3, $4, $5)", aciinfo.BlobKey, aciinfo.Name, aciinfo.ImportTime, aciinfo.LastUsedTime, aciinfo.Latest)
 	if err != nil {
 		return err
 	}

--- a/store/schema.go
+++ b/store/schema.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// Incremental db version at the current code revision.
-	dbVersion = 3
+	dbVersion = 4
 )
 
 // Statement to run when creating a db. These are the statements to create the
@@ -37,7 +37,7 @@ var dbCreateStmts = [...]string{
 	"CREATE UNIQUE INDEX IF NOT EXISTS aciurlidx ON remote (aciurl)",
 
 	// aciinfo table. The primary key is "blobkey" and it matches the key used to save that aci in the blob store
-	"CREATE TABLE IF NOT EXISTS aciinfo (blobkey string, name string, importtime time, latest bool);",
+	"CREATE TABLE IF NOT EXISTS aciinfo (blobkey string, name string, importtime time, lastusedtime time, latest bool);",
 	"CREATE UNIQUE INDEX IF NOT EXISTS blobkeyidx ON aciinfo (blobkey)",
 	"CREATE INDEX IF NOT EXISTS nameidx ON aciinfo (name)",
 }


### PR DESCRIPTION
This commit makes rkt image gc remove images from the store apart from
unreferenced treestores.
    
By default, images not used in the last 24h will be removed. This can be
configured with the `--grace-period`.

Fixes #1205