### PR TITLE
(WIP) stage1: app exit code propagated to rkt exit code

### DIFF
--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -36,8 +36,6 @@ import (
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/goaci/proj2aci"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/coreos/go-systemd/util"
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/godbus/dbus"
-	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/godbus/dbus/introspect"
 
 	stage1common "github.com/coreos/rkt/stage1/common"
 	stage1commontypes "github.com/coreos/rkt/stage1/common/types"
@@ -123,35 +121,9 @@ func init() {
 
 // machinedRegister checks if nspawn should register the pod to machined
 func machinedRegister() bool {
-	// machined has a D-Bus interface following versioning guidelines, see:
-	// http://www.freedesktop.org/wiki/Software/systemd/machined/
-	// Therefore we can just check if the D-Bus method we need exists and we
-	// don't need to check the signature.
-	var found int
-
-	conn, err := dbus.SystemBus()
-	if err != nil {
-		return false
-	}
-	node, err := introspect.Call(conn.Object("org.freedesktop.machine1", "/org/freedesktop/machine1"))
-	if err != nil {
-		return false
-	}
-	for _, iface := range node.Interfaces {
-		if iface.Name != "org.freedesktop.machine1.Manager" {
-			continue
-		}
-		// machined v215 supports methods "RegisterMachine" and "CreateMachine" called by nspawn v215.
-		// machined v216+ (since commit 5aa4bb) additionally supports methods "CreateMachineWithNetwork"
-		// and "RegisterMachineWithNetwork", called by nspawn v216+.
-		for _, method := range iface.Methods {
-			if method.Name == "CreateMachineWithNetwork" || method.Name == "RegisterMachineWithNetwork" {
-				found++
-			}
-		}
-		break
-	}
-	return found == 2
+	// Disable registration. See:
+	// https://github.com/coreos/rkt/issues/1782
+	return false
 }
 
 func lookupPath(bin string, paths string) (string, error) {

--- a/stage1/reaper/reaper.sh
+++ b/stage1/reaper/reaper.sh
@@ -7,5 +7,8 @@ if [ $# -eq 1 ]; then
     app=$1
     status=$(${SYSCTL} show --property ExecMainStatus "${app}.service")
     echo "${status#*=}" > "/rkt/status/$app"
+    if [ "${status#*=}" != 0 ] ; then
+        ${SYSCTL} exit ${status#*=}
+    fi
     exit 0
 fi

--- a/stage1/units/units/shutdown.service
+++ b/stage1/units/units/shutdown.service
@@ -6,4 +6,4 @@ DefaultDependencies=false
 
 [Service]
 RemainAfterExit=yes
-ExecStop=/usr/bin/systemctl halt --force
+ExecStop=/usr/bin/systemctl exit --force


### PR DESCRIPTION
This only works with systemd-v228 in stage1 because it uses the new
command "systemctl exit". You can try with:

```
sh autogen.sh && ./configure \
  --with-stage1-flavors=src \
  --enable-functional-tests \
  --with-stage1-systemd-version=v228 \
  && make
```

I disabled machine registration because of issue #1782.

Fixes https://github.com/coreos/rkt/issues/1460