### PR TITLE
stage1: set permissions for implicit empty volumes

### DIFF
--- a/stage1/init/common/mount.go
+++ b/stage1/init/common/mount.go
@@ -61,9 +61,15 @@ func GenerateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume
 		// there is no volume for this mount point, creating an "empty" volume
 		// implicitly
 		if !ok {
+			defaultMode := "0755"
+			defaultUID := 0
+			defaultGID := 0
 			emptyVol := types.Volume{
 				Name: mp.Name,
 				Kind: "empty",
+				Mode: &defaultMode,
+				UID:  &defaultUID,
+				GID:  &defaultGID,
 			}
 
 			fmt.Fprintf(os.Stderr, "rkt: warning: no volume specified for mount point %q, implicitly creating an \"empty\" volume. This volume will be removed when the pod is garbage-collected.\n", mp.Name)

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -75,7 +75,7 @@ var volTests = []struct {
 	},
 	// Check that an implicit empty volume is created if the user didn't provide it but there's a mount point in the app
 	{
-		`/bin/sh -c "export FILE=/dir1/file CONTENT=1 ; ^RKT_BIN^ --debug --insecure-options=image run --mds-register=false --inherit-env=true ^WRITE_FILE^"`,
+		`/bin/sh -c "export FILE=/dir1/file CONTENT=1 ; ^RKT_BIN^ --debug --insecure-options=image run --mds-register=false --inherit-env=true ^VOL_RW_WRITE_FILE^"`,
 		`<<<1>>>`,
 	},
 }


### PR DESCRIPTION
We added the mandatory Mode, UID and GID flags to empty volumes but we
weren't setting them when we generated implicit empty volumes.

This wasn't caught in the tests because they were wrong: we were using a test ACI that didn't include a mount point so we were not really testing implicit empty volume generation.