### PR TITLE
travis: Work around problems with go vet on go 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,9 @@
 
 language: go
 
-matrix:
- include:
-  - go: 1.4.3
-    install:
-     - go get golang.org/x/tools/cmd/cover
-     - go get golang.org/x/tools/cmd/vet
-  - go: 1.5.2
+go:
+  - 1.4.2
+  - 1.5.2
 
 before_install:
  - sudo apt-get update -qq

--- a/tests/rkt_api_service_test.go
+++ b/tests/rkt_api_service_test.go
@@ -288,7 +288,7 @@ func TestAPIServiceListInspectPods(t *testing.T) {
 		t.Fatalf("Cannot generate types.Hash from %v: %v", iresp.Images[0].Id, err)
 	}
 	pm := schema.BlankPodManifest()
-	pm.Apps = schema.AppList{
+	pm.Apps = []schema.RuntimeApp{
 		schema.RuntimeApp{
 			Name: types.ACName("rkt-inspect"),
 			Image: schema.RuntimeImage{


### PR DESCRIPTION
Go 1.4.3 tarball by mistake does not provide some tools we require, so
we were go-getting them. Unfortunately go vet recently became broken
for go 1.4, so we revert to go 1.4.2, which had those tools.