### PR TITLE
tests: add output when the test fails

### DIFF
--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -111,11 +111,11 @@ func waitOrFail(t *testing.T, child *gexpect.ExpectSubprocess, shouldSucceed boo
 	err := child.Wait()
 	switch {
 	case !shouldSucceed && err == nil:
-		t.Fatalf("Expected test to fail but it didn't")
+		t.Fatalf("Expected test to fail but it didn't\nOutput:\n%s", child.Collect())
 	case shouldSucceed && err != nil:
-		t.Fatalf("rkt didn't terminate correctly: %v", err)
+		t.Fatalf("rkt didn't terminate correctly: %v\nOutput:\n%s", err, child.Collect())
 	case err != nil && err.Error() != "exit status 1":
-		t.Fatalf("rkt terminated with unexpected error: %v", err)
+		t.Fatalf("rkt terminated with unexpected error: %v\nOutput:\n%s", err, child.Collect())
 	}
 }
 


### PR DESCRIPTION
The [previous error](https://semaphoreci.com/coreos/rkt/branches/pull-request-1696/builds/12) on #1696 was:
```
--- FAIL: TestAPIServiceGetInfo (0.10s)
	rkt_api_service_test.go:37: Running rkt install
	rkt_api_service_test.go:42: Running rkt api service
	rkt_tests.go:125: rkt didn't terminate correctly: exit status 2
```

This patch should add more output.

/cc @yifan-gu 
