### PR TITLE
Add insecure option http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## vUNRELEASED
+
+#### New features and UX changes
+
+- Explicitly allow http connections via a new 'http' option to `--insecure-options`. Any data and credentials will be sent in the clear.
+
 ## v0.15.0
 
 rkt v0.15.0 is an incremental release with UX improvements, bug fixes, API service enhancements and new support for Go 1.5.

--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -68,7 +68,7 @@ In addition to the flags used by individual `rkt` commands, `rkt` has a set of g
 | --- | --- | --- | --- |
 | `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
 | `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
+| `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
 | `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |

--- a/rkt/flag/rktflag_test.go
+++ b/rkt/flag/rktflag_test.go
@@ -137,6 +137,7 @@ func TestSecFlags(t *testing.T) {
 		image  bool
 		tls    bool
 		onDisk bool
+		http   bool
 		err    bool
 	}{
 		{
@@ -144,36 +145,49 @@ func TestSecFlags(t *testing.T) {
 			image:  false,
 			tls:    false,
 			onDisk: false,
+			http:   false,
 		},
 		{
 			opts:   "image",
 			image:  true,
 			tls:    false,
 			onDisk: false,
+			http:   false,
 		},
 		{
 			opts:   "tls",
 			image:  false,
 			tls:    true,
 			onDisk: false,
+			http:   false,
 		},
 		{
 			opts:   "onDisk",
 			image:  false,
 			tls:    false,
 			onDisk: true,
+			http:   false,
+		},
+		{
+			opts:   "http",
+			image:  false,
+			tls:    false,
+			onDisk: false,
+			http:   true,
 		},
 		{
 			opts:   "all",
 			image:  true,
 			tls:    true,
 			onDisk: true,
+			http:   true,
 		},
 		{
 			opts:   "image,tls",
 			image:  true,
 			tls:    true,
 			onDisk: false,
+			http:   false,
 		},
 		{
 			opts: "i-am-sure-we-will-not-get-this-insecure-flag",
@@ -204,12 +218,16 @@ func TestSecFlags(t *testing.T) {
 			t.Errorf("test %d: expected on disk skip to be %v, got %v", i, tt.onDisk, got)
 		}
 
-		all := tt.onDisk && tt.tls && tt.image
+		if got := sf.AllowHTTP(); tt.http != got {
+			t.Errorf("test %d: expected http allowed to be %v, got %v", i, tt.http, got)
+		}
+
+		all := tt.http && tt.onDisk && tt.tls && tt.image
 		if got := sf.SkipAllSecurityChecks(); all != got {
 			t.Errorf("test %d: expected all skip to be %v, got %v", i, all, got)
 		}
 
-		any := tt.onDisk || tt.tls || tt.image
+		any := tt.http || tt.onDisk || tt.tls || tt.image
 		if got := sf.SkipAnySecurityChecks(); any != got {
 			t.Errorf("test %d: expected all skip to be %v, got %v", i, any, got)
 		}

--- a/rkt/flag/secflags.go
+++ b/rkt/flag/secflags.go
@@ -19,19 +19,21 @@ const (
 	insecureImage = 1 << (iota - 1)
 	insecureTls
 	insecureOnDisk
+	insecureHTTP
 
-	insecureAll = (insecureImage | insecureTls | insecureOnDisk)
+	insecureAll = (insecureImage | insecureTls | insecureOnDisk | insecureHTTP)
 )
 
 var (
-	insecureOptions = []string{"none", "image", "tls", "ondisk", "all"}
+	insecureOptions = []string{"none", "image", "tls", "ondisk", "http", "all"}
 
 	insecureOptionsMap = map[string]int{
 		insecureOptions[0]: insecureNone,
 		insecureOptions[1]: insecureImage,
 		insecureOptions[2]: insecureTls,
 		insecureOptions[3]: insecureOnDisk,
-		insecureOptions[4]: insecureAll,
+		insecureOptions[4]: insecureHTTP,
+		insecureOptions[5]: insecureAll,
 	}
 )
 
@@ -61,6 +63,10 @@ func (sf *SecFlags) SkipTlsCheck() bool {
 
 func (sf *SecFlags) SkipOnDiskCheck() bool {
 	return sf.hasFlag(insecureOnDisk)
+}
+
+func (sf *SecFlags) AllowHTTP() bool {
+	return sf.hasFlag(insecureHTTP)
 }
 
 func (sf *SecFlags) SkipAllSecurityChecks() bool {

--- a/rkt/image/namefetcher.go
+++ b/rkt/image/namefetcher.go
@@ -59,15 +59,12 @@ func (f *nameFetcher) GetHash(app *discovery.App, a *asc) (string, error) {
 }
 
 func (f *nameFetcher) discoverApp(app *discovery.App) (*discovery.Endpoints, error) {
-	// TODO(krnowak): Instead of hardcoding InsecureHttp, we probably
-	// should use f.InsecureFlags.AllowHttp and
-	// f.InsecureFlags.AllowHttpCredentials (if they are
-	// introduced) on it. Needs some work first on appc/spec side.
-	// https://github.com/appc/spec/issues/545
-	// https://github.com/coreos/rkt/issues/1836
-	insecure := discovery.InsecureHttp
+	insecure := discovery.InsecureNone
 	if f.InsecureFlags.SkipTlsCheck() {
 		insecure = insecure | discovery.InsecureTls
+	}
+	if f.InsecureFlags.AllowHTTP() {
+		insecure = insecure | discovery.InsecureHttp
 	}
 	hostHeaders := config.ResolveAuthPerHost(f.Headers)
 	ep, attempts, err := discovery.DiscoverEndpoints(*app, hostHeaders, insecure)


### PR DESCRIPTION
This adds code, tests, and documentation for a new "http" `--insecure-options` flag.

fixes https://github.com/coreos/rkt/issues/1836