### PR TITLE
rkt/image: lock temp files to avoid problems with concurrent fetches

### DIFF
--- a/rkt/image/io.go
+++ b/rkt/image/io.go
@@ -117,9 +117,16 @@ func getTmpROC(s *store.Store, path string) (*removeOnClose, error) {
 	}
 	// let's lock the file to avoid concurrent writes to the temporary file, it
 	// will go away when removing the temp file
-	_, err = lock.ExclusiveLock(tmp.Name(), lock.RegFile)
+	_, err = lock.TryExclusiveLock(tmp.Name(), lock.RegFile)
 	if err != nil {
-		return nil, err
+		if err != lock.ErrLocked {
+			return nil, errwrap.Wrap(errors.New("failed to lock temporary file"), err)
+		}
+		log.Printf("another rkt instance is downloading this file, waiting...")
+		_, err = lock.ExclusiveLock(tmp.Name(), lock.RegFile)
+		if err != nil {
+			return nil, errwrap.Wrap(errors.New("failed to lock temporary file"), err)
+		}
 	}
 	roc := &removeOnClose{File: tmp}
 	return roc, nil

--- a/rkt/image/resumablesession.go
+++ b/rkt/image/resumablesession.go
@@ -148,6 +148,9 @@ func (s *resumableSession) maybeSetupDownloadResume(u *url.URL) error {
 	}
 	if res.StatusCode != http.StatusOK {
 		log.Printf("bad HTTP status code from HEAD request: %d", res.StatusCode)
+		if err := s.reset(); err != nil {
+			return err
+		}
 		return nil
 	}
 	status := s.verifyAcceptRange(res, fi.ModTime())


### PR DESCRIPTION
Whenever we create a Store temporary file, we lock it so concurrent
downloads don't corrupt it.

Fixes #2165