### PR TITLE
rkt: add --full flag to fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Explicitly allow http connections via a new 'http' option to `--insecure-options` ([#1945](https://github.com/coreos/rkt/pull/1945)). Any data and credentials will be sent in the clear.
 - When using `bash`, `rkt` commands can be auto-completed ([#1955](https://github.com/coreos/rkt/pull/1955)).
 - The executables given on the command line via the `--exec` parameters don't need to be absolute paths anymore ([#1953](https://github.com/coreos/rkt/pull/1953)). This change reflects an update in the appc spec since [v0.7.2](https://github.com/appc/spec/releases/tag/v0.7.2). See rkt's [rkt run --exec](https://github.com/coreos/rkt/blob/master/Documentation/subcommands/run.md#overriding-executable-to-launch) documentation.
+- Add a `--full` flag to rkt fetch so it returns full hash of the image. ([#1976](https://github.com/coreos/rkt/pull/1976))
 
 #### Build improvements
 

--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -36,6 +36,7 @@ var (
 		Short: "Fetch image(s) and store them in the local store",
 		Run:   runWrapper(runFetch),
 	}
+	flagFullHash bool
 )
 
 func init() {
@@ -48,6 +49,7 @@ func init() {
 	cmdFetch.Flags().Var((*appAsc)(&rktApps), "signature", "local signature file to use in validating the preceding image")
 	cmdFetch.Flags().BoolVar(&flagStoreOnly, "store-only", false, "use only available images in the store (do not discover or download from remote URLs)")
 	cmdFetch.Flags().BoolVar(&flagNoStore, "no-store", false, "fetch images ignoring the local store")
+	cmdFetch.Flags().BoolVar(&flagFullHash, "full", false, "print the full image hash after fetching")
 }
 
 func runFetch(cmd *cobra.Command, args []string) (exit int) {
@@ -96,8 +98,10 @@ func runFetch(cmd *cobra.Command, args []string) (exit int) {
 		if err != nil {
 			return err
 		}
-		shortHash := types.ShortHash(hash)
-		stdout(shortHash)
+		if !flagFullHash {
+			hash = types.ShortHash(hash)
+		}
+		stdout(hash)
 		return nil
 	})
 	if err != nil {

--- a/tests/rkt_image_cat_manifest_test.go
+++ b/tests/rkt_image_cat_manifest_test.go
@@ -53,7 +53,7 @@ func TestImageCatManifest(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	testImageHash := importImageAndFetchHash(t, ctx, testImage)
+	testImageHash := importImageAndFetchHash(t, ctx, "", testImage)
 
 	tests := []struct {
 		image      string

--- a/tests/rkt_image_dependencies_test.go
+++ b/tests/rkt_image_dependencies_test.go
@@ -78,7 +78,7 @@ func TestImageDependencies(t *testing.T) {
 	defer server.Close()
 
 	baseImage := getInspectImagePath()
-	_ = importImageAndFetchHash(t, ctx, baseImage)
+	_ = importImageAndFetchHash(t, ctx, "", baseImage)
 	emptyImage := getEmptyImagePath()
 	fileSet := make(map[string]string)
 
@@ -171,7 +171,7 @@ func TestImageDependencies(t *testing.T) {
 		img := imageList[i]
 		if img.prefetch {
 			t.Logf("Importing image %q: %q", img.imageName, img.fileName)
-			testImageShortHash := importImageAndFetchHash(t, ctx, img.fileName)
+			testImageShortHash := importImageAndFetchHash(t, ctx, "", img.fileName)
 			t.Logf("Imported image %q: %s", img.imageName, testImageShortHash)
 		}
 	}

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -55,7 +55,7 @@ func TestImageExport(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	testImageID := importImageAndFetchHash(t, ctx, testImage)
+	testImageID := importImageAndFetchHash(t, ctx, "", testImage)
 
 	testImageHash, err := getHash(testImage)
 	if err != nil {

--- a/tests/rkt_image_extract_test.go
+++ b/tests/rkt_image_extract_test.go
@@ -39,7 +39,7 @@ func TestImageExtract(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	testImageShortHash := importImageAndFetchHash(t, ctx, testImage)
+	testImageShortHash := importImageAndFetchHash(t, ctx, "", testImage)
 
 	tests := []struct {
 		image        string

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -61,8 +61,8 @@ func TestImageRender(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	_ = importImageAndFetchHash(t, ctx, baseImage)
-	testImageShortHash := importImageAndFetchHash(t, ctx, testImage)
+	_ = importImageAndFetchHash(t, ctx, "", baseImage)
+	testImageShortHash := importImageAndFetchHash(t, ctx, "", testImage)
 
 	tests := []struct {
 		image        string

--- a/tests/rkt_non_root_test.go
+++ b/tests/rkt_non_root_test.go
@@ -104,7 +104,7 @@ func TestNonRootFetchRmGCImage(t *testing.T) {
 
 	rootImg := patchTestACI("rkt-inspect-root-rm.aci", "--exec=/inspect --print-msg=foobar")
 	defer os.Remove(rootImg)
-	rootImgHash := importImageAndFetchHash(t, ctx, rootImg)
+	rootImgHash := importImageAndFetchHash(t, ctx, "", rootImg)
 
 	// Launch/gc a pod so we can test non-root image gc.
 	runCmd := fmt.Sprintf("%s --insecure-options=image run --mds-register=false %s", ctx.Cmd(), rootImg)
@@ -125,7 +125,7 @@ func TestNonRootFetchRmGCImage(t *testing.T) {
 	// Should be able to remove the image fetched by ourselves.
 	nonrootImg := patchTestACI("rkt-inspect-non-root-rm.aci", "--exec=/inspect")
 	defer os.Remove(nonrootImg)
-	nonrootImgHash := importImageAndFetchHashAsGid(t, ctx, nonrootImg, gid)
+	nonrootImgHash := importImageAndFetchHashAsGid(t, ctx, nonrootImg, "", gid)
 
 	imgRmCmd = fmt.Sprintf("%s image rm %s", ctx.Cmd(), nonrootImgHash)
 	t.Logf("Running %s", imgRmCmd)

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -161,7 +161,7 @@ func TestMissingOrInvalidOSArchFetchRun(t *testing.T) {
 	defer osArchTestRemoveImages(tests)
 
 	for i, tt := range tests {
-		imgHash := importImageAndFetchHash(t, ctx, tt.image)
+		imgHash := importImageAndFetchHash(t, ctx, "", tt.image)
 		rktCmd := fmt.Sprintf("%s run --mds-register=false %s", ctx.Cmd(), imgHash)
 		t.Logf("Running test #%v: %v", i, rktCmd)
 		runRktAndCheckOutput(t, rktCmd, tt.expectedLine, tt.expectError)


### PR DESCRIPTION
It prints the full image hash instead of a truncated one.

Fixes #1967