### PR TITLE
Follow up for #2033: documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Replaced the `--stage1-image` flag with a new set of flags. `--stage1-url`, `--stage-path`, `--stage1-name` do the usual fetching from remote if the image does not exist in the store. `--stage1-hash` takes the stage1 image directly from the store. `--stage1-from-dir` works together with the default stage1 images directory and is described in the next point ([#1977](https://github.com/coreos/rkt/pull/1977)).
 - Added default stage1 images directory. User can use the newly added `--stage1-from-dir` parameter to avoid typing the full path. `--stage1-from-dir` behaves like `--stage1-path` ([#1977](https://github.com/coreos/rkt/pull/1977)).
 - Removed the deprecated `--insecure-skip-verify` flag ([#2068](https://github.com/coreos/rkt/pull/2068)).
+- Fetched keys are no longer automatically trusted by default, unless `--trust-keys-from-https` is used. Additionally, newly fetched key have to be explicitely trusted with `rkt trust` if a previous key was trusted for the same image prefix ([#2033](https://github.com/coreos/rkt/pull/2033)).
 
 #### Bug fixes
 

--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -76,7 +76,7 @@ In addition to the flags used by individual `rkt` commands, `rkt` has a set of g
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |
 
 ## Logging

--- a/Documentation/subcommands/api-service.md
+++ b/Documentation/subcommands/api-service.md
@@ -33,5 +33,5 @@ Here is a small [Go program](../../api/v1alpha/client_example.go) that illustrat
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |

--- a/Documentation/subcommands/cat-manifest.md
+++ b/Documentation/subcommands/cat-manifest.md
@@ -25,5 +25,5 @@ For debugging or inspection you may want to extract the PodManifest to stdout.
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |

--- a/Documentation/subcommands/enter.md
+++ b/Documentation/subcommands/enter.md
@@ -47,5 +47,5 @@ Work in progress. Please contribute!
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |

--- a/Documentation/subcommands/fetch.md
+++ b/Documentation/subcommands/fetch.md
@@ -99,5 +99,5 @@ Note that the configuration kind for images downloaded via https:// and images d
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |

--- a/Documentation/subcommands/gc.md
+++ b/Documentation/subcommands/gc.md
@@ -39,5 +39,5 @@ Garbage collecting pod "f07a4070-79a9-4db0-ae65-a090c9c393a3"
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |

--- a/Documentation/subcommands/image.md
+++ b/Documentation/subcommands/image.md
@@ -150,5 +150,5 @@ rkt: 2 image(s) successfully removed
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |

--- a/Documentation/subcommands/install.md
+++ b/Documentation/subcommands/install.md
@@ -11,5 +11,5 @@ This command sets up the rkt data directory (`/var/lib/rkt` by default) with the
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |

--- a/Documentation/subcommands/list.md
+++ b/Documentation/subcommands/list.md
@@ -36,5 +36,5 @@ UUID                                   APP     IMAGE NAME              IMAGE ID 
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |

--- a/Documentation/subcommands/metadata-service.md
+++ b/Documentation/subcommands/metadata-service.md
@@ -41,5 +41,5 @@ See [App Container specification](https://github.com/appc/spec/blob/master/spec/
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |

--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -61,5 +61,5 @@ c9fad0e6-8236-4fc2-ad17-55d0a4c7d742
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |

--- a/Documentation/subcommands/rm.md
+++ b/Documentation/subcommands/rm.md
@@ -24,5 +24,5 @@ rkt rm --uuid-file=/run/rkt-uuids/mypod
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |

--- a/Documentation/subcommands/run-prepared.md
+++ b/Documentation/subcommands/run-prepared.md
@@ -61,5 +61,5 @@ c9fad0e6    etcd    coreos.com/etcd prepared
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -345,5 +345,5 @@ If you don't use systemd, you can use [daemon](http://www.libslack.org/daemon/) 
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |

--- a/Documentation/subcommands/status.md
+++ b/Documentation/subcommands/status.md
@@ -31,5 +31,5 @@ If the pod is still running, you can wait for it to finish and then get the stat
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |

--- a/Documentation/subcommands/trust.md
+++ b/Documentation/subcommands/trust.md
@@ -101,5 +101,5 @@ $ find /etc/rkt/trustedkeys/
 | `--insecure-options` |  none | <ul><li>**none**: All security features are enabled</li><li>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.</li><li>**image**: Disables verifying image signatures</li><li>**tls**: Accept any certificate from the server and any host name in that certificate</li><li>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.</li><li>**all**: Disables all security checks</li></ul>  | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `true` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |


### PR DESCRIPTION
Follow-up for https://github.com/coreos/rkt/pull/2033:
- update documentation on `--trust-keys-from-https`
- add an entry in the changelog

-----

/cc @dgonyeo @iaguis 