### PR TITLE
prepare-app: create /dev/log for stage2

### DIFF
--- a/Documentation/app-environment.md
+++ b/Documentation/app-environment.md
@@ -1,0 +1,24 @@
+## App Environment
+
+Apps launched by rkt have access to some basic devices and file systems as defined by the App Container spec in the [OS-SPEC](https://github.com/appc/spec/blob/master/spec/OS-SPEC.md) section.
+
+In addition to the basic devices and file systems mandated by the App Container spec, rkt gives access to the following files.
+
+#### /etc/hosts
+
+Support for /etc/hosts is optional in the App Container spec. rkt creates it.
+
+#### /etc/resolv.conf
+
+/etc/resolv.conf is automatically prepared by rkt as described in the [DNS support](Documentation/networking/dns.md).
+
+#### /run/systemd/journal
+
+Since rkt v1.2.0, rkt gives access to systemd-journald's sockets in the /run/systemd/journal directory:
+- /run/systemd/journal/dev-log
+- /run/systemd/journal/socket
+- /run/systemd/journal/stdout
+
+#### /dev/log
+
+Since rkt v1.2.0, /dev/log is created as a symlink to /run/systemd/journal/dev-log.

--- a/stage1/prepare-app/prepare-app.c
+++ b/stage1/prepare-app/prepare-app.c
@@ -135,6 +135,9 @@ int main(int argc, char *argv[])
 		dir("sys",	0755),
 		dir("tmp",	01777),
 		dir("dev/pts",	0755),
+		dir("run",			0755),
+		dir("run/systemd",		0755),
+		dir("run/systemd/journal",	0755),
 	};
 	static const char *devnodes[] = {
 		"/dev/null",
@@ -152,6 +155,7 @@ int main(int argc, char *argv[])
 		{ "/sys", "/sys", "bind", NULL, MS_BIND|MS_REC },
 		{ "/dev/shm", "/dev/shm", "bind", NULL, MS_BIND },
 		{ "/dev/pts", "/dev/pts", "bind", NULL, MS_BIND },
+		{ "/run/systemd/journal", "/run/systemd/journal", "bind", NULL, MS_BIND },
 	};
 	static const mount_point files_mount_table[] = {
 		{ "/etc/rkt-resolv.conf", "/etc/resolv.conf", "bind", NULL, MS_BIND },
@@ -281,6 +285,12 @@ int main(int argc, char *argv[])
 		"Path too long: \"%s\"", to);
 	pexit_if(symlink("/dev/pts/ptmx", to) == -1,
 		"Failed to create /dev/ptmx symlink");
+
+	/* /dev/log -> /run/systemd/journal/dev-log */
+	exit_if(snprintf(to, sizeof(to), "%s/dev/log", root) >= sizeof(to),
+		"Path too long: \"%s\"", to);
+	pexit_if(symlink("/run/systemd/journal/dev-log", to) == -1,
+		"Failed to create /dev/log symlink");
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
rkt starts systemd-journald in the pod and creates the symlink in the
stage1 rootfs:
/dev/log -> /run/systemd/journal/dev-log (socket file)

But unfortunately it isn't directly available for the app because the
app is chrooted.

systemd-journald listens on the following sockets and other paths:
- /dev/kmsg,
- /dev/log,
- /run/systemd/journal/dev-log,
- /run/systemd/journal/socket,
- /run/systemd/journal/stdout

This patch prepares /dev/log in stage2 as a symlink to
/run/systemd/journal/dev-log and bind mounts the directory
/run/systemd/journal from stage1 to stage2, so both /dev/log and
journald's native logging will work for the application

This will help haproxy and nginx.

See https://groups.google.com/forum/#!topic/rkt-dev/P6HEylgrv8U