### PR TITLE
Store used MCS contexts on the filesystem

### DIFF
--- a/pkg/label/label_selinux.go
+++ b/pkg/label/label_selinux.go
@@ -48,6 +48,12 @@ func InitLabels(options []string) (string, string, error) {
 			if con[0] == "level" || con[0] == "user" {
 				mcon[con[0]] = con[1]
 			}
+			if con[0] == "mcsdir" {
+				err := selinux.SetMCSDir(con[1])
+				if err != nil {
+					return "", "", fmt.Errorf("Unable to configure MCS storage directory: %v", err)
+				}
+			}
 		}
 		processLabel = pcon.Get()
 		mountLabel = mcon.Get()

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -197,7 +197,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	processLabel, mountLabel, err := label.InitLabels(nil)
+	processLabel, mountLabel, err := label.InitLabels([]string{"mcsdir:/var/run/rkt/mcs"})
 	if err != nil {
 		stderr("Error initialising SELinux: %v", err)
 		return 1


### PR DESCRIPTION
In the absence of a long-running daemon, the current code that ensures that
SELinux contexts aren't reused makes no sense - it's simply keeping a map
of used contexts, which means independent instances of rkt aren't sharing
this list. Keep the contexts in the filesystem instead in order to avoid
this.