### PR TITLE
Add size to api response

### DIFF
--- a/api/v1alpha/api.pb.go
+++ b/api/v1alpha/api.pb.go
@@ -226,6 +226,8 @@ type Image struct {
 	ImportTimestamp int64 `protobuf:"varint,5,opt,name=import_timestamp" json:"import_timestamp,omitempty"`
 	// JSON-encoded byte array that represents the image manifest, optional.
 	Manifest []byte `protobuf:"bytes,6,opt,name=manifest,proto3" json:"manifest,omitempty"`
+	// Size of the image, (aci size) + (tree size).
+	Size int64 `protobuf:"varint,7,opt,name=size" json:"size,omitempty"`
 }
 
 func (m *Image) Reset()         { *m = Image{} }

--- a/api/v1alpha/api.proto
+++ b/api/v1alpha/api.proto
@@ -74,8 +74,8 @@ message Image {
         // JSON-encoded byte array that represents the image manifest, optional.
         bytes manifest = 6;
 
-	// Size of the image, (aci size) + (tree size).
-	int64 size = 7;
+        // Size is the size in bytes of this image in the store.
+        int64 size = 7;
 }
 
 // Network describes the network information of a pod.

--- a/api/v1alpha/api.proto
+++ b/api/v1alpha/api.proto
@@ -73,6 +73,9 @@ message Image {
 
         // JSON-encoded byte array that represents the image manifest, optional.
         bytes manifest = 6;
+
+	// Size of the image, (aci size) + (tree size).
+	int64 size = 7;
 }
 
 // Network describes the network information of a pod.

--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -479,6 +479,7 @@ func aciInfoToV1AlphaAPIImage(store *store.Store, aciInfo *store.ACIInfo) (*v1al
 		Version:         version,
 		ImportTimestamp: aciInfo.ImportTime.Unix(),
 		Manifest:        manifest,
+		Size:            aciInfo.Size,
 	}, &im, nil
 }
 

--- a/tests/rkt_api_service_test.go
+++ b/tests/rkt_api_service_test.go
@@ -171,6 +171,9 @@ func checkImage(t *testing.T, ctx *testutils.RktRunCtx, m *v1alpha.Image, hasMan
 	if imgInfo.importTime != m.ImportTimestamp {
 		t.Errorf("Expected %q, saw %q", imgInfo.importTime, m.ImportTimestamp)
 	}
+	if imgInfo.size != m.Size {
+		t.Errorf("Expected size %d, saw %d", imgInfo.size, m.Size)
+	}
 
 	if hasManifest && !bytes.Equal(imgInfo.manifest, m.Manifest) {
 		t.Errorf("Expected %q, saw %q", string(imgInfo.manifest), string(m.Manifest))

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -367,6 +367,7 @@ type imageInfo struct {
 	name       string
 	version    string
 	importTime int64
+	size       int64
 	manifest   []byte
 }
 
@@ -514,7 +515,7 @@ func getPodInfo(t *testing.T, ctx *testutils.RktRunCtx, podID string) *podInfo {
 // For example, the 'result' can be:
 // 'sha512-e9b77714dbbfda12cb9e136318b103a6f0ce082004d09d0224a620d2bbf38133 nginx:latest 2015-10-16 17:42:57.741 -0700 PDT true'
 func parseImageInfoOutput(t *testing.T, result string) *imageInfo {
-	fields := regexp.MustCompile("\t+").Split(result, 4)
+	fields := regexp.MustCompile("\t+").Split(result, 6)
 	nameVersion := strings.Split(fields[1], ":")
 	if len(nameVersion) != 2 {
 		t.Fatalf("Failed to parse name version string: %q", fields[1])
@@ -523,12 +524,17 @@ func parseImageInfoOutput(t *testing.T, result string) *imageInfo {
 	if err != nil {
 		t.Fatalf("Failed to parse time string: %q", fields[2])
 	}
+	size, err := strconv.Atoi(fields[4])
+	if err != nil {
+		t.Fatalf("Failed to parse image size string: %q", fields[4])
+	}
 
 	return &imageInfo{
 		id:         fields[0],
 		name:       nameVersion[0],
 		version:    nameVersion[1],
 		importTime: importTime.Unix(),
+		size:       int64(size),
 	}
 }
 


### PR DESCRIPTION
Partially implements #1872. This patch adds "Size" to the API response. It does not add annotations, I was planning on adding that in another PR but can fold it into this one if that's preferred.