### PR TITLE
*: remove old app-container directory

### DIFF
--- a/app-container/README.md
+++ b/app-container/README.md
@@ -1,3 +1,0 @@
-# App Container
-
-The App Container repository has moved to https://github.com/appc/spec/

--- a/app-container/SPEC.md
+++ b/app-container/SPEC.md
@@ -1,3 +1,0 @@
-# App Container Specification
-
-The App Container Specification has moved to https://github.com/appc/spec/blob/master/SPEC.md


### PR DESCRIPTION
Winter cleaning time. appc has long, long had its own identity
and home, and it is extraordinarily unlikely anything is still
linking to this location.