### PR TITLE
stage0: brute-force GC on GC failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /makelib/variables.mk
 /build-rkt*
 .vagrant
+/tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ rkt vUNRELEASED is an incremental release with UX improvements, bug fixes and im
 
 - make data directory configurable with a config file ([#1806](https://github.com/coreos/rkt/pull/1806)). See rkt's [paths configuration](https://github.com/coreos/rkt/blob/master/Documentation/configuration.md#rktkind-paths) documentation.
 - kvm: resource isolators ([#1404](https://github.com/coreos/rkt/pull/1404))
+- fallback to forced GC when pod dir is in inconsistent state ([#1828](https://github.com/coreos/rkt/pull/1828))
 
 #### Bug fixes
 

--- a/rkt/gc.go
+++ b/rkt/gc.go
@@ -179,6 +179,49 @@ func emptyGarbage() error {
 	return nil
 }
 
+// cleanExitedGarbage prepares the pod's directory for removal. If anything
+// fails here then we can conclude that the pod's directory is in a bad state
+// and needs to be cleaned up forcibly.
+func cleanExitedGarbage(p *pod, s *store.Store) error {
+	stage1TreeStoreID, err := p.getStage1TreeStoreID()
+	if err != nil {
+		return fmt.Errorf("error getting stage1 treeStoreID: %v", err)
+	}
+	stage1RootFS := s.GetTreeStoreRootFS(stage1TreeStoreID)
+
+	// execute stage1's GC
+	if err := stage0.GC(p.path(), p.uuid, stage1RootFS, globalFlags.Debug); err != nil {
+		return fmt.Errorf("problem performing stage1 GC on %q: %v", p.uuid, err)
+	}
+
+	if p.usesOverlay() {
+		apps, err := p.getApps()
+		if err != nil {
+			return fmt.Errorf("error retrieving app hashes from pod manifest: %v", err)
+		}
+		for _, a := range apps {
+			dest := filepath.Join(common.AppPath(p.path(), a.Name), "rootfs")
+			if err := syscall.Unmount(dest, 0); err != nil {
+				// machine could have been rebooted and mounts lost.
+				// ignore "does not exist" and "not a mount point" errors
+				if err != syscall.ENOENT && err != syscall.EINVAL {
+					return fmt.Errorf("error unmounting dest at %v: %v", dest, err)
+				}
+			}
+		}
+
+		s1 := filepath.Join(common.Stage1ImagePath(p.path()), "rootfs")
+		if err := syscall.Unmount(s1, 0); err != nil {
+			// machine could have been rebooted and mounts lost.
+			// ignore "does not exist" and "not a mount point" errors
+			if err != syscall.ENOENT && err != syscall.EINVAL {
+				return fmt.Errorf("error unmounting s1 at %v: %v", s1, err)
+			}
+		}
+	}
+	return nil
+}
+
 // deletePod cleans up files and resource associated with the pod
 // pod must be under exclusive lock and be in either ExitedGarbage
 // or Garbage state
@@ -194,45 +237,15 @@ func deletePod(p *pod) {
 			return
 		}
 		defer s.Close()
-		stage1TreeStoreID, err := p.getStage1TreeStoreID()
-		if err != nil {
-			stderr("Error getting stage1 treeStoreID: %v", err)
-			return
-		}
-		stage1RootFS := s.GetTreeStoreRootFS(stage1TreeStoreID)
 
-		// execute stage1's GC
-		if err := stage0.GC(p.path(), p.uuid, stage1RootFS, globalFlags.Debug); err != nil {
-			stderr("Stage1 GC of pod %q failed: %v", p.uuid, err)
-			return
-		}
-
-		if p.usesOverlay() {
-			apps, err := p.getApps()
-			if err != nil {
-				stderr("Error retrieving app hashes from pod manifest: %v", err)
+		if err := cleanExitedGarbage(p, s); err != nil {
+			stderr("Received error performing GC for pod %q: %v", p.uuid, err)
+			stderr("Attempting forced GC of pod %q...", p.uuid)
+			if err := stage0.ForceMountGC(p.path(), p.uuid.String()); err != nil {
+				stderr("Forced GC of pod %q failed: %v\n", p.uuid, err)
 				return
 			}
-			for _, a := range apps {
-				dest := filepath.Join(common.AppPath(p.path(), a.Name), "rootfs")
-				if err := syscall.Unmount(dest, 0); err != nil {
-					// machine could have been rebooted and mounts lost.
-					// ignore "does not exist" and "not a mount point" errors
-					if err != syscall.ENOENT && err != syscall.EINVAL {
-						stderr("Error unmounting app at %v: %v", dest, err)
-					}
-				}
-			}
-
-			s1 := filepath.Join(common.Stage1ImagePath(p.path()), "rootfs")
-			if err := syscall.Unmount(s1, 0); err != nil {
-				// machine could have been rebooted and mounts lost.
-				// ignore "does not exist" and "not a mount point" errors
-				if err != syscall.ENOENT && err != syscall.EINVAL {
-					stderr("Error unmounting stage1 at %v: %v", s1, err)
-					return
-				}
-			}
+			stderr("Forced GC of pod %q succeeded.", p.uuid)
 		}
 	}
 

--- a/stage0/gc_test.go
+++ b/stage0/gc_test.go
@@ -1,0 +1,62 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stage0
+
+import (
+	"strings"
+	"testing"
+)
+
+var mountinfo = `8 7 0:1 / /my/mount/prefix/blah ignore this stuff
+7 6 0:2 / /my/mount/prefix/foo bar
+6 4 4.5 / /my/mount/prefix/foo car
+9 7 0:3 / /my/mount/prefix/foo rar
+2 6 0:5 / /my/mount/prefix/foo scar
+5 0 0:18 / /not/my/mount/prefix sly dog`
+
+func TestMountOrdering(t *testing.T) {
+	tests := []struct {
+		prefix     string
+		ids        []int
+		shouldPass bool
+	}{
+		{
+			prefix:     "/my/mount/prefix",
+			ids:        []int{2, 9, 8, 7, 6},
+			shouldPass: true,
+		},
+	}
+
+	for i, tt := range tests {
+		mi := strings.NewReader(mountinfo)
+		mnts, err := getMountsForPrefix(tt.prefix, mi)
+		if err != nil {
+			t.Errorf("problems finding mount points: %v", err)
+		}
+
+		if len(mnts) != len(tt.ids) {
+			t.Errorf("test  %d: didn't find the expected number of mounts. found %d but wanted %d.", i, len(mnts), len(tt.ids))
+			return
+		}
+
+		for j, mnt := range mnts {
+			if mnt.id != tt.ids[j] {
+				t.Errorf("test #%d: problem with mount ordering; mount at index %d is %d not %d",
+					i, j, mnt.id, tt.ids[j])
+				return
+			}
+		}
+	}
+}


### PR DESCRIPTION
When a pod directory is in an unexpected state, it may happen that the
standard garbage collection fails. When this happens mounts can be left
around, requiring manual removal.

This change forces a GC of the pod mount points when the pod GC
otherwise fails. To do this, the /proc/self/mountinfo file is parsed,
the pod mount points are extracted, ordered, then unmounted.

fixes #1572