### PR TITLE
Godeps: bump go-tspi

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -173,15 +173,15 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/go-tspi/attestation",
-			"Rev": "5b86c15a590e0dd6de7ae28357bbc20c3a1dbb49"
+			"Rev": "8d98d77f9fc5e3a93227cbcde7abb8bdf1a29869"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-tspi/tpmclient",
-			"Rev": "5b86c15a590e0dd6de7ae28357bbc20c3a1dbb49"
+			"Rev": "8d98d77f9fc5e3a93227cbcde7abb8bdf1a29869"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-tspi/tspi",
-			"Rev": "5b86c15a590e0dd6de7ae28357bbc20c3a1dbb49"
+			"Rev": "8d98d77f9fc5e3a93227cbcde7abb8bdf1a29869"
 		},
 		{
 			"ImportPath": "github.com/coreos/ioprogress",

--- a/Godeps/_workspace/src/github.com/coreos/go-tspi/tpmclient/tpmclient.go
+++ b/Godeps/_workspace/src/github.com/coreos/go-tspi/tpmclient/tpmclient.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/coreos/go-tspi/attestation"
 	"github.com/coreos/go-tspi/tspi"
@@ -30,18 +31,25 @@ import (
 // TPMClient represents a connection to a system running a daemon providing
 // access to TPM functionality
 type TPMClient struct {
-	host string
+	host    string
+	timeout time.Duration
 }
 
 func (client *TPMClient) get(endpoint string) (*http.Response, error) {
 	url := fmt.Sprintf("http://%s/%s", client.host, endpoint)
-	resp, err := http.Get(url)
+	httpClient := &http.Client{
+		Timeout: client.timeout,
+	}
+	resp, err := httpClient.Get(url)
 	return resp, err
 }
 
 func (client *TPMClient) post(endpoint string, data io.Reader) (*http.Response, error) {
 	url := fmt.Sprintf("http://%s/%s", client.host, endpoint)
-	resp, err := http.Post(url, "application/json", data)
+	httpClient := &http.Client{
+		Timeout: client.timeout,
+	}
+	resp, err := httpClient.Post(url, "application/json", data)
 	return resp, err
 }
 
@@ -243,7 +251,10 @@ func (client *TPMClient) GetQuote(aikpub []byte, aikblob []byte, pcrs []int) (pc
 }
 
 // New returns a TPMClient structure configured to connect to the provided
-// host
-func New(host string) *TPMClient {
-	return &TPMClient{host: host}
+// host with the provided timeout.
+func New(host string, timeout time.Duration) *TPMClient {
+	return &TPMClient{
+		host:    host,
+		timeout: timeout,
+	}
 }

--- a/pkg/tpm/tpm.go
+++ b/pkg/tpm/tpm.go
@@ -17,12 +17,17 @@
 package tpm
 
 import (
+	"time"
+
 	"github.com/coreos/go-tspi/tpmclient"
 )
 
+// we're connecting to localhost, so 10ms is a reasonable timeout value
+const timeout = 10 * time.Millisecond
+
 // Extend extends the TPM log with the provided string. Returns any error.
 func Extend(description string) error {
-	connection := tpmclient.New("localhost:12041")
+	connection := tpmclient.New("localhost:12041", timeout)
 	err := connection.Extend(15, 0x1000, nil, description)
 	return err
 }


### PR DESCRIPTION
It allows defining a timeout for requests to the TPM server.

Fixes #1816 