### PR TITLE
rkt gc: look up for plugins in localConfigDir

### DIFF
--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -94,6 +94,7 @@ For example, it removes the network namespace of a pod.
 #### Arguments
 
 * `--debug` to activate debugging
+* `--local-config=$PATH` to override the local configuration directory
 * UUID of the pod
 
 Examples

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -185,7 +185,7 @@ func (n *Networking) enableDefaultLocalnetRouting() error {
 
 // Load creates the Networking object from saved state.
 // Assumes the current netns is that of the host.
-func Load(podRoot string, podID *types.UUID) (*Networking, error) {
+func Load(podRoot string, podID *types.UUID, localConfig string) (*Networking, error) {
 	// the current directory is pod root
 	pdirfd, err := syscall.Open(podRoot, syscall.O_RDONLY|syscall.O_DIRECTORY, 0)
 	if err != nil {
@@ -221,8 +221,9 @@ func Load(podRoot string, podID *types.UUID) (*Networking, error) {
 
 	return &Networking{
 		podEnv: podEnv{
-			podRoot: podRoot,
-			podID:   *podID,
+			podRoot:     podRoot,
+			podID:       *podID,
+			localConfig: localConfig,
 		},
 		hostNS: hostNS,
 		nets:   nets,

--- a/rkt/gc.go
+++ b/rkt/gc.go
@@ -211,7 +211,7 @@ func deletePod(p *pod) {
 				stage0.InitDebug()
 			}
 			stage1RootFS := s.GetTreeStoreRootFS(stage1TreeStoreID)
-			if err = stage0.GC(p.path(), p.uuid, stage1RootFS); err != nil {
+			if err = stage0.GC(p.path(), p.uuid, stage1RootFS, globalFlags.LocalConfigDir); err != nil {
 				stderr.PrintE(fmt.Sprintf("problem performing stage1 GC on %q", p.uuid), err)
 			}
 		}

--- a/stage0/gc.go
+++ b/stage0/gc.go
@@ -36,7 +36,7 @@ import (
 // GC enters the pod by fork/exec()ing the stage1's /gc similar to /init.
 // /gc can expect to have its CWD set to the pod root.
 // stage1Path is the path of the stage1 rootfs
-func GC(pdir string, uuid *types.UUID, stage1Path string) error {
+func GC(pdir string, uuid *types.UUID, stage1Path string, localConfig string) error {
 	err := unregisterPod(pdir, uuid)
 	if err != nil {
 		// Probably not worth abandoning the rest
@@ -51,6 +51,9 @@ func GC(pdir string, uuid *types.UUID, stage1Path string) error {
 	args := []string{filepath.Join(stage1Path, ep)}
 	if debugEnabled {
 		args = append(args, "--debug")
+	}
+	if localConfig != "" {
+		args = append(args, "--local-config="+localConfig)
 	}
 	args = append(args, uuid.String())
 

--- a/stage1/gc/gc.go
+++ b/stage1/gc/gc.go
@@ -32,11 +32,13 @@ import (
 )
 
 var (
-	debug bool
+	debug       bool
+	localConfig string
 )
 
 func init() {
 	flag.BoolVar(&debug, "debug", false, "Run in debug mode")
+	flag.StringVar(&localConfig, "local-config", common.DefaultLocalConfigDir, "Local config path")
 
 	// this ensures that main runs only on main thread (thread group leader).
 	// since namespace ops (unshare, setns) are done for a single thread, we
@@ -73,7 +75,7 @@ func gcNetworking(podID *types.UUID) error {
 		}
 	}
 
-	n, err := networking.Load(".", podID)
+	n, err := networking.Load(".", podID, localConfig)
 	switch {
 	case err == nil:
 		n.Teardown(flavor, debug)


### PR DESCRIPTION
When running 'rkt run --net=mynetwork', it looks for the network plugin
in three different places [1][1]:
- /etc/rkt/net.d/ (or something else with --local-config)
- /usr/lib/rkt/plugins/net
- ${STAGE1_ROOTFS}/usr/lib/rkt/plugins/net

This code works fine for 'rkt run' but does not work for 'rkt gc' or
'rkt rm' because there is a bug in the way --local-config is handled.

When stage1's 'run' entrypoint [2][2] is called, the --local-config flag
is passed. But this --local-config flag was not passed to stage1's 'gc'
entrypoint [3][3]. This patch adds this.

It might be unfortunate that plugin binaries can be stored in a
configuration directory but this is part of the stable rkt 1.0 interface
now. And plugins like calico rely on it.

It is also unfortunate that this fix adds a flag in stage1's 'gc'
entrypoint, changing the interface between stage0 and stage1. However,
it does not impact the API between rkt and other applications.

[1]: https://github.com/coreos/rkt/blob/master/networking/net_plugin.go#L79
[2]: https://github.com/coreos/rkt/blob/master/Documentation/devel/stage1-implementors-guide.md#rkt-run--coreoscomrktstage1run
[3]: https://github.com/coreos/rkt/blob/master/Documentation/devel/stage1-implementors-guide.md#rkt-gc--coreoscomrktstage1gc

-----

Fixes https://github.com/coreos/rkt/issues/2168

/cc @steveeJ @tomdee