### PR TITLE
cat-manifest cmd for pods

### DIFF
--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -32,6 +32,7 @@ rkt provides subcommands to list, get status, and clean its pods.
 * [status](subcommands/status.md)
 * [gc](subcommands/gc.md)
 * [rm](subcommands/rm.md)
+* [cat-manifest](subcommands/cat-manifest.md)
 
 ## Interacting with the local image store
 

--- a/Documentation/subcommands/cat-manifest.md
+++ b/Documentation/subcommands/cat-manifest.md
@@ -1,0 +1,11 @@
+# rkt cat-manifest
+
+For debugging or inspection you may want to extract the PodManifest to stdout.
+
+```
+# rkt cat-manifest --pretty-print UUID
+{
+  "acVersion":"0.7.0",
+  "acKind":"PodManifest"
+...
+```

--- a/rkt/cat_manifest.go
+++ b/rkt/cat_manifest.go
@@ -1,0 +1,69 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/spf13/cobra"
+)
+
+var (
+	cmdCatManifest = &cobra.Command{
+		Use:   "cat-manifest UUID",
+		Short: "Inspect and print the pod manifest",
+		Long:  `UUID should be the UUID of a pod`,
+		Run:   runWrapper(runCatManifest),
+	}
+	flagPMPrettyPrint bool
+)
+
+func init() {
+	cmdRkt.AddCommand(cmdCatManifest)
+	cmdCatManifest.Flags().BoolVar(&flagPMPrettyPrint, "pretty-print", false, "apply indent to format the output")
+}
+
+func runCatManifest(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) != 1 {
+		cmd.Usage()
+		return 1
+	}
+
+	pod, err := getPodFromUUIDString(args[0])
+	if err != nil {
+		stderr("cat-manifest: problem retrieving pod: %v", err)
+		return 1
+	}
+	defer pod.Close()
+
+	manifest, err := pod.getManifest()
+	if err != nil {
+		return 1
+	}
+
+	var b []byte
+	if flagPMPrettyPrint {
+		b, err = json.MarshalIndent(manifest, "", "\t")
+	} else {
+		b, err = json.Marshal(manifest)
+	}
+	if err != nil {
+		stderr("cat-manifest: cannot read the pod manifest: %v", err)
+		return 1
+	}
+
+	stdout(string(b))
+	return 0
+}

--- a/rkt/enter.go
+++ b/rkt/enter.go
@@ -57,27 +57,21 @@ func runEnter(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	podUUID, err := resolveUUID(args[0])
+	p, err := getPodFromUUIDString(args[0])
 	if err != nil {
-		stderr("Unable to resolve UUID: %v", err)
-		return 1
-	}
-
-	p, err := getPod(podUUID)
-	if err != nil {
-		stderr("Failed to open pod %q: %v", podUUID, err)
+		stderr("Problem problem retrieving pod: %v", err)
 		return 1
 	}
 	defer p.Close()
 
 	if !p.isRunning() {
-		stderr("Pod %q isn't currently running", podUUID)
+		stderr("Pod %q isn't currently running", p.uuid)
 		return 1
 	}
 
 	podPID, err := p.getContainerPID1()
 	if err != nil {
-		stderr("Unable to determine the pid for pod %q: %v", podUUID, err)
+		stderr("Unable to determine the pid for pod %q: %v", p.uuid, err)
 		return 1
 	}
 

--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -943,15 +943,24 @@ func (p *pod) getAppsImageManifests() (AppsImageManifests, error) {
 	return aim, nil
 }
 
-// getApps returns a list of apps in the pod
-func (p *pod) getApps() (schema.AppList, error) {
+// getManifest returns the PodManifest of the pod
+func (p *pod) getManifest() (*schema.PodManifest, error) {
 	pmb, err := p.readFile("pod")
 	if err != nil {
 		return nil, fmt.Errorf("error reading pod manifest: %v", err)
 	}
-	pm := new(schema.PodManifest)
+	pm := &schema.PodManifest{}
 	if err = pm.UnmarshalJSON(pmb); err != nil {
 		return nil, fmt.Errorf("invalid pod manifest: %v", err)
+	}
+	return pm, nil
+}
+
+// getApps returns a list of apps in the pod
+func (p *pod) getApps() (schema.AppList, error) {
+	pm, err := p.getManifest()
+	if err != nil {
+		return nil, err
 	}
 	return pm.Apps, nil
 }

--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -281,6 +281,22 @@ func getPod(uuid *types.UUID) (*pod, error) {
 	return p, nil
 }
 
+// getPodFromUUIDString attempts to resolve the supplied UUID and return a pod.
+// The pod must be closed using pod.Close()
+func getPodFromUUIDString(uuid string) (*pod, error) {
+	podUUID, err := resolveUUID(uuid)
+	if err != nil {
+		return nil, fmt.Errorf("unable to resolve UUID: %v", err)
+	}
+
+	p, err := getPod(podUUID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get pod: %v", err)
+	}
+
+	return p, nil
+}
+
 // path returns the path to the pod according to the current (cached) state.
 func (p *pod) path() string {
 	if p.isEmbryo {

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -51,11 +51,12 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	podUUID, err := resolveUUID(args[0])
+	p, err := getPodFromUUIDString(args[0])
 	if err != nil {
-		stderr("Unable to resolve UUID: %v", err)
+		stderr("prepared-run: problem retrieving pod: %v", err)
 		return 1
 	}
+	defer p.Close()
 
 	s, err := store.NewStore(globalFlags.Dir)
 	if err != nil {
@@ -63,14 +64,8 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	p, err := getPod(podUUID)
-	if err != nil {
-		stderr("prepared-run: cannot get pod: %v", err)
-		return 1
-	}
-
 	if !p.isPrepared {
-		stderr("prepared-run: pod %q is not prepared", podUUID.String())
+		stderr("prepared-run: pod %q is not prepared", p.uuid)
 		return 1
 	}
 

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -44,15 +44,9 @@ func runStatus(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	podUUID, err := resolveUUID(args[0])
+	p, err := getPodFromUUIDString(args[0])
 	if err != nil {
-		stderr("Unable to resolve UUID: %v", err)
-		return 1
-	}
-
-	p, err := getPod(podUUID)
-	if err != nil {
-		stderr("Unable to get pod: %v", err)
+		stderr("Problem retrieving pod: %v", err)
 		return 1
 	}
 	defer p.Close()

--- a/tests/rkt_image_cat_manifest_test.go
+++ b/tests/rkt_image_cat_manifest_test.go
@@ -1,0 +1,90 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+const (
+
+	// The expected image manifest of the 'rkt-inspect-image-cat-manifest.aci'.
+	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.1","name":"IMG_NAME","labels":[{"name":"version","value":"1.0.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+)
+
+// TestImageCatManifest tests 'rkt image cat-manifest', it will:
+// Read some existing image manifest via the image name, and verify the result.
+// Read some existing image manifest via the image hash, and verify the result.
+// Read some non-existing image manifest via the image name, and verify nothing is found.
+// Read some non-existing image manifest via the image hash, and verify nothing is found.
+func TestImageCatManifest(t *testing.T) {
+	testImageName := "coreos.com/rkt-image-cat-manifest-test"
+	expectManifest := strings.Replace(manifestTemplate, "IMG_NAME", testImageName, -1)
+
+	tmpManifest, err := ioutil.TempFile("", "rkt-TestImageCatManifest-")
+	if err != nil {
+		t.Fatalf("Cannot create temp manifest: %v", err)
+	}
+	defer os.Remove(tmpManifest.Name())
+	if err := ioutil.WriteFile(tmpManifest.Name(), []byte(expectManifest), 0600); err != nil {
+		t.Fatalf("Cannot write to temp manifest: %v", err)
+	}
+
+	testImage := patchTestACI("rkt-inspect-image-cat-manifest.aci", "--manifest", tmpManifest.Name())
+	defer os.Remove(testImage)
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	testImageHash := importImageAndFetchHash(t, ctx, testImage)
+
+	tests := []struct {
+		image      string
+		shouldFind bool
+		expect     string
+	}{
+		{
+			testImageName,
+			true,
+			expectManifest,
+		},
+		{
+			testImageHash,
+			true,
+			expectManifest,
+		},
+		{
+			"sha512-not-existed",
+			false,
+			"",
+		},
+		{
+			"some~random~aci~name",
+			false,
+			"",
+		},
+	}
+
+	for i, tt := range tests {
+		runCmd := fmt.Sprintf("%s image cat-manifest %s", ctx.Cmd(), tt.image)
+		t.Logf("Running test #%d", i)
+		runRktAndCheckOutput(t, runCmd, tt.expect, !tt.shouldFind)
+	}
+}


### PR DESCRIPTION
We've had a cat-manifest for the ImageManifest but not for the PodManifest. This adds that missing functionality.

There is also a bit of related refactoring included.

Should close issue #1730