### PR TITLE
tests: new script to run test on AWS

### DIFF
--- a/tests/aws.sh
+++ b/tests/aws.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -e
+
+SCRIPTPATH=$(dirname "$0")
+cd $SCRIPTPATH
+
+KEY_PAIR_NAME=rkt-testing-${USER}
+SECURITY_GROUP=rkt-testing-${USER}-security-group
+
+## First time only
+if [ "$1" = "setup" ] ; then
+  MYIP=$(curl --silent http://checkip.amazonaws.com/)
+
+  aws ec2 create-key-pair --key-name $KEY_PAIR_NAME --query 'KeyMaterial' --output text > ${KEY_PAIR_NAME}.pem
+  chmod 0600 ${KEY_PAIR_NAME}.pem
+  aws ec2 create-security-group --group-name $SECURITY_GROUP --description "Security group for rkt testing"
+  aws ec2 authorize-security-group-ingress --group-name $SECURITY_GROUP --protocol tcp --port 22 --cidr $MYIP/32
+  exit 0
+fi
+
+DISTRO=$1
+GIT_URL=${2-https://github.com/coreos/rkt.git}
+GIT_BRANCH=${3-master}
+
+test -f cloudinit/${DISTRO}.cloudinit
+CLOUDINIT_IN=$PWD/cloudinit/${DISTRO}.cloudinit
+
+if [ "$DISTRO" = "fedora" ] ; then
+  # https://getfedora.org/en/cloud/download/
+  # Search Fedora-Cloud-Base-23-20160106.x86_64-eu-central-1-HVM-standard-0 on AWS
+  # Or look at https://apps.fedoraproject.org/datagrepper/raw?category=fedimg
+  # Sources: https://github.com/fedora-infra/fedimg/blob/develop/bin/list-the-amis.py
+  AMI=ami-d76a74bb
+  AWS_USER=fedora
+elif [ "$DISTRO" = "ubuntu" ] ; then
+  # https://cloud-images.ubuntu.com/locator/ec2/
+  AMI=ami-b4a5b9d8
+  AWS_USER=ubuntu
+elif [ "$DISTRO" = "debian" ] ; then
+  # https://wiki.debian.org/Cloud/AmazonEC2Image/Jessie
+  AMI=ami-02b78e1f
+  AWS_USER=admin
+elif [ "$DISTRO" = "centos" ] ; then
+  # Needs to subscribe first, see:
+  # https://wiki.centos.org/Cloud/AWS
+  AMI=ami-e68f82fb
+  AWS_USER=centos
+fi
+
+test -n "$AMI"
+test -n "$AWS_USER"
+test -f "${KEY_PAIR_NAME}.pem"
+
+CLOUDINIT=$(mktemp --tmpdir rkt-cloudinit.XXXXXXXXXX)
+sed -e "s#@GIT_URL@#${GIT_URL}#g" \
+    -e "s#@GIT_BRANCH@#${GIT_BRANCH}#g" \
+    < $CLOUDINIT_IN >> $CLOUDINIT
+
+INSTANCE_ID=$(aws ec2 run-instances \
+	--image-id $AMI \
+	--count 1 \
+	--key-name $KEY_PAIR_NAME \
+	--security-groups $SECURITY_GROUP \
+	--instance-type t2.micro \
+	--instance-initiated-shutdown-behavior terminate \
+	--user-data file://$CLOUDINIT \
+	--output text \
+	--query 'Instances[*].InstanceId' \
+	)
+echo INSTANCE_ID=$INSTANCE_ID
+
+while state=$(aws ec2 describe-instances \
+	--instance-ids $INSTANCE_ID \
+	--output text \
+	--query 'Reservations[*].Instances[*].State.Name' \
+	); test "$state" = "pending"; do
+  sleep 1; echo -n '.'
+done; echo " $state"
+
+AWS_IP=$(aws ec2 describe-instances \
+	--instance-ids $INSTANCE_ID \
+	--output text \
+	--query 'Reservations[*].Instances[*].PublicIpAddress' \
+	)
+echo AWS_IP=$AWS_IP
+
+rm -f $CLOUDINIT
+
+sleep 5
+aws ec2 get-console-output --instance-id $INSTANCE_ID --output text |
+  perl -ne 'print if /BEGIN SSH .* FINGERPRINTS/../END SSH .* FINGERPRINTS/'
+
+echo "Connect with:"
+echo ssh -o ServerAliveInterval=20 -i ${SCRIPTPATH}/${KEY_PAIR_NAME}.pem ${AWS_USER}@${AWS_IP}
+echo "Check the logs with:"
+echo tail -n 5000 -f /var/tmp/rkt-test.log
+

--- a/tests/cloudinit/centos.cloudinit
+++ b/tests/cloudinit/centos.cloudinit
@@ -1,0 +1,40 @@
+#!/bin/bash
+cat > /var/tmp/rkt-test.sh <<TESTEOF
+#!/bin/bash
+
+set -e
+set -x
+
+# Sometimes journald does not work on CentOS :-(
+exec > >(tee -a "/var/tmp/rkt-test.log") 2>&1
+
+groupadd rkt
+gpasswd -a centos rkt
+
+#yum update -y
+yum -y -v install epel-release # Needed for golang-vet and golang-cover
+yum -y -v groupinstall "Development Tools"
+yum -y -v install wget squashfs-tools patch glibc-static gnupg golang libacl-devel golang-vet golang-cover
+
+# # No need to do that with CentOS's go1.4.2
+# # https://github.com/coreos/rkt/pull/1877#issuecomment-169614067
+# GOPATH=/tmp /usr/bin/go get golang.org/x/tools/cmd/vet
+# GOPATH=/tmp /usr/bin/go get golang.org/x/tools/cmd/cover
+
+/usr/sbin/setenforce 0
+
+# unsquashfs is in /usr/sbin
+export PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/centos/.local/bin:/home/centos/bin
+
+# sudo/su without tty is disabled on old CentOS.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1020147
+# Cannot workaround with /usr/bin/expect because this would need expect > 2.27
+sed -i 's/ requiretty$/ !requiretty/g' /etc/sudoers
+
+su - centos --command="cd /var/tmp ; git clone --branch @GIT_BRANCH@ @GIT_URL@ rkt"
+su - centos --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/run-build.sh coreos"
+TESTEOF
+
+chmod +x /var/tmp/rkt-test.sh
+
+systemd-run --unit=rkt-test /var/tmp/rkt-test.sh

--- a/tests/cloudinit/debian.cloudinit
+++ b/tests/cloudinit/debian.cloudinit
@@ -1,0 +1,28 @@
+#!/bin/bash
+cat > /var/tmp/rkt-test.sh <<TESTEOF
+#!/bin/bash
+
+set -e
+set -x
+
+# Sometimes journald does not work well on old versions
+exec > >(tee -a "/var/tmp/rkt-test.log") 2>&1
+
+sudo groupadd rkt
+sudo gpasswd -a admin rkt
+
+export DEBIAN_FRONTEND=noninteractive
+echo 'deb http://cloudfront.debian.net/debian testing main' | tee -a /etc/apt/sources.list
+echo 'deb-src http://cloudfront.debian.net/debian testing main' | tee -a /etc/apt/sources.list
+apt-get update -y
+#apt-get dist-upgrade -y --force-yes
+apt-get install -y --force-yes build-essential autoconf
+apt-get install -y --force-yes wget squashfs-tools patch gnupg golang git dbus libacl1-dev
+
+su - admin --command="cd /var/tmp ; git clone --branch @GIT_BRANCH@ @GIT_URL@ rkt"
+su - admin --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/run-build.sh coreos"
+TESTEOF
+
+chmod +x /var/tmp/rkt-test.sh
+
+systemd-run --unit=rkt-test /var/tmp/rkt-test.sh

--- a/tests/cloudinit/fedora.cloudinit
+++ b/tests/cloudinit/fedora.cloudinit
@@ -1,0 +1,31 @@
+#!/bin/bash
+cat > /var/tmp/rkt-test.sh <<TESTEOF
+#!/bin/bash
+
+set -e
+set -x
+
+# Sometimes journald does not work well on old versions
+exec > >(tee -a "/var/tmp/rkt-test.log") 2>&1
+
+groupadd rkt
+gpasswd -a fedora rkt
+
+dnf -y -v update
+dnf -y -v groupinstall "Development Tools"
+dnf -y -v groupinstall "C Development Tools and Libraries"
+dnf -y -v install wget squashfs-tools patch glibc-static gnupg golang libacl-devel
+
+# Workarounds on Fedora
+/usr/sbin/setenforce 0
+
+# unsquashfs is in /usr/sbin
+export PATH=/usr/lib64/ccache:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/fedora/.local/bin:/home/fedora/bin
+
+su - fedora --command="cd /var/tmp ; git clone --branch @GIT_BRANCH@ @GIT_URL@ rkt"
+su - fedora --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/run-build.sh coreos"
+TESTEOF
+
+chmod +x /var/tmp/rkt-test.sh
+
+systemd-run --unit=rkt-test /var/tmp/rkt-test.sh

--- a/tests/cloudinit/ubuntu.cloudinit
+++ b/tests/cloudinit/ubuntu.cloudinit
@@ -1,0 +1,27 @@
+#!/bin/bash
+cat > /var/tmp/rkt-test.sh <<TESTEOF
+#!/bin/bash
+
+set -e
+set -x
+
+# Sometimes journald does not work well on old versions
+exec > >(tee -a "/var/tmp/rkt-test.log") 2>&1
+
+export DEBIAN_FRONTEND=noninteractive
+
+groupadd rkt
+gpasswd -a ubuntu rkt
+
+apt-get update -y
+apt-get dist-upgrade -y --force-yes
+apt-get install -y build-essential autoconf
+apt-get install -y wget squashfs-tools patch gnupg golang libacl1-dev
+
+su - ubuntu --command="cd /var/tmp ; git clone --branch @GIT_BRANCH@ @GIT_URL@ rkt"
+su - ubuntu --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/run-build.sh coreos"
+TESTEOF
+
+chmod +x /var/tmp/rkt-test.sh
+
+systemd-run --unit=rkt-test /var/tmp/rkt-test.sh

--- a/tests/test-on-several-distro.md
+++ b/tests/test-on-several-distro.md
@@ -1,0 +1,48 @@
+# Tests on several Linux distributions
+
+rkt aims to be supported on several Linux distributions.
+In order to notice distro-specific issues, Continuous Integration should ideally run the tests on several Linux distributions.
+This is not done yet but there is a script to help with manual testing on several Linux distributions.
+
+rkt tests can be intrusive and require full root privileges.
+Each test should be run on a fresh VM.
+VMs should not be reused for next tests.
+
+## AWS
+
+The script `tests/aws.sh` can automatically spawn a fresh VM of the specified Linux distribution and start the rkt tests.
+
+First, install [aws-cli](https://github.com/aws/aws-cli) and configure it with your AWS credentials.
+Then, create a key pair and a security group for rkt tests:
+
+```
+$ tests/aws.sh setup
+```
+
+Then run the tests with the specified Linux distribution:
+
+```
+$ tests/aws.sh debian
+$ tests/aws.sh ubuntu
+$ tests/aws.sh fedora
+$ tests/aws.sh centos
+```
+
+By default, this tests the upstream master branch.
+A specific branch can be tested with:
+
+```
+$ tests/aws.sh ubuntu https://github.com/coreos/rkt.git branch-name
+```
+
+The VM instances are configured to terminate automatically on shutdown to reduce costs.
+However they are not shut down automatically after the tests.
+It is recommended to check in the AWS console that instances are terminated.
+
+## Jenkins
+
+This could be automatised with [Jenkins](https://jenkins-ci.org/).
+In order to spawn a new VM for each test, the [Amazon EC2 Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Amazon+EC2+Plugin) could be used.
+However, it would require additional fixes: [JENKINS-8618](https://issues.jenkins-ci.org/browse/JENKINS-8618).
+
+


### PR DESCRIPTION
Support Fedora, Ubuntu, Debian, CentOS.

rkt does not have a Continuous Integration system that can run the tests
on all Linux distributions yet. But this script helps with manual
testing.

-----

See also https://github.com/coreos/rkt/issues/847

/cc @iaguis @steveeJ 