### PR TITLE
networking: initialize stderr in Teardown

### DIFF
--- a/networking/networking.go
+++ b/networking/networking.go
@@ -184,7 +184,10 @@ func (n *Networking) GetDefaultHostIP() (net.IP, error) {
 }
 
 // Teardown cleans up a produced Networking object.
-func (n *Networking) Teardown(flavor string) {
+func (n *Networking) Teardown(flavor string, debug bool) {
+
+	stderr = log.New(os.Stderr, "networking", debug)
+
 	// Teardown everything in reverse order of setup.
 	// This should be idempotent -- be tolerant of missing stuff
 

--- a/stage1/gc/gc.go
+++ b/stage1/gc/gc.go
@@ -76,7 +76,7 @@ func gcNetworking(podID *types.UUID) error {
 	n, err := networking.Load(".", podID)
 	switch {
 	case err == nil:
-		n.Teardown(flavor)
+		n.Teardown(flavor, debug)
 	case os.IsNotExist(err):
 		// probably ran with --net=host
 	default:

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -516,7 +516,7 @@ func stage1() int {
 
 		if err = n.Save(); err != nil {
 			log.PrintE("failed to save networking state", err)
-			n.Teardown(flavor)
+			n.Teardown(flavor, debug)
 			return 6
 		}
 


### PR DESCRIPTION
This fixes a NullPointerException that happened because stderr was not
initiliazed in Teardown(), but only in Setup().

Fixes #2051 

/cc @blixtra 