### PR TITLE
Look for network plugin using name as path

### DIFF
--- a/networking/net_plugin.go
+++ b/networking/net_plugin.go
@@ -84,6 +84,11 @@ func (e *podEnv) pluginPaths() []string {
 }
 
 func (e *podEnv) findNetPlugin(plugin string) string {
+	// try to find the plugin directly first
+	if fi, err := os.Stat(plugin); err == nil && fi.Mode().IsRegular() {
+		return plugin
+	}
+
 	for _, p := range e.pluginPaths() {
 		fullname := filepath.Join(p, plugin)
 		if fi, err := os.Stat(fullname); err == nil && fi.Mode().IsRegular() {


### PR DESCRIPTION
Solves the problem where the plugin path is hardcoded to a
read only directory on CoreOS.

This approach allows the most flexibility for plugin users
and is straightforward to implement.

Fixes #1948