### PR TITLE
rkt/status.go: return -1 for pid if pod is not running.

### DIFF
--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -800,6 +800,9 @@ func getChildPID(ppid int) (int, error) {
 
 // getPID returns the pid of the stage1 process that started the pod.
 func (p *pod) getPID() (int, error) {
+	if !p.isRunning() {
+		return -1, nil
+	}
 	pid, err := p.readIntFromFile("ppid")
 	if err != nil {
 		return -1, err

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -80,7 +80,7 @@ func printStatus(p *pod) error {
 		stdout("networks=%s", fmtNets(p.nets))
 	}
 
-	if !p.isEmbryo && !p.isPreparing && !p.isPrepared && !p.isAbortedPrepare && !p.isGarbage && !p.isGone {
+	if p.isExited || p.isExitedGarbage || p.isExitedDeleting {
 		pid, err := p.getPID()
 		if err != nil {
 			return err
@@ -91,7 +91,7 @@ func printStatus(p *pod) error {
 			return err
 		}
 
-		stdout("pid=%d\nexited=%t", pid, p.isExited)
+		stdout("pid=%d", pid)
 		for app, stat := range stats {
 			stdout("app-%s=%d", app, stat)
 		}


### PR DESCRIPTION
Also remove `exited=false/true` because it duplicates the pod's state.

Fix #1714 