### PR TITLE
rkt: change getAppsImageManifests to getAppImageManifest

### DIFF
--- a/rkt/list.go
+++ b/rkt/list.go
@@ -212,18 +212,13 @@ func fmtNets(nis []netinfo.NetInfo) string {
 }
 
 func getImageName(p *pod, appName types.ACName) (string, error) {
-	aim, err := p.getAppsImageManifests()
+	aim, err := p.getAppImageManifest(appName)
 	if err != nil {
 		return "", fmt.Errorf("problem retrieving ImageManifests from pod: %v", err)
 	}
 
-	im, ok := aim[appName]
-	if !ok {
-		return "", fmt.Errorf("could not find appName in pod: %v", err)
-	}
-
-	imageName := im.Name.String()
-	if version, ok := im.Labels.Get("version"); ok {
+	imageName := aim.Name.String()
+	if version, ok := aim.Labels.Get("version"); ok {
 		imageName = fmt.Sprintf("%s:%s", imageName, version)
 	}
 

--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -915,29 +915,16 @@ func (p *pod) getAppsHashes() ([]types.Hash, error) {
 	return hashes, nil
 }
 
-type AppsImageManifests map[types.ACName]*schema.ImageManifest
-
-// getAppsImageManifests returns a map of ImageManifests keyed to the
-// corresponding App name.
-func (p *pod) getAppsImageManifests() (AppsImageManifests, error) {
-	apps, err := p.getApps()
+// getAppImageManifest returns an ImageManifest for the corresponding AppName.
+func (p *pod) getAppImageManifest(appName types.ACName) (*schema.ImageManifest, error) {
+	imb, err := ioutil.ReadFile(common.AppInfoImageManifestPath(p.path(), appName))
 	if err != nil {
 		return nil, err
 	}
 
-	aim := make(AppsImageManifests)
-	for _, a := range apps {
-		imb, err := ioutil.ReadFile(common.AppInfoImageManifestPath(p.path(), a.Name))
-		if err != nil {
-			return nil, err
-		}
-
-		im := &schema.ImageManifest{}
-		if err := im.UnmarshalJSON(imb); err != nil {
-			return nil, fmt.Errorf("invalid image manifest for app %q: %v", a.Name.String(), err)
-		}
-
-		aim[a.Name] = im
+	aim := &schema.ImageManifest{}
+	if err := aim.UnmarshalJSON(imb); err != nil {
+		return nil, fmt.Errorf("invalid image manifest for app %q: %v", appName.String(), err)
 	}
 
 	return aim, nil


### PR DESCRIPTION
Because we already had the app names, it's better to get a specific app's
image manifest rather than getting the image manifests from all the
apps and forcing the caller to sort through those.

This was requested by @yifan-gu here:  https://github.com/coreos/rkt/pull/1701#discussion-diff-48934836