### PR TITLE
*: Move to go 1.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,18 @@
 
 language: go
 
-go:
- - 1.4
+matrix:
+ include:
+  - go: 1.4.3
+    install:
+     - go get golang.org/x/tools/cmd/cover
+     - go get golang.org/x/tools/cmd/vet
+  - go: 1.5.2
 
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -y cpio realpath squashfs-tools
  - sudo apt-get install -y build-essential
-
-install:
- - go get golang.org/x/tools/cmd/cover
- - go get golang.org/x/tools/cmd/vet
 
 script:
  - ./autogen.sh

--- a/Documentation/hacking.md
+++ b/Documentation/hacking.md
@@ -68,7 +68,7 @@ Alternatively, you can build rkt in a Docker container with the following comman
 Replace $SRC with the absolute path to your rkt source code:
 
 ```
-# docker run -v $SRC:/opt/rkt -i -t golang:1.4 /bin/bash -c "apt-get update && apt-get install -y coreutils cpio squashfs-tools realpath autoconf file xz-utils patch bc && cd /opt/rkt && go get github.com/appc/spec/... && ./autogen.sh && ./configure && make"
+# docker run -v $SRC:/opt/rkt -i -t golang:1.5 /bin/bash -c "apt-get update && apt-get install -y coreutils cpio squashfs-tools realpath autoconf file xz-utils patch bc && cd /opt/rkt && go get github.com/appc/spec/... && ./autogen.sh && ./configure && make"
 ```
 
 ### Building systemd in stage1 from the sources

--- a/configure.ac
+++ b/configure.ac
@@ -476,24 +476,36 @@ RKT_REQ_ABS_PROG([ABS_GO], [go])
 
 #### LINKER FLAGS
 
-dnl Detect go version. Go 1.4 and earlier support only "-X variable
-dnl 'value'" format of assigning values to variables via linker
-dnl flags. Go 1.5 deprecates this format in favor of "-X
-dnl 'variable=value'" format. Drop this ugliness when we drop support
-dnl for Go older than 1.5.
-GO_VERSION=`$ABS_GO version | grep -o 'go@<:@@<:@:digit:@:>@@:>@\+\.@<:@@<:@:digit:@:>@@:>@\+' | grep -o '@<:@@<:@:digit:@:>@@:>@\+\.@<:@@<:@:digit:@:>@@:>@\+'`
-GO_MAJOR=`echo $GO_VERSION | grep -o '^@<:@@<:@:digit:@:>@@:>@\+'`
-GO_MINOR=`echo $GO_VERSION | grep -o '@<:@@<:@:digit:@:>@@:>@\+$'`
+dnl Digits regexp class. Square brackets are used by m4 for quoting,
+dnl so to get literal square brackets, m4 provides ugly @<:@ and @:>@
+dnl for [ and ].
+m4_define([DIGITS],[@<:@0-9@:>@])
 
-AS_IF([test $GO_MAJOR -gt 1 -o $GO_MINOR -gt 4],
-      dnl We have Go 1.5 or greater.
-      [RKT_XF() {
+dnl Detect go version. Go 1.4 support only "-X variable 'value'"
+dnl format of assigning values to variables via linker flags. Go 1.5
+dnl deprecates this format in favor of "-X 'variable=value'"
+dnl format. Drop this ugliness when we drop support for Go 1.4.
+GO_VERSION=`"${ABS_GO}" version | sed -e 's/^go version go\(DIGITS*\.DIGITS*\).*/\1/'`
+GO_MAJOR=`echo "${GO_VERSION}" | grep -o '^DIGITS\+'`
+GO_MINOR=`echo "${GO_VERSION}" | grep -o 'DIGITS\+$'`
+
+GO_BEST_MAJOR=1
+GO_BEST_MINOR=5
+GO_BEST_VERSION="${GO_BEST_MAJOR}.${GO_BEST_MINOR}"
+AC_MSG_CHECKING([whether we have go ${GO_BEST_VERSION} or newer])
+AS_IF([test "${GO_MAJOR}" -gt "${GO_BEST_MAJOR}" || test "${GO_MAJOR}" -eq "${GO_BEST_MAJOR}" -a "${GO_MINOR}" -ge "${GO_BEST_MINOR}"],
+      [AC_MSG_RESULT([yes])
+       RKT_XF() {
            echo "-X '$1=$2'"
        }],
-      dnl We have Go 1.4 or lesser.
-      [RKT_XF() {
-           echo "-X $1 '$2'"
-       }])
+      [AC_MSG_RESULT([no])
+       AC_MSG_CHECKING([whether we have go 1.4])
+       AS_VAR_IF([GO_VERSION],[1.4],
+                 [AC_MSG_RESULT([yes])
+                  RKT_XF() {
+                      echo "-X $1 '$2'"
+                  }],
+                 [AC_MSG_ERROR([*** go is too old (${GO_VERSION})])])])
 
 RKT_STAGE1_DEFAULT_NAME_LDFLAGS=`RKT_XF main.defaultStage1Name "${RKT_STAGE1_DEFAULT_NAME}"`
 RKT_STAGE1_DEFAULT_VERSION_LDFLAGS=`RKT_XF main.defaultStage1Version "${RKT_STAGE1_DEFAULT_VERSION}"`

--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -3,7 +3,7 @@
 set -e
 
 export DEBIAN_FRONTEND=noninteractive
-VERSION=1.4.3
+VERSION=1.5.2
 OS=linux
 ARCH=amd64
 

--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -29,12 +29,6 @@ if [ "${CI-}" == true ] ; then
 
 		#sudo apt-get update -qq || true
 
-		# Fix for go 1.4.3: see https://github.com/coreos/rkt/issues
-		# GOPATH is only needed to allow go to work; the actual
-		# binaries are installed in GOROOT for these commands
-		sudo -E GOPATH=/tmp go get golang.org/x/tools/cmd/vet
-		sudo -E GOPATH=/tmp go get golang.org/x/tools/cmd/cover
-
 		# libmount: https://github.com/systemd/systemd/pull/986#issuecomment-138451264
 		# sudo add-apt-repository --yes ppa:pitti/systemd-semaphore
 		# sudo apt-get update -qq || true

--- a/tests/run-build.sh
+++ b/tests/run-build.sh
@@ -34,7 +34,7 @@ if [ "${SEMAPHORE-}" == true ] ; then
         # Set up go environment on semaphore
         if [ -f /opt/change-go-version.sh ]; then
             . /opt/change-go-version.sh
-            change-go-version 1.4
+            change-go-version 1.5
         fi
 fi
 

--- a/tests/run-build.sh
+++ b/tests/run-build.sh
@@ -44,7 +44,7 @@ if [[ ${HEAD} == ${MASTER} ]]; then
     SRC_CHANGES=1
     DOC_CHANGES=1
 elif [[ ${SRC_CHANGES} -eq 0 && ${DOC_CHANGES} -eq 0 ]]; then
-    echo No changes detected and HEAD is not origin/master
+    echo "No changes detected and HEAD is not origin/master"
     exit 0
 fi
 
@@ -59,8 +59,8 @@ cd builds
 git clone ../ "${BUILD_DIR}"
 pushd "${BUILD_DIR}"
 
-if [ ${SRC_CHANGES} -gt 0 ]; then 
-    echo Changes in sources detected. Running functional tests.
+if [ ${SRC_CHANGES} -gt 0 ]; then
+    echo "Changes in sources detected. Running functional tests."
     ./autogen.sh
     case "${RKT_STAGE1_USR_FROM}" in
         coreos|kvm)


### PR DESCRIPTION
~~At this point we drop support for go 1.4.~~

We still support go 1.4, but it is only used in travis. Semaphore builds with go 1.5 only now.