### PR TITLE
stage0: set journal permissions/ACLs to allow access to rkt group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -y cpio realpath squashfs-tools
  - sudo apt-get install -y build-essential
+ - sudo apt-get install -y libacl1-dev
 
 script:
  - ./autogen.sh

--- a/Documentation/hacking.md
+++ b/Documentation/hacking.md
@@ -20,6 +20,7 @@ For the most part the codebase is self-contained (e.g. all dependencies are vend
   * gcc
   * glibc development and static pieces (on Fedora/RHEL/Centos: glibc-devel and glibc-static packages, on Debian/Ubuntu libc6-dev package)
   * gpg
+  * libacl development files (on Fedora/RHEL/Centos: libacl-devel, on Debian/Ubuntu libacl1-dev)
   * make
   * openssl
   * patch

--- a/Documentation/using-rkt-with-systemd.md
+++ b/Documentation/using-rkt-with-systemd.md
@@ -293,6 +293,7 @@ To actually see all the cgroups, use `--all` flag. This will show two cgroups fo
 ## journalctl -M
 
 To see the logs from your service, use `journalctl -M <machine-id>`. You can get machine id from `machinectl list`.
+For journalctl to work for non-root users, you need to have the proper permissions in rkt's data directory (you can achieve that by running `rkt install`) and belong to the `rkt` group.
 
 ```
 -- Logs begin at Fri 2015-07-17 12:38:27 CEST, end at Fri 2015-07-17 12:38:29 CEST. --

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -279,6 +279,10 @@
 			"Rev": "f7ee69f31298ecbe5d2b349c711e2547a617d398"
 		},
 		{
+			"ImportPath": "github.com/naegelejd/go-acl",
+			"Rev": "c78b6dad599cb929480c906df0069a90b3fbc597"
+		},
+		{
 			"ImportPath": "github.com/pborman/uuid",
 			"Rev": "cccd189d45f7ac3368a0d127efb7f4d08ae0b655"
 		},

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/.gitignore
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/.gitignore
@@ -1,0 +1,26 @@
+# Vim
+*.swp
+
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.test
+*.exe

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/README.md
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/README.md
@@ -1,0 +1,29 @@
+# go-acl
+
+Golang POSIX.1e ACL bindings.
+Essentially bindings to /usr/include/sys/acl.h
+## notes
+
+### mac os x
+Mac OS X does not seem to support basic POSIX1.e ACLs. They do
+provide the POSIX API for NFSv4 ACLs. It would be nice for this
+package to also support NFSv4 ACLs.
+
+### freebsd
+By default, FreeBSD does not enable POSIX1.e ACLs on the root
+partition. To enable them, reboot into single-user mode and execute:
+
+    $ tunefs -a enable
+    $ reboot
+
+Source: https://www.freebsd.org/doc/handbook/fs-acl.html
+
+## info
+
+The IEEE POSIX.1e specification describes five security extensions to the base
+POSIX.1 API: Access Control Lists (ACLs), Auditing, Capabilities,
+Mandatory Access Control, and Information Flow Labels.
+The specificaiton was abandoned before finalization, however most
+UNIX-like operating systems have some form of ACL implementation.
+
+Source: http://www.gsp.com/cgi-bin/man.cgi?section=3&topic=posix1e

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/acl.go
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/acl.go
@@ -1,0 +1,235 @@
+// Package acl provides an interface to Posix.1e Access Control Lists
+// as well as additional ACL implementations (NFS).
+package acl
+
+// #ifdef __APPLE__
+//  #include <sys/types.h>
+// #endif
+// #include <sys/acl.h>
+// #cgo linux LDFLAGS: -lacl
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+const (
+	otherExec  = 1 << iota
+	otherWrite = 1 << iota
+	otherRead  = 1 << iota
+	groupExec  = 1 << iota
+	groupWrite = 1 << iota
+	groupRead  = 1 << iota
+	userExec   = 1 << iota
+	userWrite  = 1 << iota
+	userRead   = 1 << iota
+)
+
+// UID/GID values are returned as ints in package "os".
+type Uid int
+type Gid int
+
+type Tag int
+type Type int
+
+// ACL represents an Access Control List.
+type ACL struct {
+	a C.acl_t
+}
+
+// DeleteDefaultACL removes the default ACL from the specified path.
+// Unsupported on Mac OS X.
+func DeleteDefaultACL(path string) error {
+	rv, _ := C.acl_delete_def_file(C.CString(path))
+	if rv < 0 {
+		return fmt.Errorf("unable to delete default ACL from file")
+	}
+	return nil
+}
+
+// Unsupported on Mac OS X?
+func (acl *ACL) CalcMask() error {
+	rv, _ := C.acl_calc_mask(&acl.a)
+	if rv < 0 {
+		return fmt.Errorf("unable to calculate mask")
+	}
+	return nil
+}
+
+// String returns the string representation of the ACL.
+func (acl *ACL) String() string {
+	cs, _ := C.acl_to_text(acl.a, nil)
+	if cs == nil {
+		return ""
+	}
+	defer C.acl_free(unsafe.Pointer(cs))
+	return C.GoString(cs)
+}
+
+// Valid checks if the ACL is valid.
+func (acl *ACL) Valid() bool {
+	rv := C.acl_valid(acl.a)
+	if rv < 0 {
+		return false
+	}
+	return true
+}
+
+// CreateEntry creates a new, empty Entry in the ACL.
+func (acl *ACL) CreateEntry() (*Entry, error) {
+	var e C.acl_entry_t
+	rv, _ := C.acl_create_entry(&acl.a, &e)
+	if rv < 0 {
+		return nil, fmt.Errorf("unable to create entry")
+	}
+	return &Entry{e}, nil
+}
+
+// AddEntry adds an Entry to the ACL.
+func (acl *ACL) AddEntry(entry *Entry) error {
+	newEntry, err := acl.CreateEntry()
+	if err != nil {
+		return err
+	}
+	rv, _ := C.acl_copy_entry(newEntry.e, entry.e)
+	if rv < 0 {
+		return fmt.Errorf("unable to copy entry while adding new entry")
+	}
+	return nil
+}
+
+// DeleteEntry removes a specific Entry from the ACL.
+func (acl *ACL) DeleteEntry(entry *Entry) error {
+	rv, _ := C.acl_delete_entry(acl.a, entry.e)
+	if rv < 0 {
+		return fmt.Errorf("unable to delete entry")
+	}
+	return nil
+}
+
+// Dup makes a copy of the ACL.
+func (acl *ACL) Dup() (*ACL, error) {
+	cdup, _ := C.acl_dup(acl.a)
+	if cdup == nil {
+		return nil, fmt.Errorf("unable to dup ACL")
+	}
+	return &ACL{cdup}, nil
+}
+
+// New returns a new, initialized ACL.
+func New() *ACL {
+	cacl, _ := C.acl_init(C.int(1))
+	if cacl == nil {
+		// If acl_init fails, *ACL is invalid
+		return nil
+	}
+	return &ACL{cacl}
+}
+
+// FirstEntry returns the first entry in the ACL,
+// or nil of there are no more entries.
+func (acl *ACL) FirstEntry() *Entry {
+	var e C.acl_entry_t
+	rv, _ := C.acl_get_entry(acl.a, C.ACL_FIRST_ENTRY, &e)
+	if rv <= 0 {
+		// either error obtaining entry or entries at all
+		return nil
+	}
+	return &Entry{e}
+}
+
+// NextEntry returns the next entry in the ACL,
+// or nil of there are no more entries.
+func (acl *ACL) NextEntry() *Entry {
+	var e C.acl_entry_t
+	rv, _ := C.acl_get_entry(acl.a, C.ACL_NEXT_ENTRY, &e)
+	if rv <= 0 {
+		// either error obtaining entry or no more entries
+		return nil
+	}
+	return &Entry{e}
+}
+
+func (acl *ACL) setFile(path string, tp C.acl_type_t) error {
+	if !acl.Valid() {
+		if err := acl.addBaseEntries(path); err != nil {
+			return err
+		}
+		if !acl.Valid() {
+			return fmt.Errorf("Invalid ACL: %s", acl)
+		}
+	}
+
+	rv, _ := C.acl_set_file(C.CString(path), tp, acl.a)
+	if rv < 0 {
+		return fmt.Errorf("unable to apply ACL to file")
+	}
+	return nil
+}
+
+// SetFileAccess applies the access ACL to a file.
+func (acl *ACL) SetFileAccess(path string) error {
+	return acl.setFile(path, C.ACL_TYPE_ACCESS)
+}
+
+// SetFileDefault applies the default ACL to a file.
+func (acl *ACL) SetFileDefault(path string) error {
+	return acl.setFile(path, C.ACL_TYPE_DEFAULT)
+}
+
+// Free releases the memory used by the ACL.
+func (acl *ACL) Free() {
+	C.acl_free(unsafe.Pointer(acl.a))
+}
+
+// Parse constructs and ACL from a string representation.
+func Parse(s string) (*ACL, error) {
+	cs := C.CString(s)
+	cacl, _ := C.acl_from_text(cs)
+	if cacl == nil {
+		return nil, fmt.Errorf("unable to parse ACL")
+	}
+	return &ACL{cacl}, nil
+}
+
+func getFile(path string, tp C.acl_type_t) (*ACL, error) {
+	cacl, _ := C.acl_get_file(C.CString(path), tp)
+	if cacl == nil {
+		return nil, fmt.Errorf("unable to get ACL from file")
+	}
+	return &ACL{cacl}, nil
+}
+
+// GetFileAccess returns the access ACL associated with the given file path.
+func GetFileAccess(path string) (*ACL, error) {
+	return getFile(path, C.ACL_TYPE_ACCESS)
+}
+
+// GetFileDefault returns the default ACL associated with the given file path.
+func GetFileDefault(path string) (*ACL, error) {
+	return getFile(path, C.ACL_TYPE_DEFAULT)
+}
+
+func (acl *ACL) Size() int64 {
+	return int64(C.acl_size(acl.a))
+}
+
+func (acl *ACL) CopyExt(buffer []byte) (int64, error) {
+	p := unsafe.Pointer(&buffer[0])
+	l := C.ssize_t(len(buffer))
+	i, err := C.acl_copy_ext(p, acl.a, l)
+	if i < 0 {
+		return int64(i), err
+	}
+	return int64(i), nil
+}
+
+func CopyInt(buffer []byte) (*ACL, error) {
+	p := unsafe.Pointer(&buffer[0])
+	cacl, err := C.acl_copy_int(p)
+	if cacl == nil {
+		return nil, err
+	}
+	return &ACL{cacl}, nil
+}

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/acl_darwin.go
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/acl_darwin.go
@@ -1,0 +1,5 @@
+package acl
+
+func (acl *ACL) addBaseEntries(path string) error {
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/acl_linux.go
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/acl_linux.go
@@ -1,0 +1,113 @@
+package acl
+
+// #include <sys/acl.h>
+// #include <acl/libacl.h>
+// #cgo linux LDFLAGS: -lacl
+import "C"
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	TagUserObj  Tag = C.ACL_USER_OBJ
+	TagUser     Tag = C.ACL_USER
+	TagGroupObj Tag = C.ACL_GROUP_OBJ
+	TagGroup    Tag = C.ACL_GROUP
+	TagMask     Tag = C.ACL_MASK
+	TagOther    Tag = C.ACL_OTHER
+
+	PermRead  Perm = C.ACL_READ
+	PermWrite Perm = C.ACL_WRITE
+)
+
+func (acl *ACL) addBaseEntries(path string) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	mode := fi.Mode().Perm()
+	var r, w, e bool
+
+	// Set USER_OBJ entry
+	r = mode&userRead == userRead
+	w = mode&userWrite == userWrite
+	e = mode&userExec == userExec
+	if err := acl.addBaseEntryFromMode(TagUserObj, r, w, e); err != nil {
+		return err
+	}
+
+	// Set GROUP_OBJ entry
+	r = mode&groupRead == groupRead
+	w = mode&groupWrite == groupWrite
+	e = mode&groupExec == groupExec
+	if err := acl.addBaseEntryFromMode(TagGroupObj, r, w, e); err != nil {
+		return err
+	}
+
+	// Set OTHER entry
+	r = mode&otherRead == otherRead
+	w = mode&otherWrite == otherWrite
+	e = mode&otherExec == otherExec
+	if err := acl.addBaseEntryFromMode(TagOther, r, w, e); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (acl *ACL) addBaseEntryFromMode(tag Tag, read, write, execute bool) error {
+	e, err := acl.CreateEntry()
+	if err != nil {
+		return err
+	}
+	if err = e.SetTag(tag); err != nil {
+		return err
+	}
+	p, err := e.GetPermset()
+	if err != nil {
+		return err
+	}
+	if err := p.addPermsFromMode(read, write, execute); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Permset) addPermsFromMode(read, write, execute bool) error {
+	if read {
+		if err := p.AddPerm(PermRead); err != nil {
+			return err
+		}
+	}
+	if write {
+		if err := p.AddPerm(PermWrite); err != nil {
+			return err
+		}
+	}
+	if execute {
+		if err := p.AddPerm(PermExecute); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (pset *Permset) String() string {
+	r, w, e := '-', '-', '-'
+
+	rv, _ := C.acl_get_perm(pset.p, C.ACL_READ)
+	if rv > 0 {
+		r = 'r'
+	}
+	rv, _ = C.acl_get_perm(pset.p, C.ACL_WRITE)
+	if rv > 0 {
+		w = 'w'
+	}
+	rv, _ = C.acl_get_perm(pset.p, C.ACL_EXECUTE)
+	if rv > 0 {
+		e = 'e'
+	}
+
+	return fmt.Sprintf("%c%c%c", r, w, e)
+}

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/entry.go
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/entry.go
@@ -1,0 +1,88 @@
+package acl
+
+// #ifdef __APPLE__
+//  #include <sys/types.h>
+// #endif
+// #include <sys/acl.h>
+// #cgo linux LDFLAGS: -lacl
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+const (
+	TagUndefined Tag = C.ACL_UNDEFINED_TAG
+)
+
+// Entry is an entry in an ACL.
+type Entry struct {
+	e C.acl_entry_t
+}
+
+// SetPermset sets the permissions for an ACL Entry.
+func (entry *Entry) SetPermset(pset *Permset) error {
+	rv, _ := C.acl_set_permset(entry.e, pset.p)
+	if rv < 0 {
+		return fmt.Errorf("unable to set permset on entry")
+	}
+	return nil
+}
+
+// Copy copies an Entry.
+func (entry *Entry) Copy() (*Entry, error) {
+	var cdst C.acl_entry_t
+	rv, _ := C.acl_copy_entry(cdst, entry.e)
+	if rv < 0 {
+		return nil, fmt.Errorf("unable to copy entry")
+	}
+	return &Entry{cdst}, nil
+}
+
+// SetQualifier sets the Uid or Gid the entry applies to.
+func (entry *Entry) SetQualifier(id int) error {
+	rv, _ := C.acl_set_qualifier(entry.e, unsafe.Pointer(&id))
+	if rv < 0 {
+		return fmt.Errorf("unable to set qualifier")
+	}
+	return nil
+}
+
+// GetQualifier returns the Uid or Gid the entry applies to.
+func (entry *Entry) GetQualifier() (int, error) {
+	var id int
+	rv, _ := C.acl_set_qualifier(entry.e, unsafe.Pointer(&id))
+	if rv < 0 {
+		return -1, fmt.Errorf("unable to get qualifier")
+	}
+	return id, nil
+}
+
+// GetPermset returns the permission for an Entry.
+func (entry *Entry) GetPermset() (*Permset, error) {
+	var ps C.acl_permset_t
+	rv, _ := C.acl_get_permset(entry.e, &ps)
+	if rv < 0 {
+		return nil, fmt.Errorf("unable to get permset")
+	}
+	return &Permset{ps}, nil
+}
+
+// GetTag returns the Tag for an Entry.
+func (entry *Entry) GetTag() (Tag, error) {
+	var t C.acl_tag_t
+	rv, _ := C.acl_get_tag_type(entry.e, &t)
+	if rv < 0 {
+		return TagUndefined, fmt.Errorf("unable to get tag")
+	}
+	return Tag(t), nil
+}
+
+// SetTag sets the Tag for an Entry.
+func (entry *Entry) SetTag(t Tag) error {
+	rv, _ := C.acl_set_tag_type(entry.e, C.acl_tag_t(t))
+	if rv < 0 {
+		return fmt.Errorf("unable to set tag")
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/example/.gitignore
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/example/.gitignore
@@ -1,0 +1,1 @@
+example

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/example/unix.go
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/example/unix.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/naegelejd/go-acl"
+)
+
+func main() {
+	flag.Parse()
+	if flag.NArg() < 1 {
+		log.Fatal("Missing filename")
+	}
+	filename := flag.Arg(0)
+
+	a, err := acl.GetFileAccess(filename)
+	if err != nil {
+		log.Fatalf("Failed to get ACL from %s (%s)", filename, err)
+	}
+	defer a.Free()
+
+	fmt.Print("ACL repr:\n", a)
+}

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/getfacl/.gitignore
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/getfacl/.gitignore
@@ -1,0 +1,1 @@
+getfacl

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/getfacl/getfacl.go
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/getfacl/getfacl.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/naegelejd/go-acl"
+	os2 "github.com/coreos/rkt/Godeps/_workspace/src/github.com/naegelejd/go-acl/os"
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/naegelejd/go-acl/os/group"
+)
+
+func main() {
+	recursive := flag.Bool("recursive", false, "recurse into directories")
+	omitheader := flag.Bool("omit-header", false, "omit header for each path")
+
+	flag.Parse()
+	if flag.NArg() < 1 {
+		flag.Usage()
+	}
+
+	for i := 0; i < flag.NArg(); i++ {
+		if err := getfacl(flag.Arg(i), *recursive, !*omitheader); err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func getfacl(p string, recursive, header bool) error {
+	a, err := acl.GetFileAccess(p)
+	if err != nil {
+		return fmt.Errorf("Failed to get ACL from %s (%s)", p, err)
+	}
+
+	uid, gid, err := os2.Owner(p)
+	if err != nil {
+		return fmt.Errorf("Failed to lookup owner and group (%s)", err)
+	}
+	user, err := user.LookupId(strconv.Itoa(int(uid)))
+	if err != nil {
+		return fmt.Errorf("Failed to lookup user (%s)", err)
+	}
+	group, err := group.LookupId(strconv.Itoa(int(gid)))
+	if err != nil {
+		return fmt.Errorf("Failed to lookup group (%s)", err)
+	}
+
+	if header {
+		fmt.Printf("# file: %s\n# user: %s\n# group: %s\n", p, user.Username, group.Name)
+	}
+	fmt.Println(a)
+
+	// Free ACL before recursing
+	a.Free()
+
+	if recursive {
+		if err := recurse(p, header); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func recurse(p string, header bool) error {
+	fi, err := os.Stat(p)
+	if err != nil {
+		return fmt.Errorf("Failed to stat path %s (%s)", p, err)
+	}
+	if fi.IsDir() {
+		dirents, err := ioutil.ReadDir(p)
+		if err != nil {
+			return err
+		}
+		for _, child := range dirents {
+			if err := getfacl(filepath.Join(p, child.Name()), true, header); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/os/group/group.go
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/os/group/group.go
@@ -1,0 +1,33 @@
+// Package group allows group lookups by name or id.
+package group
+
+var implemented = true // set to false by lookup_stubs.go's init
+
+// Group represents a group
+//
+// On posix systems Gid contains a decimal number
+// representing gid. On windows Gid contain security
+// identifier (SID) in a string format. On Plan 9,
+// Gid, and Name will be the contents of /dev/group.
+type Group struct {
+	Gid      string
+	Name     string
+	Password string
+	Members  []string
+}
+
+// UnknownGroupIdError is returned by LookupId when
+// a group cannot be found.
+type UnknownGroupIdError int
+
+func (e UnknownGroupIdError) Error() string {
+	return "unknown group id"
+}
+
+// UnknownGroupError is returned by Lookup when
+// a group cannot be found
+type UnknownGroupError string
+
+func (e UnknownGroupError) Error() string {
+	return "unknown group name"
+}

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/os/group/lookup.go
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/os/group/lookup.go
@@ -1,0 +1,24 @@
+// Derived from os/user/lookup.go in the Go source code
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// - Joseph Naegele 2015
+
+package group
+
+// Current returns the current user's group.
+func Current() (*Group, error) {
+	return current()
+}
+
+// Lookup looks up a group by name. If the group cannot be found,
+// the returned error is of type UnknownGroupError.
+func Lookup(groupname string) (*Group, error) {
+	return lookup(groupname)
+}
+
+// LookupId looks up a group by groupid. If the group cannot be found, the
+// returned error is of type UnknownGroupIdError.
+func LookupId(gid string) (*Group, error) {
+	return lookupId(gid)
+}

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/os/group/lookup_stubs.go
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/os/group/lookup_stubs.go
@@ -1,0 +1,28 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !cgo,!windows,!plan9 android
+
+package group
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func init() {
+	implemented = false
+}
+
+func current() (*Group, error) {
+	return nil, fmt.Errorf("group: Current not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+func lookup(groupname string) (*Group, error) {
+	return nil, fmt.Errorf("group: Lookup not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+func lookupId(gid string) (*Group, error) {
+	return nil, fmt.Errorf("group: LookupId not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/os/group/lookup_unix.go
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/os/group/lookup_unix.go
@@ -1,0 +1,114 @@
+// Derived from os/user/lookup_unix.go in the Go source code
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// - Joseph Naegele 2015
+
+// +build darwin dragonfly freebsd !android,linux netbsd openbsd solaris
+// +build cgo
+
+package group
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"syscall"
+	"unsafe"
+)
+
+/*
+#include <unistd.h>
+#include <grp.h>
+#include <stdlib.h>
+
+static int mygetgrgid_r(int uid, struct group *grp,
+	char *buf, size_t buflen, struct group **result) {
+    return getgrgid_r(uid, grp, buf, buflen, result);
+}
+*/
+import "C"
+
+func current() (*Group, error) {
+	return lookupUnix(syscall.Getgid(), "", false)
+}
+
+func lookup(groupname string) (*Group, error) {
+	return lookupUnix(-1, groupname, true)
+}
+
+func lookupId(gid string) (*Group, error) {
+	id, err := strconv.Atoi(gid)
+	if err != nil {
+		return nil, err
+	}
+	return lookupUnix(id, "", false)
+}
+
+func lookupUnix(gid int, groupname string, lookupByName bool) (*Group, error) {
+	var grp C.struct_group
+	var result *C.struct_group
+
+	var bufSize C.long
+	if runtime.GOOS == "dragonfly" || runtime.GOOS == "freebsd" {
+		// DragonFly and FreeBSD do not have _SC_GETGR_R_SIZE_MAX
+		// and just return -1.  So just use the same
+		// size that Linux returns.
+		bufSize = 1024
+	} else {
+		bufSize = C.sysconf(C._SC_GETGR_R_SIZE_MAX)
+		if bufSize <= 0 || bufSize > 1<<20 {
+			return nil, fmt.Errorf("user: unreasonable _SC_GETGR_R_SIZE_MAX of %d", bufSize)
+		}
+	}
+	buf := C.malloc(C.size_t(bufSize))
+	defer C.free(buf)
+
+	var rv C.int
+	if lookupByName {
+		nameC := C.CString(groupname)
+		defer C.free(unsafe.Pointer(nameC))
+		rv = C.getgrnam_r(nameC,
+			&grp,
+			(*C.char)(buf),
+			C.size_t(bufSize),
+			&result)
+		if rv != 0 {
+			return nil, fmt.Errorf("group: lookup group %s: %s", groupname, syscall.Errno(rv))
+		}
+		if result == nil {
+			return nil, UnknownGroupError(groupname)
+		}
+	} else {
+		// mygetgrgid_r is a wrapper around getgrgid_r to
+		// to avoid using uid_t because C.uid_t(uid) for
+		// unknown reasons doesn't work on linux.
+		rv = C.mygetgrgid_r(C.int(gid),
+			&grp,
+			(*C.char)(buf),
+			C.size_t(bufSize),
+			&result)
+		if rv != 0 {
+			return nil, fmt.Errorf("grp: lookup groupid %d: %s", gid, syscall.Errno(rv))
+		}
+		if result == nil {
+			return nil, UnknownGroupIdError(gid)
+		}
+	}
+
+	members := make([]string, 0)
+	for memptr := grp.gr_mem; *memptr != nil; memptr =
+		(**C.char)(unsafe.Pointer(uintptr(unsafe.Pointer(memptr)) +
+			unsafe.Sizeof(*grp.gr_mem))) {
+		members = append(members, C.GoString(*memptr))
+	}
+
+	g := &Group{
+		Gid:      strconv.Itoa(int(grp.gr_gid)),
+		Name:     C.GoString(grp.gr_name),
+		Password: C.GoString(grp.gr_passwd),
+		Members:  members,
+	}
+
+	return g, nil
+}

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/os/owner.go
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/os/owner.go
@@ -1,0 +1,36 @@
+package os
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func Owner(fname string) (owner, group int, err error) {
+	var f *os.File
+	f, err = os.Open(fname)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	g := &File{*f}
+	return g.Owner()
+}
+
+type File struct{ os.File }
+
+func (f *File) Owner() (owner, group int, err error) {
+	var fi os.FileInfo
+	fi, err = f.Stat()
+	if err != nil {
+		return
+	}
+
+	sys, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		err = fmt.Errorf("could not stat file")
+	}
+
+	return int(sys.Uid), int(sys.Gid), nil
+}

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/perms.go
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/perms.go
@@ -1,0 +1,49 @@
+package acl
+
+// #ifdef __APPLE__
+//  #include <sys/types.h>
+// #endif
+// #include <sys/acl.h>
+// #cgo linux LDFLAGS: -lacl
+import "C"
+import "fmt"
+
+const (
+	PermExecute Perm = C.ACL_EXECUTE
+)
+
+// Perm represents a permission.
+type Perm int
+
+// Permset is a collection of permissions.
+type Permset struct {
+	p C.acl_permset_t
+}
+
+// AddPerm adds a new permission to a Permset.
+func (pset *Permset) AddPerm(perm Perm) error {
+	rv, _ := C.acl_add_perm(pset.p, C.acl_perm_t(perm))
+	if rv < 0 {
+		return fmt.Errorf("unable to add perm to permset")
+	}
+	return nil
+}
+
+// ClearPerms removes all permissions from a Permset.
+func (pset *Permset) ClearPerms() error {
+	rv, _ := C.acl_clear_perms(pset.p)
+	if rv < 0 {
+		return fmt.Errorf("unable to clear perms")
+	}
+	return nil
+}
+
+// DeletePerm removes a single permission from a Permset.
+func (pset *Permset) DeletePerm(perm Perm) error {
+	p := C.acl_perm_t(perm)
+	rv, _ := C.acl_delete_perm(pset.p, p)
+	if rv < 0 {
+		return fmt.Errorf("unable to delete perm")
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/setfacl/.gitignore
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/setfacl/.gitignore
@@ -1,0 +1,1 @@
+setfacl

--- a/Godeps/_workspace/src/github.com/naegelejd/go-acl/setfacl/setfacl.go
+++ b/Godeps/_workspace/src/github.com/naegelejd/go-acl/setfacl/setfacl.go
@@ -1,0 +1,367 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/naegelejd/go-acl"
+)
+
+// Usage: setfacl [-bkndRLP] { -m|-M|-x|-X ... } file ...
+// -m, --modify=acl        modify the current ACL(s) of file(s)
+// -M, --modify-file=file  read ACL entries to modify from file
+// -x, --remove=acl        remove entries from the ACL(s) of file(s)
+// -X, --remove-file=file  read ACL entries to remove from file
+// -b, --remove-all        remove all extended ACL entries
+// -k, --remove-default    remove the default ACL
+//     --set=acl           set the ACL of file(s), replacing the current ACL
+//     --set-file=file     read ACL entries to set from file
+//     --mask              do recalculate the effective rights mask
+// -n, --no-mask           don't recalculate the effective rights mask
+// -d, --default           operations apply to the default ACL
+// -R, --recursive         recurse into subdirectories
+// -L, --logical           logical walk, follow symbolic links
+// -P, --physical          physical walk, do not follow symbolic links
+//     --restore=file      restore ACLs (inverse of `getfacl -R')
+//     --test              test mode (ACLs are not modified)
+// -v, --version           print version and exit
+// -h, --help              this help text
+
+// AUTOMATICALLY CREATED ENTRIES
+// Initially, files and directories contain only the three base ACL entries for the owner, the group, and others.
+// There are some rules that need to be satisfied in order for an ACL to be valid:
+
+// * The  three  base  entries  cannot  be removed. There must be exactly one entry of each of these base entry
+//   types.
+
+// * Whenever an ACL contains named user entries or named group objects, it  must  also  contain  an  effective
+//   rights mask.
+
+// * Whenever  an  ACL  contains  any  Default  ACL entries, the three Default ACL base entries (default owner,
+//   default group, and default others) must also exist.
+
+// * Whenever a Default ACL contains named user entries or named group objects, it must also contain a  default
+//   effective rights mask.
+
+// To  help the user ensure these rules, setfacl creates entries from existing entries under the following condi‐
+// tions:
+
+// * If an ACL contains named user or named group entries, and no mask entry exists, a  mask  entry  containing
+//   the  same permissions as the group entry is created. Unless the -n option is given, the permissions of the
+//   mask entry are further adjusted to include the union of all permissions affected by the mask  entry.  (See
+//   the -n option description).
+
+// * If a Default ACL entry is created, and the Default ACL contains no owner, owning group, or others entry, a
+//   copy of the ACL owner, owning group, or others entry is added to the Default ACL.
+
+// * If a Default ACL contains named user entries or named group entries, and no  mask  entry  exists,  a  mask
+//   entry  containing  the  same  permissions as the default Default ACL's group entry is added. Unless the -n
+//   option is given, the permissions of the mask entry are further adjusted to inclu de the union of all  per‐
+//   missions affected by the mask entry. (See the -n option description).
+var (
+	recursive    bool
+	ignoreLinks  bool
+	calcMask     bool
+	applyDefault bool
+	dryRun       bool
+)
+
+type Mode int
+
+const (
+	setMode int = iota
+	modMode
+	delMode
+)
+
+type ACLSetter func(p string) error
+
+func main() {
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+
+	set := flag.String("s", "", "set ACL(s) of file(s), replacing the current ACL")
+	mod := flag.String("m", "", "modify current ACL(s) of file(s)")
+	del := flag.String("x", "", "remove entries from ACL(s) of file(s)")
+	delall := flag.Bool("b", false, "remove all extended ACL entries")
+	deldef := flag.Bool("k", false, "remove the default ACL")
+	// fromfile := flag.String("f", "", "read ACL entries to set from file")
+	// restore := flag.String("g", "", "restore ACL (inverse of `getfacl -R`)")
+
+	flag.BoolVar(&applyDefault, "d", false, "apply operations to the default ACL")
+	flag.BoolVar(&recursive, "r", false, "recurse into subdirectories")
+	flag.BoolVar(&ignoreLinks, "p", false, "do NOT follow symbolic links")
+	flag.BoolVar(&calcMask, "mask", true, "recalculate the effective rights mask")
+	// flag.BoolVar(&dryRun, "n", false, "print the resulting ACLs")
+
+	// var text string
+	// var mode Mode
+
+	// Sources
+	// command line
+	// existing entries
+
+	// Modes
+	// set new ACL entries
+	// modify existing ACL entries
+	// delete existing ACL entries
+	// delete every entry
+	// delete default entries
+	// test existing entries
+
+	// Set: parse ACL, apply ACL to every file
+	// Mod: parse ACL, "add" to ACL of every file
+	// Del: parse ACL, "find" and "remove" matching ACL of every file
+
+	flag.Parse()
+	if flag.NArg() < 1 {
+		flag.Usage()
+	}
+
+	// User must select exactly one mode
+	if countModes(len(*set) > 0, len(*mod) > 0, len(*del) > 0, *delall, *deldef) != 1 {
+		fmt.Println("Wrong: must choose one of s|m|x|b|k")
+		flag.Usage()
+	}
+
+	var g func(*acl.ACL) ACLSetter
+	var a *acl.ACL
+
+	if *delall {
+		a = acl.New()
+		g = deleteAll
+	} else if *deldef {
+		a = acl.New()
+		g = deleteDefault
+	} else {
+		var source string
+		switch {
+		case len(*set) > 0:
+			source = *set
+			g = setACL
+		case len(*mod) > 0:
+			source = *mod
+			g = modACL
+		case len(*del) > 0:
+			source = *del
+			g = delACL
+		default:
+			log.Fatal("Invalid mode. Contact author")
+		}
+		var err error
+		a, err = acl.Parse(source)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	defer a.Free()
+	f := g(a)
+
+	for i := 0; i < flag.NArg(); i++ {
+		p := flag.Arg(i)
+		if err := apply(f, p); err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func countModes(modes ...bool) int {
+	count := 0
+	for _, m := range modes {
+		if m {
+			count++
+		}
+	}
+	return count
+}
+
+func calculateMask(a *acl.ACL) error {
+	if calcMask {
+		if err := a.CalcMask(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setACL(a *acl.ACL) ACLSetter {
+	return func(p string) error {
+		var err error
+		if err = calculateMask(a); err != nil {
+			return err
+		}
+		if applyDefault {
+			err = a.SetFileDefault(p)
+		} else {
+			log.Printf("Setting %s on %s\n", a, p)
+			err = a.SetFileAccess(p)
+		}
+		return err
+	}
+}
+
+func modACL(a *acl.ACL) ACLSetter {
+	return func(p string) error {
+		var x *acl.ACL
+		var err error
+
+		if applyDefault {
+			x, err = acl.GetFileDefault(p)
+		} else {
+			x, err = acl.GetFileAccess(p)
+		}
+		if err != nil {
+			return err
+		}
+
+		// copy each entry to existing ACL
+		for e := a.FirstEntry(); e != nil; e = a.NextEntry() {
+			if err := x.AddEntry(e); err != nil {
+				log.Printf("Error copying entry (%s)\n", err)
+			}
+		}
+
+		if err = calculateMask(x); err != nil {
+			return err
+		}
+		if applyDefault {
+			err = x.SetFileDefault(p)
+		} else {
+			err = x.SetFileAccess(p)
+		}
+		return err
+	}
+}
+
+func delACL(a *acl.ACL) ACLSetter {
+	return func(p string) error {
+		var x *acl.ACL
+		var err error
+
+		if applyDefault {
+			x, err = acl.GetFileDefault(p)
+		} else {
+			x, err = acl.GetFileAccess(p)
+		}
+		if err != nil {
+			return err
+		}
+
+		// TODO: remove existing ACL matching specified ACL
+		// for each entry in a, for each entry in x, if tag and qualifier match, remove from x
+		for delEntry := a.FirstEntry(); delEntry != nil; delEntry = a.NextEntry() {
+			delTag, err := delEntry.GetTag()
+			if err != nil {
+				continue
+				return err
+			}
+			delQual, err := delEntry.GetQualifier()
+			if err != nil {
+				continue
+			}
+			for exEntry := x.FirstEntry(); exEntry != nil; exEntry = x.NextEntry() {
+				exTag, err := exEntry.GetTag()
+				if err != nil {
+					continue
+				}
+				exQual, err := exEntry.GetQualifier()
+				if err != nil {
+					continue
+				}
+				if delTag == exTag && delQual == exQual {
+					if err := x.DeleteEntry(delEntry); err != nil {
+						return err
+					}
+				}
+			}
+		}
+
+		if err = calculateMask(x); err != nil {
+			return err
+		}
+		if applyDefault {
+			err = x.SetFileDefault(p)
+		} else {
+			err = x.SetFileAccess(p)
+		}
+		return err
+	}
+}
+
+func deleteAll(a *acl.ACL) ACLSetter {
+	return func(p string) error {
+		var err error
+		if err = calculateMask(a); err != nil {
+			return err
+		}
+		if err = a.SetFileAccess(p); err != nil {
+			return err
+		}
+		if err = a.SetFileDefault(p); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func deleteDefault(a *acl.ACL) ACLSetter {
+	return func(p string) error {
+		var err error
+		if err = calculateMask(a); err != nil {
+			return err
+		}
+		if err = a.SetFileDefault(p); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func isLink(p string) (bool, error) {
+	fi, err := os.Lstat(p)
+	if err != nil {
+		return false, err
+	}
+	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+		return true, nil
+	}
+	return false, nil
+}
+
+func apply(f ACLSetter, p string) error {
+	islink, err := isLink(p)
+	if err != nil {
+		return err
+	}
+
+	if islink && ignoreLinks {
+		return nil
+	}
+
+	// do something to the path
+	if err := f(p); err != nil {
+		return err
+	}
+
+	fi, err := os.Stat(p)
+	if err != nil {
+		return err
+	}
+	if fi.IsDir() && recursive {
+		dirents, err := ioutil.ReadDir(p)
+		if err != nil {
+			return err
+		}
+		for _, child := range dirents {
+			p = filepath.Join(p, child.Name())
+			if err := apply(f, p); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/configure.ac
+++ b/configure.ac
@@ -463,6 +463,9 @@ AC_SUBST(RKT_DEFINES_FOR_ENTER)
 # Check whether we can build TPM support code
 AC_CHECK_HEADER(trousers/tss.h, [TPM_TAGS=tpm], [], [AC_INCLUDES_DEFAULT])
 
+# Check whether we have libacl
+AC_CHECK_HEADER(acl/libacl.h, [], [AC_MSG_ERROR([*** No development headers for libacl found. Try to install libacl-devel or libacl1-dev])], [AC_INCLUDES_DEFAULT])
+
 AC_SUBST(TPM_TAGS)
 
 AC_LANG_POP([C])

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -546,6 +546,10 @@ func stage1() int {
 		return 2
 	}
 
+	if err := stage1initcommon.SetJournalPermissions(p); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: error setting journal ACLs, you'll need root to read the pod journal: %v", err)
+	}
+
 	if flavor == "kvm" {
 		if err := KvmPodToSystemd(p, n); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to configure systemd for kvm: %v\n", err)

--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -27,7 +27,8 @@ if [ "${CI-}" == true ] ; then
 		# uncomment the following line and add "sudo apt-get
 		# install -y <dep>" after it.
 
-		#sudo apt-get update -qq || true
+		sudo apt-get update -qq || true
+		sudo apt-get install -y libacl1-dev
 
 		# libmount: https://github.com/systemd/systemd/pull/986#issuecomment-138451264
 		# sudo add-apt-repository --yes ppa:pitti/systemd-semaphore


### PR DESCRIPTION
Mimicking my host's `/var/log/journal` permissions, set pod's
`/var/log/journal` to:

```
    # file: journal
    # owner: root
    # group: root
    # flags: -s
    user::rwx
    group::r-x
    group:rkt:r-x
    mask::r-x
    other::r-x
    default:user::rwx
    default:group::r-x
    default:group:rkt:r-x
    default:mask::r-x
    default:other::r-x
```

Fixes #1755