### PR TITLE
travis: Fix the build after build system changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ before_install:
  - sudo apt-get install -y build-essential
  - sudo apt-get install -y libacl1-dev
 
+install: true
+
 script:
  - ./autogen.sh
  # Build host and fly to ensure we build stage1 init. We don't build everything


### PR DESCRIPTION
Travis does not see Makefile in the toplevel directory anymore (it is
now Makefile.in), so it is running `go get -t -v ./..` in install
phase. This is documented in
https://docs.travis-ci.com/user/languages/go#Dependency-Management.

Fix it by explicitly overriding the install phase, as documented in
https://docs.travis-ci.com/user/customizing-the-build/#Skipping-the-Installation-Step.