### PR TITLE
documentation: fix link to Vagrant instructions

### DIFF
--- a/Documentation/getting-started-guide.md
+++ b/Documentation/getting-started-guide.md
@@ -1,7 +1,7 @@
 # Getting Started with rkt
 
 The following guide will show you how to build and run a self-contained Go app using rkt, the reference implementation of the [App Container Specification](https://github.com/appc/spec).
-If you're not on Linux, you should do all of this inside [the rkt Vagrant](https://github.com/coreos/rkt#trying-out-rkt-using-vagrant).
+If you're not on Linux, you should do all of this inside [the rkt Vagrant](https://github.com/coreos/rkt/blob/master/Documentation/trying-out-rkt.md#rkt-using-vagrant).
 
 ## Create a hello go application
 


### PR DESCRIPTION
The prior link just ended up pointing at the main Github page for rkt.