### PR TITLE
rkt,store,tests: delete images by name

### DIFF
--- a/Documentation/subcommands/image.md
+++ b/Documentation/subcommands/image.md
@@ -20,12 +20,13 @@ sha512-96323da393621d846c632e71551b77089ac0b004ceb5c2362be4f5ced2212db9   regist
 
 ## rkt image rm
 
-Given an image ID you can remove it from the local store.
+Given an image ID or image name you can remove it from the local store.
 
 ```
-# rkt image rm sha512-a03f6bad952b
-rkt: successfully removed aci for image ID: "sha512-a03f6bad952b"
-rkt: 1 image(s) successfully remove
+# rkt image rm sha512-a03f6bad952b coreos.com/etcd
+rkt: successfully removed aci for image: "sha512-a03f6bad952b"
+rkt: successfully removed aci for image: "coreos.com/etcd"
+rkt: 2 image(s) successfully removed
 ```
 
 ## rkt image gc
@@ -39,8 +40,8 @@ This can be configured with the `--grace-period` flag.
 # rkt image gc --grace-period 48h
 rkt: removed treestore "deps-sha512-219204dd54481154aec8f6eafc0f2064d973c8a2c0537eab827b7414f0a36248"
 rkt: removed treestore "deps-sha512-3f2a1ad0e9739d977278f0019b6d7d9024a10a2b1166f6c9fdc98f77a357856d"
-rkt: successfully removed aci for image ID: "sha512-e39d4089a224718c41e6bef4c1ac692a6c1832c8c69cf28123e1f205a9355444"
-rkt: successfully removed aci for image ID: "sha512-0648aa44a37a8200147d41d1a9eff0757d0ac113a22411f27e4e03cbd1e84d0d"
+rkt: successfully removed aci for image: "sha512-e39d4089a224718c41e6bef4c1ac692a6c1832c8c69cf28123e1f205a9355444"
+rkt: successfully removed aci for image: "sha512-0648aa44a37a8200147d41d1a9eff0757d0ac113a22411f27e4e03cbd1e84d0d"
 rkt: 2 image(s) successfully removed
 ```
 

--- a/Documentation/subcommands/image.md
+++ b/Documentation/subcommands/image.md
@@ -24,8 +24,8 @@ Given an image ID or image name you can remove it from the local store.
 
 ```
 # rkt image rm sha512-a03f6bad952b coreos.com/etcd
-rkt: successfully removed aci for image: "sha512-a03f6bad952b"
-rkt: successfully removed aci for image: "coreos.com/etcd"
+rkt: successfully removed aci for image: "sha512-a03f6bad952bd548c2a57a5d2fbb46679aff697ccdacd6c62e1e1068d848a9d4" ("coreos.com/rkt/stage1")
+rkt: successfully removed aci for image: "sha512-91e98d7f167905b69cce91b163963ccd6a8e1c4bd34eeb44415f0462e4647e27" ("coreos.com/etcd")
 rkt: 2 image(s) successfully removed
 ```
 
@@ -40,8 +40,8 @@ This can be configured with the `--grace-period` flag.
 # rkt image gc --grace-period 48h
 rkt: removed treestore "deps-sha512-219204dd54481154aec8f6eafc0f2064d973c8a2c0537eab827b7414f0a36248"
 rkt: removed treestore "deps-sha512-3f2a1ad0e9739d977278f0019b6d7d9024a10a2b1166f6c9fdc98f77a357856d"
-rkt: successfully removed aci for image: "sha512-e39d4089a224718c41e6bef4c1ac692a6c1832c8c69cf28123e1f205a9355444"
-rkt: successfully removed aci for image: "sha512-0648aa44a37a8200147d41d1a9eff0757d0ac113a22411f27e4e03cbd1e84d0d"
+rkt: successfully removed aci for image: "sha512-e39d4089a224718c41e6bef4c1ac692a6c1832c8c69cf28123e1f205a9355444" ("coreos.com/rkt/stage1")
+rkt: successfully removed aci for image: "sha512-0648aa44a37a8200147d41d1a9eff0757d0ac113a22411f27e4e03cbd1e84d0d" ("coreos.com/etcd")
 rkt: 2 image(s) successfully removed
 ```
 

--- a/rkt/image_rm.go
+++ b/rkt/image_rm.go
@@ -24,8 +24,8 @@ import (
 
 var (
 	cmdImageRm = &cobra.Command{
-		Use:   "rm IMAGEID...",
-		Short: "Remove image(s) with the given ID(s) from the local store",
+		Use:   "rm IMAGE...",
+		Short: "Remove image(s) with the given ID(s) or name(s) from the local store",
 		Run:   runWrapper(runRmImage),
 	}
 )
@@ -39,34 +39,51 @@ func rmImages(s *store.Store, images []string) error {
 	errors := 0
 	staleErrors := 0
 	for _, pkey := range images {
+		var keys []string
 		errors++
 		h, err := types.NewHash(pkey)
 		if err != nil {
-			stderr("rkt: wrong image ID %q: %v", pkey, err)
-			continue
-		}
-		key, err := s.ResolveKey(h.String())
-		if err != nil {
-			stderr("rkt: image ID %q not valid: %v", pkey, err)
-			continue
-		}
-		if key == "" {
-			stderr("rkt: image ID %q doesn't exist", pkey)
-			continue
-		}
-
-		if err = s.RemoveACI(key); err != nil {
-			if serr, ok := err.(*store.StoreRemovalError); ok {
-				staleErrors++
-				stderr("rkt: some files cannot be removed for image ID %q: %v", pkey, serr)
-			} else {
-				stderr("rkt: error removing aci for image ID %q: %v", pkey, err)
+			var found bool
+			keys, found, err = s.ResolveName(pkey)
+			if len(keys) > 0 {
+				errors += len(keys) - 1
+			}
+			if !found {
+				stderr("rkt: image name %q not found", pkey)
 				continue
 			}
+			if err != nil {
+				stderr("rkt: image name %q not valid: %v", pkey, err)
+				continue
+			}
+		} else {
+			key, err := s.ResolveKey(h.String())
+			if err != nil {
+				stderr("rkt: image ID %q not valid: %v", pkey, err)
+				continue
+			}
+			if key == "" {
+				stderr("rkt: image ID %q doesn't exist", pkey)
+				continue
+			}
+
+			keys = append(keys, key)
 		}
-		stdout("rkt: successfully removed aci for image ID: %q", pkey)
-		errors--
-		done++
+
+		for _, key := range keys {
+			if err = s.RemoveACI(key); err != nil {
+				if serr, ok := err.(*store.StoreRemovalError); ok {
+					staleErrors++
+					stderr("rkt: some files cannot be removed for image %q: %v", pkey, serr)
+				} else {
+					stderr("rkt: error removing aci for image %q: %v", pkey, err)
+					continue
+				}
+			}
+			stdout("rkt: successfully removed aci for image: %q", pkey)
+			errors--
+			done++
+		}
 	}
 
 	if done > 0 {

--- a/store/store.go
+++ b/store/store.go
@@ -389,6 +389,28 @@ func (s *Store) ResolveKey(key string) (string, error) {
 	return aciInfos[0].BlobKey, nil
 }
 
+func (s *Store) ResolveName(name string) ([]string, bool, error) {
+	var (
+		aciInfos []*ACIInfo
+		found    bool
+	)
+	err := s.db.Do(func(tx *sql.Tx) error {
+		var err error
+		aciInfos, found, err = GetACIInfosWithName(tx, name)
+		return err
+	})
+	if err != nil {
+		return []string{}, found, fmt.Errorf("error retrieving ACI Infos: %v", err)
+	}
+
+	keys := make([]string, len(aciInfos))
+	for i, aciInfo := range aciInfos {
+		keys[i] = aciInfo.BlobKey
+	}
+
+	return keys, found, nil
+}
+
 func (s *Store) ReadStream(key string) (io.ReadCloser, error) {
 	key, err := s.ResolveKey(key)
 	if err != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -389,6 +389,8 @@ func (s *Store) ResolveKey(key string) (string, error) {
 	return aciInfos[0].BlobKey, nil
 }
 
+// ResolveName resolves an image name to a list of full keys and using the
+// store for resolution.
 func (s *Store) ResolveName(name string) ([]string, bool, error) {
 	var (
 		aciInfos []*ACIInfo
@@ -400,7 +402,7 @@ func (s *Store) ResolveName(name string) ([]string, bool, error) {
 		return err
 	})
 	if err != nil {
-		return []string{}, found, fmt.Errorf("error retrieving ACI Infos: %v", err)
+		return nil, found, fmt.Errorf("error retrieving ACI Infos: %v", err)
 	}
 
 	keys := make([]string, len(aciInfos))

--- a/tests/rkt_image_rm_test.go
+++ b/tests/rkt_image_rm_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-	rmImageReferenced = `rkt: image ID %q is referenced by some containers, cannot remove.`
-	rmImageOk         = "rkt: successfully removed aci for image ID:"
+	rmImageReferenced = `rkt: image %q is referenced by some containers, cannot remove.`
+	rmImageOk         = "rkt: successfully removed aci for image:"
 
 	unreferencedACI = "rkt-unreferencedACI.aci"
 	unreferencedApp = "coreos.com/rkt-unreferenced"
@@ -38,7 +38,45 @@ const (
 	stage1App = "coreos.com/rkt/stage1"
 )
 
-func TestImageRunRm(t *testing.T) {
+func TestImageRunRmName(t *testing.T) {
+	imageFile := patchTestACI(unreferencedACI, fmt.Sprintf("--name=%s", unreferencedApp))
+	defer os.Remove(imageFile)
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	cmd := fmt.Sprintf("%s --insecure-options=image fetch %s", ctx.Cmd(), imageFile)
+	t.Logf("Fetching %s: %v", imageFile, cmd)
+	spawnAndWaitOrFail(t, cmd, true)
+
+	// at this point we know that RKT_INSPECT_IMAGE env var is not empty
+	referencedACI := os.Getenv("RKT_INSPECT_IMAGE")
+	cmd = fmt.Sprintf("%s --insecure-options=image run --mds-register=false %s", ctx.Cmd(), referencedACI)
+	t.Logf("Running %s: %v", referencedACI, cmd)
+	spawnAndWaitOrFail(t, cmd, true)
+
+	t.Logf("Retrieving stage1 image name")
+	stage1ImageName, err := getImageName(ctx, stage1App)
+	if err != nil {
+		t.Fatalf("rkt didn't terminate correctly: %v", err)
+	}
+
+	t.Logf("Removing stage1 image (should work)")
+	if err := removeImage(ctx, stage1ImageName, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	t.Logf("Removing image for app %s (should work)", referencedApp)
+	if err := removeImage(ctx, referencedApp, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	t.Logf("Removing image for app %s (should work)", unreferencedApp)
+	if err := removeImage(ctx, unreferencedApp, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestImageRunRmID(t *testing.T) {
 	imageFile := patchTestACI(unreferencedACI, fmt.Sprintf("--name=%s", unreferencedApp))
 	defer os.Remove(imageFile)
 	ctx := testutils.NewRktRunCtx()
@@ -73,22 +111,74 @@ func TestImageRunRm(t *testing.T) {
 	}
 
 	t.Logf("Removing stage1 image (should work)")
-	if err := removeImageId(ctx, stage1ImageID, true); err != nil {
+	if err := removeImage(ctx, stage1ImageID, true); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	t.Logf("Removing image for app %s (should work)", referencedApp)
-	if err := removeImageId(ctx, referencedImageID, true); err != nil {
+	if err := removeImage(ctx, referencedImageID, true); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	t.Logf("Removing image for app %s (should work)", unreferencedApp)
-	if err := removeImageId(ctx, unreferencedImageID, true); err != nil {
+	if err := removeImage(ctx, unreferencedImageID, true); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestImagePrepareRmRun(t *testing.T) {
+func TestImagePrepareRmNameRun(t *testing.T) {
+	imageFile := patchTestACI(unreferencedACI, fmt.Sprintf("--name=%s", unreferencedApp))
+	defer os.Remove(imageFile)
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	cmd := fmt.Sprintf("%s --insecure-options=image fetch %s", ctx.Cmd(), imageFile)
+	t.Logf("Fetching %s: %v", imageFile, cmd)
+	spawnAndWaitOrFail(t, cmd, true)
+
+	// at this point we know that RKT_INSPECT_IMAGE env var is not empty
+	referencedACI := os.Getenv("RKT_INSPECT_IMAGE")
+	cmds := strings.Fields(ctx.Cmd())
+	prepareCmd := exec.Command(cmds[0], cmds[1:]...)
+	prepareCmd.Args = append(prepareCmd.Args, "--insecure-options=image", "prepare", referencedACI)
+	output, err := prepareCmd.Output()
+	if err != nil {
+		t.Fatalf("Cannot read the output: %v", err)
+	}
+
+	podIDStr := strings.TrimSpace(string(output))
+	podID, err := types.NewUUID(podIDStr)
+	if err != nil {
+		t.Fatalf("%q is not a valid UUID: %v", podIDStr, err)
+	}
+
+	t.Logf("Retrieving stage1 image name")
+	stage1ImageName, err := getImageName(ctx, stage1App)
+	if err != nil {
+		t.Fatalf("rkt didn't terminate correctly: %v", err)
+	}
+
+	t.Logf("Removing stage1 image (should work)")
+	if err := removeImage(ctx, stage1ImageName, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	t.Logf("Removing image for app %s (should work)", referencedApp)
+	if err := removeImage(ctx, referencedApp, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	t.Logf("Removing image for app %s (should work)", unreferencedApp)
+	if err := removeImage(ctx, unreferencedApp, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cmd = fmt.Sprintf("%s run-prepared --mds-register=false %s", ctx.Cmd(), podID.String())
+	t.Logf("Running %s: %v", referencedACI, cmd)
+	spawnAndWaitOrFail(t, cmd, true)
+}
+
+func TestImagePrepareRmIDRun(t *testing.T) {
 	imageFile := patchTestACI(unreferencedACI, fmt.Sprintf("--name=%s", unreferencedApp))
 	defer os.Remove(imageFile)
 	ctx := testutils.NewRktRunCtx()
@@ -133,23 +223,41 @@ func TestImagePrepareRmRun(t *testing.T) {
 	}
 
 	t.Logf("Removing stage1 image (should work)")
-	if err := removeImageId(ctx, stage1ImageID, true); err != nil {
+	if err := removeImage(ctx, stage1ImageID, true); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	t.Logf("Removing image for app %s (should work)", referencedApp)
-	if err := removeImageId(ctx, referencedImageID, true); err != nil {
+	if err := removeImage(ctx, referencedImageID, true); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	t.Logf("Removing image for app %s (should work)", unreferencedApp)
-	if err := removeImageId(ctx, unreferencedImageID, true); err != nil {
+	if err := removeImage(ctx, unreferencedImageID, true); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	cmd = fmt.Sprintf("%s run-prepared --mds-register=false %s", ctx.Cmd(), podID.String())
 	t.Logf("Running %s: %v", referencedACI, cmd)
 	spawnAndWaitOrFail(t, cmd, true)
+}
+
+func getImageName(ctx *testutils.RktRunCtx, name string) (string, error) {
+	cmd := fmt.Sprintf(`/bin/sh -c "%s image list --fields=name --no-legend | grep %s | cut -d: -f1"`, ctx.Cmd(), name)
+	child, err := gexpect.Spawn(cmd)
+	if err != nil {
+		return "", fmt.Errorf("Cannot exec rkt: %v", err)
+	}
+	imageName, err := child.ReadLine()
+	imageName = strings.TrimSpace(imageName)
+	imageName = string(bytes.Trim([]byte(imageName), "\x00"))
+	if err != nil {
+		return "", fmt.Errorf("Cannot exec: %v", err)
+	}
+	if err := child.Wait(); err != nil {
+		return "", fmt.Errorf("rkt didn't terminate correctly: %v", err)
+	}
+	return imageName, nil
 }
 
 func getImageId(ctx *testutils.RktRunCtx, name string) (string, error) {
@@ -170,12 +278,12 @@ func getImageId(ctx *testutils.RktRunCtx, name string) (string, error) {
 	return imageID, nil
 }
 
-func removeImageId(ctx *testutils.RktRunCtx, imageID string, shouldWork bool) error {
-	expect := fmt.Sprintf(rmImageReferenced, imageID)
+func removeImage(ctx *testutils.RktRunCtx, image string, shouldWork bool) error {
+	expect := fmt.Sprintf(rmImageReferenced, image)
 	if shouldWork {
 		expect = rmImageOk
 	}
-	cmd := fmt.Sprintf("%s image rm %s", ctx.Cmd(), imageID)
+	cmd := fmt.Sprintf("%s image rm %s", ctx.Cmd(), image)
 	child, err := gexpect.Spawn(cmd)
 	if err != nil {
 		return fmt.Errorf("Cannot exec: %v", err)


### PR DESCRIPTION
Images can be deleted by both ID and name. Should there be multiple
images with the same name, all of them will be removed.

Resolves #1779