### PR TITLE
api: Add 'detail' field in ListPods and ListImages request.

### DIFF
--- a/api/v1alpha/api.pb.go
+++ b/api/v1alpha/api.pb.go
@@ -487,6 +487,7 @@ func (m *GetInfoResponse) GetInfo() *Info {
 // Request for ListPods().
 type ListPodsRequest struct {
 	Filter *PodFilter `protobuf:"bytes,1,opt,name=filter" json:"filter,omitempty"`
+	Detail bool       `protobuf:"varint,2,opt,name=detail" json:"detail,omitempty"`
 }
 
 func (m *ListPodsRequest) Reset()         { *m = ListPodsRequest{} }
@@ -545,6 +546,7 @@ func (m *InspectPodResponse) GetPod() *Pod {
 // Request for ListImages().
 type ListImagesRequest struct {
 	Filter *ImageFilter `protobuf:"bytes,1,opt,name=filter" json:"filter,omitempty"`
+	Detail bool         `protobuf:"varint,2,opt,name=detail" json:"detail,omitempty"`
 }
 
 func (m *ListImagesRequest) Reset()         { *m = ListImagesRequest{} }

--- a/api/v1alpha/api.proto
+++ b/api/v1alpha/api.proto
@@ -291,7 +291,6 @@ message EventFilter {
         int64 until_time = 5;
 }
 
-
 // Request for GetInfo().
 message GetInfoRequest {}
 
@@ -303,6 +302,7 @@ message GetInfoResponse {
 // Request for ListPods().
 message ListPodsRequest {
         PodFilter filter = 1; // Optional.
+        bool detail = 2; // Optional.
 }
 
 // Response for ListPods().
@@ -324,6 +324,7 @@ message InspectPodResponse {
 // Request for ListImages().
 message ListImagesRequest {
         ImageFilter filter = 1; // Optional.
+        bool detail = 2; // Optional.
 }
 
 // Response for ListImages().

--- a/tests/README.md
+++ b/tests/README.md
@@ -92,3 +92,13 @@ make functional-check GO_TEST_FUNC_ARGS='-run NameOfTheTest'
 ```
 
 Run `go help testflag` to get more informations about possible flags accepted by `go test`.
+
+## Running the benchmark
+
+Running the benchmark is similar to running the other tests, we just need to pass additional
+parameters to `go test`:
+
+```
+make check GO_TEST_FUNC_ARGS='-bench=. -run=Benchmark'
+make functional-check GO_TEST_FUNC_ARGS='-bench=. -run=Benchmark'
+```

--- a/tests/rkt_api_service_bench_test.go
+++ b/tests/rkt_api_service_bench_test.go
@@ -1,0 +1,257 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/coreos/gexpect"
+	"github.com/coreos/rkt/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/coreos/rkt/Godeps/_workspace/src/google.golang.org/grpc"
+	"github.com/coreos/rkt/api/v1alpha"
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+func setup() (*testutils.RktRunCtx, *gexpect.ExpectSubprocess, v1alpha.PublicAPIClient, *grpc.ClientConn, string) {
+	t := new(testing.T) // Print no messages.
+	ctx := testutils.NewRktRunCtx()
+	svc := startAPIService(t, ctx)
+	c, conn := newAPIClientOrFail(t, "localhost:15441")
+	imagePath := patchTestACI("rkt-inspect-print.aci", "--exec=/inspect --print-msg=HELLO_API --exit-code=42")
+
+	return ctx, svc, c, conn, imagePath
+}
+
+func cleanup(ctx *testutils.RktRunCtx, svc *gexpect.ExpectSubprocess, conn *grpc.ClientConn, imagePath string) {
+	t := new(testing.T) // Print no messages.
+	os.Remove(imagePath)
+	conn.Close()
+	stopAPIService(t, svc)
+	ctx.Cleanup()
+}
+
+func launchPods(ctx *testutils.RktRunCtx, numOfPods int, imagePath string) {
+	t := new(testing.T) // Print no messages.
+	cmd := fmt.Sprintf("%s --insecure-options=all run %s", ctx.Cmd(), imagePath)
+
+	var wg sync.WaitGroup
+	wg.Add(numOfPods)
+	for i := 0; i < numOfPods; i++ {
+		go func() {
+			spawnAndWaitOrFail(t, cmd, true)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func benchListPods(b *testing.B, c v1alpha.PublicAPIClient, detail bool) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := c.ListPods(context.Background(), &v1alpha.ListPodsRequest{Detail: detail})
+		if err != nil {
+			b.Error(err)
+		}
+	}
+	b.StopTimer()
+}
+
+func benchInspectPod(b *testing.B, c v1alpha.PublicAPIClient) {
+	resp, err := c.ListPods(context.Background(), &v1alpha.ListPodsRequest{})
+	if err != nil {
+		b.Fatalf("Unexpected error: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := c.InspectPod(context.Background(), &v1alpha.InspectPodRequest{Id: resp.Pods[0].Id})
+		if err != nil {
+			b.Error(err)
+		}
+	}
+	b.StopTimer()
+}
+
+func fetchImages(ctx *testutils.RktRunCtx, numOfImages int) {
+	t := new(testing.T) // Print no messages.
+
+	var wg sync.WaitGroup
+	wg.Add(numOfImages)
+	for i := 0; i < numOfImages; i++ {
+		go func(i int) {
+			patchImportAndFetchHash(fmt.Sprintf("rkt-inspect-sleep-%d.aci", i), []string{"--exec=/inspect"}, t, ctx)
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+}
+
+func benchListImages(b *testing.B, c v1alpha.PublicAPIClient, detail bool) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := c.ListImages(context.Background(), &v1alpha.ListImagesRequest{Detail: detail})
+		if err != nil {
+			b.Error(err)
+		}
+	}
+	b.StopTimer()
+}
+
+func benchInspectImage(b *testing.B, c v1alpha.PublicAPIClient) {
+	resp, err := c.ListImages(context.Background(), &v1alpha.ListImagesRequest{})
+	if err != nil {
+		b.Fatalf("Unexpected error: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := c.InspectImage(context.Background(), &v1alpha.InspectImageRequest{Id: resp.Images[0].Id})
+		if err != nil {
+			b.Error(err)
+		}
+	}
+	b.StopTimer()
+}
+
+func BenchmarkList1PodNoDetail(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	launchPods(ctx, 1, imagePath)
+	benchListPods(b, client, false)
+}
+
+func BenchmarkList10PodsNoDetail(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	launchPods(ctx, 10, imagePath)
+	benchListPods(b, client, false)
+}
+
+func BenchmarkList100PodsNoDetail(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	launchPods(ctx, 100, imagePath)
+	benchListPods(b, client, false)
+}
+
+func BenchmarkList1PodDetail(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	launchPods(ctx, 1, imagePath)
+	benchListPods(b, client, true)
+}
+
+func BenchmarkList10PodsDetail(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	launchPods(ctx, 10, imagePath)
+	benchListPods(b, client, true)
+}
+
+func BenchmarkList100PodsDetail(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	launchPods(ctx, 100, imagePath)
+	benchListPods(b, client, true)
+}
+
+func BenchmarkInspectPodIn10Pods(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	launchPods(ctx, 10, imagePath)
+	benchInspectPod(b, client)
+}
+
+func BenchmarkInspectPodIn100Pods(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	launchPods(ctx, 100, imagePath)
+	benchInspectPod(b, client)
+}
+
+func BenchmarkList1ImageNoDetail(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	fetchImages(ctx, 1)
+	benchListImages(b, client, false)
+}
+
+func BenchmarkList10ImagesNoDetail(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	fetchImages(ctx, 10)
+	benchListImages(b, client, false)
+}
+
+func BenchmarkList100ImagesNoDetail(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	fetchImages(ctx, 100)
+	benchListImages(b, client, false)
+}
+
+func BenchmarkList1ImageDetail(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	fetchImages(ctx, 1)
+	benchListImages(b, client, true)
+}
+
+func BenchmarkList10ImagesDetail(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	fetchImages(ctx, 10)
+	benchListImages(b, client, true)
+}
+
+func BenchmarkList100ImagesDetail(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	fetchImages(ctx, 100)
+	benchListImages(b, client, true)
+}
+
+func BenchmarkInspectImageIn10Images(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	fetchImages(ctx, 10)
+	benchInspectImage(b, client)
+}
+
+func BenchmarkInspectImageIn100Images(b *testing.B) {
+	ctx, svc, client, conn, imagePath := setup()
+	defer cleanup(ctx, svc, conn, imagePath)
+
+	fetchImages(ctx, 100)
+	benchInspectImage(b, client)
+}

--- a/tests/rkt_api_service_test.go
+++ b/tests/rkt_api_service_test.go
@@ -229,6 +229,7 @@ func TestAPIServiceListInspectPods(t *testing.T) {
 
 	patchImportAndRun("rkt-inspect-print.aci", []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=42"}, t, ctx)
 
+	// ListPods(detail=false).
 	resp, err = c.ListPods(context.Background(), &v1alpha.ListPodsRequest{})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -247,6 +248,20 @@ func TestAPIServiceListInspectPods(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		checkPodDetails(t, ctx, inspectResp.Pod)
+	}
+
+	// ListPods(detail=true).
+	resp, err = c.ListPods(context.Background(), &v1alpha.ListPodsRequest{Detail: true})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(resp.Pods) == 0 {
+		t.Errorf("Unexpected result: %v, should see non-zero pods", resp.Pods)
+	}
+
+	for _, p := range resp.Pods {
+		checkPodDetails(t, ctx, p)
 	}
 }
 
@@ -271,6 +286,7 @@ func TestAPIServiceListInspectImages(t *testing.T) {
 
 	patchImportAndFetchHash("rkt-inspect-sleep.aci", []string{"--exec=/inspect"}, t, ctx)
 
+	// ListImages(detail=false).
 	resp, err = c.ListImages(context.Background(), &v1alpha.ListImagesRequest{})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -289,5 +305,19 @@ func TestAPIServiceListInspectImages(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		checkImageDetails(t, ctx, inspectResp.Image)
+	}
+
+	// ListImages(detail=true).
+	resp, err = c.ListImages(context.Background(), &v1alpha.ListImagesRequest{Detail: true})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(resp.Images) == 0 {
+		t.Errorf("Unexpected result: %v, should see non-zero images", resp.Images)
+	}
+
+	for _, m := range resp.Images {
+		checkImageDetails(t, ctx, m)
 	}
 }


### PR DESCRIPTION
This enables the API service to return detailed pod/image infos
if required. So for some use case where the users want to get N
pods' detailed info, this saves N grpc round trips.

cc @jonboulle @alban 
cc @dgonyeo you might take advantage of this to not to inspect each pod later.