### PR TITLE
network: add network tuning plugin from CNI

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -11,73 +11,79 @@
 		"github.com/appc/cni/plugins/main/macvlan",
 		"github.com/appc/cni/plugins/main/ptp",
 		"github.com/appc/cni/plugins/meta/flannel",
+		"github.com/appc/cni/plugins/meta/tuning",
 		"github.com/appc/spec/ace"
 	],
 	"Deps": [
 		{
 			"ImportPath": "github.com/appc/cni/pkg/invoke",
-			"Comment": "v0.1.0-50-gf777ca5",
-			"Rev": "f777ca50e50ddecdca561cb22ca4a0c4e5ec17c9"
+			"Comment": "v0.1.0-84-gb7ff8ab",
+			"Rev": "b7ff8ab158bd2fbc700d0fe6e0a58712970fabc0"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/pkg/ip",
-			"Comment": "v0.1.0-50-gf777ca5",
-			"Rev": "f777ca50e50ddecdca561cb22ca4a0c4e5ec17c9"
+			"Comment": "v0.1.0-84-gb7ff8ab",
+			"Rev": "b7ff8ab158bd2fbc700d0fe6e0a58712970fabc0"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/pkg/ipam",
-			"Comment": "v0.1.0-50-gf777ca5",
-			"Rev": "f777ca50e50ddecdca561cb22ca4a0c4e5ec17c9"
+			"Comment": "v0.1.0-84-gb7ff8ab",
+			"Rev": "b7ff8ab158bd2fbc700d0fe6e0a58712970fabc0"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/pkg/ns",
-			"Comment": "v0.1.0-50-gf777ca5",
-			"Rev": "f777ca50e50ddecdca561cb22ca4a0c4e5ec17c9"
+			"Comment": "v0.1.0-84-gb7ff8ab",
+			"Rev": "b7ff8ab158bd2fbc700d0fe6e0a58712970fabc0"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/pkg/skel",
-			"Comment": "v0.1.0-50-gf777ca5",
-			"Rev": "f777ca50e50ddecdca561cb22ca4a0c4e5ec17c9"
+			"Comment": "v0.1.0-84-gb7ff8ab",
+			"Rev": "b7ff8ab158bd2fbc700d0fe6e0a58712970fabc0"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/pkg/types",
-			"Comment": "v0.1.0-50-gf777ca5",
-			"Rev": "f777ca50e50ddecdca561cb22ca4a0c4e5ec17c9"
+			"Comment": "v0.1.0-84-gb7ff8ab",
+			"Rev": "b7ff8ab158bd2fbc700d0fe6e0a58712970fabc0"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/plugins/ipam/dhcp",
-			"Comment": "v0.1.0-50-gf777ca5",
-			"Rev": "f777ca50e50ddecdca561cb22ca4a0c4e5ec17c9"
+			"Comment": "v0.1.0-84-gb7ff8ab",
+			"Rev": "b7ff8ab158bd2fbc700d0fe6e0a58712970fabc0"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/plugins/ipam/host-local",
-			"Comment": "v0.1.0-50-gf777ca5",
-			"Rev": "f777ca50e50ddecdca561cb22ca4a0c4e5ec17c9"
+			"Comment": "v0.1.0-84-gb7ff8ab",
+			"Rev": "b7ff8ab158bd2fbc700d0fe6e0a58712970fabc0"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/plugins/main/bridge",
-			"Comment": "v0.1.0-50-gf777ca5",
-			"Rev": "f777ca50e50ddecdca561cb22ca4a0c4e5ec17c9"
+			"Comment": "v0.1.0-84-gb7ff8ab",
+			"Rev": "b7ff8ab158bd2fbc700d0fe6e0a58712970fabc0"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/plugins/main/ipvlan",
-			"Comment": "v0.1.0-50-gf777ca5",
-			"Rev": "f777ca50e50ddecdca561cb22ca4a0c4e5ec17c9"
+			"Comment": "v0.1.0-84-gb7ff8ab",
+			"Rev": "b7ff8ab158bd2fbc700d0fe6e0a58712970fabc0"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/plugins/main/macvlan",
-			"Comment": "v0.1.0-50-gf777ca5",
-			"Rev": "f777ca50e50ddecdca561cb22ca4a0c4e5ec17c9"
+			"Comment": "v0.1.0-84-gb7ff8ab",
+			"Rev": "b7ff8ab158bd2fbc700d0fe6e0a58712970fabc0"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/plugins/main/ptp",
-			"Comment": "v0.1.0-50-gf777ca5",
-			"Rev": "f777ca50e50ddecdca561cb22ca4a0c4e5ec17c9"
+			"Comment": "v0.1.0-84-gb7ff8ab",
+			"Rev": "b7ff8ab158bd2fbc700d0fe6e0a58712970fabc0"
 		},
 		{
 			"ImportPath": "github.com/appc/cni/plugins/meta/flannel",
-			"Comment": "v0.1.0-50-gf777ca5",
-			"Rev": "f777ca50e50ddecdca561cb22ca4a0c4e5ec17c9"
+			"Comment": "v0.1.0-84-gb7ff8ab",
+			"Rev": "b7ff8ab158bd2fbc700d0fe6e0a58712970fabc0"
+		},
+		{
+			"ImportPath": "github.com/appc/cni/plugins/meta/tuning",
+			"Comment": "v0.1.0-84-gb7ff8ab",
+			"Rev": "b7ff8ab158bd2fbc700d0fe6e0a58712970fabc0"
 		},
 		{
 			"ImportPath": "github.com/appc/docker2aci/lib",

--- a/Godeps/_workspace/src/github.com/appc/cni/pkg/ip/ipmasq.go
+++ b/Godeps/_workspace/src/github.com/appc/cni/pkg/ip/ipmasq.go
@@ -26,7 +26,7 @@ import (
 func SetupIPMasq(ipn *net.IPNet, chain string) error {
 	ipt, err := iptables.New()
 	if err != nil {
-		return fmt.Errorf("failed to locate iptabes: %v", err)
+		return fmt.Errorf("failed to locate iptables: %v", err)
 	}
 
 	if err = ipt.NewChain("nat", chain); err != nil {
@@ -51,7 +51,7 @@ func SetupIPMasq(ipn *net.IPNet, chain string) error {
 func TeardownIPMasq(ipn *net.IPNet, chain string) error {
 	ipt, err := iptables.New()
 	if err != nil {
-		return fmt.Errorf("failed to locate iptabes: %v", err)
+		return fmt.Errorf("failed to locate iptables: %v", err)
 	}
 
 	if err = ipt.Delete("nat", "POSTROUTING", "-s", ipn.String(), "-j", chain); err != nil {

--- a/Godeps/_workspace/src/github.com/appc/cni/pkg/types/types.go
+++ b/Godeps/_workspace/src/github.com/appc/cni/pkg/types/types.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 )
@@ -61,16 +62,32 @@ type NetConf struct {
 	IPAM struct {
 		Type string `json:"type,omitempty"`
 	} `json:"ipam,omitempty"`
+	DNS DNS `json:"dns"`
 }
 
 // Result is what gets returned from the plugin (via stdout) to the caller
 type Result struct {
 	IP4 *IPConfig `json:"ip4,omitempty"`
 	IP6 *IPConfig `json:"ip6,omitempty"`
+	DNS DNS       `json:"dns,omitempty"`
 }
 
 func (r *Result) Print() error {
 	return prettyPrint(r)
+}
+
+// String returns a formatted string in the form of "[IP4: $1,][ IP6: $2,] DNS: $3" where
+// $1 represents the receiver's IPv4, $2 represents the receiver's IPv6 and $3 the
+// receiver's DNS. If $1 or $2 are nil, they won't be present in the returned string.
+func (r *Result) String() string {
+	var str string
+	if r.IP4 != nil {
+		str = fmt.Sprintf("IP4:%+v, ", *r.IP4)
+	}
+	if r.IP6 != nil {
+		str += fmt.Sprintf("IP6:%+v, ", *r.IP6)
+	}
+	return fmt.Sprintf("%sDNS:%+v", str, r.DNS)
 }
 
 // IPConfig contains values necessary to configure an interface
@@ -78,6 +95,14 @@ type IPConfig struct {
 	IP      net.IPNet
 	Gateway net.IP
 	Routes  []Route
+}
+
+// DNS contains values interesting for DNS resolvers
+type DNS struct {
+	Nameservers []string `json:"nameservers,omitempty"`
+	Domain      string   `json:"domain,omitempty"`
+	Search      []string `json:"search,omitempty"`
+	Options     []string `json:"options,omitempty"`
 }
 
 type Route struct {

--- a/Godeps/_workspace/src/github.com/appc/cni/plugins/ipam/host-local/config.go
+++ b/Godeps/_workspace/src/github.com/appc/cni/plugins/ipam/host-local/config.go
@@ -35,7 +35,7 @@ type IPAMConfig struct {
 }
 
 type IPAMArgs struct {
-	IP net.IP `json:"ip",omitempty`
+	IP net.IP `json:"ip,omitempty"`
 }
 
 type Net struct {

--- a/Godeps/_workspace/src/github.com/appc/cni/plugins/main/bridge/bridge.go
+++ b/Godeps/_workspace/src/github.com/appc/cni/plugins/main/bridge/bridge.go
@@ -226,6 +226,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
+	result.DNS = n.DNS
 	return result.Print()
 }
 

--- a/Godeps/_workspace/src/github.com/appc/cni/plugins/main/ipvlan/ipvlan.go
+++ b/Godeps/_workspace/src/github.com/appc/cni/plugins/main/ipvlan/ipvlan.go
@@ -138,6 +138,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
+	result.DNS = n.DNS
 	return result.Print()
 }
 

--- a/Godeps/_workspace/src/github.com/appc/cni/plugins/main/macvlan/macvlan.go
+++ b/Godeps/_workspace/src/github.com/appc/cni/plugins/main/macvlan/macvlan.go
@@ -142,6 +142,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
+	result.DNS = n.DNS
 	return result.Print()
 }
 

--- a/Godeps/_workspace/src/github.com/appc/cni/plugins/main/ptp/ptp.go
+++ b/Godeps/_workspace/src/github.com/appc/cni/plugins/main/ptp/ptp.go
@@ -185,6 +185,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
+	result.DNS = conf.DNS
 	return result.Print()
 }
 

--- a/Godeps/_workspace/src/github.com/appc/cni/plugins/meta/tuning/tuning.go
+++ b/Godeps/_workspace/src/github.com/appc/cni/plugins/meta/tuning/tuning.go
@@ -1,0 +1,83 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a "meta-plugin". It reads in its own netconf, it does not create
+// any network interface but just changes the network sysctl.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/appc/cni/pkg/ns"
+	"github.com/appc/cni/pkg/skel"
+	"github.com/appc/cni/pkg/types"
+)
+
+// TuningConf represents the network tuning configuration.
+type TuningConf struct {
+	types.NetConf
+	SysCtl map[string]string `json:"sysctl"`
+}
+
+func cmdAdd(args *skel.CmdArgs) error {
+	tuningConf := TuningConf{}
+	if err := json.Unmarshal(args.StdinData, &tuningConf); err != nil {
+		return fmt.Errorf("failed to load netconf: %v", err)
+	}
+
+	// The directory /proc/sys/net is per network namespace. Enter in the
+	// network namespace before writing on it.
+
+	err := ns.WithNetNSPath(args.Netns, false, func(hostNS *os.File) error {
+		for key, value := range tuningConf.SysCtl {
+			fileName := filepath.Join("/proc/sys", strings.Replace(key, ".", "/", -1))
+			fileName = filepath.Clean(fileName)
+
+			// Refuse to modify sysctl parameters that don't belong
+			// to the network subsystem.
+			if !strings.HasPrefix(fileName, "/proc/sys/net/") {
+				return fmt.Errorf("invalid net sysctl key: %q", key)
+			}
+			content := []byte(value)
+			err := ioutil.WriteFile(fileName, content, 0644)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	result := types.Result{}
+	return result.Print()
+}
+
+func cmdDel(args *skel.CmdArgs) error {
+	// TODO: the settings are not reverted to the previous values. Reverting the
+	// settings is not useful when the whole container goes away but it could be
+	// useful in scenarios where plugins are added and removed at runtime.
+	return nil
+}
+
+func main() {
+	skel.PluginMain(cmdAdd, cmdDel)
+}

--- a/networking/net_plugin.go
+++ b/networking/net_plugin.go
@@ -58,11 +58,12 @@ func (e *podEnv) netPluginAdd(n *activeNet, netns string) (ip, hostIP net.IP, er
 
 	pr := cnitypes.Result{}
 	if err = json.Unmarshal(output, &pr); err != nil {
+		err = errwrap.Wrap(fmt.Errorf("parsing %q", string(output)), err)
 		return nil, nil, errwrap.Wrap(fmt.Errorf("error parsing %q result", n.conf.Name), err)
 	}
 
 	if pr.IP4 == nil {
-		return nil, nil, fmt.Errorf("net-plugin returned no IPv4 configuration")
+		return nil, nil, nil
 	}
 
 	return pr.IP4.IP.IP, pr.IP4.Gateway, nil

--- a/stage1/net-plugins/net-plugins.mk
+++ b/stage1/net-plugins/net-plugins.mk
@@ -15,7 +15,8 @@ NPM_PLUGIN_NAMES := \
 	main/ipvlan \
 	ipam/host-local \
 	ipam/dhcp \
-	meta/flannel
+	meta/flannel \
+	meta/tuning
 
 # both lists below have the same number of elements
 # array of path to built plugins

--- a/vendoredApps
+++ b/vendoredApps
@@ -9,6 +9,7 @@ github.com/appc/cni/plugins/main/ipvlan
 github.com/appc/cni/plugins/main/macvlan
 github.com/appc/cni/plugins/main/ptp
 github.com/appc/cni/plugins/meta/flannel
+github.com/appc/cni/plugins/meta/tuning
 
 # Vendor in ACE, which is used in functional tests
 github.com/appc/spec/ace


### PR DESCRIPTION
Allow users to tune net network parameters such as somaxconn.

With this patch, users can add a new network configuration:
```
> # cat /etc/rkt/net.d/mytuning.conf
> {
>       "name": "mytuning",
>       "type": "tuning",
>       "sysctl": {
>               "net.core.somaxconn": "500"
>       }
> }
```
Then, start rkt with that configuration file:
```
> # rkt run --net=default,mytuning /tmp/mycontainer.aci
```
The value /proc/sys/net/core/somaxconn will be set to 500 in the pod but
will remain unchanged on the host.

Only sysctl parameters that belong to the network subsystem can be
modified.

-----

/cc @slallema: In addition to `net.core.somaxconn`, is there any other settings that would be useful to let users configure?

/cc @steveeJ 

Fixes https://github.com/coreos/rkt/issues/2075