### PR TITLE
Godeps: update to the last docker2aci

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/coreos/rkt",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.4.3",
 	"Packages": [
 		"./..."
 	],
@@ -72,11 +72,11 @@
 		},
 		{
 			"ImportPath": "github.com/appc/docker2aci/lib",
-			"Rev": "9c1b472ce804899a5db94a98fb2ad791f4bce2b2"
+			"Rev": "fce83d1375e33a840e455f51a102491111984924"
 		},
 		{
 			"ImportPath": "github.com/appc/docker2aci/tarball",
-			"Rev": "9c1b472ce804899a5db94a98fb2ad791f4bce2b2"
+			"Rev": "fce83d1375e33a840e455f51a102491111984924"
 		},
 		{
 			"ImportPath": "github.com/appc/goaci/proj2aci",

--- a/Godeps/_workspace/src/github.com/appc/docker2aci/lib/conversion_store.go
+++ b/Godeps/_workspace/src/github.com/appc/docker2aci/lib/conversion_store.go
@@ -45,6 +45,7 @@ func (ms *ConversionStore) WriteACI(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer cr.Close()
 
 	h := sha512.New()
 	r := io.TeeReader(cr, h)
@@ -98,7 +99,7 @@ func (ms *ConversionStore) ReadStream(key string) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	return ioutil.NopCloser(tr), nil
+	return tr, nil
 }
 
 func (ms *ConversionStore) ResolveKey(key string) (string, error) {

--- a/Godeps/_workspace/src/github.com/golang/protobuf/proto/testdata/test.pb.go
+++ b/Godeps/_workspace/src/github.com/golang/protobuf/proto/testdata/test.pb.go
@@ -39,7 +39,7 @@ It has these top-level messages:
 */
 package testdata
 
-import proto "github.com/golang/protobuf/proto"
+import proto "github.com/coreos/rkt/Godeps/_workspace/src/github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 


### PR DESCRIPTION
The last docker2aci should help with the following issues:
- https://github.com/coreos/rkt/issues/1653 (whiteout-ed hard links)
- https://github.com/coreos/rkt/issues/1617 (/dev/stdout)