### PR TITLE
stage1: return an error if an app has empty exec

### DIFF
--- a/stage1/init/pod.go
+++ b/stage1/init/pod.go
@@ -249,6 +249,10 @@ func (p *Pod) appToSystemd(ra *schema.RuntimeApp, interactive bool, flavor strin
 	}
 	imgName := image.Name
 
+	if len(app.Exec) == 0 {
+		return fmt.Errorf(`image %q has an empty "exec" (try --exec=BINARY)`, imgName)
+	}
+
 	workDir := "/"
 	if app.WorkingDirectory != "" {
 		workDir = app.WorkingDirectory


### PR DESCRIPTION
We were assuming that if "exec" is present, it won't be empty. This is
incorrect because the spec lists exec as optional.

Fixes #1841 