### PR TITLE
build: Check for patch and bc for kvm flavor

### DIFF
--- a/Documentation/packaging.md
+++ b/Documentation/packaging.md
@@ -21,6 +21,10 @@ It covers dependencies, file ownership and permissions, and tips to observe pack
 
 wget, gpg, mktemp, md5sum, cpio, gzip, unsquashfs, sort
 
+#### Additional build-time dependencies for the kvm flavor
+
+patch, bc
+
 #### Additional build-time dependencies for the src flavor
 
 intltoolize, libtoolize and all systemd dependencies.

--- a/configure.ac
+++ b/configure.ac
@@ -211,7 +211,9 @@ RKT_ITERATE_FLAVORS([${RKT_STAGE1_FLAVORS}],[flavor],
                                       RKT_REQ_PROG([UNSQUASHFS],[unsquashfs],[unsquashfs])
                                       RKT_REQ_PROG([SORT],[sort],[sort])],
                              [kvm],
-                                     [AC_MSG_WARN([* kvm is an experimental stage1 implementation, some features are missing])],
+                                     [AC_MSG_WARN([* kvm is an experimental stage1 implementation, some features are missing])
+                                      RKT_REQ_PROG([PATCH],[patch],[patch])
+                                      RKT_REQ_PROG([BC],[bc],[bc])],
                              [host],
                                      [],
                              [AC_MSG_ERROR([*** Unhandled flavor "${flavor}", should not happen])])])


### PR DESCRIPTION
We use patch to patch the kernel and kvmtool. bc is used somewhere
during kernel build.