### PR TITLE
build: fix devel go version detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -575,47 +575,56 @@ dnl Digits regexp class. Square brackets are used by m4 for quoting,
 dnl so to get literal square brackets, m4 provides ugly @<:@ and @:>@
 dnl for [ and ].
 m4_define([DIGITS],[@<:@0-9@:>@])
-m4_define([CHARS],[@<:@a-z@:>@])
+m4_define([ALNUM],[@<:@a-z0-9@:>@])
 
 dnl Detect go version. Go 1.4 support only "-X variable 'value'"
 dnl format of assigning values to variables via linker flags. Go 1.5
 dnl deprecates this format in favor of "-X 'variable=value'"
 dnl format. Drop this ugliness when we drop support for Go 1.4.
-dnl Successfully parse versions like "go1.5", "go1.5.3", "go1.6rc1"
-GO_VERSION=`"${ABS_GO}" version | sed -e 's/^go version go\(DIGITS*\.DIGITS*CHARS*\(\.\)\{0,1\}DIGITS*\).*/\1/'`
-GO_MAJOR=`echo "${GO_VERSION}" | grep -o '^DIGITS\+'`
-GO_MINOR=`echo "${GO_VERSION}" | grep -o '^DIGITS\+\.DIGITS\+' | grep -o 'DIGITS\+$'`
-GO_MAJOR_MINOR=`echo "${GO_MAJOR}.${GO_MINOR}"`
-GO_MICRO=`echo "${GO_VERSION}" | grep -o '^DIGITS\+\.DIGITS\+\.DIGITS\+' | sed -e 's/^DIGITS*\.DIGITS*\.\(DIGITS*\).*/\1/'`
-AS_VAR_IF([GO_MICRO],[],
-          [GO_MICRO=0])
+dnl Successfully parse versions like "go1.5", "go1.5.3", "go1.6rc1",
+dnl "devel +66330d8 Wed Jan 13 23:40:13 2016 +0000".
+GO_VERSION_OUTPUT=`"${ABS_GO}" version`
+GO_VERSION=`AS_ECHO(["${GO_VERSION_OUTPUT}"]) | sed -e 's/^go version \(.*\) ALNUM*\/ALNUM*$/\1/'`
+AS_CASE([$GO_VERSION],
+        [devel*],
+                [AC_MSG_WARN([* Using development version of go, all bets are off])
+                 RKT_XF() {
+                     AS_ECHO(["-X '$1=$2'"])
+                 }],
+        [go*],
+                [GO_VERSION=`AS_ECHO(["${GO_VERSION}"]) | sed -e 's/^go\(.*\)/\1/'`
+                 GO_MAJOR=`AS_ECHO(["${GO_VERSION}"]) | grep -o '^DIGITS\+'`
+                 GO_MINOR=`AS_ECHO(["${GO_VERSION}"]) | grep -o '^DIGITS\+\.DIGITS\+' | grep -o 'DIGITS\+$'`
+                 GO_MICRO=`AS_ECHO(["${GO_VERSION}"]) | grep -o '^DIGITS\+\.DIGITS\+\.DIGITS\+' | sed -e 's/^DIGITS*\.DIGITS*\.\(DIGITS*\).*/\1/'`
+                 AS_VAR_IF([GO_MICRO],[],
+                           [GO_MICRO=0])
 
-GO_BEST_MAJOR=1
-GO_BEST_MINOR=5
-GO_BEST_VERSION="${GO_BEST_MAJOR}.${GO_BEST_MINOR}"
-AC_MSG_CHECKING([whether we have go ${GO_BEST_VERSION} or newer])
-AS_IF([test "${GO_MAJOR}" -gt "${GO_BEST_MAJOR}" || test "${GO_MAJOR}" -eq "${GO_BEST_MAJOR}" -a "${GO_MINOR}" -ge "${GO_BEST_MINOR}"],
-      [AC_MSG_RESULT([yes])
-       RKT_XF() {
-           echo "-X '$1=$2'"
-       }],
-      [AC_MSG_RESULT([no])
-       AC_MSG_CHECKING([whether we have go 1.4])
-       AS_VAR_IF([GO_MAJOR_MINOR],[1.4],
-                 [AC_MSG_RESULT([yes])
-                  RKT_XF() {
-                      echo "-X $1 '$2'"
-                  }],
-                 [AC_MSG_ERROR([*** go is too old (${GO_VERSION})])])])
+                 GO_BEST_MAJOR=1
+                 GO_BEST_MINOR=5
+                 AC_MSG_CHECKING([whether we have go ${GO_BEST_MAJOR}.${GO_BEST_MINOR} or newer])
+                 AS_IF([test "${GO_MAJOR}" -gt "${GO_BEST_MAJOR}" || test "${GO_MAJOR}" -eq "${GO_BEST_MAJOR}" -a "${GO_MINOR}" -ge "${GO_BEST_MINOR}"],
+                       [AC_MSG_RESULT([yes])
+                        RKT_XF() {
+                            AS_ECHO(["-X '$1=$2'"])
+                        }],
+                       [AC_MSG_RESULT([no])
+                        AC_MSG_CHECKING([whether we have go 1.4])
+                        AS_IF([test "${GO_MAJOR}" -eq "1" -a "${GO_MINOR}" -eq "4"],
+                              [AC_MSG_RESULT([yes])
+                               RKT_XF() {
+                                   AS_ECHO(["-X $1 '$2'"])
+                               }],
+                              [AC_MSG_ERROR([*** go is too old (${GO_VERSION})])])])
 
-AC_MSG_CHECKING([whether we have a go version without CVE-2015-8618])
-AS_IF([test "${GO_MAJOR}" -eq "1" -a "${GO_MINOR}" -eq "5" -a "${GO_MICRO}" -lt "3"],
-      [AC_MSG_RESULT([no])
-       insecure_go_warning="go version is vulnerable to CVE-2015-8618 (${GO_VERSION})"
-       AS_VAR_IF([RKT_INSECURE_GO],[no],
-                 [AC_MSG_ERROR([*** ${insecure_go_warning}])],
-                 [AC_MSG_WARN([* ${insecure_go_warning}])])],
-      [AC_MSG_RESULT([yes])])
+                 AC_MSG_CHECKING([whether we have a go version without CVE-2015-8618])
+                 AS_IF([test "${GO_MAJOR}" -eq "1" -a "${GO_MINOR}" -eq "5" -a "${GO_MICRO}" -lt "3"],
+                       [AC_MSG_RESULT([no])
+                        insecure_go_warning="go version is vulnerable to CVE-2015-8618 (${GO_VERSION})"
+                        AS_VAR_IF([RKT_INSECURE_GO],[no],
+                                  [AC_MSG_ERROR([*** ${insecure_go_warning}])],
+                                  [AC_MSG_WARN([* ${insecure_go_warning}])])],
+                       [AC_MSG_RESULT([yes])])],
+        [AC_MSG_ERROR([*** Could not parse the output of go version])])
 
 RKT_STAGE1_DEFAULT_NAME_LDFLAGS=`RKT_XF main.buildDefaultStage1Name "${RKT_STAGE1_DEFAULT_NAME}"`
 RKT_STAGE1_DEFAULT_VERSION_LDFLAGS=`RKT_XF main.buildDefaultStage1Version "${RKT_STAGE1_DEFAULT_VERSION}"`

--- a/configure.ac
+++ b/configure.ac
@@ -24,12 +24,12 @@ RKT_REQ_ABS_PROG([BASH_SHELL], [bash])
 dnl this will be printed in configure summary and by rkt version
 RKT_FEATURES=""
 RKT_ADD_FEATURE() {
-    RKT_FEATURES=`echo "${RKT_FEATURES} $1" | sed -e 's/^ \+//'`
+    RKT_FEATURES=`AS_ECHO(["${RKT_FEATURES} $1"]) | sed -e 's/^ \+//'`
 }
 dnl if version ends with +git, append a short git-hash.
 AS_IF([test `expr match 'AC_PACKAGE_VERSION' '.*+git$'` -gt 0],
       dnl version has +git suffix, ignore errors (not a git repo)
-      [RKT_VERSION="AC_PACKAGE_VERSION`git rev-parse --short HEAD 2>/dev/null``git diff-index --quiet HEAD 2>/dev/null || echo -dirty`"],
+      [RKT_VERSION="AC_PACKAGE_VERSION`git rev-parse --short HEAD 2>/dev/null``git diff-index --quiet HEAD 2>/dev/null || AS_ECHO(["-dirty"])`"],
       dnl version has no +git suffix
       [RKT_VERSION="AC_PACKAGE_VERSION"])
 
@@ -194,7 +194,7 @@ AS_VAR_IF([RKT_STAGE1_FLAVORS_VERSION_OVERRIDE], [auto],
           [RKT_STAGE1_FLAVORS_VERSION_OVERRIDE=''],
           dnl check if we override the version, even if we build no flavors at all
           [AS_VAR_IF([RKT_STAGE1_FLAVORS], [],
-                     [AC_MSG_WARN([* overriding stage1 version, but no stage1 flavors are built])])])
+                     [AC_MSG_WARN([* Overriding stage1 version, but no stage1 flavors are built])])])
 
 ## Stage1 default image directory
 
@@ -216,7 +216,7 @@ AS_CASE([${RKT_STAGE1_DEFAULT_IMAGES_DIR}],
         [/*],
                 dnl alright, the path is absolute
                 [:],
-        [AC_MSG_ERROR([*** path to the stage1 images directory must be absolute])])
+        [AC_MSG_ERROR([*** Path to the stage1 images directory must be absolute])])
 
 ## Built stage1 flavors verification
 
@@ -240,7 +240,7 @@ AC_DEFUN([RKT_IS_VALID_FLAVOR],
                   [coreos|kvm|host|src|fly],
                           [],
                   dnl Bogus flavor, bail out.
-                  [AC_MSG_ERROR([*** unknown stage1 flavor "$1" $2])])])
+                  [AC_MSG_ERROR([*** Unknown stage1 flavor "$1" $2])])])
 
 dnl RKT_IF_HAS_FLAVOR checks if the comma-separated list of flavors in
 dnl $1 contains any flavor in the comma-separated list of flavors in
@@ -429,7 +429,7 @@ AS_IF([test "x${RKT_RUN_FUNCTIONAL_TESTS}" = 'xyes' -o "x${RKT_RUN_FUNCTIONAL_TE
                        dnl we are on linux, checks can continue
                        [],
                dnl non-linux host
-               [rkt_functional_tests_msg="functional tests are supported only under linux"])
+               [rkt_functional_tests_msg='Functional tests are supported only under linux'])
       AS_VAR_IF([rkt_functional_tests_msg],[],
                 dnl we are on linux host; check if we have default
                 dnl flavor set
@@ -455,7 +455,7 @@ AS_IF([test "x${RKT_RUN_FUNCTIONAL_TESTS}" = 'xyes' -o "x${RKT_RUN_FUNCTIONAL_TE
                 dnl gpg found, alright
                 [:],
                 dnl gpg not found, running functional tests is impossible
-                [rkt_functional_tests_msg="Cannot run functional tests - no gpg found"])
+                [rkt_functional_tests_msg='Cannot run functional tests - no gpg found'])
       AS_VAR_IF([rkt_functional_tests_msg], [],
                  dnl no message, tests can be run
                  [RKT_RUN_FUNCTIONAL_TESTS=yes

--- a/configure.ac
+++ b/configure.ac
@@ -587,6 +587,8 @@ GO_MAJOR=`echo "${GO_VERSION}" | grep -o '^DIGITS\+'`
 GO_MINOR=`echo "${GO_VERSION}" | grep -o '^DIGITS\+\.DIGITS\+' | grep -o 'DIGITS\+$'`
 GO_MAJOR_MINOR=`echo "${GO_MAJOR}.${GO_MINOR}"`
 GO_MICRO=`echo "${GO_VERSION}" | grep -o '^DIGITS\+\.DIGITS\+\.DIGITS\+' | sed -e 's/^DIGITS*\.DIGITS*\.\(DIGITS*\).*/\1/'`
+AS_VAR_IF([GO_MICRO],[],
+          [GO_MICRO=0])
 
 GO_BEST_MAJOR=1
 GO_BEST_MINOR=5


### PR DESCRIPTION
This fixes detection of development version of go, fixes a warning about expecting integer expression and replaces uses of echo with something portable.

Fixes #2156