### PR TITLE
docs: fix broken reference to signing process

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Trusting "https://coreos.com/dist/pubkeys/aci-pubkeys.gpg" for prefix "coreos.co
 Added key for prefix "coreos.com/etcd" at "/etc/rkt/trustedkeys/prefix.d/coreos.com/etcd/8b86de38890ddb7291867b025210bd8888182190"
 ```
 
-In Documentation, you can find a [detailed, step-by-step guide for the signing procedure](Documentation/getting-started-ubuntu-vivid.md#trust-the-coreos-signing-key).
+In Documentation, you can find a [detailed, step-by-step guide for the signing procedure](Documentation/signing-and-verification-guide.md).
 
 Now that we've trusted the CoreOS public key, we can fetch the ACI using `rkt fetch`:
 


### PR DESCRIPTION
The signing procedure guide was incorrectly linked to old vivid docs. Now links
to signing and verification guide.