### PR TITLE
build: print a warning on go version 1.5.{1,2}

### DIFF
--- a/Documentation/build-configure.md
+++ b/Documentation/build-configure.md
@@ -144,11 +144,14 @@ Otherwise, it will disable them without any errors.
 
 ## Security
 
-There is only one security-related flag; to enable TPM for logging.
+These flags are related to security.
 
 #### `--enable-tpm`
 
 This option to enable [logging to the TPM][rkt-tpm] is set by default. For logging to work, [TrouSerS](http://trousers.sourceforge.net/) is required. Set this option to `auto` to conditionally enable TPM features based on build support.
 
+#### `--enable-insecure-go`
+
+This option to allow building rkt with go having known security issues is unset by default. Use it with caution.
 
 [rkt-tpm]: devel/tpm.md

--- a/configure.ac
+++ b/configure.ac
@@ -130,6 +130,14 @@ AC_ARG_ENABLE([tpm],
               [RKT_ENABLE_TPM="${enableval}"],
               [RKT_ENABLE_TPM="yes"])
 
+## insecure go
+
+AC_ARG_ENABLE([insecure-go],
+              [AS_HELP_STRING([--enable-insecure-go],
+                              [allow building rkt with go having known security issues, default: no])],
+              [RKT_INSECURE_GO="${enableval}"],
+              [RKT_INSECURE_GO="no"])
+
 #### CHECKING
 
 ## STAGE1 - initial verification and setup
@@ -601,7 +609,10 @@ AS_IF([test "${GO_MAJOR}" -gt "${GO_BEST_MAJOR}" || test "${GO_MAJOR}" -eq "${GO
 AC_MSG_CHECKING([whether we have a go version without CVE-2015-8618])
 AS_IF([test "${GO_MAJOR}" -eq "1" -a "${GO_MINOR}" -eq "5" -a "${GO_MICRO}" -lt "3"],
       [AC_MSG_RESULT([no])
-       AC_MSG_WARN([*** go version is vulnerable to CVE-2015-8618 (${GO_VERSION})])],
+       insecure_go_warning="go version is vulnerable to CVE-2015-8618 (${GO_VERSION})"
+       AS_VAR_IF([RKT_INSECURE_GO],[no],
+                 [AC_MSG_ERROR([*** ${insecure_go_warning}])],
+                 [AC_MSG_WARN([* ${insecure_go_warning}])])],
       [AC_MSG_RESULT([yes])])
 
 RKT_STAGE1_DEFAULT_NAME_LDFLAGS=`RKT_XF main.buildDefaultStage1Name "${RKT_STAGE1_DEFAULT_NAME}"`

--- a/configure.ac
+++ b/configure.ac
@@ -601,7 +601,7 @@ AS_IF([test "${GO_MAJOR}" -gt "${GO_BEST_MAJOR}" || test "${GO_MAJOR}" -eq "${GO
 AC_MSG_CHECKING([whether we have a go version without CVE-2015-8618])
 AS_IF([test "${GO_MAJOR}" -eq "1" -a "${GO_MINOR}" -eq "5" -a "${GO_MICRO}" -lt "3"],
       [AC_MSG_RESULT([no])
-       AC_MSG_ERROR([*** go version is vulnerable to CVE-2015-8618 (${GO_VERSION})])],
+       AC_MSG_WARN([*** go version is vulnerable to CVE-2015-8618 (${GO_VERSION})])],
       [AC_MSG_RESULT([yes])])
 
 RKT_STAGE1_DEFAULT_NAME_LDFLAGS=`RKT_XF main.buildDefaultStage1Name "${RKT_STAGE1_DEFAULT_NAME}"`

--- a/tests/run-build.sh
+++ b/tests/run-build.sh
@@ -66,24 +66,28 @@ if [ ${SRC_CHANGES} -gt 0 ]; then
         coreos|kvm)
         ./configure --with-stage1-flavors="${RKT_STAGE1_USR_FROM}" \
                 --with-stage1-default-flavor="${RKT_STAGE1_USR_FROM}" \
-                --enable-functional-tests --enable-tpm=auto
+                --enable-functional-tests --enable-tpm=auto \
+                --enable-insecure-go
         ;;
         host)
         ./configure --with-stage1-flavors=host \
                 --with-default-stage1-flavor=host \
-                --enable-functional-tests=auto --enable-tpm=auto
+                --enable-functional-tests=auto --enable-tpm=auto \
+                --enable-insecure-go
         ;;
         src)
         ./configure --with-stage1-flavors="${RKT_STAGE1_USR_FROM}" \
                 --with-stage1-default-flavor="${RKT_STAGE1_USR_FROM}" \
                 --with-stage1-systemd-version="${RKT_STAGE1_SYSTEMD_VER}" \
-                --enable-functional-tests --enable-tpm=auto
+                --enable-functional-tests --enable-tpm=auto \
+                --enable-insecure-go
         ;;
         none)
         # Not a flavor per se, so perform a detailed setup for some
         # hypothetical 3rd party stage1 image
         ./configure --with-stage1-default-name="example.com/some-stage1-for-rkt" \
-                --with-stage1-default-version="0.0.1" --enable-tpm=auto
+                --with-stage1-default-version="0.0.1" --enable-tpm=auto \
+                --enable-insecure-go
         ;;
         *)
         echo "Unknown flavor: ${RKT_STAGE1_USR_FROM}"


### PR DESCRIPTION
Ubuntu does not have golang 1.5.3 yet, so the check was completely
blocking the build on Ubuntu. Replace it with a warning.

Related to https://github.com/coreos/rkt/pull/2006

-----

/cc @krnowak 