### PR TITLE
rkt: add --hostname option

### DIFF
--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -56,6 +56,7 @@ Stage 1 must write the host PIDs of the pod's process #1 and that process's pare
 * `/var/lib/rkt/pods/run/$uuid/ppid`: the PID of the parent of the process that is PID 1 in the container.
 
 #### Arguments
+
 * `--debug` to activate debugging
 * `--net[=$NET1,$NET2,...]` to configure the creation of a contained network.
   See the [rkt networking documentation](../networking.md) for details.
@@ -63,6 +64,10 @@ Stage 1 must write the host PIDs of the pod's process #1 and that process's pare
 * `--interactive` to run a pod interactively, that is, pass standard input to the application (only for pods with one application)
 * `--local-config=$PATH` to override the local configuration directory
 * `--private-users=$SHIFT` to define a UID/GID shift when using user namespaces. SHIFT is a two-value colon-separated parameter, the first value is the first host UID to assign to the container and the second one is the number of host UIDs to assign.
+
+##### Arguments added in interface version 2
+
+* `--hostname=$HOSTNAME` configures the host name of the pod. If empty, it will be "rkt-$PODUUID".
 
 ### `rkt enter` => `coreos.com/rkt/stage1/enter`
 
@@ -102,7 +107,7 @@ Versioning
 The stage1 command line interface is versioned using an annotation with the name `coreos.com/rkt/stage1/interface-version`.
 If the annotation is not present, rkt assumes the version is 1.
 
-The current version of the stage1 interface is 1.
+The current version of the stage1 interface is 2.
 
 Examples
 --------
@@ -143,7 +148,7 @@ Examples
         },
         {
             "name": "coreos.com/rkt/stage1/interface-version",
-            "value": "1"
+            "value": "2"
         }
     ]
 }

--- a/Documentation/subcommands/run-prepared.md
+++ b/Documentation/subcommands/run-prepared.md
@@ -48,6 +48,7 @@ c9fad0e6    etcd    coreos.com/etcd prepared
 | `--dns` |  `` | IP Address | Name server to write in `/etc/resolv.conf`. It can be specified several times |
 | `--dns-opt` |  `` | Option as described in the options section in resolv.conf(5) | DNS option to write in `/etc/resolv.conf`. It can be specified several times |
 | `--dns-search` |  `` | Domain name | DNS search domain to write in `/etc/resolv.conf`. It can be specified several times |
+| `--hostname` |  `` | A host name | Pod's hostname. If empty, it will be "rkt-$PODUUID" |
 | `--interactive` |  `false` | `true` or `false` | Run pod interactively. If true, only one image may be supplied |
 | `--mds-register` |  `false` | `true` or `false` | Register pod with metadata service. It needs network connectivity to the host (`--net=(default|default-restricted|host)` |
 | `--net` |  `default` | A comma-separated list of networks. Syntax: `--net[=n[:args], ...]` | Configure the pod's networking. Optionally, pass a list of user-configured networks to load and set arguments to pass to each network, respectively |

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -314,6 +314,7 @@ If you don't use systemd, you can use [daemon](http://www.libslack.org/daemon/) 
 | `--dns-opt` |  `` | Option as described in the options section in resolv.conf(5) | DNS option to write in `/etc/resolv.conf`. It can be specified several times |
 | `--dns-search` |  `` | Domain name | DNS search domain to write in `/etc/resolv.conf`. It can be specified several times |
 | `--exec` |  `` | A path | Override the exec command for the preceding image |
+| `--hostname` |  `` | A host name | Pod's hostname. If empty, it will be "rkt-$PODUUID" |
 | `--inherit-env` |  `false` | `true` or `false` | Inherit all environment variables not set by apps |
 | `--interactive` |  `false` | `true` or `false` | Run pod interactively. If true, only one image may be supplied |
 | `--mds-register` |  `false` | `true` or `false` | Register pod with metadata service. It needs network connectivity to the host (`--net=(default|default-restricted|host)` |

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -67,6 +67,7 @@ image arguments with a lone "---" to resume argument parsing.`,
 	flagPodManifest  string
 	flagMDSRegister  bool
 	flagUUIDFileSave string
+	flagHostname     string
 )
 
 func init() {
@@ -89,6 +90,7 @@ func init() {
 	cmdRun.Flags().StringVar(&flagPodManifest, "pod-manifest", "", "the path to the pod manifest. If it's non-empty, then only '--net', '--no-overlay' and '--interactive' will have effect")
 	cmdRun.Flags().BoolVar(&flagMDSRegister, "mds-register", false, "register pod with metadata service. needs network connectivity to the host (--net=(default|default-restricted|host)")
 	cmdRun.Flags().StringVar(&flagUUIDFileSave, "uuid-file-save", "", "write out pod UUID to specified file")
+	cmdRun.Flags().StringVar(&flagHostname, "hostname", "", `pod's hostname. If empty, it will be "rkt-$PODUUID"`)
 	cmdRun.Flags().Var((*appsVolume)(&rktApps), "volume", "volumes to make available in the pod")
 
 	// per-app flags
@@ -290,6 +292,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		MDSRegister:  flagMDSRegister,
 		LocalConfig:  globalFlags.LocalConfigDir,
 		RktGid:       rktgid,
+		Hostname:     flagHostname,
 	}
 
 	apps, err := p.getApps()

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -46,6 +46,7 @@ func init() {
 	cmdRunPrepared.Flags().Var(&flagDNSOpt, "dns-opt", "DNS options to write in /etc/resolv.conf")
 	cmdRunPrepared.Flags().BoolVar(&flagInteractive, "interactive", false, "the pod is interactive")
 	cmdRunPrepared.Flags().BoolVar(&flagMDSRegister, "mds-register", false, "register pod with metadata service")
+	cmdRunPrepared.Flags().StringVar(&flagHostname, "hostname", "", `pod's hostname. If empty, it will be "rkt-$PODUUID"`)
 }
 
 func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
@@ -132,6 +133,7 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		MDSRegister: flagMDSRegister,
 		Apps:        apps,
 		RktGid:      rktgid,
+		Hostname:    flagHostname,
 	}
 	if globalFlags.Debug {
 		stage0.InitDebug()

--- a/stage0/interface.go
+++ b/stage0/interface.go
@@ -55,3 +55,7 @@ func getStage1InterfaceVersion(cdir string) (int, error) {
 	// "interface-version" annotation not found, assume version 1
 	return 1, nil
 }
+
+func interfaceVersionSupportsHostname(version int) bool {
+	return version > 1
+}

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -88,6 +88,7 @@ type RunConfig struct {
 	MDSRegister bool           // whether to register with metadata service or not
 	Apps        schema.AppList // applications (prepare gets them via Apps)
 	LocalConfig string         // Path to local configuration
+	Hostname    string         // hostname of the pod
 	RktGid      int            // group id of the 'rkt' group, -1 if there's no rkt group.
 	DNS         []string       // DNS name servers to write in /etc/resolv.conf
 	DNSSearch   []string       // DNS search domains to write in /etc/resolv.conf
@@ -489,6 +490,19 @@ func Run(cfg RunConfig, dir string, dataDir string) {
 
 	if cfg.LocalConfig != "" {
 		args = append(args, "--local-config="+cfg.LocalConfig)
+	}
+
+	s1v, err := getStage1InterfaceVersion(dir)
+	if err != nil {
+		log.FatalE("error determining stage1 interface version", err)
+	}
+
+	if cfg.Hostname != "" {
+		if interfaceVersionSupportsHostname(s1v) {
+			args = append(args, "--hostname="+cfg.Hostname)
+		} else {
+			log.Printf("warning: --hostname option is not supported by stage1")
+		}
 	}
 
 	args = append(args, cfg.UUID.String())

--- a/stage1/aci/aci-manifest.in
+++ b/stage1/aci/aci-manifest.in
@@ -31,7 +31,7 @@
         },
         {
             "name": "coreos.com/rkt/stage1/interface-version",
-            "value": "1"
+            "value": "2"
         }
     ]
 }

--- a/tests/inspect/inspect.go
+++ b/tests/inspect/inspect.go
@@ -64,6 +64,7 @@ var (
 		PrintDefaultGWv6   bool
 		PrintGWv4          string
 		PrintGWv6          string
+		PrintHostname      bool
 		GetHTTP            string
 		ServeHTTP          string
 		ServeHTTPTimeout   int
@@ -100,6 +101,7 @@ func init() {
 	globalFlagset.BoolVar(&globalFlags.PrintDefaultGWv6, "print-defaultgwv6", false, "Print the default IPv6 gateway")
 	globalFlagset.StringVar(&globalFlags.PrintGWv4, "print-gwv4", "", "Takes an interface name and prints its gateway's IPv4")
 	globalFlagset.StringVar(&globalFlags.PrintGWv6, "print-gwv6", "", "Takes an interface name and prints its gateway's IPv6")
+	globalFlagset.BoolVar(&globalFlags.PrintHostname, "print-hostname", false, "Prints the pod hostname")
 	globalFlagset.StringVar(&globalFlags.GetHTTP, "get-http", "", "HTTP-Get from the given address")
 	globalFlagset.StringVar(&globalFlags.ServeHTTP, "serve-http", "", "Serve the hostname via HTTP on the given address:port")
 	globalFlagset.IntVar(&globalFlags.ServeHTTPTimeout, "serve-http-timeout", 30, "HTTP Timeout to wait for a client connection")
@@ -414,6 +416,15 @@ func main() {
 
 	if globalFlags.PrintGWv6 != "" {
 		// TODO
+	}
+
+	if globalFlags.PrintHostname {
+		hostname, err := os.Hostname()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Hostname: %s\n", hostname)
 	}
 
 	if globalFlags.ServeHTTP != "" {

--- a/tests/rkt_hostname_test.go
+++ b/tests/rkt_hostname_test.go
@@ -1,0 +1,59 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+// TestHostname test that the --hostname option works.
+func TestHostname(t *testing.T) {
+	imageFile := patchTestACI("rkt-inspect-hostname.aci", "--exec=/inspect --print-hostname")
+	defer os.Remove(imageFile)
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	tests := []struct {
+		hostname string
+	}{
+		{
+			"test-hostname",
+		},
+		{
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+		rktCmd := fmt.Sprintf("%s prepare --insecure-options=image %s", ctx.Cmd(), imageFile)
+		uuid := runRktAndGetUUID(t, rktCmd)
+
+		expectedHostname := "rkt-" + uuid
+		hostnameParam := ""
+		if tt.hostname != "" {
+			expectedHostname = tt.hostname
+			hostnameParam = fmt.Sprintf("--hostname=%s", tt.hostname)
+		}
+
+		rktCmd = fmt.Sprintf("%s run-prepared %s %s", ctx.Cmd(), hostnameParam, uuid)
+		expected := fmt.Sprintf("Hostname: %s", expectedHostname)
+		runRktAndCheckOutput(t, rktCmd, expected, false)
+	}
+}


### PR DESCRIPTION
It allows the user to specify a host name for the pod. If not specified, it will be "rkt-$PODUUID".

This approach might not be OK if we want to use systemd-resolved, apparently it expects container's machine name to match the hostname.

cc @steveeJ @yifan-gu @sjpotter 

Fixes #2245 