### PR TITLE
Metadata-service: Handle annotation names that contain slash.

### DIFF
--- a/rkt/metadata_service.go
+++ b/rkt/metadata_service.go
@@ -614,12 +614,12 @@ func runPublicServer(l net.Listener) {
 	mr := r.Methods("GET").Subrouter()
 
 	mr.HandleFunc("/pod/annotations/", logReq(podGet(handlePodAnnotations)))
-	mr.HandleFunc("/pod/annotations/{name}", logReq(podGet(handlePodAnnotation)))
+	mr.HandleFunc("/pod/annotations/{name:.*}", logReq(podGet(handlePodAnnotation)))
 	mr.HandleFunc("/pod/manifest", logReq(podGet(handlePodManifest)))
 	mr.HandleFunc("/pod/uuid", logReq(handlePodUUID))
 
 	mr.HandleFunc("/apps/{app:.*}/annotations/", logReq(appGet(handleAppAnnotations)))
-	mr.HandleFunc("/apps/{app:.*}/annotations/{name}", logReq(appGet(handleAppAnnotation)))
+	mr.HandleFunc("/apps/{app:.*}/annotations/{name:.*}", logReq(appGet(handleAppAnnotation)))
 	mr.HandleFunc("/apps/{app:.*}/image/manifest", logReq(appGet(handleImageManifest)))
 	mr.HandleFunc("/apps/{app:.*}/image/id", logReq(appGet(handleAppID)))
 

--- a/tests/inspect/inspect.go
+++ b/tests/inspect/inspect.go
@@ -37,37 +37,38 @@ import (
 var (
 	globalFlagset = flag.NewFlagSet("inspect", flag.ExitOnError)
 	globalFlags   = struct {
-		ReadStdin         bool
-		CheckTty          bool
-		PrintExec         bool
-		PrintMsg          string
-		PrintEnv          string
-		PrintCapsPid      int
-		PrintUser         bool
-		PrintGroups       bool
-		CheckCwd          string
-		ExitCode          int
-		ReadFile          bool
-		WriteFile         bool
-		StatFile          bool
-		Sleep             int
-		PreSleep          int
-		PrintMemoryLimit  bool
-		PrintCPUQuota     bool
-		FileName          string
-		Content           string
-		CheckCgroupMounts bool
-		PrintNetNS        bool
-		PrintIPv4         string
-		PrintIPv6         string
-		PrintDefaultGWv4  bool
-		PrintDefaultGWv6  bool
-		PrintGWv4         string
-		PrintGWv6         string
-		GetHTTP           string
-		ServeHTTP         string
-		ServeHTTPTimeout  int
-		PrintIfaceCount   bool
+		ReadStdin          bool
+		CheckTty           bool
+		PrintExec          bool
+		PrintMsg           string
+		PrintEnv           string
+		PrintCapsPid       int
+		PrintUser          bool
+		PrintGroups        bool
+		CheckCwd           string
+		ExitCode           int
+		ReadFile           bool
+		WriteFile          bool
+		StatFile           bool
+		Sleep              int
+		PreSleep           int
+		PrintMemoryLimit   bool
+		PrintCPUQuota      bool
+		FileName           string
+		Content            string
+		CheckCgroupMounts  bool
+		PrintNetNS         bool
+		PrintIPv4          string
+		PrintIPv6          string
+		PrintDefaultGWv4   bool
+		PrintDefaultGWv6   bool
+		PrintGWv4          string
+		PrintGWv6          string
+		GetHTTP            string
+		ServeHTTP          string
+		ServeHTTPTimeout   int
+		PrintIfaceCount    bool
+		PrintAppAnnotation string
 	}{}
 )
 
@@ -103,6 +104,7 @@ func init() {
 	globalFlagset.StringVar(&globalFlags.ServeHTTP, "serve-http", "", "Serve the hostname via HTTP on the given address:port")
 	globalFlagset.IntVar(&globalFlags.ServeHTTPTimeout, "serve-http-timeout", 30, "HTTP Timeout to wait for a client connection")
 	globalFlagset.BoolVar(&globalFlags.PrintIfaceCount, "print-iface-count", false, "Print the interface count")
+	globalFlagset.StringVar(&globalFlags.PrintAppAnnotation, "print-app-annotation", "", "Take an annotation name of the app, and prints its value")
 }
 
 func in(list []int, el int) bool {
@@ -437,6 +439,16 @@ func main() {
 			os.Exit(1)
 		}
 		fmt.Printf("Interface count: %d\n", ifaceCount)
+	}
+
+	if globalFlags.PrintAppAnnotation != "" {
+		mdsUrl, appName := os.Getenv("AC_METADATA_URL"), os.Getenv("AC_APP_NAME")
+		body, err := testutils.HTTPGet(fmt.Sprintf("%s/acMetadata/v1/apps/%s/annotations/%s", mdsUrl, appName, globalFlags.PrintAppAnnotation))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Annotation %s=%s\n", globalFlags.PrintAppAnnotation, body)
 	}
 
 	os.Exit(globalFlags.ExitCode)

--- a/tests/rkt_metadata_service_test.go
+++ b/tests/rkt_metadata_service_test.go
@@ -1,0 +1,39 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+func TestFetchAppAnnotation(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	if err := ctx.LaunchMDS(); err != nil {
+		t.Fatalf("Failed to launch metadata service: %v", err)
+	}
+
+	patches := []string{"--exec=/inspect --print-app-annotation=coreos.com/rkt/stage1/run"}
+	fileName := patchTestACI("rkt-get-annotation.aci", patches...)
+	defer os.Remove(fileName)
+
+	cmd := fmt.Sprintf("%s run --insecure-options=image --mds-register=true %s", ctx.Cmd(), fileName)
+	runRktAndCheckOutput(t, cmd, "Annotation coreos.com/rkt/stage1/run=/ex/run", false)
+}


### PR DESCRIPTION
Fix #2029 