### PR TITLE
docs: perhaps maybe really fix doc-skip check

### DIFF
--- a/tests/run-build.sh
+++ b/tests/run-build.sh
@@ -24,16 +24,14 @@ BUILD_DIR="build-rkt-${RKT_STAGE1_USR_FROM}-${RKT_STAGE1_SYSTEMD_VER}"
 
 # https://semaphoreci.com/docs/available-environment-variables.html
 if [ "${SEMAPHORE-}" == true ] ; then
-        # We might not need to run functional tests
-        ( 
-                # Ensure origin is updated
-                git fetch
-                SRC_CHANGES=`git diff-tree --no-commit-id --name-only -r HEAD..origin/master | grep -cEv ${DOC_CHANGE_PATTERN}`
-                # We might not need to process the docs
-                DOC_CHANGES=`git diff-tree --no-commit-id --name-only -r HEAD..origin/master | grep -cE ${DOC_CHANGE_PATTERN}`
-        ) || true # let the checks not fail the script
+        # We might not need to run functional tests or process docs.
+        # This is best-effort; || true ensures this does not affect test outcome
+        # First, ensure origin is updated - semaphore can do some weird caching
+        git fetch || true
+        SRC_CHANGES=$(git diff-tree --no-commit-id --name-only -r HEAD..origin/master | grep -cEv ${DOC_CHANGE_PATTERN}) || true
+        DOC_CHANGES=$(git diff-tree --no-commit-id --name-only -r HEAD..origin/master | grep -cE ${DOC_CHANGE_PATTERN}) || true
 
-        # Setup go environment on semaphore
+        # Set up go environment on semaphore
         if [ -f /opt/change-go-version.sh ]; then
             . /opt/change-go-version.sh
             change-go-version 1.4


### PR DESCRIPTION
:facepalm: running these commands in a sub-shell (to ensure failures
don't propagate) means that the variables are never appropriately
replaced in the parent.