### PR TITLE
Change Travis CI Badge from PNG to SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rkt - App Container runtime
 
 [![godoc](https://godoc.org/github.com/coreos/rkt?status.svg)](http://godoc.org/github.com/coreos/rkt)
-[![Build Status (Travis)](https://travis-ci.org/coreos/rkt.png?branch=master)](https://travis-ci.org/coreos/rkt)
+[![Build Status (Travis)](https://travis-ci.org/coreos/rkt.svg?branch=master)](https://travis-ci.org/coreos/rkt)
 [![Build Status (SemaphoreCI)](https://semaphoreci.com/api/v1/projects/28468e19-4fd0-483e-9c29-6c8368661333/395211/badge.svg)](https://semaphoreci.com/coreos/rkt)
 
 ![rkt Logo](logos/rkt-horizontal-color.png)


### PR DESCRIPTION
This replaces the Travis CI Badge in README.md with SVG, makes the badges much nicer on hi-dpi devices.