### PR TITLE
tests: skip userns tests when userns does not work

### DIFF
--- a/tests/rkt_non_root_test.go
+++ b/tests/rkt_non_root_test.go
@@ -25,6 +25,14 @@ import (
 
 // TestNonRootReadInfo tests that non-root users that can do rkt list, rkt image list.
 func TestNonRootReadInfo(t *testing.T) {
+	if !common.SupportsUserNS() {
+		t.Skip("User namespaces are not supported on this host.")
+	}
+
+	if err := checkUserNS(); err != nil {
+		t.Skip("User namespaces don't work on this host.")
+	}
+
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -647,3 +647,10 @@ func runRktTrust(t *testing.T, ctx *testutils.RktRunCtx, prefix string) {
 		t.Fatalf("Expected but didn't find %q in %v", expected, err)
 	}
 }
+
+func checkUserNS() error {
+	// CentOS 7 pretends to support user namespaces, but does not.
+	// See https://bugzilla.redhat.com/show_bug.cgi?id=1168776#c5
+	// Check if it really works
+	return exec.Command("/bin/bash", "-c", "unshare -U true").Run()
+}

--- a/tests/rkt_userns_test.go
+++ b/tests/rkt_userns_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/coreos/gexpect"
+	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/tests/testutils"
 )
 
@@ -49,6 +50,14 @@ var usernsTests = []struct {
 }
 
 func TestUserns(t *testing.T) {
+	if !common.SupportsUserNS() {
+		t.Skip("User namespaces are not supported on this host.")
+	}
+
+	if err := checkUserNS(); err != nil {
+		t.Skip("User namespaces don't work on this host.")
+	}
+
 	image := patchTestACI("rkt-inspect-stat.aci", "--exec=/inspect --stat-file")
 	defer os.Remove(image)
 	ctx := testutils.NewRktRunCtx()


### PR DESCRIPTION
CentOS 7 pretends to support user namespaces but does not. See
https://bugzilla.redhat.com/show_bug.cgi?id=1168776#c5

Skip rkt tests with user namespaces when the host cannot do user
namespaces.

https://github.com/coreos/rkt/issues/1927