### PR TITLE
rkt: return the pid of stage1 in "rkt status"

### DIFF
--- a/rkt/enter.go
+++ b/rkt/enter.go
@@ -75,7 +75,7 @@ func runEnter(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	podPID, err := p.getPID()
+	podPID, err := p.getContainerPID1()
 	if err != nil {
 		stderr("Unable to determine the pid for pod %q: %v", podUUID, err)
 		return 1

--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -799,8 +799,17 @@ func getChildPID(ppid int) (int, error) {
 	return -1, ErrChildNotReady{}
 }
 
-// getPID returns the pid of the pod.
-func (p *pod) getPID() (pid int, err error) {
+// getPID returns the pid of the stage1 process that started the pod.
+func (p *pod) getPID() (int, error) {
+	pid, err := p.readIntFromFile("ppid")
+	if err != nil {
+		return -1, err
+	}
+	return pid, nil
+}
+
+// getContainerPID1 returns the pid of the process with pid 1 in the pod.
+func (p *pod) getContainerPID1() (pid int, err error) {
 	// rkt supports two methods to find the container's PID 1:
 	// the pid file and the ppid file.
 	// See Documentation/devel/stage1-implementors-guide.md


### PR DESCRIPTION
Instead of returning the PID of the process that's PID 1 inside the
container, we return the pid of the rkt process that started the pod.

Users can, for example, terminate the pod by sending SIGTERM to that PID
if the container was started with systemd-nspawn.