### PR TITLE
rkt gc: look up for plugins in default local config

### DIFF
--- a/networking/networking.go
+++ b/networking/networking.go
@@ -185,7 +185,7 @@ func (n *Networking) enableDefaultLocalnetRouting() error {
 
 // Load creates the Networking object from saved state.
 // Assumes the current netns is that of the host.
-func Load(podRoot string, podID *types.UUID) (*Networking, error) {
+func Load(podRoot string, podID *types.UUID, localConfig string) (*Networking, error) {
 	// the current directory is pod root
 	pdirfd, err := syscall.Open(podRoot, syscall.O_RDONLY|syscall.O_DIRECTORY, 0)
 	if err != nil {
@@ -221,8 +221,9 @@ func Load(podRoot string, podID *types.UUID) (*Networking, error) {
 
 	return &Networking{
 		podEnv: podEnv{
-			podRoot: podRoot,
-			podID:   *podID,
+			podRoot:     podRoot,
+			podID:       *podID,
+			localConfig: localConfig,
 		},
 		hostNS: hostNS,
 		nets:   nets,

--- a/stage1/gc/gc.go
+++ b/stage1/gc/gc.go
@@ -73,7 +73,7 @@ func gcNetworking(podID *types.UUID) error {
 		}
 	}
 
-	n, err := networking.Load(".", podID)
+	n, err := networking.Load(".", podID, common.DefaultLocalConfigDir)
 	switch {
 	case err == nil:
 		n.Teardown(flavor, debug)


### PR DESCRIPTION
When running 'rkt run --net=mynetwork', it looks for the network plugin
in three different places [1][1]:
- /etc/rkt/net.d/ (or something else with --local-config)
- /usr/lib/rkt/plugins/net
- ${STAGE1_ROOTFS}/usr/lib/rkt/plugins/net

This code works fine for 'rkt run' but does not work for 'rkt gc' or
'rkt rm' because there is a bug in the way --local-config is handled.

When stage1's 'run' entrypoint [2][2] is called, the --local-config flag
is passed. But this --local-config flag was not passed to stage1's 'gc'
entrypoint [3][3].

It might be unfortunate that plugin binaries can be stored in a
configuration directory but this is part of the stable rkt 1.0 interface
now. And plugins like calico rely on it.

Adding this --local-config flag would change the API between stage0 and
stage1, so we would need API versioning first. Meanwhile, use the
default local config directory.

[1]: https://github.com/coreos/rkt/blob/master/networking/net_plugin.go#L79
[2]: https://github.com/coreos/rkt/blob/master/Documentation/devel/stage1-implementors-guide.md#rkt-run--coreoscomrktstage1run
[3]: https://github.com/coreos/rkt/blob/master/Documentation/devel/stage1-implementors-guide.md#rkt-gc--coreoscomrktstage1gc

-----

/cc @krnowak this PR is the step 1 from https://github.com/coreos/rkt/pull/2173#issuecomment-182858955