### PR TITLE
stage1: pass SYSTEMD_NSPAWN_CONTAINER_SERVICE env var

### DIFF
--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -430,6 +430,8 @@ func getArgsEnv(p *Pod, flavor string, debug bool, n *networking.Networking) ([]
 		env = append(env, "SYSTEMD_LOG_LEVEL=err") // silence log_warning too
 	}
 
+	env = append(env, "SYSTEMD_NSPAWN_CONTAINER_SERVICE=rkt")
+
 	if len(privateUsers) > 0 {
 		args = append(args, "--private-users="+privateUsers)
 	}


### PR DESCRIPTION
With https://github.com/systemd/systemd/pull/1817, systemd-nspawn can
receive the name of the container service that's calling it.

This commit passes "rkt", which allows the container to be registered to
machined with the "rkt" name.

Note that this will start working when we update stage1's systemd to
v228, but doing it now doesn't hurt and we'll be ready.