### PR TITLE
build: Correct erroneous test for squashfs-tools

### DIFF
--- a/scripts/vagrant/install-rkt.sh
+++ b/scripts/vagrant/install-rkt.sh
@@ -16,7 +16,7 @@ if ! [ -d app-spec ]; then
   popd
 fi
 
-which unsquash || sudo apt-get install -y squashfs-tools autoconf
+which unsquashfs || sudo apt-get install -y squashfs-tools autoconf
 
 pushd /vagrant
 ./autogen.sh && ./configure && make BUILDDIR=build-rkt


### PR DESCRIPTION
The `scripts/vagrant/install-rkt.sh` script erroneously tests for the
existence of a `unsquash` command. It should be `unsquashfs` instead.
