### PR TITLE
Documentation/devel/release.md: small updates

### DIFF
--- a/Documentation/devel/release.md
+++ b/Documentation/devel/release.md
@@ -4,11 +4,11 @@ How to perform a release of rkt.
 This guide is probably unnecessarily verbose, so improvements welcomed.
 Only parts of the procedure are automated; this is somewhat intentional (manual steps for sanity checking) but it can probably be further scripted, please help.
 
-The following example assumes we're going from version 0.6.1 (`v0.6.1`) to 0.7.0 (`v0.7.0`).
+The following example assumes we're going from version 0.15.0 (`v0.15.0`) to 0.16.0 (`v0.16.0`).
 
 Let's get started:
 
-- Start at the relevant milestone on GitHub (e.g. https://github.com/coreos/rkt/milestones/v0.7.0): ensure all referenced issues are closed (or moved elsewhere, if they're not done). Close the milestone.
+- Start at the relevant milestone on GitHub (e.g. https://github.com/coreos/rkt/milestones/v0.16.0): ensure all referenced issues are closed (or moved elsewhere, if they're not done). Close the milestone.
 - Update the [roadmap](https://github.com/coreos/rkt/blob/master/ROADMAP.md) to remove the release you're performing, if necessary
 - Branch from the latest master, make sure your git status is clean
 - Ensure the build is clean!
@@ -19,8 +19,8 @@ Let's get started:
 
 The rkt version is [hardcoded in the repository](https://github.com/coreos/rkt/blob/master/configure.ac#L2), so the first thing to do is bump it:
 
-- Run `scripts/bump-release v0.7.0`.
-  This should generate two commits: a bump to the actual release (e.g. v0.7.0), and then a bump to the release+git (e.g. v0.7.0+git).
+- Run `scripts/bump-release v0.16.0`.
+  This should generate two commits: a bump to the actual release (e.g. v0.16.0), and then a bump to the release+git (e.g. v0.16.0+git).
   The actual release version should only exist in a single commit!
 - Sanity check what the script did with `git diff HEAD^^` or similar.
   As well as changing the actual version, it also attempts to fix a bunch of references in the documentation etc.
@@ -35,18 +35,18 @@ After merging and going back to master branch, we check out the release version 
 
 - `git checkout HEAD^` should work; sanity check configure.ac (2nd line) after doing this
 - Build rkt, we'll use this in a minute:
-  - `git clean -ffdx && ./autogen.sh && ./configure && make BUILDDIR=release-build`
-    - This will build both `coreos` and `kvm` flavors and make `coreos` the default
+  - `git clean -ffdx && ./autogen.sh && ./configure && make BUILDDIR=release-build -j 4`
+    - This will build the `coreos`, `kvm` and `fly` flavors and make `coreos` the default
     - Use make's `-j` parameter as you see fit
   - Sanity check `release-build/bin/rkt version`
-- Add a signed tag: `git tag -s v0.7.0`.
+- Add a signed tag: `git tag -s v0.16.0`.
   (We previously used tags for release notes, but now we store them in CHANGELOG.md, so a short tag with the release name is fine).
 - Push the tag to GitHub: `git push --tags`
 
 Now we switch to the GitHub web UI to conduct the release:
 
 - https://github.com/coreos/rkt/releases/new
-- Tag "v0.7.0", release title "v0.7.0"
+- Tag "v0.16.0", release title "v0.16.0"
 - For now, check "This is a pre-release"
 - Copy-paste the release notes you added earlier in [CHANGELOG.md](https://github.com/coreos/rkt/blob/master/CHANGELOG.md)
 - You can also add a little more detail and polish to the release notes here if you wish, as it is more targeted towards users (vs the changelog being more for developers); use your best judgement and see previous releases on GH for examples.
@@ -54,9 +54,9 @@ Now we switch to the GitHub web UI to conduct the release:
   This is a simple tarball:
 
 ```
-	export NAME="rkt-v0.7.0"
+	export NAME="rkt-v0.16.0"
 	mkdir $NAME
-	cp release-build/bin/rkt release-build/bin/stage1-{coreos,kvm}.aci $NAME/
+	cp release-build/bin/rkt release-build/bin/stage1-{coreos,kvm,fly}.aci $NAME/
 	tar czvf $NAME.tar.gz $NAME/
 ```
 
@@ -74,5 +74,7 @@ Use your discretion and see [previous release emails](https://groups.google.com/
 Make sure to include a list of authors that contributed since the previous release - something like the following might be handy:
 
 ```
-	git log ...v0.6.1 --pretty=format:"%an" | sort | uniq | tr '\n' ',' | sed -e 's#,#, #g' -e 's#, $##'
+	git log ...v0.15.0 --pretty=format:"%an" | sort | uniq | tr '\n' ',' | sed -e 's#,#, #g' -e 's#, $#\n#'
 ```
+
+- Prepare CHANGELOG.md for the next release: add a "vUNRELEASED" section. The CHANGELOG should be updated alongside the code as pull requests are merged into master, so that the releaser does not need to start from scratch.


### PR DESCRIPTION
Small updates explaining how to do a release:
- include the "fly" stage1
- nicer "sed" command to get the authors
- use more recent version as example
- suggest to add a vUNRELEASED section in CHANGELOG.md