### PR TITLE
MAINTAINERS: remove eyakubovich, add dgonyeo

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,6 @@
 Alban Crequy <alban.crequy@coreos.com> (@alban)
 Brandon Philips <brandon.philips@coreos.com> (@philips)
-Eugene Yakubovich <eugene.yakubovich@coreos.com> (@eyakubovich)
+Derek Gonyeo <derek.gonyeo@coreos.com> (@dgonyeo)
 Iago López Galeiras <iago.lopez@coreos.com> (@iaguis)
 Jonathan Boulle <jonathan.boulle@coreos.com> (@jonboulle)
 Krzesimir Nowak <krzesimir.nowak@coreos.com> (@krnowak)


### PR DESCRIPTION
Eugene is sadly no longer with CoreOS, so remove his handle from
the list of maintainers. He will be gladly welcomed back if he
decides to continue contributing to the project.

In happier news, Derek has joined us as an active and effective
contributor, so add him to the maintainers.