### PR TITLE
stage1: fix socket activation port matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## vUNRELEASED
+
+#### Bug fixes
+- Socket activation was not working if the port on the host is different from the app port as set in the image manifest ([#2137](https://github.com/coreos/rkt/pull/2137)).
+
 ## v1.0.0
 
 This marks the first release of rkt recommended for use in production.

--- a/Documentation/using-rkt-with-systemd.md
+++ b/Documentation/using-rkt-with-systemd.md
@@ -146,9 +146,9 @@ To make socket activation work, add a [socket-activated port][aci-socketActivate
         ...
         "ports": [
             {
-                "name": "8080-tcp",
+                "name": "80-tcp",
                 "protocol": "tcp",
-                "port": 8080,
+                "port": 80,
                 "count": 1,
                 "socketActivated": true
             }
@@ -157,7 +157,9 @@ To make socket activation work, add a [socket-activated port][aci-socketActivate
 }
 ```
 
-Then you will need a pair of `.service` and `.socket` unit files. The socket unit file will have the same port you've set in the image manifest of your app, and the service unit file will run `rkt`:
+Then you will need a pair of `.service` and `.socket` unit files.
+
+In this example, we want to use the port 8080 on the host instead of the app's default 80, so we use rkt's `--port` option to override it.
 
 ```
 # my-socket-activated-app.socket
@@ -174,7 +176,7 @@ ListenStream=8080
 Description=My socket-activated app
 
 [Service]
-ExecStart=/usr/bin/rkt run myapp.com/my-socket-activated-app:v1.0
+ExecStart=/usr/bin/rkt run --port 80-tcp:8080 myapp.com/my-socket-activated-app:v1.0
 KillMode=mixed
 ```
 
@@ -189,10 +191,9 @@ $ systemctl status my-socket-activated-app.socket
    Listen: [::]:8080 (Stream)
 
 Jul 30 12:24:50 locke-work systemd[1]: Listening on My socket-activated app's socket.
-Jul 30 12:24:50 locke-work systemd[1]: Starting My socket-activated app's socket.
 ```
 
-Now a new connection to port 8080 will start your container to handle the request.
+Now, a new connection to port 8080 will start your container to handle the request.
 
 ## Other tools for managing pods
 

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -435,6 +435,7 @@ func getArgsEnv(p *stage1commontypes.Pod, flavor string, debug bool, n *networki
 func forwardedPorts(pod *stage1commontypes.Pod) ([]networking.ForwardedPort, error) {
 	var fps []networking.ForwardedPort
 
+NextPort:
 	for _, ep := range pod.Manifest.Ports {
 		n := ""
 		fp := networking.ForwardedPort{}
@@ -443,6 +444,10 @@ func forwardedPorts(pod *stage1commontypes.Pod) ([]networking.ForwardedPort, err
 			for _, p := range a.App.Ports {
 				if p.Name == ep.Name {
 					if n == "" {
+						// skip socket-activated ports, they don't need port forwarding
+						if p.SocketActivated {
+							continue NextPort
+						}
 						fp.Protocol = p.Protocol
 						fp.HostPort = ep.HostPort
 						fp.PodPort = p.Port

--- a/tests/rkt_socket_activation_test.go
+++ b/tests/rkt_socket_activation_test.go
@@ -64,7 +64,7 @@ func TestSocketActivation(t *testing.T) {
 
 	echoImage := patchTestACI("rkt-inspect-echo.aci",
 		"--exec=/echo-socket-activated",
-		fmt.Sprintf("--ports=test-port,protocol=tcp,port=80,socketActivated=true"))
+		"--ports=test-port,protocol=tcp,port=80,socketActivated=true")
 	defer os.Remove(echoImage)
 
 	ctx := testutils.NewRktRunCtx()

--- a/tests/rkt_socket_activation_test.go
+++ b/tests/rkt_socket_activation_test.go
@@ -64,7 +64,7 @@ func TestSocketActivation(t *testing.T) {
 
 	echoImage := patchTestACI("rkt-inspect-echo.aci",
 		"--exec=/echo-socket-activated",
-		fmt.Sprintf("--ports=%d-tcp,protocol=tcp,port=%d,socketActivated=true", port, port))
+		fmt.Sprintf("--ports=test-port,protocol=tcp,port=80,socketActivated=true"))
 	defer os.Remove(echoImage)
 
 	ctx := testutils.NewRktRunCtx()
@@ -91,7 +91,7 @@ func TestSocketActivation(t *testing.T) {
 	// systemd v219 as it does not work with absolute paths.
 	unitsDir := "/run/systemd/system"
 
-	cmd := fmt.Sprintf("%s --insecure-options=image run --mds-register=false %s", ctx.Cmd(), echoImage)
+	cmd := fmt.Sprintf("%s --insecure-options=image run --port=test-port:%d --mds-register=false %s", ctx.Cmd(), port, echoImage)
 	serviceContent := fmt.Sprintf(rktTestingEchoService, cmd)
 	serviceTargetBase := fmt.Sprintf("rkt-testing-socket-activation-%d.service", rnd)
 	serviceTarget := filepath.Join(unitsDir, serviceTargetBase)


### PR DESCRIPTION
We were using the port of the image manifest to set up the socket unit
file inside the pod. This means it only worked if the port in the image
manifest and the pod in the pod manifest (set by rkt at runtime) were
the same.

The reason is that systemd inside the host matches based on the socket
port number, and since the socket is created on the host, it will have
the host port number. If this number is different from the one in the
image manifest, systemd will not assign the socket to the correct app in
the pod because it will expect a socket with the image manifest port
number.

The solution is using the host port number for the socket unit file.

Fixes https://github.com/coreos/rkt/issues/2135