### PR TITLE
tests: aws: test the 'host' stage1

### DIFF
--- a/tests/aws.sh
+++ b/tests/aws.sh
@@ -95,6 +95,15 @@ INSTANCE_ID=$(aws ec2 run-instances \
 	)
 echo INSTANCE_ID=$INSTANCE_ID
 
+aws ec2 create-tags --resources $INSTANCE_ID \
+	--tags \
+	Key=Name,Value=rkt-tst-${DISTRO}-${GIT_BRANCH}-${FLAVOR} \
+	Key=Distro,Value=${DISTRO} \
+	Key=Repo,Value=${GIT_URL} \
+	Key=Branch,Value=${GIT_BRANCH} \
+	Key=Flavor,Value=${FLAVOR} \
+	Key=User,Value=${USER}
+
 while state=$(aws ec2 describe-instances \
 	--instance-ids $INSTANCE_ID \
 	--output text \

--- a/tests/aws.sh
+++ b/tests/aws.sh
@@ -22,6 +22,7 @@ fi
 DISTRO=$1
 GIT_URL=${2-https://github.com/coreos/rkt.git}
 GIT_BRANCH=${3-master}
+FLAVOR=${4-coreos}
 
 test -f cloudinit/${DISTRO}.cloudinit
 CLOUDINIT_IN=$PWD/cloudinit/${DISTRO}.cloudinit
@@ -78,6 +79,7 @@ test -f "${KEY_PAIR_NAME}.pem"
 CLOUDINIT=$(mktemp --tmpdir rkt-cloudinit.XXXXXXXXXX)
 sed -e "s#@GIT_URL@#${GIT_URL}#g" \
     -e "s#@GIT_BRANCH@#${GIT_BRANCH}#g" \
+    -e "s#@FLAVOR@#${FLAVOR}#g" \
     < $CLOUDINIT_IN >> $CLOUDINIT
 
 INSTANCE_ID=$(aws ec2 run-instances \

--- a/tests/cloudinit/centos.cloudinit
+++ b/tests/cloudinit/centos.cloudinit
@@ -32,7 +32,7 @@ export PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/centos/.loca
 sed -i 's/ requiretty$/ !requiretty/g' /etc/sudoers
 
 su - centos --command="cd /var/tmp ; git clone --branch @GIT_BRANCH@ @GIT_URL@ rkt"
-su - centos --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/run-build.sh coreos"
+su - centos --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/run-build.sh @FLAVOR@"
 TESTEOF
 
 chmod +x /var/tmp/rkt-test.sh

--- a/tests/cloudinit/debian.cloudinit
+++ b/tests/cloudinit/debian.cloudinit
@@ -17,7 +17,7 @@ echo 'deb-src http://cloudfront.debian.net/debian testing main' | tee -a /etc/ap
 apt-get update -y
 #apt-get dist-upgrade -y --force-yes
 apt-get install -y --force-yes build-essential autoconf
-apt-get install -y --force-yes wget squashfs-tools patch gnupg golang git dbus libacl1-dev
+apt-get install -y --force-yes wget squashfs-tools patch gnupg golang git dbus libacl1-dev systemd-container
 
 su - admin --command="cd /var/tmp ; git clone --branch @GIT_BRANCH@ @GIT_URL@ rkt"
 su - admin --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/run-build.sh @FLAVOR@"

--- a/tests/cloudinit/debian.cloudinit
+++ b/tests/cloudinit/debian.cloudinit
@@ -20,7 +20,7 @@ apt-get install -y --force-yes build-essential autoconf
 apt-get install -y --force-yes wget squashfs-tools patch gnupg golang git dbus libacl1-dev
 
 su - admin --command="cd /var/tmp ; git clone --branch @GIT_BRANCH@ @GIT_URL@ rkt"
-su - admin --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/run-build.sh coreos"
+su - admin --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/run-build.sh @FLAVOR@"
 TESTEOF
 
 chmod +x /var/tmp/rkt-test.sh

--- a/tests/cloudinit/fedora.cloudinit
+++ b/tests/cloudinit/fedora.cloudinit
@@ -24,7 +24,7 @@ dnf -y -v install wget squashfs-tools patch glibc-static gnupg golang libacl-dev
 export PATH=/usr/lib64/ccache:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/fedora/.local/bin:/home/fedora/bin
 
 su - fedora --command="cd /var/tmp ; git clone --branch @GIT_BRANCH@ @GIT_URL@ rkt"
-su - fedora --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/run-build.sh coreos"
+su - fedora --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/run-build.sh @FLAVOR@"
 TESTEOF
 
 chmod +x /var/tmp/rkt-test.sh

--- a/tests/cloudinit/ubuntu.cloudinit
+++ b/tests/cloudinit/ubuntu.cloudinit
@@ -16,7 +16,7 @@ gpasswd -a ubuntu rkt
 apt-get update -y
 apt-get dist-upgrade -y --force-yes
 apt-get install -y build-essential autoconf
-apt-get install -y wget squashfs-tools patch gnupg golang libacl1-dev
+apt-get install -y wget squashfs-tools patch gnupg golang libacl1-dev systemd-container
 
 su - ubuntu --command="cd /var/tmp ; git clone --branch @GIT_BRANCH@ @GIT_URL@ rkt"
 su - ubuntu --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/run-build.sh @FLAVOR@"

--- a/tests/cloudinit/ubuntu.cloudinit
+++ b/tests/cloudinit/ubuntu.cloudinit
@@ -19,7 +19,7 @@ apt-get install -y build-essential autoconf
 apt-get install -y wget squashfs-tools patch gnupg golang libacl1-dev
 
 su - ubuntu --command="cd /var/tmp ; git clone --branch @GIT_BRANCH@ @GIT_URL@ rkt"
-su - ubuntu --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/run-build.sh coreos"
+su - ubuntu --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/run-build.sh @FLAVOR@"
 TESTEOF
 
 chmod +x /var/tmp/rkt-test.sh

--- a/tests/test-on-several-distro.md
+++ b/tests/test-on-several-distro.md
@@ -22,11 +22,12 @@ $ tests/aws.sh setup
 Then run the tests with the specified Linux distribution:
 
 ```
-$ tests/aws.sh debian
-$ tests/aws.sh ubuntu
 $ tests/aws.sh fedora-22
 $ tests/aws.sh fedora-23
 $ tests/aws.sh fedora-rawhide
+$ tests/aws.sh ubuntu-1604
+$ tests/aws.sh ubuntu-1510
+$ tests/aws.sh debian
 $ tests/aws.sh centos
 ```
 
@@ -34,7 +35,12 @@ By default, this tests the upstream master branch.
 A specific branch can be tested with:
 
 ```
-$ tests/aws.sh ubuntu https://github.com/coreos/rkt.git branch-name
+$ tests/aws.sh fedora-23 https://github.com/coreos/rkt.git branch-name
+```
+
+Additionally, a stage1 flavor can be selected:
+```
+$ tests/aws.sh fedora-23 https://github.com/coreos/rkt.git branch-name coreos
 ```
 
 The VM instances are configured to terminate automatically on shutdown to reduce costs.


### PR DESCRIPTION
Previously, tests/aws.sh could only test the default 'coreos' stage1. Add a parameter to the script to select the stage1 flavor to use for the tests.

Also, install nspawn on Debian/Ubuntu. It is not installed by default on Debian and Ubuntu. In order to test the 'host' flavor, I need to install it.
