### PR TITLE
Improve readability of error message

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -263,7 +263,7 @@ func NewStore(baseDir string) (*Store, error) {
 			needsMigrate = true
 		}
 		if version > dbVersion {
-			return fmt.Errorf("current store db version: %d greater than the current rkt expected version: %d", version, dbVersion)
+			return fmt.Errorf("current store db version: %d (greater than the current rkt expected version: %d)", version, dbVersion)
 		}
 		if version < 5 {
 			needsSizePopulation = true


### PR DESCRIPTION
The current error message reads for example: "current store db version: 5 greater than the current rkt expected version: 3"
This is misleading and could also mean that it is "5 greater than the rkt expected version: 3". (Hence: 8).

I suggest using brackets around the error message to improve the readability.