### PR TITLE
configure: print full go version and check against CVE-2015-8618

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: go
 
 go:
   - 1.4.2
-  - 1.5.2
+  - 1.5.3
 
 before_install:
  - sudo apt-get update -qq

--- a/configure.ac
+++ b/configure.ac
@@ -488,9 +488,11 @@ dnl Detect go version. Go 1.4 support only "-X variable 'value'"
 dnl format of assigning values to variables via linker flags. Go 1.5
 dnl deprecates this format in favor of "-X 'variable=value'"
 dnl format. Drop this ugliness when we drop support for Go 1.4.
-GO_VERSION=`"${ABS_GO}" version | sed -e 's/^go version go\(DIGITS*\.DIGITS*\).*/\1/'`
+GO_VERSION=`"${ABS_GO}" version | sed -e 's/^go version go\(DIGITS*\.DIGITS*\.DIGITS*\).*/\1/'`
 GO_MAJOR=`echo "${GO_VERSION}" | grep -o '^DIGITS\+'`
-GO_MINOR=`echo "${GO_VERSION}" | grep -o 'DIGITS\+$'`
+GO_MINOR=`echo "${GO_VERSION}" | grep -o '^DIGITS\+\.DIGITS\+' | grep -o 'DIGITS\+$'`
+GO_MAJOR_MINOR=`echo "${GO_MAJOR}.${GO_MINOR}"`
+GO_MICRO=`echo "${GO_VERSION}" | grep -o 'DIGITS\+$'`
 
 GO_BEST_MAJOR=1
 GO_BEST_MINOR=5
@@ -503,12 +505,18 @@ AS_IF([test "${GO_MAJOR}" -gt "${GO_BEST_MAJOR}" || test "${GO_MAJOR}" -eq "${GO
        }],
       [AC_MSG_RESULT([no])
        AC_MSG_CHECKING([whether we have go 1.4])
-       AS_VAR_IF([GO_VERSION],[1.4],
+       AS_VAR_IF([GO_MAJOR_MINOR],[1.4],
                  [AC_MSG_RESULT([yes])
                   RKT_XF() {
                       echo "-X $1 '$2'"
                   }],
                  [AC_MSG_ERROR([*** go is too old (${GO_VERSION})])])])
+
+AC_MSG_CHECKING([whether we have a go version without CVE-2015-8618])
+AS_IF([test "${GO_MAJOR}" -eq "1" -a "${GO_MINOR}" -eq "5" -a "${GO_MICRO}" -lt "3"],
+      [AC_MSG_RESULT([no])
+       AC_MSG_ERROR([*** go version is vulnerable to CVE-2015-8618 (${GO_VERSION})])],
+      [AC_MSG_RESULT([yes])])
 
 RKT_STAGE1_DEFAULT_NAME_LDFLAGS=`RKT_XF main.defaultStage1Name "${RKT_STAGE1_DEFAULT_NAME}"`
 RKT_STAGE1_DEFAULT_VERSION_LDFLAGS=`RKT_XF main.defaultStage1Version "${RKT_STAGE1_DEFAULT_VERSION}"`


### PR DESCRIPTION
./configure already prints the go version, but unfortunately only the
major.minor numbers without the micro:
>        go version:                             '1.5'

This patch prints the full version instead:
>        go version:                             '1.5.3'

Additionally, it checks that the go version is not 1.5.0, 1.5.1 or 1.5.2
to be absolutely sure it is not vulnerable to CVE-2015-8618.