### PR TITLE
rkt: add rkt stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Ensure that the initial name and labels used for discovery match the name and labels in the Image Manifest as specified in the appc spec ([#2311](https://github.com/coreos/rkt/pull/2311)). Users wanting the latest image should use `rkt prepare/run/fetch example.com/aci` without any labels. If the discovery server supports the "latest" pattern, the user can bypass a locally cached image in the store and fetch an updated image using `rkt prepare/run/fetch --no-store example.com/aci` option.
 
+- Add a new subcommand `rkt stop` ([#1959](https://github.com/coreos/rkt/pull/1959)).
+
 #### Note for packagers
 
 Files generated from sources are no longer checked-in the git repository. Instead, packagers should build them:

--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -28,6 +28,7 @@ If an ACI hasn't been cached on disk, rkt will attempt to find and download it.
 To use rkt's [metadata service][metadata-spec], enable registration with the `--mds-register` flag when [invoking it][rkt-mds].
 
 * [run](subcommands/run.md)
+* [stop](subcommands/stop.md)
 * [enter](subcommands/enter.md)
 * [prepare](subcommands/prepare.md)
 * [run-prepared](subcommands/run-prepared.md)

--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -101,13 +101,27 @@ For example, it removes the network namespace of a pod.
 * `--debug` to activate debugging
 * UUID of the pod
 
+### `rkt stop` => "coreos.com/rkt/stage1/stop"
+
+The optional stop entrypoint initiates an orderly shutdown of stage1.
+
+In the bundled rkt stage 1, the entrypoint is a statically-linked C program that sends a SIGTERM to the systemd-nspawn process, which will deal with shutting down the container.
+
+This entrypoint was added in interface version 3.
+
 Versioning
 ----------
 
 The stage1 command line interface is versioned using an annotation with the name `coreos.com/rkt/stage1/interface-version`.
 If the annotation is not present, rkt assumes the version is 1.
 
-The current version of the stage1 interface is 2.
+The current version of the stage1 interface is 3.
+
+#### Arguments
+
+* `--force` to force the stopping of the pod. E.g. in the bundled rkt stage 1, stop sends SIGKILL instead of SIGTERM.
+* UUID of the pod
+>>>>>>> Documentation: add the stop entrypoint to stage1 implementors doc
 
 Examples
 --------
@@ -147,8 +161,12 @@ Examples
             "value": "/ex/gc"
         },
         {
+            "name": "coreos.com/rkt/stage1/stop",
+            "value": "/ex/stop"
+        },
+        {
             "name": "coreos.com/rkt/stage1/interface-version",
-            "value": "2"
+            "value": "3"
         }
     ]
 }

--- a/Documentation/subcommands/stop.md
+++ b/Documentation/subcommands/stop.md
@@ -1,0 +1,32 @@
+# rkt stop
+
+Given a list of pod UUIDs, rkt stop will shut them down, for the shipped stage1 images, this means:
+
+* default systemd-nspawn stage1: the apps in the pod receive a TERM signal and, after a timeout, a KILL signal.
+* kvm stage1: the virtual machine is shut down with `lkvm stop`.
+* rkt fly stage1: the app receives a TERM signal.
+
+The `--force` flag will stop a pod forcibly, that is:
+
+* default systemd-nspawn stage1: the container is killed.
+* kvm stage1: the lkvm process receives a KILL signal.
+* rkt fly stage1: the app receives a KILL signal.
+
+```
+# rkt stop 387fc8eb cbbf5c01
+"387fc8eb-eabd-4e77-b080-d8c0001eb50c"
+"cbbf5c01-dd52-4ccc-a1e0-cfd8f1e88418"
+# rkt stop --force 93e516b0
+"93e516b0-e84b-40cf-a45b-531b14dfcce2"
+```
+
+## Other ways to stop a rkt pod
+
+If you started rkt as a systemd service, you can stop the pod with `systemctl stop`.
+
+If you started rkt interactively:
+
+* For a stage1 with systemd-nspawn, you can stop the pod by pressing `^]` three times within 5 seconds.
+If you're using systemd on the host, you can also use `machinectl` with the `poweroff` or `terminate` subcommand.
+* For a stage1 with kvm, you can stop the pod by pressing Ctrl+A and then x.
+

--- a/rkt/stop.go
+++ b/rkt/stop.go
@@ -31,10 +31,12 @@ var (
 		Short: "Stop a pod",
 		Run:   runWrapper(runStop),
 	}
+	flagForce bool
 )
 
 func init() {
 	cmdRkt.AddCommand(cmdStop)
+	cmdStop.Flags().BoolVar(&flagForce, "force", false, "forced stopping")
 }
 
 func runStop(cmd *cobra.Command, args []string) (exit int) {
@@ -69,7 +71,7 @@ func runStop(cmd *cobra.Command, args []string) (exit int) {
 			continue
 		}
 
-		if err := stage0.StopPod(p.path()); err == nil {
+		if err := stage0.StopPod(p.path(), flagForce, podUUID); err == nil {
 			stdout.Printf("%q", p.uuid)
 		} else {
 			stderr.PrintE(fmt.Sprintf("stop: error stopping %q", p.uuid), err)

--- a/rkt/stop.go
+++ b/rkt/stop.go
@@ -1,0 +1,86 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/coreos/rkt/stage0"
+
+	"github.com/appc/spec/schema/types"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdStop = &cobra.Command{
+		Use:   "stop UUID ...",
+		Short: "Stop a pod",
+		Run:   runWrapper(runStop),
+	}
+)
+
+func init() {
+	cmdRkt.AddCommand(cmdStop)
+}
+
+func runStop(cmd *cobra.Command, args []string) (exit int) {
+	var podUUID *types.UUID
+	var podUUIDs []*types.UUID
+	var errors int
+
+	if len(args) < 1 {
+		cmd.Usage()
+		return 1
+	}
+
+	for _, uuid := range args {
+		podUUID, err := resolveUUID(uuid)
+		if err != nil {
+			stderr.PrintE("stop: unable to resolve UUID: %v", err)
+		} else {
+			podUUIDs = append(podUUIDs, podUUID)
+		}
+	}
+
+	for _, podUUID = range podUUIDs {
+		p, err := getPod(podUUID)
+		if err != nil {
+			errors++
+			stderr.PrintE("stop: cannot get pod", err)
+		}
+
+		if !p.isRunning() {
+			stderr.Error(fmt.Errorf("stop: pod %q is not running", p.uuid))
+			errors++
+			continue
+		}
+
+		if err := stage0.StopPod(p.path()); err == nil {
+			stdout.Printf("%q", p.uuid)
+		} else {
+			stderr.PrintE(fmt.Sprintf("stop: error stopping %q", p.uuid), err)
+			errors++
+		}
+	}
+
+	if errors > 0 {
+		stderr.Error(fmt.Errorf("stop: failed to stop %d pod(s)", errors))
+		return 1
+	}
+
+	return 0
+}

--- a/stage0/entrypoint.go
+++ b/stage0/entrypoint.go
@@ -31,6 +31,7 @@ const (
 	enterEntrypoint = "coreos.com/rkt/stage1/enter"
 	runEntrypoint   = "coreos.com/rkt/stage1/run"
 	gcEntrypoint    = "coreos.com/rkt/stage1/gc"
+	stopEntrypoint  = "coreos.com/rkt/stage1/stop"
 )
 
 // getStage1Entrypoint retrieves the named entrypoint from the stage1 manifest for a given pod

--- a/stage0/interface.go
+++ b/stage0/interface.go
@@ -59,3 +59,7 @@ func getStage1InterfaceVersion(cdir string) (int, error) {
 func interfaceVersionSupportsHostname(version int) bool {
 	return version > 1
 }
+
+func interfaceVersionSupportsStop(version int) bool {
+	return version > 2
+}

--- a/stage0/stop.go
+++ b/stage0/stop.go
@@ -23,9 +23,11 @@ import (
 	"path/filepath"
 
 	"github.com/coreos/rkt/common"
+
+	"github.com/appc/spec/schema/types"
 )
 
-func StopPod(dir string) error {
+func StopPod(dir string, force bool, uuid *types.UUID) error {
 	s1v, err := getStage1InterfaceVersion(dir)
 	if err != nil {
 		return fmt.Errorf("error determining stage1 interface version: %v", err)
@@ -47,6 +49,12 @@ func StopPod(dir string) error {
 	}
 	args := []string{filepath.Join(s1rootfs, ep)}
 	debug("Execing %s", ep)
+
+	if force {
+		args = append(args, "--force")
+	}
+
+	args = append(args, uuid.String())
 
 	c := exec.Cmd{
 		Path:   args[0],

--- a/stage0/stop.go
+++ b/stage0/stop.go
@@ -1,0 +1,59 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+package stage0
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/coreos/rkt/common"
+)
+
+func StopPod(dir string) error {
+	s1v, err := getStage1InterfaceVersion(dir)
+	if err != nil {
+		return fmt.Errorf("error determining stage1 interface version: %v", err)
+	}
+
+	if !interfaceVersionSupportsStop(s1v) {
+		return fmt.Errorf("stop entrypoint not supported by stage1")
+	}
+
+	s1rootfs := common.Stage1RootfsPath(dir)
+
+	if err := os.Chdir(dir); err != nil {
+		return fmt.Errorf("failed changing to dir: %v", err)
+	}
+
+	ep, err := getStage1Entrypoint(dir, stopEntrypoint)
+	if err != nil {
+		return fmt.Errorf("rkt stop not implemented for pod's stage1: %v", err)
+	}
+	args := []string{filepath.Join(s1rootfs, ep)}
+	debug("Execing %s", ep)
+
+	c := exec.Cmd{
+		Path:   args[0],
+		Args:   args,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	return c.Run()
+}

--- a/stage1/aci/aci-install.mk
+++ b/stage1/aci/aci-install.mk
@@ -63,6 +63,7 @@ endif
 AMI_SED_NAME := $(call sed-replacement-escape,$(AMI_NAME))
 AMI_SED_VERSION := $(call sed-replacement-escape,$(AMI_STAGE1_VERSION))
 AMI_SED_ENTER := $(call sed-replacement-escape,$(STAGE1_ENTER_CMD_$(AMI_FLAVOR)))
+AMI_SED_STOP := $(call sed-replacement-escape,$(STAGE1_STOP_CMD_$(AMI_FLAVOR)))
 
 # main stamp ensures everything is done
 $(call setup-stamp-file,AMI_STAMP,$(AMI_FLAVOR)-main)
@@ -86,7 +87,7 @@ $(call generate-stamp-rule,$(AMI_STAMP),$(AMI_INSTALLED_FILES) $(AMI_MANIFEST_KV
 
 # this rule generates a manifest
 $(call forward-vars,$(AMI_GEN_MANIFEST), \
-	AMI_FLAVOR AMI_SED_NAME AMI_SED_VERSION AMI_SED_ENTER)
+	AMI_FLAVOR AMI_SED_NAME AMI_SED_VERSION AMI_SED_ENTER AMI_SED_STOP)
 $(AMI_GEN_MANIFEST): $(AMI_SRC_MANIFEST) | $(AMI_TMPDIR)
 	$(VQ) \
 	set -e; \
@@ -95,6 +96,7 @@ $(AMI_GEN_MANIFEST): $(AMI_SRC_MANIFEST) | $(AMI_TMPDIR)
 		-e 's/@RKT_STAGE1_NAME@/$(AMI_SED_NAME)/g' \
 		-e 's/@RKT_STAGE1_VERSION@/$(AMI_SED_VERSION)/g' \
 		-e 's/@RKT_STAGE1_ENTER@/$(AMI_SED_ENTER)/g' \
+		-e 's/@RKT_STAGE1_STOP@/$(AMI_SED_STOP)/g' \
 	"$<" >"$@.tmp"; \
 	$(call bash-cond-rename,$@.tmp,$@)
 

--- a/stage1/aci/aci-manifest.in
+++ b/stage1/aci/aci-manifest.in
@@ -30,8 +30,12 @@
             "value": "/gc"
         },
         {
+            "name": "coreos.com/rkt/stage1/stop",
+            "value": "/stop"
+        },
+        {
             "name": "coreos.com/rkt/stage1/interface-version",
-            "value": "2"
+            "value": "3"
         }
     ]
 }

--- a/stage1/aci/aci-manifest.in
+++ b/stage1/aci/aci-manifest.in
@@ -31,7 +31,7 @@
         },
         {
             "name": "coreos.com/rkt/stage1/stop",
-            "value": "/stop"
+            "value": "@RKT_STAGE1_STOP@"
         },
         {
             "name": "coreos.com/rkt/stage1/interface-version",

--- a/stage1/secondary-stuff.mk
+++ b/stage1/secondary-stuff.mk
@@ -9,6 +9,7 @@ _S1_SS_SUBDIRS_ := \
 	init \
 	gc \
 	reaper \
+	stop \
 	units \
 	aci
 

--- a/stage1/secondary-stuff.mk
+++ b/stage1/secondary-stuff.mk
@@ -10,6 +10,7 @@ _S1_SS_SUBDIRS_ := \
 	gc \
 	reaper \
 	stop \
+	stop_kvm \
 	units \
 	aci
 

--- a/stage1/stage1.mk
+++ b/stage1/stage1.mk
@@ -53,6 +53,9 @@
 #
 # STAGE1_ENTER_CMD_$(flavor) - an enter command in stage1 to be used
 # for the "rkt enter" command.
+#
+# STAGE1_STOP_CMD_$(flavor) - an enter command in stage1 to be used
+# for the "rkt stop" command.
 
 STAGE1_FLAVORS := $(call commas-to-spaces,$(RKT_STAGE1_ALL_FLAVORS))
 STAGE1_BUILT_FLAVORS := $(call commas-to-spaces,$(RKT_STAGE1_FLAVORS))
@@ -71,7 +74,8 @@ $(foreach f,$(STAGE1_FLAVORS), \
 	$(eval STAGE1_INSTALL_SYMLINKS_$f :=) \
 	$(eval STAGE1_INSTALL_DIRS_$f :=) \
 	$(eval STAGE1_CREATE_DIRS_$f :=) \
-	$(eval STAGE1_ENTER_CMD_$f :=))
+	$(eval STAGE1_ENTER_CMD_$f :=) \
+	$(eval STAGE1_STOP_CMD_$f :=))
 
 # Main stamp that tells whether all the ACIs have been built.
 $(call setup-stamp-file,_STAGE1_BUILT_ACI_STAMP_,built_aci)

--- a/stage1/stop/stop.go
+++ b/stage1/stop/stop.go
@@ -1,0 +1,52 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"syscall"
+)
+
+func readIntFromFile(path string) (i int, err error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return
+	}
+	_, err = fmt.Sscanf(string(b), "%d", &i)
+	return
+}
+
+func stop() int {
+	pid, err := readIntFromFile("ppid")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error reading pid: %v\n", err)
+		return 1
+	}
+
+	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+		fmt.Fprintf(os.Stderr, "error sending SIGTERM: %v\n", err)
+		return 1
+	}
+
+	return 0
+}
+
+func main() {
+	os.Exit(stop())
+}

--- a/stage1/stop/stop.mk
+++ b/stage1/stop/stop.mk
@@ -1,0 +1,13 @@
+STP_FLAVORS := $(filter-out kvm,$(STAGE1_FLAVORS))
+
+ifneq ($(STP_FLAVORS),)
+
+ASSCB_FLAVORS := $(STP_FLAVORS)
+
+$(foreach f,$(ASSCB_FLAVORS),$(eval STAGE1_STOP_CMD_$f := /stop))
+
+include stage1/makelib/aci_simple_go_bin.mk
+
+endif
+
+$(call undefine-namespaces,STP)

--- a/stage1/stop/stop_fly.mk
+++ b/stage1/stop/stop_fly.mk
@@ -1,0 +1,1 @@
+include stage1_fly/makelib/aci_binary.mk

--- a/stage1/stop_kvm/stop_kvm.go
+++ b/stage1/stop_kvm/stop_kvm.go
@@ -1,0 +1,50 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+const lkvmBinPath string = "stage1/rootfs/lkvm"
+
+func stop() int {
+	pwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error getting current directory: %v", err)
+		return 1
+	}
+
+	podUUID := filepath.Base(pwd)
+	lkvmName := "rkt-" + podUUID
+
+	args := []string{lkvmBinPath, "stop", "-n", lkvmName}
+
+	if err := syscall.Exec(args[0], args, os.Environ()); err != nil {
+		fmt.Fprintf(os.Stderr, "error execing lkvm: %v", err)
+		return 1
+	}
+
+	return 0
+}
+
+func main() {
+	os.Exit(stop())
+}

--- a/stage1/stop_kvm/stop_kvm.mk
+++ b/stage1/stop_kvm/stop_kvm.mk
@@ -1,0 +1,13 @@
+STK_FLAVORS := $(filter kvm,$(STAGE1_FLAVORS))
+
+ifneq ($(STK_FLAVORS),)
+
+ASGB_FLAVORS := $(STK_FLAVORS)
+
+$(foreach f,$(ASGB_FLAVORS),$(eval STAGE1_STOP_CMD_$f := /stop_kvm))
+
+include stage1/makelib/aci_simple_go_bin.mk
+
+endif
+
+$(undefine-namespaces,STK)

--- a/stage1_fly/aci/aci-manifest.in
+++ b/stage1_fly/aci/aci-manifest.in
@@ -28,6 +28,14 @@
         {
             "name": "coreos.com/rkt/stage1/gc",
             "value": "/gc"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/stop",
+            "value": "/stop_fly"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/interface-version",
+            "value": "3"
         }
     ]
 }

--- a/stage1_fly/stage1_fly.mk
+++ b/stage1_fly/stage1_fly.mk
@@ -9,6 +9,8 @@ $(call setup-stamp-file,FLY_STAMP,aci-build)
 
 $(call inc-many,$(foreach sd,$(FLY_SUBDIRS),$(sd)/$(sd).mk))
 
+$(call inc-one,../stage1/stop/stop_fly.mk)
+
 $(call generate-stamp-rule,$(FLY_STAMP),$(FLY_STAMPS) $(ACTOOL_STAMP),, \
 	$(call vb,vt,ACTOOL,$(call vsp,$(FLY_STAGE1))) \
 	"$(ACTOOL)" build --overwrite --owner-root "$(FLY_ACIDIR)" "$(FLY_STAGE1)")

--- a/tests/rkt_list_test.go
+++ b/tests/rkt_list_test.go
@@ -55,9 +55,6 @@ func TestRktList(t *testing.T) {
 	// Get hash
 	imageID := fmt.Sprintf("sha512-%s", imgID.hash[:12])
 
-	tmpDir := createTempDirOrPanic(imgName)
-	defer os.RemoveAll(tmpDir)
-
 	// Define tests
 	tests := []struct {
 		cmd           string

--- a/tests/rkt_stop_test.go
+++ b/tests/rkt_stop_test.go
@@ -1,0 +1,86 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+func TestRktStop(t *testing.T) {
+	const imgName = "rkt-stop-test"
+
+	image := patchTestACI(fmt.Sprintf("%s.aci", imgName), fmt.Sprintf("--name=%s", imgName), "--exec=/inspect --read-stdin")
+	defer os.Remove(image)
+
+	imageHash := getHashOrPanic(image)
+	imgID := ImageID{image, imageHash}
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	// Define tests
+	tests := []struct {
+		cmd        string
+		expectKill bool
+	}{
+		// Test regular stop
+		{
+			"stop",
+			false,
+		},
+		// Test forced stop
+		{
+			"stop --force",
+			true,
+		},
+	}
+
+	// Run tests
+	for i, tt := range tests {
+		// Prepare image
+		cmd := fmt.Sprintf("%s --insecure-options=image prepare %s", ctx.Cmd(), imgID.path)
+		podUUID := runRktAndGetUUID(t, cmd)
+
+		// Run image
+		cmd = fmt.Sprintf("%s --insecure-options=image run-prepared --interactive %s", ctx.Cmd(), podUUID)
+		child := spawnOrFail(t, cmd)
+
+		// Sleep to make sure the pod is started
+		time.Sleep(1 * time.Second)
+
+		runCmd := fmt.Sprintf("%s %s %s", ctx.Cmd(), tt.cmd, podUUID)
+		t.Logf("Running test #%d, %s", i, runCmd)
+		runRktAndCheckRegexOutput(t, runCmd, fmt.Sprintf("^%q", podUUID))
+
+		// Sleep to make sure the pod is stopped
+		time.Sleep(1 * time.Second)
+
+		podInfo := getPodInfo(t, ctx, podUUID)
+		if podInfo.state != "exited" {
+			t.Fatalf("Expected pod %q to be exited, but it is %q", podUUID, podInfo.state)
+		}
+
+		if tt.expectKill {
+			child.Wait()
+		} else {
+			waitOrFail(t, child, 0)
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces a new `stop` entrypoint that deals with shutting down the pod.

* For the nspawn and fly, It sends SIGTERM to the top-level stage1 process.
* For the lkvm flavor, it execs lkvm stop.

Fixes partially #1417
Closes #1496

-----
- [x] tests