### PR TITLE
This patch make rkt work better with SELinux

### DIFF
--- a/common/cgroup/cgroup.go
+++ b/common/cgroup/cgroup.go
@@ -275,7 +275,7 @@ func IsControllerMounted(c string) bool {
 
 // CreateCgroups mounts the cgroup controllers hierarchy in /sys/fs/cgroup
 // under root
-func CreateCgroups(root string, enabledCgroups map[int][]string) error {
+func CreateCgroups(root string, enabledCgroups map[int][]string, mountContext string) error {
 	controllers := GetControllerDirs(enabledCgroups)
 	var flags uintptr
 
@@ -300,7 +300,13 @@ func CreateCgroups(root string, enabledCgroups map[int][]string) error {
 		syscall.MS_NOEXEC |
 		syscall.MS_NODEV |
 		syscall.MS_STRICTATIME
-	if err := syscall.Mount("tmpfs", cgroupTmpfs, "tmpfs", flags, "mode=755"); err != nil {
+
+	options := "mode=755"
+	if mountContext != "" {
+		options = fmt.Sprintf("mode=755,context=\"%s\"", mountContext)
+	}
+
+	if err := syscall.Mount("tmpfs", cgroupTmpfs, "tmpfs", flags, options); err != nil {
 		return errwrap.Wrap(fmt.Errorf("error mounting %q", cgroupTmpfs), err)
 	}
 

--- a/common/common.go
+++ b/common/common.go
@@ -39,6 +39,7 @@ const (
 
 	EnvLockFd                    = "RKT_LOCK_FD"
 	EnvSELinuxContext            = "RKT_SELINUX_CONTEXT"
+	EnvSELinuxMountContext       = "RKT_SELINUX_MOUNT_CONTEXT"
 	Stage1TreeStoreIDFilename    = "stage1TreeStoreID"
 	AppTreeStoreIDFilename       = "treeStoreID"
 	OverlayPreparedFilename      = "overlay-prepared"

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -450,6 +450,10 @@ func Run(cfg RunConfig, dir string, dataDir string) {
 		log.FatalE("setting SELinux context environment", err)
 	}
 
+	if err := os.Setenv(common.EnvSELinuxMountContext, fmt.Sprintf("%v", cfg.MountLabel)); err != nil {
+		log.FatalE("setting SELinux mount context enviroment", err)
+	}
+
 	debug("Pivoting to filesystem %s", dir)
 	if err := os.Chdir(dir); err != nil {
 		log.FatalE("failed changing to dir", err)


### PR DESCRIPTION
systemd-nspawn should be setting the mount point labels of tmpfs.  Need to add
-L$(MOUNT_CONTEXT) to the options to clean up this problem.

Also need to pass in the mount_context to create the tmpfs to be used with
cgroups to the proper context.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>
