### PR TITLE
Insecure options ondisk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The next version of rkt will have the following.
 - implement `rkt cat-manifest` for pods ([#1744](https://github.com/coreos/rkt/pull/1744))
 - generate an empty volume if a required one is not provided ([#1753](https://github.com/coreos/rkt/pull/1753))
 - make disabling security features granular; `--insecure-skip-verify` is now `--insecure-options={feature(s)-to-disable}` ([#1738](https://github.com/coreos/rkt/pull/1738)). See rkt's [Global Options](https://github.com/coreos/rkt/blob/master/Documentation/commands.md#global-options) documentation.
+- allow skipping the on-disk integrity check using `--insecure-options=ondisk`. This greatly speeds up start time. ([#1804](https://github.com/coreos/rkt/pull/1804))
 
 #### Bug fixes
 

--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -54,7 +54,7 @@ In addition to the flags used by individual `rkt` commands, `rkt` has a set of g
 | --- | --- | --- | --- |
 | `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
 | `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
+| `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
 | `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https || Flag | Default | Options | Desription |

--- a/rkt/rkt.go
+++ b/rkt/rkt.go
@@ -41,18 +41,20 @@ const (
 	insecureNone  = 0
 	insecureImage = 1 << (iota - 1)
 	insecureTls
+	insecureOnDisk
 
-	insecureAll = (insecureImage | insecureTls)
+	insecureAll = (insecureImage | insecureTls | insecureOnDisk)
 )
 
 var (
-	insecureOptions = []string{"none", "image", "tls", "all"}
+	insecureOptions = []string{"none", "image", "tls", "ondisk", "all"}
 
 	insecureOptionsMap = map[string]int{
 		insecureOptions[0]: insecureNone,
 		insecureOptions[1]: insecureImage,
 		insecureOptions[2]: insecureTls,
-		insecureOptions[3]: insecureAll,
+		insecureOptions[3]: insecureOnDisk,
+		insecureOptions[4]: insecureAll,
 	}
 )
 
@@ -117,6 +119,10 @@ func (sf *secFlags) SkipImageCheck() bool {
 
 func (sf *secFlags) SkipTlsCheck() bool {
 	return (*bitFlags)(sf).hasFlag(insecureTls)
+}
+
+func (sf *secFlags) SkipOnDiskCheck() bool {
+	return (*bitFlags)(sf).hasFlag(insecureOnDisk)
 }
 
 func (sf *secFlags) SkipAllSecurityChecks() bool {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -213,9 +213,10 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	pcfg := stage0.PrepareConfig{
-		CommonConfig: cfg,
-		UseOverlay:   !flagNoOverlay && common.SupportsOverlay(),
-		PrivateUsers: privateUsers,
+		CommonConfig:       cfg,
+		UseOverlay:         !flagNoOverlay && common.SupportsOverlay(),
+		PrivateUsers:       privateUsers,
+		SkipTreeStoreCheck: globalFlags.InsecureFlags.SkipOnDiskCheck(),
 	}
 
 	if len(flagPodManifest) > 0 {


### PR DESCRIPTION
Disable checking the treestore when using `--insecure-options=ondisk`
which is implemented in this change.

This reduces the start-up time of big images dramatically.

For example, with docker://jenkins.

docker://jenkins

real	0m7.200s
user	0m6.740s
sys	0m0.550s

docker://jenkins --insecure-skip-verify

real	0m0.384s
user	0m0.100s
sys	0m0.030ss

Closes #1350 