### PR TITLE
stage1: propagate app exit code to rkt exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### New features and UX changes
 
 - Add support for non-numerical UID/GID as specified in the appc spec ([#2159](https://github.com/coreos/rkt/pull/2159)).
+- Propagate app exit status to rkt's exit status ([#2198](https://github.com/coreos/rkt/pull/2198).
 
 #### Bug fixes
 - Socket activation was not working if the port on the host is different from the app port as set in the image manifest ([#2137](https://github.com/coreos/rkt/pull/2137)).

--- a/Documentation/devel/architecture.md
+++ b/Documentation/devel/architecture.md
@@ -94,6 +94,7 @@ This means that when an app service is stopped, its associated reaper will run a
 When all apps' services stop, their associated reaper services will also stop and will cease referencing the shutdown service causing the pod to exit.
 Every app service has an [*OnFailure*](http://www.freedesktop.org/software/systemd/man/systemd.unit.html#OnFailure=) flag that starts the `halt.target`.
 This means that if any app in the pod exits with a failed status, the systemd shutdown process will start, the other apps' services will automatically stop and the pod will exit.
+In this case, the failed app's exit status will get propagated to rkt.
 
 A [*Conflicts*](http://www.freedesktop.org/software/systemd/man/systemd.unit.html#Conflicts=) dependency was also added between each reaper service and the halt and poweroff targets (they are triggered when the pod is stopped from the outside when rkt receives `SIGINT`).
 This will activate all the reaper services when one of the targets is activated, causing the exit statuses to be saved and the pod to finish like it was described in the previous paragraph.

--- a/stage1/reaper/reaper.sh
+++ b/stage1/reaper/reaper.sh
@@ -7,5 +7,8 @@ if [ $# -eq 1 ]; then
     app=$1
     status=$(${SYSCTL} show --property ExecMainStatus "${app}.service")
     echo "${status#*=}" > "/rkt/status/$app"
+    if [ "${status#*=}" != 0 ] ; then
+        ${SYSCTL} exit ${status#*=}
+    fi
     exit 0
 fi

--- a/tests/rkt_ace_validator_test.go
+++ b/tests/rkt_ace_validator_test.go
@@ -52,7 +52,7 @@ func TestAceValidator(t *testing.T) {
 	rktCmd := fmt.Sprintf("%s %s", ctx.Cmd(), rktArgs)
 
 	child := spawnOrFail(t, rktCmd)
-	defer waitOrFail(t, child, true)
+	defer waitOrFail(t, child, 0)
 
 	for _, set := range expected {
 		for len(set) > 0 {

--- a/tests/rkt_api_service_bench_test.go
+++ b/tests/rkt_api_service_bench_test.go
@@ -53,7 +53,7 @@ func launchPods(ctx *testutils.RktRunCtx, numOfPods int, imagePath string) {
 	wg.Add(numOfPods)
 	for i := 0; i < numOfPods; i++ {
 		go func() {
-			spawnAndWaitOrFail(t, cmd, true)
+			spawnAndWaitOrFail(t, cmd, 0)
 			wg.Done()
 		}()
 	}

--- a/tests/rkt_api_service_test.go
+++ b/tests/rkt_api_service_test.go
@@ -57,7 +57,7 @@ func stopAPIService(t *testing.T, svc *gexpect.ExpectSubprocess) {
 	if err := svc.Cmd.Process.Signal(syscall.SIGINT); err != nil {
 		t.Fatalf("Failed to stop the api service: %v", err)
 	}
-	waitOrFail(t, svc, true)
+	waitOrFail(t, svc, 0)
 }
 
 func checkPodState(t *testing.T, rawState string, apiState v1alpha.PodState) {
@@ -296,7 +296,7 @@ func TestAPIServiceListInspectPods(t *testing.T) {
 
 	runCmd := fmt.Sprintf("%s run --pod-manifest=%s", ctx.Cmd(), manifestFile)
 	esp := spawnOrFail(t, runCmd)
-	waitOrFail(t, esp, true)
+	waitOrFail(t, esp, 0)
 
 	// ListPods(detail=false).
 	resp, err = c.ListPods(context.Background(), &v1alpha.ListPodsRequest{})

--- a/tests/rkt_caps_test.go
+++ b/tests/rkt_caps_test.go
@@ -109,7 +109,7 @@ func TestCaps(t *testing.T) {
 			if err := expectWithOutput(child, "User: uid=0 euid=0 gid=0 egid=0"); err != nil {
 				t.Fatalf("Expected user 0 but not found: %v", err)
 			}
-			waitOrFail(t, child, true)
+			waitOrFail(t, child, 0)
 		}
 		ctx.Reset()
 	}
@@ -146,7 +146,7 @@ func TestCapsNonRoot(t *testing.T) {
 			t.Fatalf("Expected user 9000 but not found: %v", err)
 		}
 
-		waitOrFail(t, child, true)
+		waitOrFail(t, child, 0)
 		ctx.Reset()
 	}
 }

--- a/tests/rkt_env_test.go
+++ b/tests/rkt_env_test.go
@@ -107,7 +107,7 @@ func TestEnv(t *testing.T) {
 			t.Fatalf("Expected %q but not found: %v", tt.runExpect, err)
 		}
 
-		waitOrFail(t, enterChild, true)
+		waitOrFail(t, enterChild, 0)
 
 		if err := child.SendLine("Bye"); err != nil {
 			t.Fatalf("rkt couldn't write to the container: %v", err)
@@ -116,7 +116,7 @@ func TestEnv(t *testing.T) {
 			t.Fatalf("Expected Bye but not found #%v: %v", i, err)
 		}
 
-		waitOrFail(t, child, true)
+		waitOrFail(t, child, 0)
 		ctx.Reset()
 	}
 }

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -259,7 +259,7 @@ func TestResumedFetch(t *testing.T) {
 	if _, _, err := expectRegexWithOutput(child, ".*"+hash); err != nil {
 		t.Fatalf("hash didn't match: %v", err)
 	}
-	waitOrFail(t, child, true)
+	waitOrFail(t, child, 0)
 }
 
 func TestResumedFetchInvalidCache(t *testing.T) {
@@ -298,7 +298,7 @@ func TestResumedFetchInvalidCache(t *testing.T) {
 	if _, s, err := expectRegexWithOutput(child, ".*"+hash); err != nil {
 		t.Fatalf("hash didn't match: %v\nin: %s", err, s)
 	}
-	waitOrFail(t, child, true)
+	waitOrFail(t, child, 0)
 }
 
 func testServerHandler(t *testing.T, shouldInterrupt *synchronizedBool, imagePath string, kill, waitforkill chan struct{}) http.HandlerFunc {
@@ -446,7 +446,7 @@ func TestDeferredSignatureDownload(t *testing.T) {
 
 	runCmd := fmt.Sprintf("%s --debug --insecure-options=tls run %s", ctx.Cmd(), imageName)
 	child := spawnOrFail(t, runCmd)
-	defer waitOrFail(t, child, true)
+	defer waitOrFail(t, child, 0)
 
 	expectedMessages := []string{
 		"server requested deferring the signature download",

--- a/tests/rkt_image_dependencies_test.go
+++ b/tests/rkt_image_dependencies_test.go
@@ -196,5 +196,5 @@ func TestImageDependencies(t *testing.T) {
 		}
 	}
 
-	waitOrFail(t, child, true)
+	waitOrFail(t, child, 0)
 }

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -90,10 +90,14 @@ func TestImageExport(t *testing.T) {
 	}
 
 	for i, tt := range tests {
+		expectedStatus := 1
+		if tt.shouldFind {
+			expectedStatus = 0
+		}
 		outputAciPath := filepath.Join(tmpDir, fmt.Sprintf("exported-%d.aci", i))
 		runCmd := fmt.Sprintf("%s image export %s %s", ctx.Cmd(), tt.image, outputAciPath)
 		t.Logf("Running 'image export' test #%v: %v", i, runCmd)
-		spawnAndWaitOrFail(t, runCmd, tt.shouldFind)
+		spawnAndWaitOrFail(t, runCmd, expectedStatus)
 
 		if !tt.shouldFind {
 			continue

--- a/tests/rkt_image_extract_test.go
+++ b/tests/rkt_image_extract_test.go
@@ -69,10 +69,14 @@ func TestImageExtract(t *testing.T) {
 	}
 
 	for i, tt := range tests {
+		expectedStatus := 1
+		if tt.shouldFind {
+			expectedStatus = 0
+		}
 		outputPath := filepath.Join(tmpDir, fmt.Sprintf("extracted-%d", i))
 		runCmd := fmt.Sprintf("%s image extract --rootfs-only %s %s", ctx.Cmd(), tt.image, outputPath)
 		t.Logf("Running 'image extract' test #%v: %v", i, runCmd)
-		spawnAndWaitOrFail(t, runCmd, tt.shouldFind)
+		spawnAndWaitOrFail(t, runCmd, expectedStatus)
 
 		if !tt.shouldFind {
 			continue

--- a/tests/rkt_image_list_test.go
+++ b/tests/rkt_image_list_test.go
@@ -73,7 +73,7 @@ func TestImageSize(t *testing.T) {
 	imageSize := fi.Size()
 
 	fetchCmd := fmt.Sprintf("%s --insecure-options=image fetch %s", ctx.Cmd(), image)
-	spawnAndWaitOrFail(t, fetchCmd, true)
+	spawnAndWaitOrFail(t, fetchCmd, 0)
 
 	imageListCmd := fmt.Sprintf("%s image list --no-legend --full", ctx.Cmd())
 
@@ -84,12 +84,12 @@ func TestImageSize(t *testing.T) {
 
 	// run the image, so rkt renders it in the tree store
 	runCmd := fmt.Sprintf("%s --insecure-options=image run %s", ctx.Cmd(), image)
-	spawnAndWaitOrFail(t, runCmd, true)
+	spawnAndWaitOrFail(t, runCmd, 0)
 
 	tmpDir := createTempDirOrPanic("rkt_image_list_test")
 	defer os.RemoveAll(tmpDir)
 	imageRenderCmd := fmt.Sprintf("%s image render --overwrite %s %s", ctx.Cmd(), imageHash, tmpDir)
-	spawnAndWaitOrFail(t, imageRenderCmd, true)
+	spawnAndWaitOrFail(t, imageRenderCmd, 0)
 	/*
 		recreate the tree store directory contents to get an accurate size:
 		- hash file
@@ -118,11 +118,11 @@ func TestImageSize(t *testing.T) {
 
 	// gc the pod
 	gcCmd := fmt.Sprintf("%s gc --grace-period=0s", ctx.Cmd())
-	spawnAndWaitOrFail(t, gcCmd, true)
+	spawnAndWaitOrFail(t, gcCmd, 0)
 
 	// image gc to remove the tree store
 	imageGCCmd := fmt.Sprintf("%s image gc", ctx.Cmd())
-	spawnAndWaitOrFail(t, imageGCCmd, true)
+	spawnAndWaitOrFail(t, imageGCCmd, 0)
 
 	// check that the size goes back to the original (only the image size)
 	expectedStr = fmt.Sprintf("(?s)%s.*%d.*", imageHash, imageSize)
@@ -161,7 +161,7 @@ func TestShortHash(t *testing.T) {
 	for _, imageID := range imageIDs {
 		cmd := fmt.Sprintf("%s --insecure-options=image fetch %s", ctx.Cmd(), imageID.path)
 		t.Logf("Fetching %s: %v", imageID.path, cmd)
-		spawnAndWaitOrFail(t, cmd, true)
+		spawnAndWaitOrFail(t, cmd, 0)
 	}
 
 	// Get hash from 'rkt image list'

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -92,10 +92,14 @@ func TestImageRender(t *testing.T) {
 	}
 
 	for i, tt := range tests {
+		expectedStatus := 1
+		if tt.shouldFind {
+			expectedStatus = 0
+		}
 		outputPath := filepath.Join(tmpDir, fmt.Sprintf("rendered-%d", i))
 		runCmd := fmt.Sprintf("%s image render --rootfs-only %s %s", ctx.Cmd(), tt.image, outputPath)
 		t.Logf("Running 'image render' test #%v: %v", i, runCmd)
-		spawnAndWaitOrFail(t, runCmd, tt.shouldFind)
+		spawnAndWaitOrFail(t, runCmd, expectedStatus)
 
 		if !tt.shouldFind {
 			continue

--- a/tests/rkt_image_rm_test.go
+++ b/tests/rkt_image_rm_test.go
@@ -44,12 +44,12 @@ func TestImageRunRmName(t *testing.T) {
 	defer ctx.Cleanup()
 
 	cmd := fmt.Sprintf("%s --insecure-options=image fetch %s", ctx.Cmd(), imageFile)
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 
 	// at this point we know that RKT_INSPECT_IMAGE env var is not empty
 	referencedACI := os.Getenv("RKT_INSPECT_IMAGE")
 	cmd = fmt.Sprintf("%s --insecure-options=image run --mds-register=false %s", ctx.Cmd(), referencedACI)
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 
 	t.Logf("Retrieving stage1 image name")
 	stage1ImageName := getImageName(t, ctx, stage1App)
@@ -72,13 +72,13 @@ func TestImageRunRmID(t *testing.T) {
 
 	cmd := fmt.Sprintf("%s --insecure-options=image fetch %s", ctx.Cmd(), imageFile)
 	t.Logf("Fetching %s", imageFile)
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 
 	// at this point we know that RKT_INSPECT_IMAGE env var is not empty
 	referencedACI := os.Getenv("RKT_INSPECT_IMAGE")
 	cmd = fmt.Sprintf("%s --insecure-options=image run --mds-register=false %s", ctx.Cmd(), referencedACI)
 	t.Logf("Running %s", referencedACI)
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 
 	t.Logf("Retrieving stage1 image ID")
 	stage1ImageID, err := getImageID(ctx, stage1App)
@@ -116,13 +116,13 @@ func TestImageRunRmDuplicate(t *testing.T) {
 
 	cmd := fmt.Sprintf("%s --insecure-options=image fetch %s", ctx.Cmd(), imageFile)
 	t.Logf("Fetching %s", imageFile)
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 
 	// at this point we know that RKT_INSPECT_IMAGE env var is not empty
 	referencedACI := os.Getenv("RKT_INSPECT_IMAGE")
 	cmd = fmt.Sprintf("%s --insecure-options=image run --mds-register=false %s", ctx.Cmd(), referencedACI)
 	t.Logf("Running %s", referencedACI)
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 
 	t.Logf("Retrieving %s image ID", referencedApp)
 	referencedImageID, err := getImageID(ctx, referencedApp)
@@ -151,7 +151,7 @@ func TestImagePrepareRmNameRun(t *testing.T) {
 
 	cmd := fmt.Sprintf("%s --insecure-options=image fetch %s", ctx.Cmd(), imageFile)
 	t.Logf("Fetching %s", imageFile)
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 
 	// at this point we know that RKT_INSPECT_IMAGE env var is not empty
 	referencedACI := os.Getenv("RKT_INSPECT_IMAGE")
@@ -183,7 +183,7 @@ func TestImagePrepareRmNameRun(t *testing.T) {
 
 	cmd = fmt.Sprintf("%s run-prepared --mds-register=false %s", ctx.Cmd(), podID.String())
 	t.Logf("Running %s", referencedACI)
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 }
 
 func TestImagePrepareRmIDRun(t *testing.T) {
@@ -194,7 +194,7 @@ func TestImagePrepareRmIDRun(t *testing.T) {
 
 	cmd := fmt.Sprintf("%s --insecure-options=image fetch %s", ctx.Cmd(), imageFile)
 	t.Logf("Fetching %s", imageFile)
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 
 	// at this point we know that RKT_INSPECT_IMAGE env var is not empty
 	referencedACI := os.Getenv("RKT_INSPECT_IMAGE")
@@ -241,7 +241,7 @@ func TestImagePrepareRmIDRun(t *testing.T) {
 
 	cmd = fmt.Sprintf("%s run-prepared --mds-register=false %s", ctx.Cmd(), podID.String())
 	t.Logf("Running %s", referencedACI)
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 }
 
 func TestImagePrepareRmDuplicate(t *testing.T) {
@@ -252,7 +252,7 @@ func TestImagePrepareRmDuplicate(t *testing.T) {
 
 	cmd := fmt.Sprintf("%s --insecure-options=image fetch %s", ctx.Cmd(), imageFile)
 	t.Logf("Fetching %s", imageFile)
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 
 	// at this point we know that RKT_INSPECT_IMAGE env var is not empty
 	referencedACI := os.Getenv("RKT_INSPECT_IMAGE")
@@ -290,7 +290,7 @@ func TestImagePrepareRmDuplicate(t *testing.T) {
 
 	cmd = fmt.Sprintf("%s run-prepared --mds-register=false %s", ctx.Cmd(), podID.String())
 	t.Logf("Running %s", referencedACI)
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 }
 
 func getImageName(t *testing.T, ctx *testutils.RktRunCtx, name string) string {
@@ -302,7 +302,7 @@ func getImageName(t *testing.T, ctx *testutils.RktRunCtx, name string) string {
 	if err != nil {
 		t.Fatalf("Cannot exec: %v", err)
 	}
-	waitOrFail(t, child, true)
+	waitOrFail(t, child, 0)
 	return imageName
 }
 

--- a/tests/rkt_list_test.go
+++ b/tests/rkt_list_test.go
@@ -170,7 +170,7 @@ func TestRktListCreatedStarted(t *testing.T) {
 	// t1: run
 	expectRun := time.Now()
 
-	waitOrFail(t, rktChild, true)
+	waitOrFail(t, rktChild, 0)
 
 	creation, start := getCreationStartTime(t, ctx, imageID)
 	if !compareTime(expectPrepare, creation) {

--- a/tests/rkt_net_test.go
+++ b/tests/rkt_net_test.go
@@ -44,7 +44,7 @@ func TestNetHost(t *testing.T) {
 	cmd := fmt.Sprintf("%s --net=host --debug --insecure-options=image run --mds-register=false %s", ctx.Cmd(), testImage)
 	child := spawnOrFail(t, cmd)
 	ctx.RegisterChild(child)
-	defer waitOrFail(t, child, true)
+	defer waitOrFail(t, child, 0)
 
 	expectedRegex := `NetNS: (net:\[\d+\])`
 	result, out, err := expectRegexWithOutput(child, expectedRegex)
@@ -132,7 +132,7 @@ func TestNetNone(t *testing.T) {
 	cmd := fmt.Sprintf("%s --debug --insecure-options=image run --net=none --mds-register=false %s", ctx.Cmd(), testImage)
 
 	child := spawnOrFail(t, cmd)
-	defer waitOrFail(t, child, true)
+	defer waitOrFail(t, child, 0)
 	expectedRegex := `NetNS: (net:\[\d+\])`
 	result, out, err := expectRegexWithOutput(child, expectedRegex)
 	if err != nil {
@@ -178,7 +178,7 @@ func TestNetDefaultNetNS(t *testing.T) {
 	f := func(argument string) {
 		cmd := fmt.Sprintf("%s --debug --insecure-options=image run %s --mds-register=false %s", ctx.Cmd(), argument, testImage)
 		child := spawnOrFail(t, cmd)
-		defer waitOrFail(t, child, true)
+		defer waitOrFail(t, child, 0)
 
 		expectedRegex := `NetNS: (net:\[\d+\])`
 		result, out, err := expectRegexWithOutput(child, expectedRegex)
@@ -729,7 +729,7 @@ func TestNetOverride(t *testing.T) {
 
 	cmd := fmt.Sprintf("%s --debug --insecure-options=image run --net=all --net=\"%s:IP=%s\" --mds-register=false %s", ctx.Cmd(), nt.Name, expectedIP, testImage)
 	child := spawnOrFail(t, cmd)
-	defer waitOrFail(t, child, true)
+	defer waitOrFail(t, child, 0)
 
 	expectedRegex := `IPv4: (\d+\.\d+\.\d+\.\d+)`
 	result, out, err := expectRegexTimeoutWithOutput(child, expectedRegex, 30*time.Second)

--- a/tests/rkt_pid_file_test.go
+++ b/tests/rkt_pid_file_test.go
@@ -115,7 +115,7 @@ func TestPidFileAbortedStart(t *testing.T) {
 	if err := runChild.SendLine("\035\035\035"); err != nil {
 		t.Fatalf("Failed to terminate the pod: %v", err)
 	}
-	waitOrFail(t, runChild, false)
+	waitOrFail(t, runChild, 1)
 
 	// Now the "enter" command terminates quickly
 	before := time.Now()

--- a/tests/rkt_stage1_loading_test.go
+++ b/tests/rkt_stage1_loading_test.go
@@ -230,7 +230,7 @@ func TestStage1LoadingFromConfigRelativePathFail(t *testing.T) {
 	setup.generateStage1Config(cfg)
 	cmd := fmt.Sprintf("%s --insecure-options=image,tls --debug run %s", setup.ctx.Cmd(), getInspectImagePath())
 	child := spawnOrFail(setup.t, cmd)
-	defer waitOrFail(setup.t, child, false)
+	defer waitOrFail(setup.t, child, 1)
 	expectedLine := "default stage1 image location is either a relative path or a URL without scheme"
 	setup.getExpectedOrFail(child, expectedLine)
 }
@@ -256,7 +256,7 @@ func TestStage1LoadingFromConfigFallback(t *testing.T) {
 	setup.generateStage1Config(cfg)
 	cmd := fmt.Sprintf("%s --insecure-options=image,tls --debug run %s", setup.ctx.Cmd(), getInspectImagePath())
 	child := spawnOrFail(setup.t, cmd)
-	defer waitOrFail(setup.t, child, true)
+	defer waitOrFail(setup.t, child, 0)
 	setup.getExpectedOrFail(child, fmt.Sprintf("image: using image from file %s", fakePath))
 	setup.getExpectedOrFail(child, fmt.Sprintf("image: using image from file %s", setup.getLocation(stubStage1PathAbs)))
 	setup.getExpectedOrFail(child, stubStage1Output)
@@ -276,7 +276,7 @@ func TestStage1LoadingFromConfigNoDiscovery(t *testing.T) {
 	setup.generateStage1Config(cfg)
 	cmd := fmt.Sprintf("%s --insecure-options=image,tls --debug run %s", setup.ctx.Cmd(), getInspectImagePath())
 	child := spawnOrFail(setup.t, cmd)
-	defer waitOrFail(setup.t, child, true)
+	defer waitOrFail(setup.t, child, 0)
 	discoveringStr := fmt.Sprintf("searching for app image %s", setup.name)
 	for {
 		matches, output, err := expectRegexWithOutput(child, `(?m)^image:.+$`)
@@ -401,7 +401,7 @@ func TestStage1LoadingFromFlagsHash(t *testing.T) {
 	stubHash := importImageAndFetchHash(setup.t, setup.ctx, "", setup.getLocation(stubStage1PathAbs))
 	cmd := fmt.Sprintf("%s --insecure-options=image,tls --debug run --stage1-hash=%s %s", setup.ctx.Cmd(), stubHash, getInspectImagePath())
 	child := spawnOrFail(setup.t, cmd)
-	defer waitOrFail(setup.t, child, true)
+	defer waitOrFail(setup.t, child, 0)
 	setup.getExpectedOrFail(child, fmt.Sprintf("using image from the store with hash %s", stubHash))
 	setup.getExpectedOrFail(child, stubStage1Output)
 }
@@ -433,7 +433,7 @@ func TestStage1LoadingFromFlagsFromDir(t *testing.T) {
 	setup.generateStage1ImagesDirectoryConfig(tmp)
 	cmd := fmt.Sprintf("%s --insecure-options=image,tls --debug run --stage1-from-dir=%s %s", setup.ctx.Cmd(), setup.getLocation(stubStage1Base), getInspectImagePath())
 	child := spawnOrFail(setup.t, cmd)
-	defer waitOrFail(setup.t, child, true)
+	defer waitOrFail(setup.t, child, 0)
 	setup.getExpectedOrFail(child, fmt.Sprintf("image: using image from file %s", stubCopyPath))
 	setup.getExpectedOrFail(child, stubStage1Output)
 }
@@ -592,7 +592,7 @@ func (s *stubStage1Setup) generateConfigContents(subdir, tmpl string, replacemen
 func (s *stubStage1Setup) check(flag, expectedLine string) {
 	cmd := fmt.Sprintf("%s --insecure-options=image,tls --debug run %s %s", s.ctx.Cmd(), flag, getInspectImagePath())
 	child := spawnOrFail(s.t, cmd)
-	defer waitOrFail(s.t, child, true)
+	defer waitOrFail(s.t, child, 0)
 	s.getExpectedOrFail(child, expectedLine)
 	s.getExpectedOrFail(child, stubStage1Output)
 }

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -118,21 +118,36 @@ func spawnOrFail(t *testing.T, cmd string) *gexpect.ExpectSubprocess {
 	return child
 }
 
-func waitOrFail(t *testing.T, child *gexpect.ExpectSubprocess, shouldSucceed bool) {
+func getExitStatus(err error) int {
+	if err == nil {
+		return 0
+	}
+	if exiterr, ok := err.(*exec.ExitError); ok {
+		// the program has exited with an exit code != 0
+		if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+			return status.ExitStatus()
+		}
+	}
+	return -1
+}
+
+func waitOrFail(t *testing.T, child *gexpect.ExpectSubprocess, expectedStatus int) {
 	err := child.Wait()
+	status := getExitStatus(err)
+	if status != expectedStatus {
+		t.Fatalf("rkt terminated with unexpected status %d, expected %d\nOutput:\n%s", status, expectedStatus, child.Collect())
+	}
 	switch {
-	case !shouldSucceed && err == nil:
+	case expectedStatus != 0 && err == nil:
 		t.Fatalf("Expected test to fail but it didn't\nOutput:\n%s", child.Collect())
-	case shouldSucceed && err != nil:
+	case expectedStatus == 0 && err != nil:
 		t.Fatalf("rkt didn't terminate correctly: %v\nOutput:\n%s", err, child.Collect())
-	case err != nil && err.Error() != "exit status 1":
-		t.Fatalf("rkt terminated with unexpected error: %v\nOutput:\n%s", err, child.Collect())
 	}
 }
 
-func spawnAndWaitOrFail(t *testing.T, cmd string, shouldSucceed bool) {
+func spawnAndWaitOrFail(t *testing.T, cmd string, expectedStatus int) {
 	child := spawnOrFail(t, cmd)
-	waitOrFail(t, child, shouldSucceed)
+	waitOrFail(t, child, expectedStatus)
 }
 
 func getEmptyImagePath() string {
@@ -205,7 +220,7 @@ func importImageAndFetchHashAsGid(t *testing.T, ctx *testutils.RktRunCtx, img st
 		t.Fatalf("Error: %v\nOutput: %v", err, out)
 	}
 
-	waitOrFail(t, child, true)
+	waitOrFail(t, child, 0)
 
 	return result[0]
 }
@@ -226,27 +241,27 @@ func patchImportAndRun(image string, patches []string, t *testing.T, ctx *testut
 	defer os.Remove(imagePath)
 
 	cmd := fmt.Sprintf("%s --insecure-options=image run %s", ctx.Cmd(), imagePath)
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 }
 
 func runGC(t *testing.T, ctx *testutils.RktRunCtx) {
 	cmd := fmt.Sprintf("%s gc --grace-period=0s", ctx.Cmd())
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 }
 
 func runImageGC(t *testing.T, ctx *testutils.RktRunCtx) {
 	cmd := fmt.Sprintf("%s image gc", ctx.Cmd())
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 }
 
 func removeFromCas(t *testing.T, ctx *testutils.RktRunCtx, hash string) {
 	cmd := fmt.Sprintf("%s image rm %s", ctx.Cmd(), hash)
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 }
 
 func runRktAndGetUUID(t *testing.T, rktCmd string) string {
 	child := spawnOrFail(t, rktCmd)
-	defer waitOrFail(t, child, true)
+	defer waitOrFail(t, child, 0)
 
 	result, out, err := expectRegexWithOutput(child, "\n[0-9a-f-]{36}")
 	if err != nil || len(result) != 1 {
@@ -280,7 +295,11 @@ func runRktAsUidGidAndCheckOutput(t *testing.T, rktCmd, expectedLine string, exp
 	if err != nil {
 		t.Fatalf("cannot start rkt: %v", err)
 	}
-	defer waitOrFail(t, child, !expectError)
+	expectedStatus := 0
+	if expectError {
+		expectedStatus = 1
+	}
+	defer waitOrFail(t, child, expectedStatus)
 
 	if expectedLine != "" {
 		if err := expectWithOutput(child, expectedLine); err != nil {
@@ -346,7 +365,7 @@ func checkAppStatus(t *testing.T, ctx *testutils.RktRunCtx, multiApps bool, appN
 
 	t.Logf("Get status for app %s\n", appName)
 	child := spawnOrFail(t, cmd)
-	defer waitOrFail(t, child, true)
+	defer waitOrFail(t, child, 0)
 
 	if err := expectWithOutput(child, expected); err != nil {
 		// For debugging purposes, print the full output of
@@ -604,7 +623,7 @@ func runSignImage(t *testing.T, imageFile string, keyIndex int) string {
 
 	cmd := fmt.Sprintf("gpg --no-default-keyring --secret-keyring ./secring.gpg --keyring ./pubring.gpg --default-key %s --output %s --detach-sig %s",
 		keyFingerprint, ascFile, imageFile)
-	spawnAndWaitOrFail(t, cmd, true)
+	spawnAndWaitOrFail(t, cmd, 0)
 	return ascFile
 }
 
@@ -618,7 +637,7 @@ func runRktTrust(t *testing.T, ctx *testutils.RktRunCtx, prefix string, keyIndex
 	}
 
 	child := spawnOrFail(t, cmd)
-	defer waitOrFail(t, child, true)
+	defer waitOrFail(t, child, 0)
 
 	expected := "Are you sure you want to trust this key"
 	if err := expectWithOutput(child, expected); err != nil {

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -122,7 +122,7 @@ func TestVolumes(t *testing.T) {
 
 		t.Logf("Running test #%v", i)
 		child := spawnOrFail(t, cmd)
-		defer waitOrFail(t, child, true)
+		defer waitOrFail(t, child, 0)
 
 		if err := expectTimeoutWithOutput(child, tt.expect, time.Minute); err != nil {
 			fmt.Printf("Command: %s\n", cmd)


### PR DESCRIPTION
If the version of the systemd running in stage1 is >=v229, the command
"systemctl exit STATUS" will set the exit status of the container. If
not, we will continue with the previous logic, so we can merge this now
and benefit from it when we actually update to v229.

Refs #1460