### PR TITLE
use go 1.6 and regex updates for 'go version'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -483,19 +483,20 @@ dnl Digits regexp class. Square brackets are used by m4 for quoting,
 dnl so to get literal square brackets, m4 provides ugly @<:@ and @:>@
 dnl for [ and ].
 m4_define([DIGITS],[@<:@0-9@:>@])
+m4_define([CHARS],[@<:@a-z@:>@])
 
 dnl Detect go version. Go 1.4 support only "-X variable 'value'"
 dnl format of assigning values to variables via linker flags. Go 1.5
 dnl deprecates this format in favor of "-X 'variable=value'"
 dnl format. Drop this ugliness when we drop support for Go 1.4.
-GO_VERSION=`"${ABS_GO}" version | sed -e 's/^go version go\(DIGITS*\.DIGITS*\.DIGITS*\).*/\1/'`
+GO_VERSION=`"${ABS_GO}" version | sed -e 's/^go version go\(DIGITS*\.DIGITS*\+CHARS*\+DIGITS*\.*DIGITS*\).*/\1/'`
 GO_MAJOR=`echo "${GO_VERSION}" | grep -o '^DIGITS\+'`
 GO_MINOR=`echo "${GO_VERSION}" | grep -o '^DIGITS\+\.DIGITS\+' | grep -o 'DIGITS\+$'`
 GO_MAJOR_MINOR=`echo "${GO_MAJOR}.${GO_MINOR}"`
 GO_MICRO=`echo "${GO_VERSION}" | grep -o 'DIGITS\+$'`
 
 GO_BEST_MAJOR=1
-GO_BEST_MINOR=5
+GO_BEST_MINOR=6
 GO_BEST_VERSION="${GO_BEST_MAJOR}.${GO_BEST_MINOR}"
 AC_MSG_CHECKING([whether we have go ${GO_BEST_VERSION} or newer])
 AS_IF([test "${GO_MAJOR}" -gt "${GO_BEST_MAJOR}" || test "${GO_MAJOR}" -eq "${GO_BEST_MAJOR}" -a "${GO_MINOR}" -ge "${GO_BEST_MINOR}"],


### PR DESCRIPTION
The current 'go version' in fedora rawhide is '1.6rc1'. This version string
doesn't get correctly parsed by the configure script and it terminates
saying, "configure: error: *** go is too old (go version go1.6rc1 linux/amd64".

This commit allows all golang versions to be correctly detected.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

Not certain off-hand if rkt is Go 1.6 ready but PTAL :)