### PR TITLE
api: Add 'full_names' in the image filter to filter images with names.

### DIFF
--- a/api/v1alpha/api.pb.go
+++ b/api/v1alpha/api.pb.go
@@ -428,6 +428,8 @@ type ImageFilter struct {
 	ImportedBefore int64 `protobuf:"varint,7,opt,name=imported_before" json:"imported_before,omitempty"`
 	// If not empty, the images that have all of the annotations will be returned.
 	Annotations []*KeyValue `protobuf:"bytes,8,rep,name=annotations" json:"annotations,omitempty"`
+	// If not empty, the images that have any of the exact full names will be returned.
+	FullNames []string `protobuf:"bytes,9,rep,name=full_names" json:"full_names,omitempty"`
 }
 
 func (m *ImageFilter) Reset()                    { *m = ImageFilter{} }

--- a/api/v1alpha/api.proto
+++ b/api/v1alpha/api.proto
@@ -234,6 +234,9 @@ message ImageFilter {
 
         // If not empty, the images that have all of the annotations will be returned.
         repeated KeyValue annotations = 8;
+
+        // If not empty, the images that have any of the exact full names will be returned.
+        repeated string full_names = 9;
 }
 
 // Info describes the information of rkt on the machine.

--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -514,6 +514,14 @@ func satisfiesImageFilter(image v1alpha.Image, manifest schema.ImageManifest, fi
 		}
 	}
 
+	// Filter according to the image full names.
+	if len(filter.FullNames) > 0 {
+		s := set.NewString(filter.FullNames...)
+		if !s.Has(image.Name) {
+			return false
+		}
+	}
+
 	// Filter according to the image name prefixes.
 	if len(filter.Prefixes) > 0 {
 		s := set.NewString(filter.Prefixes...)

--- a/rkt/api_service_test.go
+++ b/rkt/api_service_test.go
@@ -518,6 +518,24 @@ func TestFilterImage(t *testing.T) {
 			},
 			false,
 		},
+		// Match one of the full names.
+		{
+			&v1alpha.Image{Name: "foo/basename-foo"},
+			&schema.ImageManifest{},
+			&v1alpha.ImageFilter{
+				FullNames: []string{"foo/basename-foo", "foo/basename-bar"},
+			},
+			true,
+		},
+		// Doesn't match any full names.
+		{
+			&v1alpha.Image{Name: "foo/basename-foo"},
+			&schema.ImageManifest{},
+			&v1alpha.ImageFilter{
+				FullNames: []string{"bar/basename-foo", "foo/basename-bar"},
+			},
+			false,
+		},
 		// Doesn't satisfy any filter conditions.
 		{
 			&v1alpha.Image{


### PR DESCRIPTION
Fix https://github.com/coreos/rkt/issues/1939

First two commits if from https://github.com/coreos/rkt/pull/1983

cc @jonboulle @derekparker 