### PR TITLE
trust: only trust pubkeys on first use, prompt for https trust

### DIFF
--- a/rkt/image/validator.go
+++ b/rkt/image/validator.go
@@ -25,6 +25,7 @@ import (
 	"github.com/appc/spec/aci"
 	"github.com/appc/spec/schema"
 	"golang.org/x/crypto/openpgp"
+	pgperrors "golang.org/x/crypto/openpgp/errors"
 )
 
 // validator is a general image checker
@@ -76,6 +77,10 @@ func (v *validator) ValidateWithSignature(ks *keystore.Keystore, sig io.ReadSeek
 		return nil, errwrap.Wrap(errors.New("error seeking signature file"), err)
 	}
 	entity, err := ks.CheckSignature(v.GetImageName(), v.image, sig)
+	if err == pgperrors.ErrUnknownIssuer {
+		log.Print("If you expected the signing key to change, try running:")
+		log.Print("    rkt trust --prefix <image>")
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/rkt/rkt.go
+++ b/rkt/rkt.go
@@ -165,7 +165,7 @@ func init() {
 		fmt.Sprintf("comma-separated list of security features to disable. Allowed values: %s",
 			globalFlags.InsecureFlags.PermissibleString()))
 	cmdRkt.PersistentFlags().BoolVar(&globalFlags.TrustKeysFromHTTPS, "trust-keys-from-https",
-		true, "automatically trust gpg keys fetched from https")
+		false, "automatically trust gpg keys fetched from https")
 
 	// Run this before the execution of each subcommand to set up output
 	cmdRkt.PersistentPreRun = func(cmd *cobra.Command, args []string) {

--- a/rkt/trust.go
+++ b/rkt/trust.go
@@ -98,7 +98,8 @@ func runTrust(cmd *cobra.Command, args []string) (exit int) {
 	if flagSkipFingerprintReview {
 		acceptOpt = pubkey.AcceptForce
 	}
-	if err := m.AddKeys(pkls, flagPrefix, acceptOpt, pubkey.OverrideDeny); err != nil {
+
+	if err := m.AddKeys(pkls, flagPrefix, acceptOpt); err != nil {
 		stderr.PrintE("error adding keys", err)
 		return 1
 	}


### PR DESCRIPTION
    This commit changes rkt's behavior such that when fetching an image
    through meta discovery, rkt will only download and trust the gpg public
    key for the image if rkt doesn't have any local keys with a matching
    prefix. If the key for an image has changed, the user must manually
    trust the new key with `rkt trust --prefix`.
    
    In addition, `--trust-keys-from-https` now defaults to false, so the
    user is prompted to approve new keys (unless rkt isn't running in a tty,
    in which case an error is printed).

New default behavior when fetching an image in a tty:
```
[nix-shell:~/go/src/github.com/coreos/rkt]$ sudo ./build-rkt-0.15.0/bin/rkt fetch quay.io/coreos/alpine-sh
image: searching for app image quay.io/coreos/alpine-sh
image: remote fetching from URL "https://quay.io/c1/aci/quay.io/coreos/alpine-sh/latest/aci/linux/amd64/"
pubkey: prefix: "quay.io/coreos/alpine-sh"
key: "https://quay.io/aci-signing-key"
gpg key fingerprint is: BFF3 13CD AA56 0B16 A898  7B8F 72AB F5F6 799D 33BC
	Quay.io ACI Converter (ACI conversion signing key) <support@quay.io>
Are you sure you want to trust this key (yes/no)?
yes
Trusting "https://quay.io/aci-signing-key" for prefix "quay.io/coreos/alpine-sh" after fingerprint review.
Added key for prefix "quay.io/coreos/alpine-sh" at "/etc/rkt/trustedkeys/prefix.d/quay.io/coreos/alpine-sh/bff313cdaa560b16a8987b8f72abf5f6799d33bc"
image: downloading signature from https://quay.io/c1/aci/quay.io/coreos/alpine-sh/latest/aci.asc/linux/amd64/
Downloading signature: [=======================================] 473 B/473 B
Downloading ACI: [=============================================] 2.65 MB/2.65 MB
image: signature verified:
  Quay.io ACI Converter (ACI conversion signing key) <support@quay.io>
sha512-a2fb8f390702d3d9b00d2ebd93e7dd1
```

New default behavior when fetching and not in a tty:
```
Feb 01 09:36:20 rokot systemd[1]: Started /home/derek/go/src/github.com/coreos/rkt/./build-rkt-0.15.0/bin/rkt fetch quay.io/coreos/alpine-sh.
Feb 01 09:36:20 rokot rkt[10271]: image: searching for app image quay.io/coreos/alpine-sh
Feb 01 09:36:20 rokot rkt[10271]: image: remote fetching from URL "https://quay.io/c1/aci/quay.io/coreos/alpine-sh/latest/aci/linux/amd64/"
Feb 01 09:36:21 rokot rkt[10271]: pubkey: prefix: "quay.io/coreos/alpine-sh"
Feb 01 09:36:21 rokot rkt[10271]: key: "https://quay.io/aci-signing-key"
Feb 01 09:36:21 rokot rkt[10271]: gpg key fingerprint is: BFF3 13CD AA56 0B16 A898  7B8F 72AB F5F6 799D 33BC
Feb 01 09:36:21 rokot rkt[10271]: Quay.io ACI Converter (ACI conversion signing key) <support@quay.io>
Feb 01 09:36:21 rokot rkt[10271]: pubkey: To trust the key for "quay.io/coreos/alpine-sh", do one of the following:
Feb 01 09:36:21 rokot rkt[10271]: pubkey:  - call rkt with --trust-keys-from-https
Feb 01 09:36:21 rokot rkt[10271]: pubkey:  - run: rkt trust --prefix "quay.io/coreos/alpine-sh"
Feb 01 09:36:21 rokot rkt[10271]: image: error adding keys: error reviewing key: unable to ask user to review fingerprint due to lack of tty
Feb 01 09:36:21 rokot rkt[10271]: image: downloading signature from https://quay.io/c1/aci/quay.io/coreos/alpine-sh/latest/aci.asc/linux/amd64/
Feb 01 09:36:21 rokot rkt[10271]: Downloading signature:  0 B/473 B
Feb 01 09:36:21 rokot rkt[10271]: Downloading signature:  473 B/473 B
Feb 01 09:36:21 rokot rkt[10271]: image: If you expected the signing key to change, try running:
Feb 01 09:36:21 rokot rkt[10271]: image:     rkt trust --prefix "quay.io/coreos/alpine-sh"
Feb 01 09:36:21 rokot rkt[10271]: fetch: openpgp: signature made by unknown entity
Feb 01 09:36:21 rokot systemd[1]: run-rdb646d41c49b4f9595431ad80b07c459.service: Main process exited, code=exited, status=1/FAILURE
Feb 01 09:36:21 rokot systemd[1]: run-rdb646d41c49b4f9595431ad80b07c459.service: Unit entered failed state.
Feb 01 09:36:21 rokot systemd[1]: run-rdb646d41c49b4f9595431ad80b07c459.service: Failed with result 'exit-code'.
```