### PR TITLE
image: Validate docker url in dockerfetcher.

### DIFF
--- a/rkt/image/dockerfetcher.go
+++ b/rkt/image/dockerfetcher.go
@@ -51,6 +51,9 @@ type dockerFetcher struct {
 func (f *dockerFetcher) GetHash(u *url.URL) (string, error) {
 	ensureLogger(f.Debug)
 	dockerURL := d2acommon.ParseDockerURL(path.Join(u.Host, u.Path))
+	if dockerURL == nil {
+		return "", fmt.Errorf("invalid docker URL %q. Syntax docker://[REGISTRY_HOST[:REGISTRY_PORT]/]IMAGE_NAME[:TAG]", u)
+	}
 	latest := dockerURL.Tag == "latest"
 	return f.fetchImageFrom(u, latest)
 }


### PR DESCRIPTION
Passing an invalid docker url such as docker:run crashes rkt otherwise
with
```
sudo ./build-rkt-1.0.0+git/bin/rkt run docker:busybox
image: using image from file /usr/lib/rkt/stage1.aci
image: remote fetching from URL "docker:busybox"
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x5e4314]

goroutine 1 [running, locked to thread]:
github.com/coreos/rkt/rkt/image.(*dockerFetcher).GetHash(0xc82033b2f0, 0xc820322080, 0x0, 0x0, 0x0, 0x0)
        /home/raghu/repo/go/src/github.com/coreos/rkt/build-rkt-1.0.0+git/gopath/src/github.com/coreos/rkt/rkt/image/dockerfetcher.go:54 +0x1f4
github.com/coreos/rkt/rkt/image.(*Fetcher).maybeFetchDockerURLFromRemote(0xc82033ba50, 0xc820322080, 0x0, 0x0, 0x0, 0x0)
        /home/raghu/repo/go/src/github.com/coreos/rkt/build-rkt-1.0.0+git/gopath/src/github.com/coreos/rkt/rkt/image/fetcher.go:249 +0x1ab
github.com/coreos/rkt/rkt/image.(*Fetcher).fetchSingleImageByDockerURL(0xc82033ba50, 0xc820322080, 0x0, 0x0, 0x0, 0x0)
        /home/raghu/repo/go/src/github.com/coreos/rkt/build-rkt-1.0.0+git/gopath/src/github.com/coreos/rkt/rkt/image/fetcher.go:187 +0x12b
```

Full trace:
https://gist.github.com/ronin13/bb82648c5d48ee68e808

This happens because ParseDockerURL output is not checked for nil.

With the fix it shows like:
```
sudo ./build-rkt-1.0.0+git/bin/rkt run --interactive docker:busybox
image: using image from local store for image name coreos.com/rkt/stage1-coreos:1.0.0+git6146a78
image: remote fetching from URL "docker:busybox"
run: Invalid docker URL
```