### PR TITLE
masquerade and route forwarded packets from host's loopback to the pod

### DIFF
--- a/networking/networking.go
+++ b/networking/networking.go
@@ -121,7 +121,11 @@ func Setup(podRoot string, podID types.UUID, fps []ForwardedPort, netList common
 			if err = n.enableDefaultLocalnetRouting(); err != nil {
 				return err
 			}
-			return n.forwardPorts(fps, n.GetDefaultIP())
+			if err := n.forwardPorts(fps, n.GetDefaultIP()); err != nil {
+				n.unforwardPorts()
+				return err
+			}
+			return nil
 		}
 		return nil
 	})

--- a/tests/testutils/iputils.go
+++ b/tests/testutils/iputils.go
@@ -162,7 +162,15 @@ func CheckTcp4Port(port int) (bool, error) {
 }
 
 func GetNextFreePort4() (int, error) {
+	return GetNextFreePort4Banned(map[int]struct{}{})
+}
+
+func GetNextFreePort4Banned(bannedPorts map[int]struct{}) (int, error) {
 	for port := 49152; port <= 65535; port++ {
+		if _, portBanned := bannedPorts[port]; portBanned {
+			continue
+		}
+
 		avail, err := CheckTcp4Port(port)
 		if err != nil {
 			return 0, err


### PR DESCRIPTION
This implementation is not ideal because it uses heuristics to find interface names.

The host's veth interface has to be found with the only thing that's known, it's IP address. The names are randomly generated by CNI and are not returned in the CNI result. Further, due to the way the PTP plugin works, multiple veth interfaces have the same address, so they are all candidates for needing *route_localnet* enabled.

Fixes #1256.
- [x] Implementation
- [x] Tests, we have no port forwarding tests at all!


Follow-Up:
- [ ] Improve IPv4 / IPv6 address detection code
- [ ] Cleanup network tests comments
- [ ] Retrieve interface names by CNI instead of using heuristics