### PR TITLE
stage1/fly: fix error with unset exec statement

### DIFF
--- a/stage1/common/types/pod.go
+++ b/stage1/common/types/pod.go
@@ -37,6 +37,18 @@ type Pod struct {
 	Networks           []string
 }
 
+// AppNameToImageName takes the name of an app in the Pod and returns the name
+// of the app's image. The mapping between these two is populated when a Pod is
+// loaded (using LoadPod).
+func (p *Pod) AppNameToImageName(appName types.ACName) types.ACIdentifier {
+	image, ok := p.Images[appName.String()]
+	if !ok {
+		// This should be impossible as we have updated the map in LoadPod().
+		panic(fmt.Sprintf("No images for app %q", appName.String()))
+	}
+	return image.Name
+}
+
 // LoadPod loads a Pod Manifest (as prepared by stage0) and
 // its associated Application Manifests, under $root/stage1/opt/stage1/$apphash
 func LoadPod(root string, uuid *types.UUID) (*Pod, error) {
@@ -58,24 +70,24 @@ func LoadPod(root string, uuid *types.UUID) (*Pod, error) {
 	p.Manifest = pm
 
 	for i, app := range p.Manifest.Apps {
-		ampath := common.ImageManifestPath(p.Root, app.Name)
-		buf, err := ioutil.ReadFile(ampath)
+		impath := common.ImageManifestPath(p.Root, app.Name)
+		buf, err := ioutil.ReadFile(impath)
 		if err != nil {
-			return nil, errwrap.Wrap(fmt.Errorf("failed reading app manifest %q", ampath), err)
+			return nil, errwrap.Wrap(fmt.Errorf("failed reading image manifest %q", impath), err)
 		}
 
-		am := &schema.ImageManifest{}
-		if err = json.Unmarshal(buf, am); err != nil {
-			return nil, errwrap.Wrap(fmt.Errorf("failed unmarshalling app manifest %q", ampath), err)
+		im := &schema.ImageManifest{}
+		if err = json.Unmarshal(buf, im); err != nil {
+			return nil, errwrap.Wrap(fmt.Errorf("failed unmarshalling image manifest %q", impath), err)
 		}
 
 		if _, ok := p.Images[app.Name.String()]; ok {
 			return nil, fmt.Errorf("got multiple definitions for app: %v", app.Name)
 		}
 		if app.App == nil {
-			p.Manifest.Apps[i].App = am.App
+			p.Manifest.Apps[i].App = im.App
 		}
-		p.Images[app.Name.String()] = am
+		p.Images[app.Name.String()] = im
 	}
 
 	return p, nil

--- a/stage1/init/common/pod.go
+++ b/stage1/init/common/pod.go
@@ -234,12 +234,7 @@ func generateGidArg(gid int, supplGid []int) string {
 func appToSystemd(p *stage1commontypes.Pod, ra *schema.RuntimeApp, interactive bool, flavor string, privateUsers string) error {
 	app := ra.App
 	appName := ra.Name
-	image, ok := p.Images[appName.String()]
-	if !ok {
-		// This is impossible as we have updated the map in LoadPod().
-		panic(fmt.Sprintf("No images for app %q", ra.Name.String()))
-	}
-	imgName := image.Name
+	imgName := p.AppNameToImageName(appName)
 
 	if len(app.Exec) == 0 {
 		return fmt.Errorf(`image %q has an empty "exec" (try --exec=BINARY)`, imgName)


### PR DESCRIPTION
If the fly stage1 was passed an image that had an empty exec, it could
panic. This adds the same check that we use for the non-fly stage1, and
refactors the code slightly to share it between them.

Also renames a couple of old vestigial variables: appmanifest rather
than imagemanifest, etc.

Fixes #2131