### PR TITLE
kvm: Add custom permissions into mounted volumes

### DIFF
--- a/stage1/init/common/kvm_mount.go
+++ b/stage1/init/common/kvm_mount.go
@@ -169,12 +169,9 @@ func AppToSystemdMountUnits(root string, appName types.ACName, volumes []types.V
 		whatPath := filepath.Join(stage1MntDir, vol.Name.String())
 		whatFullPath := filepath.Join(root, whatPath)
 
-		if vol.Kind == "empty" {
-			diag.Printf("creating an empty volume folder for sharing: %q", whatFullPath)
-			err := os.MkdirAll(whatFullPath, 0700)
-			if err != nil {
-				return err
-			}
+		// set volume permissions
+		if err := PrepareMountpoints(whatFullPath, &vol); err != nil {
+			return err
 		}
 
 		// destination relative to stage1 rootfs and relative to pod root

--- a/stage1/init/common/pod.go
+++ b/stage1/init/common/pod.go
@@ -506,21 +506,10 @@ func appToNspawnArgs(p *stage1commontypes.Pod, ra *schema.RuntimeApp) ([]string,
 	for _, m := range mounts {
 		vol := vols[m.Volume]
 
-		if vol.Kind == "empty" {
-			p := filepath.Join(sharedVolPath, vol.Name.String())
-			if err := os.MkdirAll(p, sharedVolPerm); err != nil {
-				return nil, errwrap.Wrap(fmt.Errorf("could not create shared volume %q", vol.Name), err)
-			}
-			if err := os.Chown(p, *vol.UID, *vol.GID); err != nil {
-				return nil, errwrap.Wrap(fmt.Errorf("could not change owner of %q", p), err)
-			}
-			mod, err := strconv.ParseUint(*vol.Mode, 8, 32)
-			if err != nil {
-				return nil, errwrap.Wrap(fmt.Errorf("invalid mode %q for volume %q", *vol.Mode, vol.Name), err)
-			}
-			if err := os.Chmod(p, os.FileMode(mod)); err != nil {
-				return nil, errwrap.Wrap(fmt.Errorf("could not change permissions of %q", p), err)
-			}
+		//set volumne permissions
+		volumePath := filepath.Join(sharedVolPath, vol.Name.String())
+		if err := PrepareMountpoints(volumePath, &vol); err != nil {
+			return nil, err
 		}
 
 		opt := make([]string, 4)


### PR DESCRIPTION
Add support for pre-defined volumes modes, UIDs and GIDs for apps
inside rkt-kvm pod.

By default, rkt with kvm flavor ignores additional volumes isolators.