### PR TITLE
rkt: improve manifests unmarshaling errors

### DIFF
--- a/pkg/aci/aci.go
+++ b/pkg/aci/aci.go
@@ -116,7 +116,7 @@ func NewBasicACI(dir string, name string) (*os.File, error) {
 func NewACI(dir string, manifest string, entries []*ACIEntry) (*os.File, error) {
 	var im schema.ImageManifest
 	if err := im.UnmarshalJSON([]byte(manifest)); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid image manifest: %v", err)
 	}
 
 	tf, err := ioutil.TempFile(dir, "")

--- a/rkt/enter.go
+++ b/rkt/enter.go
@@ -132,7 +132,7 @@ func getAppName(p *pod) (*types.ACName, error) {
 
 	m := schema.PodManifest{}
 	if err = m.UnmarshalJSON(b); err != nil {
-		return nil, fmt.Errorf("unable to load manifest: %v", err)
+		return nil, fmt.Errorf("invalid pod manifest: %v", err)
 	}
 
 	switch len(m.Apps) {

--- a/rkt/images.go
+++ b/rkt/images.go
@@ -539,7 +539,7 @@ func (f *fetcher) fetch(appName string, aciURL, ascURL string, ascFile *os.File,
 
 	manifest, err := aci.ManifestFromImage(aciFile)
 	if err != nil {
-		return nil, aciFile, nil, err
+		return nil, aciFile, nil, fmt.Errorf("invalid image manifest: %v", err)
 	}
 	// Check if the downloaded ACI has the correct app name.
 	// The check is only performed when the aci is downloaded through the

--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -918,7 +918,7 @@ func (p *pod) getAppsImageManifests() (AppsImageManifests, error) {
 
 		im := &schema.ImageManifest{}
 		if err := im.UnmarshalJSON(imb); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("invalid image manifest for app %q: %v", a.Name.String(), err)
 		}
 
 		aim[a.Name] = im
@@ -935,7 +935,7 @@ func (p *pod) getApps() (schema.AppList, error) {
 	}
 	pm := new(schema.PodManifest)
 	if err = pm.UnmarshalJSON(pmb); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid pod manifest: %v", err)
 	}
 	return pm.Apps, nil
 }

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -140,7 +140,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	fn.ks = getKeystore()
 	fn.withDeps = true
 	if err := fn.findImages(&rktApps); err != nil {
-		stderr("%v", err)
+		stderr("prepare: %v", err)
 		return 1
 	}
 

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -171,14 +171,14 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 
 	s1img, err := getStage1Hash(s, cmd)
 	if err != nil {
-		stderr("%v", err)
+		stderr("run: %v", err)
 		return 1
 	}
 
 	fn.ks = getKeystore()
 	fn.withDeps = true
 	if err := fn.findImages(&rktApps); err != nil {
-		stderr("%v", err)
+		stderr("run: %v", err)
 		return 1
 	}
 


### PR DESCRIPTION
We were directly returning err so messages were confusing.

Fixes partially #1700