### PR TITLE
config: Make the data directory configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## vUNRELEASED
+
+#### New features and UX changes
+
+- make data directory configurable with a config file ([#1806](https://github.com/coreos/rkt/pull/1806))
+
 ## v0.13.0
 
 The primary motivation for this release is to add support for fetching images on the Docker Registry 2.0. It also includes other small improvements.

--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -241,3 +241,40 @@ For example, given the above system configuration and the following local config
 The result is that when downloading images from `index.docker.io`, `rkt` still sends user `foo` and password `bar`, but when downloading from `quay.io`, it uses user `baz` and password `quux`; and for `gcr.io` it will use user `goo` and password `gle`.
 
 Note that _within_ a particular configuration directory (either system or local), it is a syntax error for the same Docker registry to be defined in multiple files.
+
+### rktKind: `paths`
+
+This kind of configuration is used to customize the various paths that rkt uses.
+The configuration files should be placed inside a `paths.d` subdirectory (e.g. in `/usr/lib/rkt/paths.d` or `/etc/rkt/paths.d`).
+
+#### rktVersion: `v1`
+
+##### Description and examples
+
+This version of `paths` configuration specifies one additional field: `data`.
+
+The `data` field is a string that defines where image data and running pods are stored.
+If its value is not overridden, it is `/var/lib/rkt` by default.
+
+For example, to store images in your home partition instead of the root partition:
+
+`/etc/rkt/paths.d/paths.json`
+```json
+{
+	"rktKind": "paths",
+	"rktVersion": "v1",
+	"data": "/home/me/rkt"
+}
+```
+
+##### Override semantics
+
+Overriding is done for each directory.
+Not specifying a directory leaves it as its default path.
+
+The `data` directory can be specified via the `--dir` command line argument.
+If this is provided, this takes precedence over any configuration files.
+
+Configuration files can be added to the system configuration (`/usr/lib/rkt/paths.d`) and the local configuration (`/etc/rkt/paths.d`).
+If there are configurations in both, the local configuration takes precedence.
+If there are multiple configurations in the same directory, an error occurs.

--- a/Documentation/devel/on-disk-format.md
+++ b/Documentation/devel/on-disk-format.md
@@ -1,7 +1,9 @@
 On disk format
 ==============
 
-The data directory is `/var/lib/rkt` by default. The `--dir` command line option can be used to change this location.
+The data directory is `/var/lib/rkt`, unless configured otherwise.
+For details, see [the `paths` kind in configuration documentation](../configuration.md#rktkind-paths).
+The `--dir` command line option can be used to change this location.
 
 #### CAS database
 

--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -61,7 +61,7 @@ type v1AlphaAPIServer struct {
 var _ v1alpha.PublicAPIServer = &v1AlphaAPIServer{}
 
 func newV1AlphaAPIServer() (*v1AlphaAPIServer, error) {
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		return nil, err
 	}

--- a/rkt/config/config.go
+++ b/rkt/config/config.go
@@ -38,11 +38,16 @@ type BasicCredentials struct {
 	Password string
 }
 
+type ConfigurablePaths struct {
+	DataDir string
+}
+
 // Config is a single place where configuration for rkt frontend needs
 // resides.
 type Config struct {
 	AuthPerHost                  map[string]Headerer
 	DockerCredentialsPerRegistry map[string]BasicCredentials
+	Paths                        ConfigurablePaths
 }
 
 type configParser interface {
@@ -155,6 +160,9 @@ func newConfig() *Config {
 	return &Config{
 		AuthPerHost:                  make(map[string]Headerer),
 		DockerCredentialsPerRegistry: make(map[string]BasicCredentials),
+		Paths: ConfigurablePaths{
+			DataDir: "",
+		},
 	}
 }
 
@@ -288,5 +296,8 @@ func mergeConfigs(config *Config, subconfig *Config) {
 	}
 	for registry, creds := range subconfig.DockerCredentialsPerRegistry {
 		config.DockerCredentialsPerRegistry[registry] = creds
+	}
+	if subconfig.Paths.DataDir != "" {
+		config.Paths.DataDir = subconfig.Paths.DataDir
 	}
 }

--- a/rkt/config/paths.go
+++ b/rkt/config/paths.go
@@ -1,0 +1,47 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type configurablePathsV1 struct {
+	Data string `json:"data"`
+}
+
+func init() {
+	addParser("paths", "v1", &configurablePathsV1{})
+	// Look in 'paths.d' subdir for configs of type paths
+	registerSubDir("paths.d", []string{"paths"})
+}
+
+func (p *configurablePathsV1) parse(config *Config, raw []byte) error {
+	var dirs configurablePathsV1
+	if err := json.Unmarshal(raw, &dirs); err != nil {
+		return err
+	}
+	if dirs.Data != "" {
+		if config.Paths.DataDir != "" {
+			// A clash has occurred. Data dir has been defined more than once in
+			// the same directory
+			return fmt.Errorf("data directory is already specified")
+		}
+		config.Paths.DataDir = dirs.Data
+	}
+
+	return nil
+}

--- a/rkt/enter.go
+++ b/rkt/enter.go
@@ -87,7 +87,7 @@ func runEnter(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("Cannot open store: %v", err)
 		return 1

--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -65,7 +65,7 @@ func runFetch(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("fetch: cannot open store: %v", err)
 		return 1

--- a/rkt/gc.go
+++ b/rkt/gc.go
@@ -188,7 +188,7 @@ func deletePod(p *pod) {
 	}
 
 	if p.isExitedGarbage {
-		s, err := store.NewStore(globalFlags.Dir)
+		s, err := store.NewStore(getDataDir())
 		if err != nil {
 			stderr("Cannot open store: %v", err)
 			return

--- a/rkt/image_cat_manifest.go
+++ b/rkt/image_cat_manifest.go
@@ -43,7 +43,7 @@ func runImageCatManifest(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("image cat-manifest: cannot open store: %v", err)
 		return 1

--- a/rkt/image_export.go
+++ b/rkt/image_export.go
@@ -44,7 +44,7 @@ func runImageExport(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("image export: cannot open store: %v", err)
 		return 1

--- a/rkt/image_extract.go
+++ b/rkt/image_extract.go
@@ -52,7 +52,7 @@ func runImageExtract(cmd *cobra.Command, args []string) (exit int) {
 	}
 	outputDir := args[1]
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("image extract: cannot open store: %v", err)
 		return 1

--- a/rkt/image_gc.go
+++ b/rkt/image_gc.go
@@ -43,7 +43,7 @@ func init() {
 }
 
 func runGcImage(cmd *cobra.Command, args []string) (exit int) {
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("rkt: cannot open store: %v", err)
 		return 1

--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -152,7 +152,7 @@ func runImages(cmd *cobra.Command, args []string) int {
 		fmt.Fprintf(tabOut, "%s\n", strings.Join(headerFields, "\t"))
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("images: cannot open store: %v\n", err)
 		return 1

--- a/rkt/image_render.go
+++ b/rkt/image_render.go
@@ -51,7 +51,7 @@ func runImageRender(cmd *cobra.Command, args []string) (exit int) {
 	}
 	outputDir := args[1]
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("image render: cannot open store: %v", err)
 		return 1

--- a/rkt/image_rm.go
+++ b/rkt/image_rm.go
@@ -93,7 +93,7 @@ func runRmImage(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("rkt: cannot open store: %v", err)
 		return 1

--- a/rkt/install.go
+++ b/rkt/install.go
@@ -35,7 +35,7 @@ var (
 		Run:   runWrapper(runInstall),
 	}
 
-	// dirs relative to globalFlags.Dir
+	// dirs relative to data directory
 	dirs = map[string]os.FileMode{
 		".":   os.FileMode(0750 | os.ModeSetgid),
 		"tmp": os.FileMode(0750 | os.ModeSetgid),
@@ -94,7 +94,7 @@ func setPermissions(path string, uid int, gid int, perm os.FileMode) error {
 
 func createDirStructure(gid int) error {
 	for dir, perm := range dirs {
-		path := filepath.Join(globalFlags.Dir, dir)
+		path := filepath.Join(getDataDir(), dir)
 
 		if err := os.MkdirAll(path, perm); err != nil {
 			return fmt.Errorf("error creating %q directory: %v", path, err)
@@ -160,7 +160,7 @@ func runInstall(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	casDbPath := filepath.Join(globalFlags.Dir, "cas", "db")
+	casDbPath := filepath.Join(getDataDir(), "cas", "db")
 	if err := setCasDbFilesPermissions(casDbPath, gid, casDbPerm); err != nil {
 		stderr("install: error setting cas db permissions: %v", err)
 		return 1

--- a/rkt/pods_test.go
+++ b/rkt/pods_test.go
@@ -119,7 +119,10 @@ func TestWalkPods(t *testing.T) {
 		}
 		defer os.RemoveAll(d)
 
-		globalFlags.Dir = d
+		// This will mark the flag as changed, so it will have
+		// precendence over the configuration and the default
+		// value.
+		cmdRkt.PersistentFlags().Set("dir", d)
 		if err := initPods(); err != nil {
 			t.Fatalf("error initializing pods: %v", err)
 		}

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -107,7 +107,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("prepare: cannot open store: %v", err)
 		return 1

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -145,7 +145,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("run: cannot open store: %v", err)
 		return 1
@@ -280,7 +280,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 	rcfg.Apps = apps
-	stage0.Run(rcfg, p.path(), globalFlags.Dir) // execs, never returns
+	stage0.Run(rcfg, p.path(), getDataDir()) // execs, never returns
 
 	return 1
 }

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -58,7 +58,7 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 	}
 	defer p.Close()
 
-	s, err := store.NewStore(globalFlags.Dir)
+	s, err := store.NewStore(getDataDir())
 	if err != nil {
 		stderr("prepared-run: cannot open store: %v", err)
 		return 1
@@ -130,6 +130,6 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 	if globalFlags.Debug {
 		stage0.InitDebug()
 	}
-	stage0.Run(rcfg, p.path(), globalFlags.Dir) // execs, never returns
+	stage0.Run(rcfg, p.path(), getDataDir()) // execs, never returns
 	return 1
 }


### PR DESCRIPTION
Adds a new category of config called "paths" which is intended to
allow the user to configure various paths. At the moment, it supports
one - the data directory. By setting this, you can control where image
files are stored without having to give a CLI argument.

This is based on #1192.

I will need it for configuring default stage1 directory.