### PR TITLE
*: fix various broken links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -471,7 +471,7 @@ This release also introduces a number of key features and minor changes:
 ## v0.4.2
 
 - First support for interactive containers, with the `rkt run --interactive`
-  flag. This is currently only supported if a container has one app. [#562](https://github.com/coreos/rkt/pull/562) #[601](//github.com/coreos/rkt/pull/601)
+  flag. This is currently only supported if a container has one app. [#562](https://github.com/coreos/rkt/pull/562) #[601](https://github.com/coreos/rkt/pull/601)
 - Add container IP address information to `rkt list`
 - Provide `/sys` and `/dev/shm` to apps (per spec)
 - Introduce "latest" pattern handling for local image index

--- a/Documentation/packaging.md
+++ b/Documentation/packaging.md
@@ -34,7 +34,7 @@ The dependencies may differ depending on the version of built systemd.
 
 #### Basic run-time dependencies
 
-Linux configured with [suitable options](Documentation/hacking.md#run-time-requirements)
+Linux configured with [suitable options](hacking.md#run-time-requirements)
 
 #### Additional run-time dependencies for the host flavor
 

--- a/Documentation/subcommands/enter.md
+++ b/Documentation/subcommands/enter.md
@@ -18,7 +18,7 @@ boot  dev   etc            lib   media  opt  root  sbin  srv      tmp  var
 
 ## Use a Custom Stage 1
 
-rkt is designed and intended to be modular, using a [staged architecture](devel/architecture.md).
+rkt is designed and intended to be modular, using a [staged architecture](../devel/architecture.md).
 
 You can use a custom stage1 by using the `--stage1-image` flag.
 
@@ -26,7 +26,7 @@ You can use a custom stage1 by using the `--stage1-image` flag.
 # rkt --stage1-image=/tmp/stage1.aci run coreos.com/etcd:v2.0.0
 ```
 
-For more details see the [hacking documentation](hacking.md).
+For more details see the [hacking documentation](../hacking.md).
 
 ## Run a Pod in the Background
 

--- a/Documentation/using-rkt-with-kubernetes.md
+++ b/Documentation/using-rkt-with-kubernetes.md
@@ -1,6 +1,6 @@
 # Using rkt with Kubernetes (aka "rktnetes")
 
-[Kubernetes](https://kubernetes.io) is a system for managing containerized applications across a cluster of machines.
+[Kubernetes](http://kubernetes.io) is a system for managing containerized applications across a cluster of machines.
 Kubernetes runs all applications in containers.
 In the default setup, this is performed using the Docker engine, but Kubernetes also features support for using rkt as its container runtime backend.
 This allows a Kubernetes cluster to leverage some of rkt's security features and native pod support.


### PR DESCRIPTION
For unknown and mildly baffling reasons, kubernetes.io is only available over http