### PR TITLE
documentation: Fix typo in dockerAuth example

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -257,7 +257,7 @@ For example, given the above system configuration and the following local config
 {
 	"rktKind": "dockerAuth",
 	"rktVersion": "v1",
-	"domains": ["gcr.io"],
+	"registries": ["gcr.io"],
 	"credentials": {
 		"user": "goo",
 		"password": "gle"


### PR DESCRIPTION
* domains -> registries

Reference: https://github.com/coreos/rkt/blob/9ddb77f0fbc8d5cabbd5a70b7873882341d87ce7/rkt/config/auth.go#L47