### PR TITLE
replace single filter with multiple filters

### DIFF
--- a/api/v1alpha/api.pb.go
+++ b/api/v1alpha/api.pb.go
@@ -325,19 +325,19 @@ func (m *KeyValue) String() string { return proto.CompactTextString(m) }
 func (*KeyValue) ProtoMessage()    {}
 
 // PodFilter defines the condition that the returned pods need to satisfy in ListPods().
-// The conditions are combined by 'AND'.
+// The conditions are combined by 'AND', and different filters are combined by 'OR'.
 type PodFilter struct {
 	// If not empty, the pods that have any of the ids will be returned.
 	Ids []string `protobuf:"bytes,1,rep,name=ids" json:"ids,omitempty"`
 	// If not empty, the pods that have any of the states will be returned.
 	States []PodState `protobuf:"varint,2,rep,name=states,enum=v1alpha.PodState" json:"states,omitempty"`
-	// If not empty, the pods that have any of the apps will be returned.
+	// If not empty, the pods that all of the apps will be returned.
 	AppNames []string `protobuf:"bytes,3,rep,name=app_names" json:"app_names,omitempty"`
-	// If not empty, the pods that have any of the images(in the apps) will be returned
+	// If not empty, the pods that have all of the images(in the apps) will be returned
 	ImageIds []string `protobuf:"bytes,4,rep,name=image_ids" json:"image_ids,omitempty"`
-	// If not empty, the pods that are in any of the networks will be returned.
+	// If not empty, the pods that are in all of the networks will be returned.
 	NetworkNames []string `protobuf:"bytes,5,rep,name=network_names" json:"network_names,omitempty"`
-	// If not empty, the pods that have any of the annotations will be returned.
+	// If not empty, the pods that have all of the annotations will be returned.
 	Annotations []*KeyValue `protobuf:"bytes,6,rep,name=annotations" json:"annotations,omitempty"`
 }
 
@@ -353,7 +353,7 @@ func (m *PodFilter) GetAnnotations() []*KeyValue {
 }
 
 // ImageFilter defines the condition that the returned images need to satisfy in ListImages().
-// The conditions are combined by 'AND'.
+// The conditions are combined by 'AND', and different filters are combined by 'OR'.
 type ImageFilter struct {
 	// If not empty, the images that have any of the ids will be returned.
 	Ids []string `protobuf:"bytes,1,rep,name=ids" json:"ids,omitempty"`
@@ -366,13 +366,13 @@ type ImageFilter struct {
 	// If not empty, the images that have any of the keywords in the name will be returned.
 	// For example, both 'kubernetes-etcd', 'etcd:latest' will be returned if 'etcd' is included,
 	Keywords []string `protobuf:"bytes,4,rep,name=keywords" json:"keywords,omitempty"`
-	// If not empty, the images that have any of the labels will be returned.
+	// If not empty, the images that have all of the labels will be returned.
 	Labels []*KeyValue `protobuf:"bytes,5,rep,name=labels" json:"labels,omitempty"`
 	// If set, the images that are imported after this timestamp will be returned.
 	ImportedAfter int64 `protobuf:"varint,6,opt,name=imported_after" json:"imported_after,omitempty"`
 	// If set, the images that are imported before this timestamp will be returned.
 	ImportedBefore int64 `protobuf:"varint,7,opt,name=imported_before" json:"imported_before,omitempty"`
-	// If not empty, the images that have any of the annotations will be returned.
+	// If not empty, the images that have all of the annotations will be returned.
 	Annotations []*KeyValue `protobuf:"bytes,8,rep,name=annotations" json:"annotations,omitempty"`
 }
 
@@ -486,17 +486,17 @@ func (m *GetInfoResponse) GetInfo() *Info {
 
 // Request for ListPods().
 type ListPodsRequest struct {
-	Filter *PodFilter `protobuf:"bytes,1,opt,name=filter" json:"filter,omitempty"`
-	Detail bool       `protobuf:"varint,2,opt,name=detail" json:"detail,omitempty"`
+	Filters []*PodFilter `protobuf:"bytes,1,rep,name=filters" json:"filters,omitempty"`
+	Detail  bool         `protobuf:"varint,2,opt,name=detail" json:"detail,omitempty"`
 }
 
 func (m *ListPodsRequest) Reset()         { *m = ListPodsRequest{} }
 func (m *ListPodsRequest) String() string { return proto.CompactTextString(m) }
 func (*ListPodsRequest) ProtoMessage()    {}
 
-func (m *ListPodsRequest) GetFilter() *PodFilter {
+func (m *ListPodsRequest) GetFilters() []*PodFilter {
 	if m != nil {
-		return m.Filter
+		return m.Filters
 	}
 	return nil
 }
@@ -545,17 +545,17 @@ func (m *InspectPodResponse) GetPod() *Pod {
 
 // Request for ListImages().
 type ListImagesRequest struct {
-	Filter *ImageFilter `protobuf:"bytes,1,opt,name=filter" json:"filter,omitempty"`
-	Detail bool         `protobuf:"varint,2,opt,name=detail" json:"detail,omitempty"`
+	Filters []*ImageFilter `protobuf:"bytes,1,rep,name=filters" json:"filters,omitempty"`
+	Detail  bool           `protobuf:"varint,2,opt,name=detail" json:"detail,omitempty"`
 }
 
 func (m *ListImagesRequest) Reset()         { *m = ListImagesRequest{} }
 func (m *ListImagesRequest) String() string { return proto.CompactTextString(m) }
 func (*ListImagesRequest) ProtoMessage()    {}
 
-func (m *ListImagesRequest) GetFilter() *ImageFilter {
+func (m *ListImagesRequest) GetFilters() []*ImageFilter {
 	if m != nil {
-		return m.Filter
+		return m.Filters
 	}
 	return nil
 }

--- a/api/v1alpha/api.proto
+++ b/api/v1alpha/api.proto
@@ -162,7 +162,7 @@ message KeyValue {
 }
 
 // PodFilter defines the condition that the returned pods need to satisfy in ListPods().
-// The conditions are combined by 'AND'.
+// The conditions are combined by 'AND', and different filters are combined by 'OR'.
 message PodFilter {
         // If not empty, the pods that have any of the ids will be returned.
         repeated string ids = 1;
@@ -170,21 +170,21 @@ message PodFilter {
         // If not empty, the pods that have any of the states will be returned.
         repeated PodState states = 2;
 
-        // If not empty, the pods that have any of the apps will be returned.
+        // If not empty, the pods that all of the apps will be returned.
         repeated string app_names = 3;
 
-        // If not empty, the pods that have any of the images(in the apps) will be returned
+        // If not empty, the pods that have all of the images(in the apps) will be returned
         repeated string image_ids = 4;
 
-        // If not empty, the pods that are in any of the networks will be returned.
+        // If not empty, the pods that are in all of the networks will be returned.
         repeated string network_names = 5;
 
-        // If not empty, the pods that have any of the annotations will be returned.
+        // If not empty, the pods that have all of the annotations will be returned.
         repeated KeyValue annotations = 6;
 }
 
 // ImageFilter defines the condition that the returned images need to satisfy in ListImages().
-// The conditions are combined by 'AND'.
+// The conditions are combined by 'AND', and different filters are combined by 'OR'.
 message ImageFilter {
         // If not empty, the images that have any of the ids will be returned.
         repeated string ids = 1;
@@ -201,7 +201,7 @@ message ImageFilter {
         // For example, both 'kubernetes-etcd', 'etcd:latest' will be returned if 'etcd' is included,
         repeated string keywords = 4;
 
-        // If not empty, the images that have any of the labels will be returned.
+        // If not empty, the images that have all of the labels will be returned.
         repeated KeyValue labels = 5;
 
         // If set, the images that are imported after this timestamp will be returned.
@@ -210,7 +210,7 @@ message ImageFilter {
         // If set, the images that are imported before this timestamp will be returned.
         int64 imported_before = 7;
 
-        // If not empty, the images that have any of the annotations will be returned.
+        // If not empty, the images that have all of the annotations will be returned.
         repeated KeyValue annotations = 8;
 }
 
@@ -301,7 +301,7 @@ message GetInfoResponse {
 
 // Request for ListPods().
 message ListPodsRequest {
-        PodFilter filter = 1; // Optional.
+        repeated PodFilter filters = 1; // Optional.
         bool detail = 2; // Optional.
 }
 
@@ -323,7 +323,7 @@ message InspectPodResponse {
 
 // Request for ListImages().
 message ListImagesRequest {
-        ImageFilter filter = 1; // Optional.
+        repeated ImageFilter filters = 1; // Optional.
         bool detail = 2; // Optional.
 }
 

--- a/pkg/set/string.go
+++ b/pkg/set/string.go
@@ -1,0 +1,67 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// For how the uidshift and uidcount are generated please check:
+// http://cgit.freedesktop.org/systemd/systemd/commit/?id=03cfe0d51499e86b1573d1
+
+package set
+
+type String map[string]struct{}
+
+func NewString(items ...string) String {
+	s := String{}
+	s.Insert(items...)
+	return s
+}
+
+// Insert adds items to the set.
+func (s String) Insert(items ...string) {
+	for _, item := range items {
+		s[item] = struct{}{}
+	}
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s String) Has(item string) bool {
+	_, contained := s[item]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s String) HasAll(items ...string) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Delete removes all items from the set.
+func (s String) Delete(items ...string) {
+	for _, item := range items {
+		delete(s, item)
+	}
+}
+
+// ConditionalHas returns true if and only if there is any item 'source'
+// in the set that satisfies the conditionFunc wrt 'item'.
+func (s String) ConditionalHas(conditionFunc func(source, item string) bool, item string) bool {
+	for source := range s {
+		if conditionFunc(source, item) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/set/string_test.go
+++ b/pkg/set/string_test.go
@@ -1,0 +1,109 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// For how the uidshift and uidcount are generated please check:
+// http://cgit.freedesktop.org/systemd/systemd/commit/?id=03cfe0d51499e86b1573d1
+
+package set
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	s := NewString("a", "b", "c")
+	if len(s) != 3 {
+		t.Errorf("Expected len=3: %d", len(s))
+	}
+	if !s.Has("a") || !s.Has("b") || !s.Has("c") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+
+	if !s.HasAll("a", "b", "c") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+
+	if s.HasAll("a", "b", "c", "d") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+
+	s.Delete("a", "b")
+	if len(s) != 1 {
+		t.Errorf("Expected len=1: %d", len(s))
+	}
+	if !s.Has("c") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+
+	s.Delete("a")
+	if len(s) != 1 {
+		t.Errorf("Expected len=1: %d", len(s))
+	}
+	if !s.Has("c") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+
+	s.Delete("")
+	if len(s) != 1 {
+		t.Errorf("Expected len=1: %d", len(s))
+	}
+	if !s.Has("c") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+
+	s.Delete("c")
+	if len(s) != 0 {
+		t.Errorf("Expected len=1: %d", len(s))
+	}
+	if s.Has("a") || s.Has("b") || s.Has("c") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+}
+
+func TestContitionalHas(t *testing.T) {
+	tests := []struct {
+		keys          []string
+		item          string
+		conditionFunc func(string, string) bool
+		expectResult  bool
+	}{
+		{
+			[]string{"foo", "bar", "hello"},
+			"bar",
+			func(a, b string) bool { return a == b },
+			true,
+		},
+		{
+			[]string{"foo", "bar", "hello"},
+			"baz",
+			func(a, b string) bool { return a == b },
+			false,
+		},
+		{
+			[]string{"foo", "bar", "hello"},
+			"he",
+			strings.HasPrefix,
+			true,
+		},
+	}
+
+	for i, tt := range tests {
+		s := NewString(tt.keys...)
+		actualResult := s.ConditionalHas(tt.conditionFunc, tt.item)
+		if tt.expectResult != actualResult {
+			t.Errorf("test case %d: expected: %v, saw: %v", i, tt.expectResult, actualResult)
+		}
+	}
+}


### PR DESCRIPTION
This is a break change for API service:
1, replaces the single filter field with multiple filters in `ListPods` and `ListImages`.
2, filters are combined with `OR`, and conditions within a filter are combined with `AND`, which provides a better flexibility.

cc @dgonyeo 