### PR TITLE
[RFC] veth: change iface name and ask NetworkManager to ignore them

### DIFF
--- a/Godeps/_workspace/src/github.com/appc/cni/pkg/ip/link.go
+++ b/Godeps/_workspace/src/github.com/appc/cni/pkg/ip/link.go
@@ -74,8 +74,11 @@ func RandomVethName() (string, error) {
 		return "", fmt.Errorf("failed to generate random veth name: %v", err)
 	}
 
-	// NetworkManager (recent versions) will ignore veth devices that start with "veth"
-	return fmt.Sprintf("veth%x", entropy), nil
+	// NetworkManager (recent versions) will ignore veth devices. It is
+	// matching them with the driver name, not the iface name:
+	// ENV{ID_NET_DRIVER}=="veth"
+	// http://cgit.freedesktop.org/NetworkManager/NetworkManager/tree/data/85-nm-unmanaged.rules
+	return fmt.Sprintf("cni-%x", entropy), nil
 }
 
 // SetupVeth sets up a virtual ethernet link.

--- a/dist/udev/80-rkt.rules
+++ b/dist/udev/80-rkt.rules
@@ -1,0 +1,5 @@
+# Ignore Virtual Ethernet device pair created by rkt.
+# New versions of NetworkManager already ignore network interfaces of type
+# "veth" but we want to ignore them in old versions of NetworkManager too.
+ENV{INTERFACE}=="rkt-.*", ENV{NM_UNMANAGED}="1"
+ENV{INTERFACE}=="cni-.*", ENV{NM_UNMANAGED}="1"

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	IfNamePattern = "eth%d"
+	IfNamePattern = "eth%d" // name inside the container
 	selfNetNS     = "/proc/self/ns/net"
 )
 


### PR DESCRIPTION
Change the interface name to cni-xxx instead of vethxxx so it is clearer who created them. This is just a RFC: this patch would need to be done in cni first.

Add a udev rule to ignore network interfaces named "cni-" or "rkt-". Newer versions of NetworkManager might not need that because [it already ignore interfaces with the driver veth](http://cgit.freedesktop.org/NetworkManager/NetworkManager/tree/data/85-nm-unmanaged.rules#n25). However, that rule is still useful for me who uses NetworkManager 1.0.2. Not tested yet.

See also #1312 for a similar change with the kvm flavor.

/cc @steveeJ 