### PR TITLE
rkt: show prepared/created/exited times in rkt list

### DIFF
--- a/rkt/list.go
+++ b/rkt/list.go
@@ -106,14 +106,18 @@ func runList(cmd *cobra.Command, args []string) int {
 		}
 		var whenStr string
 		if flagFullOutput {
-			if !exited.IsZero() {
-				whenStr = exited.Format(defaultTimeLayout)
+			if p.isExited || p.isExitedGarbage {
+				if !exited.IsZero() {
+					whenStr = exited.Format(defaultTimeLayout)
+				}
 			} else if !created.IsZero() {
 				whenStr = created.Format(defaultTimeLayout)
 			}
 		} else {
-			if !exited.IsZero() {
-				whenStr = humanize.Time(exited)
+			if p.isExited || p.isExitedGarbage {
+				if !exited.IsZero() {
+					whenStr = humanize.Time(exited)
+				}
 			} else if !created.IsZero() {
 				whenStr = humanize.Time(created)
 			}

--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -755,7 +755,7 @@ func (p *pod) getState() string {
 }
 
 func (p *pod) getModTime(path string) (time.Time, error) {
-	f, err := p.openFile(path, syscall.O_RDONLY|syscall.O_DIRECTORY)
+	f, err := p.openFile(path, syscall.O_RDONLY)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -780,7 +780,9 @@ func (p *pod) getRootModTime() (time.Time, error) {
 // getExitTime returns the exit time of the pod
 func (p *pod) getExitTime() (time.Time, error) {
 	if p.afterRun() {
-		return p.getModTime("stage1")
+		if et, err := p.getModTime("exited"); err == nil {
+			return et, nil
+		}
 	}
 	return time.Time{}, nil
 }

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -16,7 +16,11 @@
 
 package main
 
-import "github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
+)
 
 var (
 	cmdStatus = &cobra.Command{
@@ -69,6 +73,24 @@ func runStatus(cmd *cobra.Command, args []string) (exit int) {
 // printStatus prints the pod's pid and per-app status codes
 func printStatus(p *pod) error {
 	stdout("state=%s", p.getState())
+
+	created, err := p.getRootModTime()
+	if err != nil {
+		return fmt.Errorf("error getting pod root modification time: %v", err)
+	}
+	exited, err := p.getExitTime()
+	if err != nil {
+		return fmt.Errorf("error getting pod exit time: %v", err)
+	}
+
+	var since string
+	if !exited.IsZero() {
+		since = exited.Format(defaultTimeLayout)
+	} else if !created.IsZero() {
+		since = created.Format(defaultTimeLayout)
+	}
+
+	stdout("since=%s", since)
 
 	if p.isRunning() {
 		stdout("networks=%s", fmtNets(p.nets))

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -84,8 +84,10 @@ func printStatus(p *pod) error {
 	}
 
 	var since string
-	if !exited.IsZero() {
-		since = exited.Format(defaultTimeLayout)
+	if p.isExited || p.isExitedGarbage {
+		if !exited.IsZero() {
+			since = exited.Format(defaultTimeLayout)
+		}
 	} else if !created.IsZero() {
 		since = created.Format(defaultTimeLayout)
 	}

--- a/tests/rkt_list_test.go
+++ b/tests/rkt_list_test.go
@@ -17,10 +17,23 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/coreos/rkt/tests/testutils"
 )
+
+const delta = 3 * time.Second
+
+// compareTime checks if a and b are roughly equal (1s precision)
+func compareTime(a time.Time, b time.Time) bool {
+	diff := a.Sub(b)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff < time.Second
+}
 
 func TestRktList(t *testing.T) {
 	const imgName = "rkt-list-test"
@@ -93,5 +106,87 @@ func TestRktList(t *testing.T) {
 		runCmd := fmt.Sprintf("%s %s", ctx.Cmd(), tt.cmd)
 		t.Logf("Running test #%d, %s", i, runCmd)
 		runRktAndCheckOutput(t, runCmd, tt.expect, !tt.shouldSucceed)
+	}
+}
+
+func getSinceTime(t *testing.T, ctx *testutils.RktRunCtx, imageID string, state string) time.Time {
+	// Run rkt list --full
+	rktCmd := fmt.Sprintf("%s list --full", ctx.Cmd())
+	child := spawnOrFail(t, rktCmd)
+	child.Wait()
+
+	// Get prepared time
+	match := fmt.Sprintf(".*%s\t%s\t(.*)\t", imageID, state)
+	result, out, err := expectRegexWithOutput(child, match)
+	if err != nil {
+		t.Fatalf("%q regex not found, Error: %v\nOutput: %v", match, err, out)
+	}
+	tmStr := strings.TrimSpace(result[1])
+	tm, err := time.Parse(defaultTimeLayout, tmStr)
+	if err != nil {
+		t.Fatalf("Error parsing %s time: %q", state, err)
+	}
+
+	return tm
+}
+
+func TestRktListWhen(t *testing.T) {
+	const imgName = "rkt-list-creation-time-test"
+
+	image := patchTestACI(fmt.Sprintf("%s.aci", imgName), fmt.Sprintf("--exec=/inspect --read-stdin"))
+	defer os.Remove(image)
+
+	imageHash := getHashOrPanic(image)
+	imgID := ImageId{image, imageHash}
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	// Prepare image
+	cmd := fmt.Sprintf("%s --insecure-skip-verify prepare %s", ctx.Cmd(), imgID.path)
+	podUuid := runRktAndGetUUID(t, cmd)
+
+	// t0: prepare
+	expectPrepare := time.Now()
+
+	// Get hash
+	imageID := fmt.Sprintf("sha512-%s", imgID.hash[:12])
+
+	tmpDir := createTempDirOrPanic(imgName)
+	defer os.RemoveAll(tmpDir)
+
+	prepared := getSinceTime(t, ctx, imageID, "prepared")
+	if !compareTime(expectPrepare, prepared) {
+		t.Fatalf("incorrect preparation time returned. Got: %q Expect: %q (1s precision)", prepared, expectPrepare)
+	}
+
+	time.Sleep(delta)
+
+	// t1: run
+	expectRun := time.Now()
+
+	// Run image
+	cmd = fmt.Sprintf("%s run-prepared --interactive %s", ctx.Cmd(), podUuid)
+	rktChild := spawnOrFail(t, cmd)
+
+	time.Sleep(delta)
+
+	running := getSinceTime(t, ctx, imageID, "running")
+	if !compareTime(expectRun, running) {
+		t.Fatalf("incorrect running time returned. Got: %q Expect: %q (1s precision)", running, expectRun)
+	}
+
+	say := "Hello"
+	if err := rktChild.SendLine(say); err != nil {
+		t.Fatalf("Failed to send %q to rkt: %v", say, err)
+	}
+	rktChild.Wait()
+
+	// t2: exit
+	expectExit := expectRun.Add(delta)
+
+	exited := getSinceTime(t, ctx, imageID, "exited")
+	if !compareTime(expectExit, exited) {
+		t.Fatalf("incorrect exit time returned. Got: %q Expect: %q (1s precision)", exited, expectExit)
 	}
 }


### PR DESCRIPTION
To get the pod preparation/creation time we use the modification time in
`/var/lib/rkt/pods/*/<UUID>`. It gets modified when the pod is prepared
and when the pod is created and doesn't change afterwards.

To get the pod exit time we use the modification time in
`/var/lib/rkt/pods/*/<UUID>/stage1`. The reason is that systemd-nspawn
creates a lock file there, and removes it when the container exits (even
if it was killed).

```
# rkt list
UUID		APP		    IMAGE NAME			     STATE		SINCE		    NETWORKS
00b6a077	busybox		busybox:latest	         exited		23 hours ago	
		    etcd		coreos.com/etcd:v2.0.10						
1308fdae	etcd		coreos.com/etcd:v2.0.10  exited		4 hours ago	
2ded32e4	busybox		busybox:latest           prepared	2 hours ago	
47c0d9c2	busybox		busybox:latest			 running    9 seconds ago   default:ip4=172.16.28.91
# rkt list --full
UUID                                    APP            IMAGE NAME                IMAGE ID               STATE        SINCE                                 NETWORKS
00b6a077-abd5-41ff-a5f6-5e5e90c16dcf    busybox        busybox:latest            sha512-77d0b085eaca    exited       2015-11-09 15:55:35.699 +0100 CET
                                        etcd           coreos.com/etcd:v2.0.10   sha512-c03b055d02e5
1308fdae-2bad-422f-9737-4b20c5960714    etcd           coreos.com/etcd:v2.0.10   sha512-c03b055d02e5    exited       2015-11-10 11:10:20.879 +0100 CET
2ded32e4-44ce-4e29-8434-09f3db276433    busybox        busybox:latest            sha512-77d0b085eaca    prepared     2015-11-10 12:33:23.902 +0100 CET
47c0d9c2-1fea-4a4b-bd1e-86d8a04cd1ee    busybox        busybox:latest            sha512-77d0b085eaca    running      2015-11-10 15:28:42.079 +0100 CET    default:ip4=172.16.28.91
# rkt status 2ded32e4
state=prepared
since=2015-11-10 12:33:23.902 +0100 CET
```
Fixes #1428
Fixes #1429 