### PR TITLE
stage1: make image ID more friendly in suggestion

### DIFF
--- a/stage1/init/common/mount.go
+++ b/stage1/init/common/mount.go
@@ -59,7 +59,7 @@ func GenerateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume
 		}
 		vol, ok := volumes[mp.Name]
 		if !ok {
-			catCmd := fmt.Sprintf("sudo rkt image cat-manifest --pretty-print %v", id)
+			catCmd := fmt.Sprintf("sudo rkt image cat-manifest --pretty-print %s", id.String()[:19])
 			volumeCmd := ""
 			for _, mp := range app.MountPoints {
 				volumeCmd += fmt.Sprintf("--volume %s,kind=host,source=/some/path ", mp.Name)


### PR DESCRIPTION
When the user forgets to provide volumes they are given a suggested
command that includes a really long image id. This commit provides ID in
the same format as the `rkt image list` command.