### PR TITLE
rkt/image: clean asc object before every fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Fix vagrant rkt build ([#1960](https://github.com/coreos/rkt/pull/1960)).
 
+#### Bug fixes
+
+- Fix bug where the wrong image signature was checked when using dependencies ([#1991](https://github.com/coreos/rkt/pull/1991)).
+
 #### Test improvements
 
 - A new script to run test on AWS makes it easier to test under several distributions: CentOS, Debian, Fedora, Ubuntu ([#1925](https://github.com/coreos/rkt/pull/1925)).

--- a/rkt/image/fetcher.go
+++ b/rkt/image/fetcher.go
@@ -66,8 +66,8 @@ func (f *Fetcher) fetchImageDeps(hash string) error {
 	imgsl := list.New()
 	seen := map[string]struct{}{}
 	f.addImageDeps(hash, imgsl, seen)
-	a := &asc{}
 	for el := imgsl.Front(); el != nil; el = el.Next() {
+		a := &asc{}
 		img := el.Value.(string)
 		hash, err := f.fetchSingleImage(img, a, apps.AppImageName)
 		if err != nil {


### PR DESCRIPTION
If we don't do this, we could use the asc object from a previous image,
resulting on the incorrect signature being fetched.

Fixes https://github.com/coreos/rkt/issues/1982

cc @krnowak 