### PR TITLE
common: fix function name AppImageManifestPath

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -121,7 +121,7 @@ func AppTreeStoreIDPath(root string, appName types.ACName) string {
 }
 
 // AppImageManifestPath returns the path to the app's ImageManifest file
-func AppInfoImageManifestPath(root string, appName types.ACName) string {
+func AppImageManifestPath(root string, appName types.ACName) string {
 	return filepath.Join(AppInfoPath(root, appName), aci.ManifestFile)
 }
 

--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -917,7 +917,7 @@ func (p *pod) getAppsHashes() ([]types.Hash, error) {
 
 // getAppImageManifest returns an ImageManifest for the corresponding AppName.
 func (p *pod) getAppImageManifest(appName types.ACName) (*schema.ImageManifest, error) {
-	imb, err := ioutil.ReadFile(common.AppInfoImageManifestPath(p.path(), appName))
+	imb, err := ioutil.ReadFile(common.AppImageManifestPath(p.path(), appName))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Noticed in #1701 that it appeared to have gained a superfluous modifier
and the docstring was out of sync with the function name