### PR TITLE
doc: --memory, --cpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ rkt vUNRELEASED is an incremental release with UX improvements, bug fixes and im
 - make data directory configurable with a config file ([#1806](https://github.com/coreos/rkt/pull/1806)). See rkt's [paths configuration](https://github.com/coreos/rkt/blob/master/Documentation/configuration.md#rktkind-paths) documentation.
 - kvm: resource isolators ([#1404](https://github.com/coreos/rkt/pull/1404))
 - fallback to forced GC when pod dir is in inconsistent state ([#1828](https://github.com/coreos/rkt/pull/1828))
+- override memory and cpu isolators on the command line ([#1851](https://github.com/coreos/rkt/pull/1851)). See rkt's [overriding isolators](https://github.com/coreos/rkt/blob/master/Documentation/subcommands/run.md#overriding-isolators) documentation.
 
 #### Bug fixes
 

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -34,6 +34,16 @@ This executable can be overridden by rkt using the `--exec` flag:
 # rkt --insecure-options=image run docker://busybox --exec /bin/date
 ```
 
+## Overriding Isolators
+
+Application images can include per-app isolators and some of them can be overridden by rkt.
+The units come from [the Kubernetes resource model](http://kubernetes.io/v1.1/docs/design/resources.html).
+In the following example, the CPU isolator is defined to 750 milli-cores and the memory isolator limits the memory usage to 128MB.
+
+```
+# rkt run coreos.com/etcd:v2.0.0 --cpu=750m --memory=128M
+```
+
 ## Passing Arguments
 
 To pass additional arguments to images use the pattern of `image1 -- [image1 flags] --- image2 -- [image2 flags]`.


### PR DESCRIPTION
The new rkt parameters --memory and --cpu were added without
documentation via https://github.com/coreos/rkt/pull/1851.

Add the documentation.