### PR TITLE
AWS tests: update to the latest Fedora AMI

### DIFF
--- a/tests/aws.sh
+++ b/tests/aws.sh
@@ -26,12 +26,22 @@ GIT_BRANCH=${3-master}
 test -f cloudinit/${DISTRO}.cloudinit
 CLOUDINIT_IN=$PWD/cloudinit/${DISTRO}.cloudinit
 
-if [ "$DISTRO" = "fedora" ] ; then
+if [ "$DISTRO" = "fedora-22" ] ; then
   # https://getfedora.org/en/cloud/download/
-  # Search Fedora-Cloud-Base-23-20160106.x86_64-eu-central-1-HVM-standard-0 on AWS
-  # Or look at https://apps.fedoraproject.org/datagrepper/raw?category=fedimg
+  # Search on AWS or look at
+  # https://apps.fedoraproject.org/datagrepper/raw?category=fedimg
   # Sources: https://github.com/fedora-infra/fedimg/blob/develop/bin/list-the-amis.py
-  AMI=ami-d76a74bb
+
+  # Fedora-Cloud-Base-22-20151026.x86_64-eu-central-1-HVM-standard-0
+  AMI=ami-844a4599
+  AWS_USER=fedora
+elif [ "$DISTRO" = "fedora-23" ] ; then
+  # Fedora-Cloud-Base-23-20160116.x86_64-eu-central-1-HVM-standard-0
+  AMI=ami-c2445dae
+  AWS_USER=fedora
+elif [ "$DISTRO" = "fedora-rawhide" ] ; then
+  # Fedora-Cloud-Base-rawhide-20160119.x86_64-eu-central-1-HVM-standard-0
+  AMI=ami-8e150ce2
   AWS_USER=fedora
 elif [ "$DISTRO" = "ubuntu" ] ; then
   # https://cloud-images.ubuntu.com/locator/ec2/

--- a/tests/cloudinit/fedora-22.cloudinit
+++ b/tests/cloudinit/fedora-22.cloudinit
@@ -1,0 +1,1 @@
+fedora.cloudinit

--- a/tests/cloudinit/fedora-23.cloudinit
+++ b/tests/cloudinit/fedora-23.cloudinit
@@ -1,0 +1,1 @@
+fedora.cloudinit

--- a/tests/cloudinit/fedora-rawhide.cloudinit
+++ b/tests/cloudinit/fedora-rawhide.cloudinit
@@ -1,0 +1,1 @@
+fedora.cloudinit

--- a/tests/cloudinit/fedora.cloudinit
+++ b/tests/cloudinit/fedora.cloudinit
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Workarounds on Fedora
+/usr/sbin/setenforce 0
+
 cat > /var/tmp/rkt-test.sh <<TESTEOF
 #!/bin/bash
 
@@ -14,10 +18,7 @@ gpasswd -a fedora rkt
 dnf -y -v update
 dnf -y -v groupinstall "Development Tools"
 dnf -y -v groupinstall "C Development Tools and Libraries"
-dnf -y -v install wget squashfs-tools patch glibc-static gnupg golang libacl-devel
-
-# Workarounds on Fedora
-/usr/sbin/setenforce 0
+dnf -y -v install wget squashfs-tools patch glibc-static gnupg golang libacl-devel file
 
 # unsquashfs is in /usr/sbin
 export PATH=/usr/lib64/ccache:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/fedora/.local/bin:/home/fedora/bin

--- a/tests/test-on-several-distro.md
+++ b/tests/test-on-several-distro.md
@@ -24,7 +24,9 @@ Then run the tests with the specified Linux distribution:
 ```
 $ tests/aws.sh debian
 $ tests/aws.sh ubuntu
-$ tests/aws.sh fedora
+$ tests/aws.sh fedora-22
+$ tests/aws.sh fedora-23
+$ tests/aws.sh fedora-rawhide
 $ tests/aws.sh centos
 ```
 


### PR DESCRIPTION
The test can now run on Fedora-23, Fedora-22 and Fedora-rawhide.