### PR TITLE
godeps: Bump coreos/gexpect

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -145,7 +145,7 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/gexpect",
-			"Rev": "5173270e159f5aa8fbc999dc7e3dcb50f4098a69"
+			"Rev": "0b5620b695de57d5fcea082b9a062157ac60ed73"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-iptables/iptables",

--- a/Godeps/_workspace/src/github.com/coreos/gexpect/README.md
+++ b/Godeps/_workspace/src/github.com/coreos/gexpect/README.md
@@ -35,9 +35,9 @@ It makes it simpler to create and control other terminal applications.
 `AsyncInteractChannels` spawns two go routines to pipe into and from `stdout`/`stdin`, allowing for some usecases to be a little simpler.
 
 	child := gexpect.spawn("sh")
-	sender, reciever := child.AsyncInteractChannels()
+	sender, receiver := child.AsyncInteractChannels()
 	sender <- "echo Hello World\n" // Send to stdin
-	line, open := <- reciever // Recieve a line from stdout/stderr
+	line, open := <- receiver // Recieve a line from stdout/stderr
 	// When the subprocess stops (e.g. with child.Close()) , receiver is closed
 	if open {
 		fmt.Printf("Received %s", line)]

--- a/Godeps/_workspace/src/github.com/coreos/gexpect/gexpect.go
+++ b/Godeps/_workspace/src/github.com/coreos/gexpect/gexpect.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package gexpect
 
 import (
@@ -13,6 +15,10 @@ import (
 
 	shell "github.com/coreos/rkt/Godeps/_workspace/src/github.com/kballard/go-shellquote"
 	"github.com/coreos/rkt/Godeps/_workspace/src/github.com/kr/pty"
+)
+
+var (
+	ErrEmptySearch = errors.New("empty search string")
 )
 
 type ExpectSubprocess struct {
@@ -141,7 +147,13 @@ func Spawn(command string) (*ExpectSubprocess, error) {
 }
 
 func (expect *ExpectSubprocess) Close() error {
-	return expect.Cmd.Process.Kill()
+	if err := expect.Cmd.Process.Kill(); err != nil {
+		return err
+	}
+	if err := expect.buf.f.Close(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (expect *ExpectSubprocess) AsyncInteractChannels() (send chan string, receive chan string) {
@@ -202,6 +214,15 @@ func (expect *ExpectSubprocess) expectRegexFind(regex string, output bool) ([]st
 
 	if len(result) == 0 {
 		err = fmt.Errorf("ExpectRegex didn't find regex '%v'.", regex)
+	} else {
+		// The number in pairs[1] is an index of a first
+		// character outside the whole match
+		putBackIdx := pairs[1]
+		if len(stringIndexedInto) > putBackIdx {
+			stringToPutBack := stringIndexedInto[putBackIdx:]
+			stringIndexedInto = stringIndexedInto[:putBackIdx]
+			expect.buf.PutBack([]byte(stringToPutBack))
+		}
 	}
 	return result, stringIndexedInto, err
 }
@@ -282,8 +303,11 @@ func (expect *ExpectSubprocess) ExpectTimeout(searchString string, timeout time.
 }
 
 func (expect *ExpectSubprocess) Expect(searchString string) (e error) {
-	chunk := make([]byte, len(searchString)*2)
 	target := len(searchString)
+	if target < 1 {
+		return ErrEmptySearch
+	}
+	chunk := make([]byte, target*2)
 	if expect.outputBuffer != nil {
 		expect.outputBuffer = expect.outputBuffer[0:]
 	}
@@ -294,7 +318,6 @@ func (expect *ExpectSubprocess) Expect(searchString string) (e error) {
 
 	for {
 		n, err := expect.buf.Read(chunk)
-
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
It includes fixes for regexp expects, which will be used later in functional tests (in #1977).