### PR TITLE
rkt: show created/started times in rkt list/status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## vUNREASED
+
+#### New features and UX changes
+
+- Add pod creation and start times to `rkt list` and `rkt status` ([#2030](https://github.com/coreos/rkt/pull/2030)). See [`rkt list`](https://github.com/coreos/rkt/blob/master/Documentation/subcommands/list.md) and [`rkt status`](https://github.com/coreos/rkt/blob/master/Documentation/subcommands/status.md) documentation.
+
 ## v0.16.0
 
 #### New features and UX changes

--- a/Documentation/subcommands/list.md
+++ b/Documentation/subcommands/list.md
@@ -3,19 +3,19 @@
 You can list all rkt pods.
 
 ```
-# rkt list
-UUID        APP     IMAGE NAME               STATE      NETWORKS
-5bc080ca    redis   redis                    running    default:ip4=172.16.28.7
+$ rkt list
+UUID        APP     IMAGE NAME               STATE      CREATED        STARTED         NETWORKS
+5bc080ca    redis   redis                    running    2 minutes ago  41 seconds ago  default:ip4=172.16.28.7
             etcd    coreos.com/etcd:v2.0.9
-3089337c    nginx   nginx                    exited
+3089337c    nginx   nginx                    exited     9 minutes ago  2 minutes ago
 ```
 
 You can view the full UUID as well as the image's ID by using the `--full` flag.
 
 ```
-# rkt list --full
-UUID                                   APP     IMAGE NAME              IMAGE ID              STATE      NETWORKS
-5bc080cav-9e03-480d-b705-5928af396cc5  redis   redis                   sha512-91e98d7f1679   running    default:ip4=172.16.28.7
+$ rkt list --full
+UUID                                   APP     IMAGE NAME              IMAGE ID              STATE      CREATED                             STARTED                             NETWORKS
+5bc080cav-9e03-480d-b705-5928af396cc5  redis   redis                   sha512-91e98d7f1679   running    2016-01-25 17:42:32.563 +0100 CET   2016-01-25 17:44:05.294 +0100 CET   default:ip4=172.16.28.7
                                        etcd    coreos.com/etcd:v2.0.9  sha512-a03f6bad952b
-3089337c4-8021-119b-5ea0-879a7c694de4  nginx   nginx                   sha512-32ad6892f21a   exited
+3089337c4-8021-119b-5ea0-879a7c694de4  nginx   nginx                   sha512-32ad6892f21a   exited     2016-01-25 17:36:40.203 +0100 CET   2016-01-25 17:42:15.1 +0100 CET
 ```

--- a/Documentation/subcommands/status.md
+++ b/Documentation/subcommands/status.md
@@ -4,12 +4,14 @@ Given a pod UUID, you can get the exit status of its apps.
 Note that the apps are prefixed by `app-`.
 
 ```
-# rkt status 5bc080ca
+$ rkt status 66ceb509
 state=exited
-pid=-1
+created=2016-01-26 14:23:34.631 +0100 CET
+started=2016-01-26 14:23:34.744 +0100 CET
+pid=16964
 exited=true
-app-etcd=0
 app-redis=0
+app-etcd=0
 ```
 
 If the pod is still running, you can wait for it to finish and then get the status with `rkt status --wait UUID`

--- a/rkt/list.go
+++ b/rkt/list.go
@@ -26,6 +26,7 @@ import (
 	"github.com/appc/spec/schema/types"
 	common "github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/networking/netinfo"
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 )
 
@@ -52,9 +53,9 @@ func runList(cmd *cobra.Command, args []string) int {
 
 	if !flagNoLegend {
 		if flagFullOutput {
-			fmt.Fprintf(tabOut, "UUID\tAPP\tIMAGE NAME\tIMAGE ID\tSTATE\tNETWORKS\n")
+			fmt.Fprintf(tabOut, "UUID\tAPP\tIMAGE NAME\tIMAGE ID\tSTATE\tCREATED\tSTARTED\tNETWORKS\n")
 		} else {
-			fmt.Fprintf(tabOut, "UUID\tAPP\tIMAGE NAME\tSTATE\tNETWORKS\n")
+			fmt.Fprintf(tabOut, "UUID\tAPP\tIMAGE NAME\tSTATE\tCREATED\tSTARTED\tNETWORKS\n")
 		}
 	}
 
@@ -87,12 +88,39 @@ func runList(cmd *cobra.Command, args []string) int {
 			imgID   string
 			state   string
 			nets    string
+			created string
+			started string
 		}
 
 		var appsToPrint []printedApp
 		uuid := p.uuid.String()
 		state := p.getState()
 		nets := fmtNets(p.nets)
+
+		created, err := p.getCreationTime()
+		if err != nil {
+			errors = append(errors, fmt.Errorf("unable to get creation time for pod %q: %v", uuid, err))
+		}
+		var createdStr string
+		if flagFullOutput {
+			createdStr = created.Format(defaultTimeLayout)
+		} else {
+			createdStr = humanize.Time(created)
+		}
+
+		started, err := p.getStartTime()
+		if err != nil {
+			errors = append(errors, fmt.Errorf("unable to get start time for pod %q: %v", uuid, err))
+		}
+		var startedStr string
+		if !started.IsZero() {
+			if flagFullOutput {
+				startedStr = started.Format(defaultTimeLayout)
+			} else {
+				startedStr = humanize.Time(started)
+			}
+		}
+
 		if !flagFullOutput {
 			uuid = uuid[:8]
 		}
@@ -115,6 +143,8 @@ func runList(cmd *cobra.Command, args []string) int {
 				imgID:   imageID,
 				state:   state,
 				nets:    nets,
+				created: createdStr,
+				started: startedStr,
 			})
 			// clear those variables so they won't be
 			// printed for another apps in the pod as they
@@ -122,15 +152,17 @@ func runList(cmd *cobra.Command, args []string) int {
 			uuid = ""
 			state = ""
 			nets = ""
+			createdStr = ""
+			startedStr = ""
 		}
 		// if we reached that point, then it means that the
 		// pod and all its apps are valid, so they can be
 		// printed
 		for _, app := range appsToPrint {
 			if flagFullOutput {
-				fmt.Fprintf(tabOut, "%s\t%s\t%s\t%s\t%s\t%s\n", app.uuid, app.appName, app.imgName, app.imgID, app.state, app.nets)
+				fmt.Fprintf(tabOut, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", app.uuid, app.appName, app.imgName, app.imgID, app.state, app.created, app.started, app.nets)
 			} else {
-				fmt.Fprintf(tabOut, "%s\t%s\t%s\t%s\t%s\n", app.uuid, app.appName, app.imgName, app.state, app.nets)
+				fmt.Fprintf(tabOut, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", app.uuid, app.appName, app.imgName, app.state, app.created, app.started, app.nets)
 			}
 		}
 

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -16,7 +16,11 @@
 
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
 
 var (
 	cmdStatus = &cobra.Command{
@@ -69,6 +73,24 @@ func runStatus(cmd *cobra.Command, args []string) (exit int) {
 // printStatus prints the pod's pid and per-app status codes
 func printStatus(p *pod) error {
 	stdout("state=%s", p.getState())
+
+	created, err := p.getCreationTime()
+	if err != nil {
+		return fmt.Errorf("unable to get creation time for pod %q: %v", p.uuid, err)
+	}
+	createdStr := created.Format(defaultTimeLayout)
+
+	stdout("created=%s", createdStr)
+
+	started, err := p.getStartTime()
+	if err != nil {
+		return fmt.Errorf("unable to get start time for pod %q: %v", p.uuid, err)
+	}
+	var startedStr string
+	if !started.IsZero() {
+		startedStr = started.Format(defaultTimeLayout)
+		stdout("started=%s", startedStr)
+	}
 
 	if p.isRunning() {
 		stdout("networks=%s", fmtNets(p.nets))

--- a/tests/rkt_list_test.go
+++ b/tests/rkt_list_test.go
@@ -17,10 +17,23 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/coreos/rkt/tests/testutils"
 )
+
+const delta = 3 * time.Second
+
+// compareTime checks if a and b are roughly equal (1s precision)
+func compareTime(a time.Time, b time.Time) bool {
+	diff := a.Sub(b)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff < time.Second
+}
 
 func TestRktList(t *testing.T) {
 	const imgName = "rkt-list-test"
@@ -93,5 +106,77 @@ func TestRktList(t *testing.T) {
 		runCmd := fmt.Sprintf("%s %s", ctx.Cmd(), tt.cmd)
 		t.Logf("Running test #%d, %s", i, runCmd)
 		runRktAndCheckOutput(t, runCmd, tt.expect, !tt.shouldSucceed)
+	}
+}
+
+func getCreationStartTime(t *testing.T, ctx *testutils.RktRunCtx, imageID string) (creation time.Time, start time.Time) {
+	// Run rkt list --full
+	rktCmd := fmt.Sprintf("%s list --full", ctx.Cmd())
+	child := spawnOrFail(t, rktCmd)
+	child.Wait()
+
+	// Get creation time
+	match := fmt.Sprintf(".*%s\t.*\t(.*)\t(.*)\t", imageID)
+	result, out, err := expectRegexWithOutput(child, match)
+	if err != nil {
+		t.Fatalf("%q regex not found, Error: %v\nOutput: %v", match, err, out)
+	}
+	tmStr := strings.TrimSpace(result[1])
+	creation, err = time.Parse(defaultTimeLayout, tmStr)
+	if err != nil {
+		t.Fatalf("Error parsing creation time: %q", err)
+	}
+
+	tmStr = strings.TrimSpace(result[2])
+	start, err = time.Parse(defaultTimeLayout, tmStr)
+	if err != nil {
+		t.Fatalf("Error parsing start time: %q", err)
+	}
+
+	return creation, start
+}
+
+func TestRktListCreatedStarted(t *testing.T) {
+	const imgName = "rkt-list-creation-start-time-test"
+
+	image := patchTestACI(fmt.Sprintf("%s.aci", imgName), fmt.Sprintf("--exec=/inspect "))
+	defer os.Remove(image)
+
+	imageHash := getHashOrPanic(image)
+	imgID := ImageID{image, imageHash}
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	// Prepare image
+	cmd := fmt.Sprintf("%s --insecure-skip-verify prepare %s", ctx.Cmd(), imgID.path)
+	podUuid := runRktAndGetUUID(t, cmd)
+
+	// t0: prepare
+	expectPrepare := time.Now()
+
+	// Get hash
+	imageID := fmt.Sprintf("sha512-%s", imgID.hash[:12])
+
+	tmpDir := createTempDirOrPanic(imgName)
+	defer os.RemoveAll(tmpDir)
+
+	time.Sleep(delta)
+
+	// Run image
+	cmd = fmt.Sprintf("%s run-prepared %s", ctx.Cmd(), podUuid)
+	rktChild := spawnOrFail(t, cmd)
+
+	// t1: run
+	expectRun := time.Now()
+
+	waitOrFail(t, rktChild, true)
+
+	creation, start := getCreationStartTime(t, ctx, imageID)
+	if !compareTime(expectPrepare, creation) {
+		t.Fatalf("incorrect creation time returned. Got: %q Expect: %q (1s precision)", creation, expectPrepare)
+	}
+	if !compareTime(expectRun, start) {
+		t.Fatalf("incorrect creation time returned. Got: %q Expect: %q (1s precision)", start, expectRun)
 	}
 }


### PR DESCRIPTION
To get the pod creation time we use the modification time in
`/var/lib/rkt/pods/*/<UUID>/pod`. It's written when the pod is prepared
and doesn't change afterwards.

To get the pod start time we use the modification time in
`/var/lib/rkt/pods/*/<UUID>/ppid`. It's written when the pod actually
starts and doesn't change afterwards.

Partially addresses #1789