### PR TITLE
Upgrade lkvm to fix a 9pfs bug

### DIFF
--- a/stage1/usr_from_kvm/lkvm.mk
+++ b/stage1/usr_from_kvm/lkvm.mk
@@ -5,7 +5,7 @@ LKVM_BINARY := $(LKVM_SRCDIR)/lkvm-static
 LKVM_ACI_BINARY := $(S1_RF_ACIROOTFSDIR)/lkvm
 LKVM_GIT := https://kernel.googlesource.com/pub/scm/linux/kernel/git/will/kvmtool
 # just last published version (for reproducible builds), not for any other reason
-LKVM_VERSION := efcf862611f2498d7b500e46a73d8a008e04325f
+LKVM_VERSION := 3c8aec9e2b5066412390559629dabeb7816ee8f2
 
 LKVM_STUFFDIR := $(MK_SRCDIR)/lkvm
 LKVM_PATCHESDIR := $(LKVM_STUFFDIR)/patches

--- a/stage1/usr_from_kvm/lkvm/patches/terminal_late_fix.patch
+++ b/stage1/usr_from_kvm/lkvm/patches/terminal_late_fix.patch
@@ -2,7 +2,7 @@ diff --git a/term.c b/term.c
 index 9763211..dec0d79 100644
 --- a/term.c
 +++ b/term.c
-@@ -202,10 +202,16 @@ int term_init(struct kvm *kvm)
+@@ -202,10 +202,16 @@ static int term_init(struct kvm *kvm)
  
  	return 0;
  }
@@ -14,7 +14,7 @@ index 9763211..dec0d79 100644
 +//dev_init(term_init);
 +firmware_init(term_init);
  
- int term_exit(struct kvm *kvm)
+ static int term_exit(struct kvm *kvm)
  {
  	return 0;
  }


### PR DESCRIPTION
stage1: Upgrade lkvm to current master branch to fix a 9pfs bug.

Fixes: https://github.com/coreos/rkt/issues/1917

Signed-off-by: Arthur Chunqi Li <chunqi.li.pku@gmail.com>