### PR TITLE
rkt/image: pass insecure-options=http to docker2aci

### DIFF
--- a/rkt/image/dockerfetcher.go
+++ b/rkt/image/dockerfetcher.go
@@ -97,8 +97,7 @@ func (f *dockerFetcher) fetch(u *url.URL) (*os.File, error) {
 
 	registryURL := strings.TrimPrefix(u.String(), "docker://")
 	user, password := f.getCreds(registryURL)
-	// for now, always use https:// when fetching docker images
-	acis, err := docker2aci.Convert(registryURL, true /* squash */, tmpDir, tmpDir, user, password, false /* insecure */)
+	acis, err := docker2aci.Convert(registryURL, true /* squash */, tmpDir, tmpDir, user, password, f.InsecureFlags.AllowHTTP())
 	if err != nil {
 		return nil, fmt.Errorf("error converting docker image to ACI: %v", err)
 	}


### PR DESCRIPTION
So we can fetch images from non-TLS docker registries.