### PR TITLE
api-service: remove "do not use it" warnings

### DIFF
--- a/api/v1alpha/README.md
+++ b/api/v1alpha/README.md
@@ -2,8 +2,6 @@
 
 The API defined here is proposed, experimental, and (for now) subject to change at any time.
 
-**Do not use it.**
-
 If you think you want to use it, or for any other queries, contact <rkt-dev@googlegroups.com> or file an [issue](https://github.com/coreos/rkt/issues/new)
 
 For more information, see:

--- a/api/v1alpha/api.proto
+++ b/api/v1alpha/api.proto
@@ -21,8 +21,6 @@
 //   The API defined here is proposed, experimental,   //
 //   and (for now) subject to change at any time.      //
 //                                                     //
-//                   Do not use it.                    //
-//                                                     //
 //  If you think you want to use it, or for any other  //
 //     queries, contact <rkt-dev@googlegroups.com>     //
 //      or file an issue on github.com/coreos/rkt      //

--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -41,7 +41,7 @@ var (
 	supportedAPIVersion = "1.0.0-alpha"
 	cmdAPIService       = &cobra.Command{
 		Use:   `api-service [--listen="localhost:15441"]`,
-		Short: "Run API service (experimental, DO NOT USE IT)",
+		Short: "Run API service (experimental)",
 		Long: `The API service listens for gRPC requests on the address and port specified by
 the --listen option.
 


### PR DESCRIPTION
I kept "experimental" but removed the "do not use it" warnings.

Is it time to remove it?

/cc @joshix @yifan-gu 