### PR TITLE
rkt: get name from ImageManifest

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -120,6 +120,11 @@ func AppTreeStoreIDPath(root string, appName types.ACName) string {
 	return filepath.Join(AppInfoPath(root, appName), AppTreeStoreIDFilename)
 }
 
+// AppImageManifestPath returns the path to the app's ImageManifest file
+func AppInfoImageManifestPath(root string, appName types.ACName) string {
+	return filepath.Join(AppInfoPath(root, appName), aci.ManifestFile)
+}
+
 // SharedVolumesPath returns the path to the shared (empty) volumes of a pod.
 func SharedVolumesPath(root string) string {
 	return filepath.Join(root, sharedVolumesDir)

--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -890,6 +890,34 @@ func (p *pod) getAppsHashes() ([]types.Hash, error) {
 	return hashes, nil
 }
 
+type AppsImageManifests map[types.ACName]*schema.ImageManifest
+
+// getAppsImageManifests returns a map of ImageManifests keyed to the
+// corresponding App name.
+func (p *pod) getAppsImageManifests() (AppsImageManifests, error) {
+	apps, err := p.getApps()
+	if err != nil {
+		return nil, err
+	}
+
+	aim := make(AppsImageManifests)
+	for _, a := range apps {
+		imb, err := ioutil.ReadFile(common.AppInfoImageManifestPath(p.path(), a.Name))
+		if err != nil {
+			return nil, err
+		}
+
+		im := &schema.ImageManifest{}
+		if err := im.UnmarshalJSON(imb); err != nil {
+			return nil, err
+		}
+
+		aim[a.Name] = im
+	}
+
+	return aim, nil
+}
+
 // getApps returns a list of apps in the pod
 func (p *pod) getApps() (schema.AppList, error) {
 	pmb, err := p.readFile("pod")

--- a/store/tree.go
+++ b/store/tree.go
@@ -50,7 +50,7 @@ type TreeStore struct {
 // the destination directory doesn't exist (usually Remove should be called
 // before Write)
 func (ts *TreeStore) Write(id string, key string, s *Store) error {
-	treepath := filepath.Join(ts.path, id)
+	treepath := ts.GetPath(id)
 	fi, _ := os.Stat(treepath)
 	if fi != nil {
 		return fmt.Errorf("treestore: path %s already exists", treepath)
@@ -98,7 +98,7 @@ func (ts *TreeStore) Write(id string, key string, s *Store) error {
 
 // Remove cleans the directory for the provided id
 func (ts *TreeStore) Remove(id string) error {
-	treepath := filepath.Join(ts.path, id)
+	treepath := ts.GetPath(id)
 	// If tree path doesn't exist we're done
 	_, err := os.Stat(treepath)
 	if err != nil && os.IsNotExist(err) {
@@ -137,7 +137,7 @@ func (ts *TreeStore) Remove(id string) error {
 func (ts *TreeStore) IsRendered(id string) (bool, error) {
 	// if the "rendered" flag file exists, assume that the store is already
 	// fully rendered.
-	treepath := filepath.Join(ts.path, id)
+	treepath := ts.GetPath(id)
 	_, err := os.Stat(filepath.Join(treepath, renderedfilename))
 	if os.IsNotExist(err) {
 		return false, nil
@@ -166,7 +166,7 @@ func (ts *TreeStore) GetRootFS(id string) string {
 // used to create a tar but instead of writing the full archive is just
 // computes the sha512 sum of the file infos and contents.
 func (ts *TreeStore) Hash(id string) (string, error) {
-	treepath := filepath.Join(ts.path, id)
+	treepath := ts.GetPath(id)
 
 	hash := sha512.New()
 	iw := NewHashWriter(hash)
@@ -183,7 +183,7 @@ func (ts *TreeStore) Hash(id string) (string, error) {
 // Check calculates the actual rendered ACI's hash and verifies that it matches
 // the saved value.
 func (ts *TreeStore) Check(id string) error {
-	treepath := filepath.Join(ts.path, id)
+	treepath := ts.GetPath(id)
 	hash, err := ioutil.ReadFile(filepath.Join(treepath, hashfilename))
 	if err != nil {
 		return fmt.Errorf("treestore: cannot read hash file: %v", err)

--- a/tests/rkt_list_test.go
+++ b/tests/rkt_list_test.go
@@ -1,0 +1,95 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestRktList(t *testing.T) {
+	const imgName = "rkt-list-test"
+
+	image := patchTestACI(fmt.Sprintf("%s.aci", imgName), fmt.Sprintf("--name=%s", imgName))
+	defer os.Remove(image)
+
+	imageHash := getHashOrPanic(image)
+	imgID := ImageId{image, imageHash}
+
+	ctx := newRktRunCtx()
+	defer ctx.cleanup()
+
+	// Prepare image
+	cmd := fmt.Sprintf("%s --insecure-skip-verify prepare %s", ctx.cmd(), imgID.path)
+	podUuid := runRktAndGetUUID(t, cmd)
+
+	// Get hash
+	imageID := fmt.Sprintf("sha512-%s", imgID.hash[:12])
+
+	tmpDir := createTempDirOrPanic(imgName)
+	defer os.RemoveAll(tmpDir)
+
+	// Define tests
+	tests := []struct {
+		cmd           string
+		shouldSucceed bool
+		expect        string
+	}{
+		// Test that pod UUID is in output
+		{
+			"list --full",
+			true,
+			podUuid,
+		},
+		// Test that image name is in output
+		{
+			"list",
+			true,
+			imgName,
+		},
+		// Test that imageID is in output
+		{
+			"list --full",
+			true,
+			imageID,
+		},
+		// Remove the image
+		{
+			fmt.Sprintf("image rm %s", imageID),
+			true,
+			"successfully removed",
+		},
+		// Name should still show up in rkt list
+		{
+			"list",
+			true,
+			imgName,
+		},
+		// Test that imageID is still in output
+		{
+			"list --full",
+			true,
+			imageID,
+		},
+	}
+
+	// Run tests
+	for i, tt := range tests {
+		runCmd := fmt.Sprintf("%s %s", ctx.cmd(), tt.cmd)
+		t.Logf("Running test #%d, %s", i, runCmd)
+		runRktAndCheckOutput(t, runCmd, tt.expect, !tt.shouldSucceed)
+	}
+}


### PR DESCRIPTION
Currently we are relying on an optional field in the PodManifest to get
the images name and version when running `rkt list` because, since one
has been able to remove referenced images, there was no guarantee that
the ImageManifest in the cas would be available.

However, little did we know, there is a copy of the ImageManifest of the
pod in the pod's appinfo directory. This commit makes use of that.

Should close #1659.