### PR TITLE
kvm: Enable functional tests for kvm

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -36,7 +36,7 @@ sudo gpasswd -a runner rkt
 
 ```
 ./tests/build-and-run-tests.sh -f none -c
-./tests/build-and-run-tests.sh -f src -s v229 -c
+./tests/build-and-run-tests.sh -f kvm -c
 ```
 
 #### Thread 2
@@ -60,7 +60,7 @@ It would be possible to add more tests with the following commands:
 ```
 ./tests/build-and-run-tests.sh -f src -s v227 -c
 ./tests/build-and-run-tests.sh -f src -s master -c
-./tests/build-and-run-tests.sh -f kvm -c
+./tests/build-and-run-tests.sh -f src -s v229 -c
 ```
 
 #### build-and-run-tests.sh parameters description

--- a/tests/build-and-run-tests.sh
+++ b/tests/build-and-run-tests.sh
@@ -11,7 +11,7 @@ function cleanup {
                 sudo umount "${mp}"
             done
 
-            for link in $(ip link | grep rkt | cut -d':' -f2); do
+            for link in $(ip link | grep rkt | cut -d':' -f2 | cut -d'@' -f1); do
                 sudo ip link del "${link}"
             done
             sudo rm -rf /var/lib/cni/networks/*

--- a/tests/rkt_api_service_bench_test.go
+++ b/tests/rkt_api_service_bench_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_api_service_nspawn_test.go
+++ b/tests/rkt_api_service_nspawn_test.go
@@ -12,28 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build coreos src
 
 package main
 
-import (
-	"fmt"
-	"os"
-	"testing"
+import "testing"
 
-	"github.com/coreos/rkt/tests/testutils"
-)
+func TestAPIServiceListInspectPods(t *testing.T) {
+	NewAPIServiceListInspectPodsTest().Execute(t)
+}
 
-func TestRktEnsureErrors(t *testing.T) {
-	const imgName = "rkt-ensure-errors-test"
-
-	image := patchTestACI(fmt.Sprintf("%s.aci", imgName), fmt.Sprintf("--name=%s", imgName))
-	defer os.Remove(image)
-
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
-
-	runCmd := fmt.Sprintf("%s run --insecure-options=image --net=notavalidnetwork %s", ctx.Cmd(), image)
-	t.Logf("Running test: %s", runCmd)
-	runRktAndCheckRegexOutput(t, runCmd, "stage1: failed to setup network")
+func TestAPIServiceCgroup(t *testing.T) {
+	NewAPIServiceCgroupTest().Execute(t)
 }

--- a/tests/rkt_app_isolator_nspawn_test.go
+++ b/tests/rkt_app_isolator_nspawn_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build coreos src
 
 package main
 
@@ -24,16 +24,16 @@ import (
 	"github.com/coreos/rkt/tests/testutils"
 )
 
-func TestRktEnsureErrors(t *testing.T) {
-	const imgName = "rkt-ensure-errors-test"
-
-	image := patchTestACI(fmt.Sprintf("%s.aci", imgName), fmt.Sprintf("--name=%s", imgName))
-	defer os.Remove(image)
-
+func TestCgroups(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	runCmd := fmt.Sprintf("%s run --insecure-options=image --net=notavalidnetwork %s", ctx.Cmd(), image)
-	t.Logf("Running test: %s", runCmd)
-	runRktAndCheckRegexOutput(t, runCmd, "stage1: failed to setup network")
+	t.Logf("Running test: %v", cgroupsTest.testName)
+
+	aciFileName := patchTestACI("rkt-inspect-isolators.aci", cgroupsTest.aciBuildArgs...)
+	defer os.Remove(aciFileName)
+
+	rktCmd := fmt.Sprintf("%s --insecure-options=image run --mds-register=false %s", ctx.Cmd(), aciFileName)
+	expectedLine := "check-cgroups: SUCCESS"
+	runRktAndCheckOutput(t, rktCmd, expectedLine, false)
 }

--- a/tests/rkt_app_isolator_test.go
+++ b/tests/rkt_app_isolator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 
@@ -100,19 +100,5 @@ func TestAppIsolatorCPU(t *testing.T) {
 
 	rktCmd = fmt.Sprintf("%s --insecure-options=image run --mds-register=false %s --cpu 900m", ctx.Cmd(), aciFileName)
 	expectedLine = "CPU Quota: " + strconv.Itoa(900)
-	runRktAndCheckOutput(t, rktCmd, expectedLine, false)
-}
-
-func TestCgroups(t *testing.T) {
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
-
-	t.Logf("Running test: %v", cgroupsTest.testName)
-
-	aciFileName := patchTestACI("rkt-inspect-isolators.aci", cgroupsTest.aciBuildArgs...)
-	defer os.Remove(aciFileName)
-
-	rktCmd := fmt.Sprintf("%s --insecure-options=image run --mds-register=false %s", ctx.Cmd(), aciFileName)
-	expectedLine := "check-cgroups: SUCCESS"
 	runRktAndCheckOutput(t, rktCmd, expectedLine, false)
 }

--- a/tests/rkt_auth_test.go
+++ b/tests/rkt_auth_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_caps_kvm_test.go
+++ b/tests/rkt_caps_kvm_test.go
@@ -12,28 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build kvm
 
 package main
 
-import (
-	"fmt"
-	"os"
-	"testing"
+import "testing"
 
-	"github.com/coreos/rkt/tests/testutils"
-)
-
-func TestRktEnsureErrors(t *testing.T) {
-	const imgName = "rkt-ensure-errors-test"
-
-	image := patchTestACI(fmt.Sprintf("%s.aci", imgName), fmt.Sprintf("--name=%s", imgName))
-	defer os.Remove(image)
-
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
-
-	runCmd := fmt.Sprintf("%s run --insecure-options=image --net=notavalidnetwork %s", ctx.Cmd(), image)
-	t.Logf("Running test: %s", runCmd)
-	runRktAndCheckRegexOutput(t, runCmd, "stage1: failed to setup network")
+func TestCaps(t *testing.T) {
+	// KVM is running VMs as stage1 pods, so root has access to all VM options.
+	// The case with access to PID 1 is skipped...
+	// KVM flavor runs systemd stage1 with full capabilities in stage1 (pid=1)
+	// so expect every capability enabled
+	NewCapsTest(true, []int{2}).Execute(t)
 }

--- a/tests/rkt_caps_nspawn_test.go
+++ b/tests/rkt_caps_nspawn_test.go
@@ -12,28 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build coreos src
 
 package main
 
-import (
-	"fmt"
-	"os"
-	"testing"
+import "testing"
 
-	"github.com/coreos/rkt/tests/testutils"
-)
-
-func TestRktEnsureErrors(t *testing.T) {
-	const imgName = "rkt-ensure-errors-test"
-
-	image := patchTestACI(fmt.Sprintf("%s.aci", imgName), fmt.Sprintf("--name=%s", imgName))
-	defer os.Remove(image)
-
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
-
-	runCmd := fmt.Sprintf("%s run --insecure-options=image --net=notavalidnetwork %s", ctx.Cmd(), image)
-	t.Logf("Running test: %s", runCmd)
-	runRktAndCheckRegexOutput(t, runCmd, "stage1: failed to setup network")
+func TestCaps(t *testing.T) {
+	NewCapsTest(false, []int{1, 2}).Execute(t)
 }

--- a/tests/rkt_cat_manifest_test.go
+++ b/tests/rkt_cat_manifest_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_env_test.go
+++ b/tests/rkt_env_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_gc_test.go
+++ b/tests/rkt_gc_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_hostname_test.go
+++ b/tests/rkt_hostname_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_image_cat_manifest_test.go
+++ b/tests/rkt_image_cat_manifest_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_image_dependencies_test.go
+++ b/tests/rkt_image_dependencies_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_image_extract_test.go
+++ b/tests/rkt_image_extract_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_image_gc_test.go
+++ b/tests/rkt_image_gc_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_image_list_test.go
+++ b/tests/rkt_image_list_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_image_rm_test.go
+++ b/tests/rkt_image_rm_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_interactive_test.go
+++ b/tests/rkt_interactive_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_list_test.go
+++ b/tests/rkt_list_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_metadata_service_test.go
+++ b/tests/rkt_metadata_service_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_net_kvm_test.go
+++ b/tests/rkt_net_kvm_test.go
@@ -12,28 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build kvm
 
 package main
 
-import (
-	"fmt"
-	"os"
-	"testing"
+import "testing"
 
-	"github.com/coreos/rkt/tests/testutils"
-)
+func TestNetDefaultPortFwdConnectivity(t *testing.T) {
+	NewNetDefaultPortFwdConnectivityTest(
+		PortFwdCase{"172.16.28.1", "--net=default", true},
+	).Execute(t)
+}
 
-func TestRktEnsureErrors(t *testing.T) {
-	const imgName = "rkt-ensure-errors-test"
-
-	image := patchTestACI(fmt.Sprintf("%s.aci", imgName), fmt.Sprintf("--name=%s", imgName))
-	defer os.Remove(image)
-
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
-
-	runCmd := fmt.Sprintf("%s run --insecure-options=image --net=notavalidnetwork %s", ctx.Cmd(), image)
-	t.Logf("Running test: %s", runCmd)
-	runRktAndCheckRegexOutput(t, runCmd, "stage1: failed to setup network")
+func TestNetCustomPtp(t *testing.T) {
+	// PTP means connection Point-To-Point. That is, connections to other pods/containers should be forbidden
+	NewNetCustomPtpTest(false)
 }

--- a/tests/rkt_net_nspawn_test.go
+++ b/tests/rkt_net_nspawn_test.go
@@ -1,0 +1,59 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build coreos src
+
+package main
+
+import "testing"
+
+func TestNetHost(t *testing.T) {
+	NewNetHostTest().Execute(t)
+}
+
+func TestNetHostConnectivity(t *testing.T) {
+	NewNetHostConnectivityTest().Execute(t)
+}
+
+func TestNetDefaultPortFwdConnectivity(t *testing.T) {
+	NewNetDefaultPortFwdConnectivityTest(
+		PortFwdCase{"172.16.28.1", "--net=default", true},
+		PortFwdCase{"127.0.0.1", "--net=default", true},
+	).Execute(t)
+}
+
+func TestNetNone(t *testing.T) {
+	NewNetNoneTest().Execute(t)
+}
+
+func TestNetCustomMacvlan(t *testing.T) {
+	NewNetCustomMacvlanTest().Execute(t)
+}
+
+func TestNetCustomBridge(t *testing.T) {
+	NewNetCustomBridgeTest().Execute(t)
+}
+
+func TestNetOverride(t *testing.T) {
+	NewNetOverrideTest().Execute(t)
+}
+
+func TestNetCustomPtp(t *testing.T) {
+	// PTP means connection Point-To-Point. That is, connections to other pods/containers should be forbidden
+	NewNetCustomPtpTest(true).Execute(t)
+}
+
+func TestNetDefaultConnectivity(t *testing.T) {
+	NewNetDefaultConnectivityTest().Execute(t)
+}

--- a/tests/rkt_net_test.go
+++ b/tests/rkt_net_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 
@@ -35,33 +35,35 @@ import (
  * ---
  * Container must have the same network namespace as the host
  */
-func TestNetHost(t *testing.T) {
-	testImageArgs := []string{"--exec=/inspect --print-netns"}
-	testImage := patchTestACI("rkt-inspect-networking.aci", testImageArgs...)
-	defer os.Remove(testImage)
+func NewNetHostTest() testutils.Test {
+	return testutils.TestFunc(func(t *testing.T) {
+		testImageArgs := []string{"--exec=/inspect --print-netns"}
+		testImage := patchTestACI("rkt-inspect-networking.aci", testImageArgs...)
+		defer os.Remove(testImage)
 
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
+		ctx := testutils.NewRktRunCtx()
+		defer ctx.Cleanup()
 
-	cmd := fmt.Sprintf("%s --net=host --debug --insecure-options=image run --mds-register=false %s", ctx.Cmd(), testImage)
-	child := spawnOrFail(t, cmd)
-	ctx.RegisterChild(child)
-	defer waitOrFail(t, child, 0)
+		cmd := fmt.Sprintf("%s --net=host --debug --insecure-options=image run --mds-register=false %s", ctx.Cmd(), testImage)
+		child := spawnOrFail(t, cmd)
+		ctx.RegisterChild(child)
+		defer waitOrFail(t, child, 0)
 
-	expectedRegex := `NetNS: (net:\[\d+\])`
-	result, out, err := expectRegexWithOutput(child, expectedRegex)
-	if err != nil {
-		t.Fatalf("Error: %v\nOutput: %v", err, out)
-	}
+		expectedRegex := `NetNS: (net:\[\d+\])`
+		result, out, err := expectRegexWithOutput(child, expectedRegex)
+		if err != nil {
+			t.Fatalf("Error: %v\nOutput: %v", err, out)
+		}
 
-	ns, err := os.Readlink("/proc/self/ns/net")
-	if err != nil {
-		t.Fatalf("Cannot evaluate NetNS symlink: %v", err)
-	}
+		ns, err := os.Readlink("/proc/self/ns/net")
+		if err != nil {
+			t.Fatalf("Cannot evaluate NetNS symlink: %v", err)
+		}
 
-	if nsChanged := ns != result[1]; nsChanged {
-		t.Fatalf("container left host netns")
-	}
+		if nsChanged := ns != result[1]; nsChanged {
+			t.Fatalf("container left host netns")
+		}
+	})
 }
 
 /*
@@ -70,52 +72,54 @@ func TestNetHost(t *testing.T) {
  * Container launches http server which must be reachable by the host via the
  * localhost address
  */
-func TestNetHostConnectivity(t *testing.T) {
-	logger.SetLogger(t)
+func NewNetHostConnectivityTest() testutils.Test {
+	return testutils.TestFunc(func(t *testing.T) {
+		logger.SetLogger(t)
 
-	httpPort, err := testutils.GetNextFreePort4()
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	httpServeAddr := fmt.Sprintf("0.0.0.0:%v", httpPort)
-	httpGetAddr := fmt.Sprintf("http://127.0.0.1:%v", httpPort)
-
-	testImageArgs := []string{"--exec=/inspect --serve-http=" + httpServeAddr}
-	testImage := patchTestACI("rkt-inspect-networking.aci", testImageArgs...)
-	defer os.Remove(testImage)
-
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
-
-	cmd := fmt.Sprintf("%s --net=host --debug --insecure-options=image run --mds-register=false %s", ctx.Cmd(), testImage)
-	child := spawnOrFail(t, cmd)
-	ctx.RegisterChild(child)
-
-	ga := testutils.NewGoroutineAssistant(t)
-	ga.Add(2)
-
-	// Child opens the server
-	go func() {
-		defer ga.Done()
-		ga.WaitOrFail(child)
-	}()
-
-	// Host connects to the child
-	go func() {
-		defer ga.Done()
-		expectedRegex := `serving on`
-		_, out, err := expectRegexWithOutput(child, expectedRegex)
+		httpPort, err := testutils.GetNextFreePort4()
 		if err != nil {
-			ga.Fatalf("Error: %v\nOutput: %v", err, out)
+			t.Fatalf("%v", err)
 		}
-		body, err := testutils.HTTPGet(httpGetAddr)
-		if err != nil {
-			ga.Fatalf("%v\n", err)
-		}
-		t.Logf("HTTP-Get received: %s", body)
-	}()
+		httpServeAddr := fmt.Sprintf("0.0.0.0:%v", httpPort)
+		httpGetAddr := fmt.Sprintf("http://127.0.0.1:%v", httpPort)
 
-	ga.Wait()
+		testImageArgs := []string{"--exec=/inspect --serve-http=" + httpServeAddr}
+		testImage := patchTestACI("rkt-inspect-networking.aci", testImageArgs...)
+		defer os.Remove(testImage)
+
+		ctx := testutils.NewRktRunCtx()
+		defer ctx.Cleanup()
+
+		cmd := fmt.Sprintf("%s --net=host --debug --insecure-options=image run --mds-register=false %s", ctx.Cmd(), testImage)
+		child := spawnOrFail(t, cmd)
+		ctx.RegisterChild(child)
+
+		ga := testutils.NewGoroutineAssistant(t)
+		ga.Add(2)
+
+		// Child opens the server
+		go func() {
+			defer ga.Done()
+			ga.WaitOrFail(child)
+		}()
+
+		// Host connects to the child
+		go func() {
+			defer ga.Done()
+			expectedRegex := `serving on`
+			_, out, err := expectRegexWithOutput(child, expectedRegex)
+			if err != nil {
+				ga.Fatalf("Error: %v\nOutput: %v", err, out)
+			}
+			body, err := testutils.HTTPGet(httpGetAddr)
+			if err != nil {
+				ga.Fatalf("%v\n", err)
+			}
+			t.Logf("HTTP-Get received: %s", body)
+		}()
+
+		ga.Wait()
+	})
 }
 
 /*
@@ -123,45 +127,47 @@ func TestNetHostConnectivity(t *testing.T) {
  * ---
  * must be in an empty netns
  */
-func TestNetNone(t *testing.T) {
-	testImageArgs := []string{"--exec=/inspect --print-netns --print-iface-count"}
-	testImage := patchTestACI("rkt-inspect-networking.aci", testImageArgs...)
-	defer os.Remove(testImage)
+func NewNetNoneTest() testutils.Test {
+	return testutils.TestFunc(func(t *testing.T) {
+		testImageArgs := []string{"--exec=/inspect --print-netns --print-iface-count"}
+		testImage := patchTestACI("rkt-inspect-networking.aci", testImageArgs...)
+		defer os.Remove(testImage)
 
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
+		ctx := testutils.NewRktRunCtx()
+		defer ctx.Cleanup()
 
-	cmd := fmt.Sprintf("%s --debug --insecure-options=image run --net=none --mds-register=false %s", ctx.Cmd(), testImage)
+		cmd := fmt.Sprintf("%s --debug --insecure-options=image run --net=none --mds-register=false %s", ctx.Cmd(), testImage)
 
-	child := spawnOrFail(t, cmd)
-	defer waitOrFail(t, child, 0)
-	expectedRegex := `NetNS: (net:\[\d+\])`
-	result, out, err := expectRegexWithOutput(child, expectedRegex)
-	if err != nil {
-		t.Fatalf("Error: %v\nOutput: %v", err, out)
-	}
+		child := spawnOrFail(t, cmd)
+		defer waitOrFail(t, child, 0)
+		expectedRegex := `NetNS: (net:\[\d+\])`
+		result, out, err := expectRegexWithOutput(child, expectedRegex)
+		if err != nil {
+			t.Fatalf("Error: %v\nOutput: %v", err, out)
+		}
 
-	ns, err := os.Readlink("/proc/self/ns/net")
-	if err != nil {
-		t.Fatalf("Cannot evaluate NetNS symlink: %v", err)
-	}
+		ns, err := os.Readlink("/proc/self/ns/net")
+		if err != nil {
+			t.Fatalf("Cannot evaluate NetNS symlink: %v", err)
+		}
 
-	if nsChanged := ns != result[1]; !nsChanged {
-		t.Fatalf("container did not leave host netns")
-	}
+		if nsChanged := ns != result[1]; !nsChanged {
+			t.Fatalf("container did not leave host netns")
+		}
 
-	expectedRegex = `Interface count: (\d+)`
-	result, out, err = expectRegexWithOutput(child, expectedRegex)
-	if err != nil {
-		t.Fatalf("Error: %v\nOutput: %v", err, out)
-	}
-	ifaceCount, err := strconv.Atoi(result[1])
-	if err != nil {
-		t.Fatalf("Error parsing interface count: %v\nOutput: %v", err, out)
-	}
-	if ifaceCount != 1 {
-		t.Fatalf("Interface count must be 1 not %q", ifaceCount)
-	}
+		expectedRegex = `Interface count: (\d+)`
+		result, out, err = expectRegexWithOutput(child, expectedRegex)
+		if err != nil {
+			t.Fatalf("Error: %v\nOutput: %v", err, out)
+		}
+		ifaceCount, err := strconv.Atoi(result[1])
+		if err != nil {
+			t.Fatalf("Error parsing interface count: %v\nOutput: %v", err, out)
+		}
+		if ifaceCount != 1 {
+			t.Fatalf("Interface count must be 1 not %q", ifaceCount)
+		}
+	})
 }
 
 /*
@@ -210,71 +216,73 @@ func TestNetDefaultNetNS(t *testing.T) {
  * default network, which is NATed
  * TODO: test connection to host on an outside interface
  */
-func TestNetDefaultConnectivity(t *testing.T) {
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
+func NewNetDefaultConnectivityTest() testutils.Test {
+	return testutils.TestFunc(func(t *testing.T) {
+		ctx := testutils.NewRktRunCtx()
+		defer ctx.Cleanup()
 
-	f := func(argument string) {
-		httpPort, err := testutils.GetNextFreePort4()
-		if err != nil {
-			t.Fatalf("%v", err)
-		}
-		httpServeAddr := fmt.Sprintf("0.0.0.0:%v", httpPort)
-		httpServeTimeout := 30
-
-		nonLoIPv4, err := testutils.GetNonLoIfaceIPv4()
-		if err != nil {
-			t.Fatalf("%v", err)
-		}
-		if nonLoIPv4 == "" {
-			t.Skipf("Can not find any NAT'able IPv4 on the host, skipping..")
-		}
-
-		httpGetAddr := fmt.Sprintf("http://%v:%v", nonLoIPv4, httpPort)
-		t.Log("Telling the child to connect via", httpGetAddr)
-
-		testImageArgs := []string{fmt.Sprintf("--exec=/inspect --get-http=%v", httpGetAddr)}
-		testImage := patchTestACI("rkt-inspect-networking.aci", testImageArgs...)
-		defer os.Remove(testImage)
-
-		hostname, err := os.Hostname()
-		if err != nil {
-			t.Fatalf("Error getting hostname: %v", err)
-		}
-
-		ga := testutils.NewGoroutineAssistant(t)
-		ga.Add(2)
-
-		// Host opens the server
-		go func() {
-			defer ga.Done()
-			err := testutils.HTTPServe(httpServeAddr, httpServeTimeout)
+		f := func(argument string) {
+			httpPort, err := testutils.GetNextFreePort4()
 			if err != nil {
-				ga.Fatalf("Error during HTTPServe: %v", err)
+				t.Fatalf("%v", err)
 			}
-		}()
+			httpServeAddr := fmt.Sprintf("0.0.0.0:%v", httpPort)
+			httpServeTimeout := 30
 
-		// Child connects to host
-		go func() {
-			defer ga.Done()
-			cmd := fmt.Sprintf("%s --debug --insecure-options=image run %s --mds-register=false %s", ctx.Cmd(), argument, testImage)
-			child := ga.SpawnOrFail(cmd)
-			defer ga.WaitOrFail(child)
-
-			expectedRegex := `HTTP-Get received: (.*)\r`
-			result, out, err := expectRegexWithOutput(child, expectedRegex)
+			nonLoIPv4, err := testutils.GetNonLoIfaceIPv4()
 			if err != nil {
-				ga.Fatalf("Error: %v\nOutput: %v", err, out)
+				t.Fatalf("%v", err)
 			}
-			if result[1] != hostname {
-				ga.Fatalf("Hostname received by client `%v` doesn't match `%v`", result[1], hostname)
+			if nonLoIPv4 == "" {
+				t.Skipf("Can not find any NAT'able IPv4 on the host, skipping..")
 			}
-		}()
 
-		ga.Wait()
-	}
-	f("--net=default")
-	f("")
+			httpGetAddr := fmt.Sprintf("http://%v:%v", nonLoIPv4, httpPort)
+			t.Log("Telling the child to connect via", httpGetAddr)
+
+			testImageArgs := []string{fmt.Sprintf("--exec=/inspect --get-http=%v", httpGetAddr)}
+			testImage := patchTestACI("rkt-inspect-networking.aci", testImageArgs...)
+			defer os.Remove(testImage)
+
+			hostname, err := os.Hostname()
+			if err != nil {
+				t.Fatalf("Error getting hostname: %v", err)
+			}
+
+			ga := testutils.NewGoroutineAssistant(t)
+			ga.Add(2)
+
+			// Host opens the server
+			go func() {
+				defer ga.Done()
+				err := testutils.HTTPServe(httpServeAddr, httpServeTimeout)
+				if err != nil {
+					ga.Fatalf("Error during HTTPServe: %v", err)
+				}
+			}()
+
+			// Child connects to host
+			go func() {
+				defer ga.Done()
+				cmd := fmt.Sprintf("%s --debug --insecure-options=image run %s --mds-register=false %s", ctx.Cmd(), argument, testImage)
+				child := ga.SpawnOrFail(cmd)
+				defer ga.WaitOrFail(child)
+
+				expectedRegex := `HTTP-Get received: (.*)\r`
+				result, out, err := expectRegexWithOutput(child, expectedRegex)
+				if err != nil {
+					ga.Fatalf("Error: %v\nOutput: %v", err, out)
+				}
+				if result[1] != hostname {
+					ga.Fatalf("Hostname received by client `%v` doesn't match `%v`", result[1], hostname)
+				}
+			}()
+
+			ga.Wait()
+		}
+		f("--net=default")
+		f("")
+	})
 }
 
 /*
@@ -304,7 +312,7 @@ func TestNetDefaultRestrictedConnectivity(t *testing.T) {
 		cmd := fmt.Sprintf("%s --debug --insecure-options=image run %s --mds-register=false %s", ctx.Cmd(), argument, testImage)
 		child := spawnOrFail(t, cmd)
 
-		expectedRegex := `IPv4: (.*)\r`
+		expectedRegex := `IPv4: (\d+\.\d+\.\d+\.\d+)`
 		result, out, err := expectRegexWithOutput(child, expectedRegex)
 		if err != nil {
 			t.Fatalf("Error: %v\nOutput: %v", err, out)
@@ -340,78 +348,93 @@ func TestNetDefaultRestrictedConnectivity(t *testing.T) {
 	f("--net=default-restricted")
 }
 
+type PortFwdCase struct {
+	HttpGetIP     string
+	RktArg        string
+	ShouldSucceed bool
+}
+
+func (ct PortFwdCase) Execute(t *testing.T, ctx *testutils.RktRunCtx) {
+
+	bannedPorts := make(map[int]struct{}, 0)
+	httpPort, err := testutils.GetNextFreePort4Banned(bannedPorts)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	bannedPorts[httpPort] = struct{}{}
+
+	httpServeAddr := fmt.Sprintf("0.0.0.0:%d", httpPort)
+	testImageArgs := []string{
+		fmt.Sprintf("--ports=http,protocol=tcp,port=%d", httpPort),
+		fmt.Sprintf("--exec=/inspect --serve-http=%v", httpServeAddr),
+	}
+	testImage := patchTestACI("rkt-inspect-networking.aci", testImageArgs...)
+	defer os.Remove(testImage)
+
+	cmd := fmt.Sprintf(
+		"%s --debug --insecure-options=image run --port=http:%d %s --mds-register=false %s",
+		ctx.Cmd(), httpPort, ct.RktArg, testImage)
+	child := spawnOrFail(t, cmd)
+
+	httpGetAddr := fmt.Sprintf("http://%v:%v", ct.HttpGetIP, httpPort)
+
+	ga := testutils.NewGoroutineAssistant(t)
+	ga.Add(2)
+
+	// Child opens the server
+	go func() {
+		defer ga.Done()
+		ga.WaitOrFail(child)
+	}()
+
+	// Host connects to the child via the forward port on localhost
+	go func() {
+		defer ga.Done()
+		expectedRegex := `serving on`
+		_, out, err := expectRegexWithOutput(child, expectedRegex)
+		if err != nil {
+			ga.Fatalf("Error: %v\nOutput: %v", err, out)
+		}
+		body, err := testutils.HTTPGet(httpGetAddr)
+		switch {
+		case err != nil && ct.ShouldSucceed:
+			ga.Fatalf("%v\n", err)
+		case err == nil && !ct.ShouldSucceed:
+			ga.Fatalf("HTTP-Get to %q should have failed! But received %q", httpGetAddr, body)
+		case err != nil && !ct.ShouldSucceed:
+			child.Close()
+			fallthrough
+		default:
+			t.Logf("HTTP-Get received: %s", body)
+		}
+	}()
+
+	ga.Wait()
+
+	// TODO: ensure that default-restricted is not accessible from non-host
+	// f("172.16.28.1", "--net=default-restricted", true)
+	// f("127.0.0.1", "--net=default-restricted", true)
+}
+
+type portFwdTest []PortFwdCase
+
+func (ct portFwdTest) Execute(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	for _, testCase := range ct {
+		testCase.Execute(t, ctx)
+	}
+}
+
 /*
  * Default net port forwarding connectivity
  * ---
  * Container launches http server on all its interfaces
  * Host must be able to connect to container's http server on it's own interfaces
  */
-func TestNetDefaultPortFwdConnectivity(t *testing.T) {
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
-
-	bannedPorts := make(map[int]struct{}, 0)
-	f := func(httpGetIP string, rktArg string, shouldSucceed bool) {
-		httpPort, err := testutils.GetNextFreePort4Banned(bannedPorts)
-		if err != nil {
-			t.Fatalf("%v", err)
-		}
-		bannedPorts[httpPort] = struct{}{}
-
-		httpServeAddr := fmt.Sprintf("0.0.0.0:%d", httpPort)
-		testImageArgs := []string{
-			fmt.Sprintf("--ports=http,protocol=tcp,port=%d", httpPort),
-			fmt.Sprintf("--exec=/inspect --serve-http=%v", httpServeAddr),
-		}
-		testImage := patchTestACI("rkt-inspect-networking.aci", testImageArgs...)
-		defer os.Remove(testImage)
-
-		cmd := fmt.Sprintf(
-			"%s --debug --insecure-options=image run --port=http:%d %s --mds-register=false %s",
-			ctx.Cmd(), httpPort, rktArg, testImage)
-		child := spawnOrFail(t, cmd)
-
-		httpGetAddr := fmt.Sprintf("http://%v:%v", httpGetIP, httpPort)
-
-		ga := testutils.NewGoroutineAssistant(t)
-		ga.Add(2)
-
-		// Child opens the server
-		go func() {
-			defer ga.Done()
-			ga.WaitOrFail(child)
-		}()
-
-		// Host connects to the child via the forward port on localhost
-		go func() {
-			defer ga.Done()
-			expectedRegex := `serving on`
-			_, out, err := expectRegexWithOutput(child, expectedRegex)
-			if err != nil {
-				ga.Fatalf("Error: %v\nOutput: %v", err, out)
-			}
-			body, err := testutils.HTTPGet(httpGetAddr)
-			switch {
-			case err != nil && shouldSucceed:
-				ga.Fatalf("%v\n", err)
-			case err == nil && !shouldSucceed:
-				ga.Fatalf("HTTP-Get to %q should have failed! But received %q", httpGetAddr, body)
-			case err != nil && !shouldSucceed:
-				child.Close()
-				fallthrough
-			default:
-				t.Logf("HTTP-Get received: %s", body)
-			}
-		}()
-
-		ga.Wait()
-	}
-	f("172.16.28.1", "--net=default", true)
-	f("127.0.0.1", "--net=default", true)
-
-	// TODO: ensure that default-restricted is not accessible from non-host
-	// f("172.16.28.1", "--net=default-restricted", true)
-	// f("127.0.0.1", "--net=default-restricted", true)
+func NewNetDefaultPortFwdConnectivityTest(cases ...PortFwdCase) testutils.Test {
+	return portFwdTest(cases)
 }
 
 func writeNetwork(t *testing.T, net networkTemplateT, netd string) error {
@@ -526,7 +549,7 @@ func testNetCustomDual(t *testing.T, nt networkTemplateT) {
 			ga.Fatalf("Error: %v\nOutput: %v", err, out)
 		}
 		container1IPv4 <- result[1]
-		expectedRegex = `(rkt-.*): serving on`
+		expectedRegex = ` ([a-zA-Z0-9\-]*): serving on`
 		result, out, err = expectRegexTimeoutWithOutput(child, expectedRegex, 30*time.Second)
 		if err != nil {
 			ga.Fatalf("Error: %v\nOutput: %v", err, out)
@@ -549,7 +572,7 @@ func testNetCustomDual(t *testing.T, nt networkTemplateT) {
 		defer ga.WaitOrFail(child)
 
 		expectedHostname := <-container1Hostname
-		expectedRegex := `HTTP-Get received: (.*)\r`
+		expectedRegex := `HTTP-Get received: (.*?)\r`
 		result, out, err := expectRegexTimeoutWithOutput(child, expectedRegex, 20*time.Second)
 		if err != nil {
 			ga.Fatalf("Error: %v\nOutput: %v", err, out)
@@ -620,7 +643,7 @@ func testNetCustomNatConnectivity(t *testing.T, nt networkTemplateT) {
 		child := ga.SpawnOrFail(cmd)
 		defer ga.WaitOrFail(child)
 
-		expectedRegex := `HTTP-Get received: (.*)\r`
+		expectedRegex := `HTTP-Get received: (.*?)\r`
 		result, out, err := expectRegexWithOutput(child, expectedRegex)
 		if err != nil {
 			ga.Fatalf("Error: %v\nOutput: %v", err, out)
@@ -633,115 +656,125 @@ func testNetCustomNatConnectivity(t *testing.T, nt networkTemplateT) {
 	ga.Wait()
 }
 
-func TestNetCustomPtp(t *testing.T) {
-	nt := networkTemplateT{
-		Name:   "ptp0",
-		Type:   "ptp",
-		IpMasq: true,
-		Ipam: ipamTemplateT{
-			Type:   "host-local",
-			Subnet: "11.11.1.0/24",
-			Routes: []map[string]string{
-				{"dst": "0.0.0.0/0"},
+func NewNetCustomPtpTest(runCustomDual bool) testutils.Test {
+	return testutils.TestFunc(func(t *testing.T) {
+		nt := networkTemplateT{
+			Name:   "ptp0",
+			Type:   "ptp",
+			IpMasq: true,
+			Ipam: ipamTemplateT{
+				Type:   "host-local",
+				Subnet: "11.11.1.0/24",
+				Routes: []map[string]string{
+					{"dst": "0.0.0.0/0"},
+				},
 			},
-		},
-	}
-	testNetCustomNatConnectivity(t, nt)
-	testNetCustomDual(t, nt)
+		}
+		testNetCustomNatConnectivity(t, nt)
+		if runCustomDual {
+			testNetCustomDual(t, nt)
+		}
+	})
 }
 
-func TestNetCustomMacvlan(t *testing.T) {
-	iface, _, err := testutils.GetNonLoIfaceWithAddrs(netlink.FAMILY_V4)
-	if err != nil {
-		t.Fatalf("Error while getting non-lo host interface: %v\n", err)
-	}
-	if iface.Name == "" {
-		t.Skipf("Cannot run test without non-lo host interface")
-	}
+func NewNetCustomMacvlanTest() testutils.Test {
+	return testutils.TestFunc(func(t *testing.T) {
+		iface, _, err := testutils.GetNonLoIfaceWithAddrs(netlink.FAMILY_V4)
+		if err != nil {
+			t.Fatalf("Error while getting non-lo host interface: %v\n", err)
+		}
+		if iface.Name == "" {
+			t.Skipf("Cannot run test without non-lo host interface")
+		}
 
-	nt := networkTemplateT{
-		Name:   "macvlan0",
-		Type:   "macvlan",
-		Master: iface.Name,
-		Ipam: ipamTemplateT{
-			Type:   "host-local",
-			Subnet: "11.11.2.0/24",
-		},
-	}
-	testNetCustomDual(t, nt)
-}
-
-func TestNetCustomBridge(t *testing.T) {
-	iface, _, err := testutils.GetNonLoIfaceWithAddrs(netlink.FAMILY_V4)
-	if err != nil {
-		t.Fatalf("Error while getting non-lo host interface: %v\n", err)
-	}
-	if iface.Name == "" {
-		t.Skipf("Cannot run test without non-lo host interface")
-	}
-
-	nt := networkTemplateT{
-		Name:      "bridge0",
-		Type:      "bridge",
-		IpMasq:    true,
-		IsGateway: true,
-		Master:    iface.Name,
-		Ipam: ipamTemplateT{
-			Type:   "host-local",
-			Subnet: "11.11.3.0/24",
-			Routes: []map[string]string{
-				{"dst": "0.0.0.0/0"},
+		nt := networkTemplateT{
+			Name:   "macvlan0",
+			Type:   "macvlan",
+			Master: iface.Name,
+			Ipam: ipamTemplateT{
+				Type:   "host-local",
+				Subnet: "11.11.2.0/24",
 			},
-		},
-	}
-	testNetCustomNatConnectivity(t, nt)
-	testNetCustomDual(t, nt)
+		}
+		testNetCustomDual(t, nt)
+	})
 }
 
-func TestNetOverride(t *testing.T) {
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
+func NewNetCustomBridgeTest() testutils.Test {
+	return testutils.TestFunc(func(t *testing.T) {
+		iface, _, err := testutils.GetNonLoIfaceWithAddrs(netlink.FAMILY_V4)
+		if err != nil {
+			t.Fatalf("Error while getting non-lo host interface: %v\n", err)
+		}
+		if iface.Name == "" {
+			t.Skipf("Cannot run test without non-lo host interface")
+		}
 
-	iface, _, err := testutils.GetNonLoIfaceWithAddrs(netlink.FAMILY_V4)
-	if err != nil {
-		t.Fatalf("Error while getting non-lo host interface: %v\n", err)
-	}
-	if iface.Name == "" {
-		t.Skipf("Cannot run test without non-lo host interface")
-	}
+		nt := networkTemplateT{
+			Name:      "bridge0",
+			Type:      "bridge",
+			IpMasq:    true,
+			IsGateway: true,
+			Master:    iface.Name,
+			Ipam: ipamTemplateT{
+				Type:   "host-local",
+				Subnet: "11.11.3.0/24",
+				Routes: []map[string]string{
+					{"dst": "0.0.0.0/0"},
+				},
+			},
+		}
+		testNetCustomNatConnectivity(t, nt)
+		testNetCustomDual(t, nt)
+	})
+}
 
-	nt := networkTemplateT{
-		Name:   "overridemacvlan",
-		Type:   "macvlan",
-		Master: iface.Name,
-		Ipam: ipamTemplateT{
-			Type:   "host-local",
-			Subnet: "11.11.4.0/24",
-		},
-	}
+func NewNetOverrideTest() testutils.Test {
+	return testutils.TestFunc(func(t *testing.T) {
+		ctx := testutils.NewRktRunCtx()
+		defer ctx.Cleanup()
 
-	netdir := prepareTestNet(t, ctx, nt)
-	defer os.RemoveAll(netdir)
+		iface, _, err := testutils.GetNonLoIfaceWithAddrs(netlink.FAMILY_V4)
+		if err != nil {
+			t.Fatalf("Error while getting non-lo host interface: %v\n", err)
+		}
+		if iface.Name == "" {
+			t.Skipf("Cannot run test without non-lo host interface")
+		}
 
-	testImageArgs := []string{"--exec=/inspect --print-ipv4=eth0"}
-	testImage := patchTestACI("rkt-inspect-networking1.aci", testImageArgs...)
-	defer os.Remove(testImage)
+		nt := networkTemplateT{
+			Name:   "overridemacvlan",
+			Type:   "macvlan",
+			Master: iface.Name,
+			Ipam: ipamTemplateT{
+				Type:   "host-local",
+				Subnet: "11.11.4.0/24",
+			},
+		}
 
-	expectedIP := "11.11.4.244"
+		netdir := prepareTestNet(t, ctx, nt)
+		defer os.RemoveAll(netdir)
 
-	cmd := fmt.Sprintf("%s --debug --insecure-options=image run --net=all --net=\"%s:IP=%s\" --mds-register=false %s", ctx.Cmd(), nt.Name, expectedIP, testImage)
-	child := spawnOrFail(t, cmd)
-	defer waitOrFail(t, child, 0)
+		testImageArgs := []string{"--exec=/inspect --print-ipv4=eth0"}
+		testImage := patchTestACI("rkt-inspect-networking1.aci", testImageArgs...)
+		defer os.Remove(testImage)
 
-	expectedRegex := `IPv4: (\d+\.\d+\.\d+\.\d+)`
-	result, out, err := expectRegexTimeoutWithOutput(child, expectedRegex, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Error: %v\nOutput: %v", err, out)
-		return
-	}
+		expectedIP := "11.11.4.244"
 
-	containerIP := result[1]
-	if expectedIP != containerIP {
-		t.Fatalf("overriding IP did not work: Got %q but expected %q", containerIP, expectedIP)
-	}
+		cmd := fmt.Sprintf("%s --debug --insecure-options=image run --net=all --net=\"%s:IP=%s\" --mds-register=false %s", ctx.Cmd(), nt.Name, expectedIP, testImage)
+		child := spawnOrFail(t, cmd)
+		defer waitOrFail(t, child, 0)
+
+		expectedRegex := `IPv4: (\d+\.\d+\.\d+\.\d+)`
+		result, out, err := expectRegexTimeoutWithOutput(child, expectedRegex, 30*time.Second)
+		if err != nil {
+			t.Fatalf("Error: %v\nOutput: %v", err, out)
+			return
+		}
+
+		containerIP := result[1]
+		if expectedIP != containerIP {
+			t.Fatalf("overriding IP did not work: Got %q but expected %q", containerIP, expectedIP)
+		}
+	})
 }

--- a/tests/rkt_non_root_test.go
+++ b/tests/rkt_non_root_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_pid_file_kvm_test.go
+++ b/tests/rkt_pid_file_kvm_test.go
@@ -12,28 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build kvm
 
 package main
 
-import (
-	"fmt"
-	"os"
-	"testing"
+import "testing"
 
-	"github.com/coreos/rkt/tests/testutils"
-)
+var pidFileName = "pid"
 
-func TestRktEnsureErrors(t *testing.T) {
-	const imgName = "rkt-ensure-errors-test"
+func TestPidFileDelayedStart(t *testing.T) {
+	NewPidFileDelayedStartTest(pidFileName)
+}
 
-	image := patchTestACI(fmt.Sprintf("%s.aci", imgName), fmt.Sprintf("--name=%s", imgName))
-	defer os.Remove(image)
-
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
-
-	runCmd := fmt.Sprintf("%s run --insecure-options=image --net=notavalidnetwork %s", ctx.Cmd(), image)
-	t.Logf("Running test: %s", runCmd)
-	runRktAndCheckRegexOutput(t, runCmd, "stage1: failed to setup network")
+func TestPidFileAbortedStart(t *testing.T) {
+	// For nspawn, the escape character is ^]^]^]. This process will exit with code 1
+	NewPidFileAbortedStartTest(pidFileName, "\001\170", 0)
 }

--- a/tests/rkt_pid_file_nspawn_test.go
+++ b/tests/rkt_pid_file_nspawn_test.go
@@ -12,28 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build coreos src
 
 package main
 
-import (
-	"fmt"
-	"os"
-	"testing"
+import "testing"
 
-	"github.com/coreos/rkt/tests/testutils"
-)
+var pidFileName = "ppid"
 
-func TestRktEnsureErrors(t *testing.T) {
-	const imgName = "rkt-ensure-errors-test"
+func TestPidFileDelayedStart(t *testing.T) {
+	NewPidFileDelayedStartTest(pidFileName)
+}
 
-	image := patchTestACI(fmt.Sprintf("%s.aci", imgName), fmt.Sprintf("--name=%s", imgName))
-	defer os.Remove(image)
-
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
-
-	runCmd := fmt.Sprintf("%s run --insecure-options=image --net=notavalidnetwork %s", ctx.Cmd(), image)
-	t.Logf("Running test: %s", runCmd)
-	runRktAndCheckRegexOutput(t, runCmd, "stage1: failed to setup network")
+func TestPidFileAbortedStart(t *testing.T) {
+	// For nspawn, the escape character is ^]^]^]. This process will exit with code 1
+	NewPidFileAbortedStartTest(pidFileName, "\035\035\035", 1)
 }

--- a/tests/rkt_root_commands_test.go
+++ b/tests/rkt_root_commands_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_service_file_test.go
+++ b/tests/rkt_service_file_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_socket_activation_test.go
+++ b/tests/rkt_socket_activation_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_socket_proxyd_test.go
+++ b/tests/rkt_socket_proxyd_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_stage1_loading_test.go
+++ b/tests/rkt_stage1_loading_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_supplementary_gids_test.go
+++ b/tests/rkt_supplementary_gids_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_trust_test.go
+++ b/tests/rkt_trust_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 

--- a/tests/rkt_volume_nspawn_test.go
+++ b/tests/rkt_volume_nspawn_test.go
@@ -12,28 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build coreos src
 
 package main
 
-import (
-	"fmt"
-	"os"
-	"testing"
+import "testing"
 
-	"github.com/coreos/rkt/tests/testutils"
-)
-
-func TestRktEnsureErrors(t *testing.T) {
-	const imgName = "rkt-ensure-errors-test"
-
-	image := patchTestACI(fmt.Sprintf("%s.aci", imgName), fmt.Sprintf("--name=%s", imgName))
-	defer os.Remove(image)
-
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
-
-	runCmd := fmt.Sprintf("%s run --insecure-options=image --net=notavalidnetwork %s", ctx.Cmd(), image)
-	t.Logf("Running test: %s", runCmd)
-	runRktAndCheckRegexOutput(t, runCmd, "stage1: failed to setup network")
+func TestVolumes(t *testing.T) {
+	NewVolumesTest().Execute(t)
 }


### PR DESCRIPTION
This is first part of enabling functional tests for `kvm` flavor.
This pr requires modification in Semaphore configuration

Right now we are skipping:
- Few network tests
- TestAceValidator
- TestAPIServiceListInspectPods
- TestAPIServiceCgroup
- TestPrepareAppEnsureEtcHosts
- TestMountSymlink
- TestNetCustomMacvlan
- TestPodManifest
- TestVolumes

Also checking error code is turned off

[![Build Status](https://semaphoreci.com/api/v1/mstachowski/rkt/branches/mstachow-rkt_functional_tests_kvm/badge.svg)](https://semaphoreci.com/mstachowski/rkt)