### PR TITLE
Add a rkt install stage1 subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fetched keys are no longer automatically trusted by default, unless `--trust-keys-from-https` is used. Additionally, newly fetched keys have to be explicitly trusted with `rkt trust` if a previous key was trusted for the same image prefix ([#2033](https://github.com/coreos/rkt/pull/2033)).
 - Use NAT loopback to make ports forwarded in pods accessible from localhost ([#1256](https://github.com/coreos/rkt/issues/1256)).
 - Show a clearer error message when unprivileged users execute commands that require root privileges ([#2081](https://github.com/coreos/rkt/pull/2081)).
+- Add a new `rkt install stage1` subcommand. It will put the stage1 image into the store and generate a stage1 configuration in system configuration marking the image as a default. It will make `rkt run` and `rkt prepare` commands faster on the first run.
 
 #### Bug fixes
 
@@ -34,6 +35,7 @@ With this release, `rkt` RPM/dpkg packages should have the following updates:
 
 - Pass `--enable-tpm=no` to configure script, if `rkt` should not use TPM.
 - Use the `--with-default-stage1-images-directory` configure flag, if the default is not acceptable and install the built stage1 images there.
+- Consider using `rkt install stage1` for defining the default stage1 image.
 
 ## v0.16.0
 

--- a/Documentation/subcommands/install.md
+++ b/Documentation/subcommands/install.md
@@ -13,3 +13,11 @@ This command sets up the rkt data directory (`/var/lib/rkt` by default) with the
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
 | `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |
+
+## rkt install stage1
+
+This installs given stage1 image in the store and generates a configuration file in a system configuration directory.
+
+```
+# rkt --insecure-options=image install stage1 /usr/lib/rkt/stage1-images/stage1-coreos.aci
+```

--- a/rkt/install_stage1.go
+++ b/rkt/install_stage1.go
@@ -1,0 +1,135 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/coreos/rkt/common/apps"
+	"github.com/coreos/rkt/rkt/image"
+	"github.com/coreos/rkt/store"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdInstallStage1 = &cobra.Command{
+		Use:   "stage1 LOCATION",
+		Short: "Fetches a stage1 image file into the store and writes a stage1 configuration file in the vendor directory",
+		Long:  "This command should be executed when installing rkt in the filesystem. It will make sure that the vendor default stage image1 is in the store, so commands like run or prepare will be will be faster. The location passed to this command should be either an absolute path or an HTTP/HTTPS/File/Docker URL",
+		Run:   runWrapper(runInstallStage1),
+	}
+)
+
+const (
+	stage1ConfigTemplate = `
+{
+	"rktKind": "stage1",
+	"rktVersion": "v1",
+	"name": "^NAME^",
+	"version": "^VERSION^",
+	"location": "^LOCATION^"
+}
+`
+)
+
+func init() {
+	cmdInstall.AddCommand(cmdInstallStage1)
+}
+
+func runInstallStage1(cmd *cobra.Command, args []string) int {
+	if len(args) != 1 {
+		stderr.Printf("must provide exactly one absolute path or URL to the stage1 image")
+		return 1
+	}
+	locType := apps.AppImageGuess
+	loc := args[0]
+	if filepath.IsAbs(loc) {
+		locType = apps.AppImagePath
+	} else {
+		u, err := url.Parse(loc)
+		if err != nil {
+			stderr.PrintE(fmt.Sprintf("location %q is neither an absolute path nor a valid URL", loc), err)
+			return 1
+		}
+		if u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "docker" && u.Scheme != "file" {
+			stderr.Printf("URL %q has an invalid scheme", loc)
+			return 1
+		}
+		locType = apps.AppImageURL
+	}
+	s, err := store.NewStore(getDataDir())
+	if err != nil {
+		stderr.PrintE("cannot open store", err)
+		return 1
+	}
+	ks := getKeystore()
+	config, err := getConfig()
+	if err != nil {
+		stderr.PrintE("cannot get configuration", err)
+		return 1
+	}
+
+	ft := &image.Fetcher{
+		S:                  s,
+		Ks:                 ks,
+		Headers:            config.AuthPerHost,
+		DockerAuth:         config.DockerCredentialsPerRegistry,
+		InsecureFlags:      globalFlags.InsecureFlags,
+		Debug:              globalFlags.Debug,
+		TrustKeysFromHTTPS: globalFlags.TrustKeysFromHTTPS,
+
+		StoreOnly: false,
+		NoStore:   false,
+		WithDeps:  true,
+	}
+
+	hash, err := ft.FetchImage(loc, "", locType)
+	if err != nil {
+		stderr.PrintE(fmt.Sprintf("cannot fetch stage1 image %q", loc), err)
+		return 1
+	}
+	im, err := s.GetImageManifest(hash)
+	if err != nil {
+		stderr.PrintE(fmt.Sprintf("cannot get the stage1 image's (%q, hash %q) manifest from store", loc, hash), err)
+		return 1
+	}
+	version, ok := im.GetLabel("version")
+	if !ok {
+		stderr.Printf("the stage1 image file %q has no version", loc)
+		return 1
+	}
+	cfg := stage1ConfigTemplate
+	cfg = strings.Replace(cfg, "^NAME^", im.Name.String(), 1)
+	cfg = strings.Replace(cfg, "^VERSION^", version, 1)
+	cfg = strings.Replace(cfg, "^LOCATION^", loc, 1)
+
+	cfgDir := filepath.Join(globalFlags.SystemConfigDir, "stage1.d")
+	cfgPath := filepath.Join(cfgDir, "vendor-stage1.json")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		stderr.PrintE(fmt.Sprintf("failed to create directories %q", cfgDir), err)
+		return 1
+	}
+	if err := ioutil.WriteFile(cfgPath, []byte(cfg), 0755); err != nil {
+		stderr.PrintE(fmt.Sprintf("failed to write a vendor configuration to %q", cfgPath), err)
+		return 1
+	}
+
+	return 0
+}

--- a/tests/rkt_install_stage1_test.go
+++ b/tests/rkt_install_stage1_test.go
@@ -1,0 +1,73 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/coreos/rkt/rkt/config"
+	"github.com/coreos/rkt/store"
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+func TestRktInstallStage1(t *testing.T) {
+	stubStage1 := testutils.GetValueFromEnvOrPanic("STUB_STAGE1")
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	if !filepath.IsAbs(stubStage1) {
+		abs, err := filepath.Abs(stubStage1)
+		if err != nil {
+			t.Fatalf("failed to get the absolute path to the stub stage1 image (based on %s): %v", abs, err)
+		}
+		stubStage1 = abs
+	}
+
+	cmd := fmt.Sprintf("%s --insecure-options=image install stage1 %s", ctx.Cmd(), stubStage1)
+	spawnAndWaitOrFail(t, cmd, true)
+	rawHash := fmt.Sprintf("sha512-%s", getHashOrPanic(stubStage1))
+	s, err := store.NewStore(ctx.DataDir())
+	if err != nil {
+		t.Fatalf("failed to open the store at %q: %v", ctx.DataDir(), err)
+	}
+	hash, err := s.ResolveKey(rawHash)
+	if err != nil {
+		t.Fatalf("failed to resolve the key for hash %q: %v", rawHash, err)
+	}
+	im, err := s.GetImageManifest(hash)
+	if err != nil {
+		t.Fatalf("failed to get manifest for hash %q: %v", hash, err)
+	}
+
+	cfg, err := config.GetConfigFrom(ctx.SystemDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if im.Name.String() != cfg.Stage1.Name {
+		t.Fatalf("expected name %q, got %q", im.Name.String(), cfg.Stage1.Name)
+	}
+	version, ok := im.GetLabel("version")
+	if !ok {
+		t.Fatal("no version label in manifest")
+	}
+	if version != cfg.Stage1.Version {
+		t.Fatalf("expected version %q, got %q", version, cfg.Stage1.Version)
+	}
+	if stubStage1 != cfg.Stage1.Location {
+		t.Fatalf("expected location %q, got %q", stubStage1, cfg.Stage1.Location)
+	}
+}

--- a/tests/stub-stage1/stub-stage1.mk
+++ b/tests/stub-stage1/stub-stage1.mk
@@ -44,7 +44,7 @@ $(call forward-vars,$(FTST_SS1_IMAGE), \
 $(FTST_SS1_IMAGE): $(FTST_SS1_MANIFEST) $(FTST_SS1_RUN_BINARY) $(FTST_SS1_ENTER_BINARY) $(FTST_SS1_GC_BINARY) $(ACTOOL_STAMP) | $(FTST_SS1_ACIDIR) $(FTST_SS1_RESERVED_DIRS_IN_ROOTFS)
 	$(VQ) \
 	$(call vb,vt,ACTOOL,$(call vsp,$@)) \
-	"$(ACTOOL)" build --overwrite "$(FTST_SS1_ACIDIR)" "$@"
+	"$(ACTOOL)" build --no-compression --overwrite "$(FTST_SS1_ACIDIR)" "$@"
 
 $(FTST_SS1_RUN_BINARY) $(FTST_SS1_ENTER_BINARY) $(FTST_SS1_GC_BINARY): | $(FTST_SS1_ACIROOTFSDIR)
 


### PR DESCRIPTION
This puts the given stage1 image in the store and generates a configuration stage1 file in the system configuration directory.

There is also a test for it.

I guess that the typical usage will be something like `rkt --insecure-options=image install stage1 /usr/lib/rkt/stage1-images/stage1-coreos.aci`.

Fixes #471 