### PR TITLE
stage1: generate empty vol if a required one is not provided

### DIFF
--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -108,9 +108,11 @@ Each ACI can define a [list of mount points](https://github.com/appc/spec/blob/m
 To fulfill these mount points, volumes are used. A volume is assigned to a mount point if they both have the same name.
 There are today two kinds of volumes:
 - `host` volumes that can expose a directory or a file from the host to the pod
-- `empty` volumes that initialize an empty storage to be accessed locally within the pod.
+- `empty` volumes that initialize an empty storage to be accessed locally within the pod. When the pod is garbage collected, it will be removed.
 
-Each volume can be selectively mounted into each application at differing mount points. Note that any volumes that are specified but do not have a matching mount point will be silently ignored.
+Each volume can be selectively mounted into each application at differing mount points. Note that any volumes that are specified but do not have a matching mount point (or [`--mount` flag](#mounting-volumes-without-mount-points)) will be silently ignored.
+
+If a mount point is specified in the image manifest but no matching volume is found, an implicit `empty` volume will be created automatically.
 
 ### Mounting Volumes
 

--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -503,21 +503,17 @@ func (p *Pod) appToNspawnArgs(ra *schema.RuntimeApp) ([]string, error) {
 	vols := make(map[types.ACName]types.Volume)
 	for _, v := range p.Manifest.Volumes {
 		vols[v.Name] = v
-
-		if v.Kind == "empty" {
-			if err := os.MkdirAll(filepath.Join(sharedVolPath, v.Name.String()), sharedVolPerm); err != nil {
-				return nil, fmt.Errorf("could not create shared volume %q: %v", v.Name, err)
-			}
-		}
 	}
 
-	mounts, err := initcommon.GenerateMounts(ra, vols)
-	if err != nil {
-		return nil, err
-	}
-
+	mounts := initcommon.GenerateMounts(ra, vols)
 	for _, m := range mounts {
 		vol := vols[m.Volume]
+
+		if vol.Kind == "empty" {
+			if err := os.MkdirAll(filepath.Join(sharedVolPath, vol.Name.String()), sharedVolPerm); err != nil {
+				return nil, fmt.Errorf("could not create shared volume %q: %v", vol.Name, err)
+			}
+		}
 
 		opt := make([]string, 4)
 

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -73,6 +73,11 @@ var volTests = []struct {
 		`/bin/sh -c "export FILE=/dir1/file CONTENT=1 ; ^RKT_BIN^ --debug --insecure-skip-verify run --mds-register=false --inherit-env=true --volume=dir1,kind=host,source=^TMPDIR^,readOnly=true ^VOL_ADD_MOUNT_RO^ --mount=volume=dir1,target=dir1"`,
 		`Cannot write to file "/dir1/file": open /dir1/file: read-only file system`,
 	},
+	// Check that an implicit empty volume is created if the user didn't provide it but there's a mount point in the app
+	{
+		`/bin/sh -c "export FILE=/dir1/file CONTENT=1 ; ^RKT_BIN^ --debug --insecure-skip-verify run --mds-register=false --inherit-env=true ^WRITE_FILE^"`,
+		`<<<1>>>`,
+	},
 }
 
 func TestVolumes(t *testing.T) {


### PR DESCRIPTION
If there is a mount point in the Image Manifest but the user didn't
provide a matching volume, we create an implicity empty volume.

We warn the user because the empty volume will be deleted when the pod
gets garbage-collected.

Fixes #1480 
Closes #1772