### PR TITLE
networking: store the network plugin path in NetInfo

### DIFF
--- a/networking/net_plugin.go
+++ b/networking/net_plugin.go
@@ -107,8 +107,10 @@ func envVars(vars [][2]string) []string {
 }
 
 func (e *podEnv) execNetPlugin(cmd string, n *activeNet, netns string) ([]byte, error) {
-	pluginPath := e.findNetPlugin(n.conf.Type)
-	if pluginPath == "" {
+	if n.runtime.PluginPath == "" {
+		n.runtime.PluginPath = e.findNetPlugin(n.conf.Type)
+	}
+	if n.runtime.PluginPath == "" {
 		return nil, fmt.Errorf("Could not find plugin %q", n.conf.Type)
 	}
 
@@ -125,8 +127,8 @@ func (e *podEnv) execNetPlugin(cmd string, n *activeNet, netns string) ([]byte, 
 	stdout := &bytes.Buffer{}
 
 	c := exec.Cmd{
-		Path:   pluginPath,
-		Args:   []string{pluginPath},
+		Path:   n.runtime.PluginPath,
+		Args:   []string{n.runtime.PluginPath},
 		Env:    envVars(vars),
 		Stdin:  stdin,
 		Stdout: stdout,

--- a/networking/netinfo/netinfo.go
+++ b/networking/netinfo/netinfo.go
@@ -27,14 +27,15 @@ import (
 const filename = "net-info.json"
 
 type NetInfo struct {
-	NetName  string          `json:"netName"`
-	ConfPath string          `json:"netConf"`
-	IfName   string          `json:"ifName"`
-	IP       net.IP          `json:"ip"`
-	Args     string          `json:"args"`
-	Mask     net.IP          `json:"mask"` // we used IP instead of IPMask because support for json serialization (we don't need specific functionalities)
-	HostIP   net.IP          `json:"-"`
-	IP4      *types.IPConfig `json:"-"`
+	NetName    string          `json:"netName"`
+	ConfPath   string          `json:"netConf"`
+	PluginPath string          `json:"pluginPath"`
+	IfName     string          `json:"ifName"`
+	IP         net.IP          `json:"ip"`
+	Args       string          `json:"args"`
+	Mask       net.IP          `json:"mask"` // we used IP instead of IPMask because support for json serialization (we don't need specific functionalities)
+	HostIP     net.IP          `json:"-"`
+	IP4        *types.IPConfig `json:"-"`
 }
 
 func LoadAt(cdirfd int) ([]NetInfo, error) {

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -185,7 +185,7 @@ func (n *Networking) enableDefaultLocalnetRouting() error {
 
 // Load creates the Networking object from saved state.
 // Assumes the current netns is that of the host.
-func Load(podRoot string, podID *types.UUID, localConfig string) (*Networking, error) {
+func Load(podRoot string, podID *types.UUID) (*Networking, error) {
 	// the current directory is pod root
 	pdirfd, err := syscall.Open(podRoot, syscall.O_RDONLY|syscall.O_DIRECTORY, 0)
 	if err != nil {
@@ -221,9 +221,8 @@ func Load(podRoot string, podID *types.UUID, localConfig string) (*Networking, e
 
 	return &Networking{
 		podEnv: podEnv{
-			podRoot:     podRoot,
-			podID:       *podID,
-			localConfig: localConfig,
+			podRoot: podRoot,
+			podID:   *podID,
 		},
 		hostNS: hostNS,
 		nets:   nets,

--- a/stage1/gc/gc.go
+++ b/stage1/gc/gc.go
@@ -73,7 +73,7 @@ func gcNetworking(podID *types.UUID) error {
 		}
 	}
 
-	n, err := networking.Load(".", podID, common.DefaultLocalConfigDir)
+	n, err := networking.Load(".", podID)
 	switch {
 	case err == nil:
 		n.Teardown(flavor, debug)


### PR DESCRIPTION
The NetInfo struct is created and serialised during "rkt run" into
/var/lib/rkt/pods/run/$UUID/net-info.json. Then, "rkt gc" deserialize
it.

Example of net-info.json, created with the command
"rkt --local-config=/etc/rkt2 run --net=mynetwork ..."
```
> [
>    {
>       "netName" : "mynetwork",
>       "netConf" : "net/mynetwork.conf",
>       "pluginPath" : "/etc/rkt2/net.d/myplugin",
>       "ifName" : "eth0",
>       "ip" : "172.16.28.3",
>       "args" : "",
>       "mask" : ""
>    }
> ]
```
This patch adds the new field "pluginPath". In this way, "rkt gc" knows
where to find the CNI plugin without having to use a --local-config
flag. In the case of network plugins in stage1, "pluginPath" can have a
local path relative to the pod directory, such as
"stage1/rootfs/usr/lib/rkt/plugins/net/ptp".

----

This reverts #2182.
This fixes #2168.

This solution does not require any API change between stage0 and stage1 because it only changes stage1 networking code.

/cc @krnowak 