### PR TITLE
rkt: always use https:// when fetching docker images

### DIFF
--- a/rkt/images.go
+++ b/rkt/images.go
@@ -445,7 +445,8 @@ func (f *fetcher) fetch(appName string, aciURL, ascURL string, ascFile *os.File,
 			user = creds.User
 			password = creds.Password
 		}
-		acis, err := docker2aci.Convert(registryURL, true, tmpDir, tmpDir, user, password, globalFlags.InsecureFlags.SkipTlsCheck())
+		// for now, always use https:// when fetching docker images
+		acis, err := docker2aci.Convert(registryURL, true /* squash */, tmpDir, tmpDir, user, password, false /* insecure */)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("error converting docker image to ACI: %v", err)
 		}

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -102,7 +102,9 @@ func TestFetch(t *testing.T) {
 		{"--insecure-options=image run --mds-register=false", "docker://busybox:latest", "", ""},
 		{"--insecure-options=image prepare", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci", "", ""},
 		{"--insecure-options=image prepare", "coreos.com/etcd:v2.1.2", "", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci"},
-		{"--insecure-options=image prepare", "docker://busybox", "", ""},
+		// test --insecure-options=tls to make sure
+		// https://github.com/coreos/rkt/issues/1829 is not an issue anymore
+		{"--insecure-options=image,tls prepare", "docker://busybox", "", ""},
 		{"--insecure-options=image prepare", "docker://busybox:latest", "", ""},
 	}
 


### PR DESCRIPTION
The insecure parameter forces docker2aci to connect to the registry
using `http://`.

Make it false while docker2aci doesn't have logic to try `https://` and
fall back to `http://` if that didn't work.

Fixes #1829 