### PR TITLE
run, run-prepared: check root uid

### DIFF
--- a/rkt/enter.go
+++ b/rkt/enter.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	"github.com/appc/spec/schema"
 	"github.com/appc/spec/schema/types"
@@ -54,6 +55,11 @@ func init() {
 }
 
 func runEnter(cmd *cobra.Command, args []string) (exit int) {
+	if os.Geteuid() != 0 {
+		stderr.Print("cannot run as unprivileged user")
+		return 1
+	}
+
 	if len(args) < 1 {
 		cmd.Usage()
 		return 1

--- a/rkt/gc.go
+++ b/rkt/gc.go
@@ -49,6 +49,11 @@ func init() {
 }
 
 func runGC(cmd *cobra.Command, args []string) (exit int) {
+	if os.Geteuid() != 0 {
+		stderr.Print("cannot run as unprivileged user")
+		return 1
+	}
+
 	if err := renameExited(); err != nil {
 		stderr.PrintE("failed to rename exited pods", err)
 		return 1

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -70,6 +70,11 @@ func init() {
 }
 
 func runPrepare(cmd *cobra.Command, args []string) (exit int) {
+	if os.Geteuid() != 0 {
+		stderr.Print("cannot run as unprivileged user")
+		return 1
+	}
+
 	var err error
 	origStdout := os.Stdout
 	privateUsers := uid.NewBlankUidRange()

--- a/rkt/rm.go
+++ b/rkt/rm.go
@@ -42,6 +42,11 @@ func runRm(cmd *cobra.Command, args []string) (exit int) {
 	var podUUIDs []*types.UUID
 	var err error
 
+	if os.Geteuid() != 0 {
+		stderr.Print("cannot run as unprivileged user")
+		return 1
+	}
+
 	switch {
 	case len(args) == 0 && flagUUIDFile != "":
 		podUUID, err = readUUIDFromFile(flagUUIDFile)

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -109,6 +110,11 @@ func init() {
 }
 
 func runRun(cmd *cobra.Command, args []string) (exit int) {
+	if os.Geteuid() != 0 {
+		stderr.Print("cannot run as unprivileged user")
+		return 1
+	}
+
 	privateUsers := uid.NewBlankUidRange()
 	err := parseApps(&rktApps, args, cmd.Flags(), true)
 	if err != nil {

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -17,6 +17,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/stage0"
 	"github.com/coreos/rkt/store"
@@ -49,6 +51,11 @@ func init() {
 }
 
 func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
+	if os.Geteuid() != 0 {
+		stderr.Print("cannot run as unprivileged user")
+		return 1
+	}
+
 	if len(args) != 1 {
 		cmd.Usage()
 		return 1


### PR DESCRIPTION
Refuse to run if started by non-root users. Example:

> $ rkt run image...
> run: cannot run as unprivileged user

Related to https://github.com/coreos/rkt/issues/2063
Related to https://github.com/coreos/rkt/issues/2062

-----

/cc @crawford