### PR TITLE
scripts: install libtspi-dev dependency

### DIFF
--- a/scripts/install-common.sh
+++ b/scripts/install-common.sh
@@ -4,7 +4,7 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates gcc libc6-dev make automake wget git coreutils cpio squashfs-tools realpath autoconf file libacl1-dev
+apt-get install -y --no-install-recommends ca-certificates gcc libc6-dev make automake wget git coreutils cpio squashfs-tools realpath autoconf file libacl1-dev libtspi-dev
 
 ./scripts/install-go.sh
 . /etc/profile


### PR DESCRIPTION
rkt build breaks in configure with
'TPM is enabled, but could not find required development files'
without it