### PR TITLE
functional tests: fix ACE validator race

### DIFF
--- a/tests/rkt_ace_validator_test.go
+++ b/tests/rkt_ace_validator_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/coreos/rkt/tests/testutils"
@@ -37,14 +36,8 @@ func TestAceValidator(t *testing.T) {
 		t.Fatalf("Cannot launch metadata service: %v", err)
 	}
 
-	aceMain := os.Getenv("RKT_ACE_MAIN_IMAGE")
-	if aceMain == "" {
-		panic("empty RKT_ACE_MAIN_IMAGE env var")
-	}
-	aceSidekick := os.Getenv("RKT_ACE_SIDEKICK_IMAGE")
-	if aceSidekick == "" {
-		panic("empty RKT_ACE_SIDEKICK_IMAGE env var")
-	}
+	aceMain := testutils.GetValueFromEnvOrPanic("RKT_ACE_MAIN_IMAGE")
+	aceSidekick := testutils.GetValueFromEnvOrPanic("RKT_ACE_SIDEKICK_IMAGE")
 
 	rktArgs := fmt.Sprintf("--debug --insecure-skip-verify run --mds-register --volume database,kind=empty %s %s",
 		aceMain, aceSidekick)


### PR DESCRIPTION
The test failed, because it expected ACE validator to print several OK messages in strict order (prestart, main, sidekick and poststop). But main and sidekick run in parallel, so the order of OK messages was sometimes prestart, sidekick, main and poststop.

Fixes #1781.