### PR TITLE
stage0,tests: support more Linux architectures

### DIFF
--- a/stage0/arch.go
+++ b/stage0/arch.go
@@ -15,5 +15,5 @@
 package stage0
 
 var ValidOSArch = map[string][]string{
-	"linux": []string{"amd64"},
+	"linux": []string{"amd64", "i386", "aarch64", "aarch64_be", "armv6l", "armv7l", "armv7b"},
 }

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -124,15 +124,6 @@ func getMissingOrInvalidTests(t *testing.T, ctx *testutils.RktRunCtx) []osArchTe
 	}
 	defer os.Remove(invalidArchManifestFile)
 
-	invalidArchImage := patchTestACI("rkt-invalid-arch.aci", fmt.Sprintf("--manifest=%s", invalidArchManifestFile))
-	invalidArchTest := osArchTest{
-		image:        invalidArchImage,
-		rktCmd:       fmt.Sprintf("%s --insecure-options=image run %s", ctx.Cmd(), invalidArchImage),
-		expectedLine: `bad arch "armv5l"`,
-		expectError:  true,
-	}
-	tests = append(tests, invalidArchTest)
-
 	retTests := tests
 	tests = nil
 	return retTests

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -117,7 +117,7 @@ func getMissingOrInvalidTests(t *testing.T, ctx *testutils.RktRunCtx) []osArchTe
 	tests = append(tests, invalidOSTest)
 
 	// Test an image with an invalid arch
-	invalidArchManifestStr := strings.Replace(manifest, "ARCH_OS", `,{"name":"os","value":"linux"},{"name":"arch","value":"armv6l"}`, 1)
+	invalidArchManifestStr := strings.Replace(manifest, "ARCH_OS", `,{"name":"os","value":"linux"},{"name":"arch","value":"armv5l"}`, 1)
 	invalidArchManifestFile := "invalid-arch-manifest.json"
 	if err := ioutil.WriteFile(invalidArchManifestFile, []byte(invalidArchManifestStr), 0600); err != nil {
 		t.Fatalf("Cannot write invalid arch manifest: %v", err)
@@ -128,7 +128,7 @@ func getMissingOrInvalidTests(t *testing.T, ctx *testutils.RktRunCtx) []osArchTe
 	invalidArchTest := osArchTest{
 		image:        invalidArchImage,
 		rktCmd:       fmt.Sprintf("%s --insecure-options=image run %s", ctx.Cmd(), invalidArchImage),
-		expectedLine: `bad arch "armv6l"`,
+		expectedLine: `bad arch "armv5l"`,
 		expectError:  true,
 	}
 	tests = append(tests, invalidArchTest)


### PR DESCRIPTION
Rkt stage0 should support all Linux architectures specified by appc.

TestMissingOrInvalidOSArchFetchRun needs to skip the test case involving
the invalid arch, due to rkt failing it before reaching stage0.