### PR TITLE
Delete the "Metadata-Flavor:" header requirement.

### DIFF
--- a/rkt/metadata_service.go
+++ b/rkt/metadata_service.go
@@ -610,8 +610,7 @@ func runRegistrationServer(l net.Listener) {
 }
 
 func runPublicServer(l net.Listener) {
-	r := mux.NewRouter().Headers("Metadata-Flavor", "AppContainer").
-		PathPrefix("/{token}/acMetadata/v1").Subrouter()
+	r := mux.NewRouter().PathPrefix("/{token}/acMetadata/v1").Subrouter()
 
 	mr := r.Methods("GET").Subrouter()
 


### PR DESCRIPTION
This was removed from the spec by appc/spec#370, and isn't documented
anywhere.