### PR TITLE
Doc/devel: Describe rkt TPM event log use

### DIFF
--- a/Documentation/build-configure.md
+++ b/Documentation/build-configure.md
@@ -148,7 +148,7 @@ There is only one security-related flag; to enable TPM for logging.
 
 #### `--enable-tpm`
 
-This option to enable [logging to the TPM][rkt-tpm] is set to `auto` by default. For logging to work, [TrouSerS](http://trousers.sourceforge.net/) is required.
+This option to enable [logging to the TPM][rkt-tpm] is set by default. For logging to work, [TrouSerS](http://trousers.sourceforge.net/) is required. Set this option to `auto` to conditionally enable TPM features based on build support.
 
 
 [rkt-tpm]: devel/tpm.md

--- a/Documentation/build-configure.md
+++ b/Documentation/build-configure.md
@@ -148,8 +148,7 @@ There is only one security-related flag; to enable TPM for logging.
 
 #### `--enable-tpm`
 
-[Logging to the TPM][rkt-tpm] is enabled by default, following the "secure by default" principle. For logging to work, [TrouSerS](http://trousers.sourceforge.net/) is required.
-Use `--enable-tpm=auto` to conditionally enable the feature.
+This option to enable [logging to the TPM][rkt-tpm] is set to `auto` by default. For logging to work, [TrouSerS](http://trousers.sourceforge.net/) is required.
 
 
 [rkt-tpm]: devel/tpm.md

--- a/Documentation/build-configure.md
+++ b/Documentation/build-configure.md
@@ -148,6 +148,8 @@ There is only one security-related flag; to enable TPM for logging.
 
 #### `--enable-tpm`
 
-Logging to TPM is enabled by default, so it follows the "secure by default" principle.
-For it to work, [TrouSerS](http://trousers.sourceforge.net/) is required.
-Use 'auto' to enable it conditionally.
+[Logging to the TPM][rkt-tpm] is enabled by default, following the "secure by default" principle. For logging to work, [TrouSerS](http://trousers.sourceforge.net/) is required.
+Use `--enable-tpm=auto` to conditionally enable the feature.
+
+
+[rkt-tpm]: devel/tpm.md

--- a/Documentation/devel/tpm.md
+++ b/Documentation/devel/tpm.md
@@ -1,0 +1,15 @@
+# rkt and the Trusted Platform Module
+
+rkt supports *measuring* container state and configuration into the Trusted Platform Module (TPM) event log. Enable this functionality by building rkt with the [`--enable-tpm=yes` option to `./configure`][build-configure-tpm]. rkt accesses the TPM via the [`tpmd` executable available from the go-tspi project][go-tspi]. `Tpmd` is expected to listen on port 12041.
+
+Events are logged to PCR 15, with event type `0x1000`. Each event contains the following data:
+
+1. The hash of the container root filesystem
+2. The hash of the contents of the container manifest data
+3. The hash of the arguments passed to `stage1`
+
+This provides a cryptographically verifiable audit log of the containers executed on a node, including the configuration of each.
+
+
+[build-configure-tpm]: build-configure.md#security
+[go-tspi]: https://github.com/coreos/go-tspi

--- a/Documentation/devel/tpm.md
+++ b/Documentation/devel/tpm.md
@@ -1,6 +1,6 @@
 # rkt and the Trusted Platform Module
 
-rkt supports *measuring* container state and configuration into the Trusted Platform Module (TPM) event log. Enable this functionality by building rkt with the [`--enable-tpm=yes` option to `./configure`][build-configure-tpm]. rkt accesses the TPM via the [`tpmd` executable available from the go-tspi project][go-tspi]. `Tpmd` is expected to listen on port 12041.
+rkt supports *measuring* container state and configuration into the Trusted Platform Module (TPM) event log. Enable this functionality by building rkt with the [`--enable-tpm=yes` option to `./configure`][build-configure-tpm]. rkt accesses the TPM via the [`tpmd` executable available from the go-tspi project][go-tspi]. This `tpmd` is expected to listen on port 12041.
 
 Events are logged to PCR 15, with event type `0x1000`. Each event contains the following data:
 


### PR DESCRIPTION
Supersedes #2083. 

Add a TPM doc under `devel/`. Link to file from build-configure document,
where the `./configure` option to enable it is covered.

Questions/Requests for particular review:
1. In build-configure, is it true that `--enable-tpm=yes` by default?
2. In build-configure, is the TrouSers requirement still true? Is it true for building only, or for building and running?
3. In tpm.md, are all three items stored in the PCR *hashes* of things (as I recall from earlier work), or are numbers 2 and 3 in fact the actual manifest and the actual argv?