### PR TITLE
<rkt>: rkt.go has 2 functions with the same name - init()

### DIFF
--- a/rkt/rkt.go
+++ b/rkt/rkt.go
@@ -105,9 +105,7 @@ func init() {
 
 	// TODO: Remove before 1.0
 	rktflag.InstallDeprecatedSkipVerify(cmdRkt.PersistentFlags(), sf)
-}
 
-func init() {
 	cobra.EnablePrefixMatching = true
 }
 


### PR DESCRIPTION
Make change to combine the 2 functions together.