### PR TITLE
tar: prefix hard link destination with extraction target

### DIFF
--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -169,7 +169,7 @@ func extractFile(tr *tar.Reader, target string, hdr *tar.Header, overwrite bool,
 		}
 		dir.Close()
 	case typ == tar.TypeLink:
-		dest := filepath.Join("/", hdr.Linkname)
+		dest := filepath.Join(target, hdr.Linkname)
 		if err := os.Link(dest, p); err != nil {
 			return err
 		}


### PR DESCRIPTION
If the extraction is not running in a chroot, the file to hard link
against must be prefaced by the target for the extraction, otherwise the
file that's being linked to will not exist and the link will fail.

Fixes appc/acbuild#139.

Replaces https://github.com/coreos/rkt/pull/1827.