### PR TITLE
functional tests: Add new test with systemd-proxyd

### DIFF
--- a/Documentation/using-rkt-with-systemd.md
+++ b/Documentation/using-rkt-with-systemd.md
@@ -202,6 +202,84 @@ Jul 30 12:24:50 locke-work systemd[1]: Listening on My socket-activated app's so
 
 Now, a new connection to port 8080 will start your container to handle the request.
 
+### Bidirectionally proxy local sockets to another (possibly remote) socket.
+
+`rkt` also supports the [socket-proxyd service][systemd-socket-proxyd]. Much like socket activation, with socket-proxyd systemd provides a listener on a given port on behalf of a container, and starts the container when a connection is received. Socket-proxy listening can be useful in environments that lack native support for socket activation. The LKVM stage1 flavor is an example of such an environment.
+
+To set up socket proxyd, create a network template consisting of three units, like the example below. This example uses the redis app and the PTP network template in `/etc/rkt/net.d/ptp0.conf`:
+
+```json
+{
+	"name": "ptp0",
+	"type": "ptp",
+	"ipMasq": true,
+	"ipam": {
+		"type": "host-local",
+		"subnet": "172.16.28.0/24",
+		"routes": [
+			{ "dst": "0.0.0.0/0" }
+		]
+	}
+}
+```
+
+```
+# rkt-redis.service
+[Unit]
+Description=Socket-proxyd redis server
+
+[Service]
+ExecStart=/usr/bin/rkt --insecure-options=image run --net="ptp:IP=172.16.28.101" docker://redis
+KillMode=process
+```
+Note that you have to specify IP manually in systemd unit.
+
+Then you will need a pair of `.service` and `.socket` unit files.
+
+We want to use the port 6379 on the localhost instead of the remote container IP,
+so we use next systemd unit to override it.
+
+```
+# proxy-to-rkt-redis.service
+[Unit]
+Requires=rkt-redis.service
+After=rkt-redis.service
+
+[Service]
+ExecStart=/usr/lib/systemd/systemd-socket-proxyd 172.16.28.101:6379
+```
+Lastly the related socket unit,
+```
+# proxy-to-rkt-redis.socket
+[Socket]
+ListenStream=6371
+
+[Install]
+WantedBy=sockets.target
+```
+
+Finally, start the socket unit:
+
+```
+# systemctl enable proxy-to-redis.socket
+$ sudo systemctl start proxy-to-redis.socket
+● proxy-to-rkt-redis.socket
+   Loaded: loaded (/etc/systemd/system/proxy-to-rkt-redis.socket; enabled; vendor preset: disabled)
+   Active: active (listening) since Mon 2016-03-07 11:53:32 CET; 8s ago
+   Listen: [::]:6371 (Stream)
+
+Mar 07 11:53:32 user-host systemd[1]: Listening on proxy-to-rkt-redis.socket.
+Mar 07 11:53:32 user-host systemd[1]: Starting proxy-to-rkt-redis.socket.
+
+```
+
+Now, a new connection to localhost port 6371 will start your container with redis, to handle the request.
+
+```
+$ curl http://localhost:6371/
+```
+
+
 ## Other tools for managing pods
 
 Let us assume the service from the simple example unit file, above, is started on the host.
@@ -309,3 +387,4 @@ $ systemd-cgls --all
 [systemd-machined]: http://www.freedesktop.org/software/systemd/man/systemd-machined.service.html
 [systemd-run]: http://www.freedesktop.org/software/systemd/man/systemd-run.html
 [systemd-socket-activated]: http://www.freedesktop.org/software/systemd/man/sd_listen_fds.html
+[systemd-socket-proxyd]: https://www.freedesktop.org/software/systemd/man/systemd-socket-proxyd.html

--- a/tests/rkt_socket_proxyd_test.go
+++ b/tests/rkt_socket_proxyd_test.go
@@ -1,0 +1,200 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	sd_dbus "github.com/coreos/go-systemd/dbus"
+	sd_util "github.com/coreos/go-systemd/util"
+	"github.com/coreos/rkt/tests/testutils"
+	"github.com/vishvananda/netlink"
+)
+
+func TestSocketProxyd(t *testing.T) {
+	if !sd_util.IsRunningSystemd() {
+		t.Skip("Systemd is not running on the host.")
+	}
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	iface, _, err := testutils.GetNonLoIfaceWithAddrs(netlink.FAMILY_V4)
+	if err != nil {
+		t.Fatalf("Error while getting non-lo host interface: %v\n", err)
+	}
+	if iface.Name == "" {
+		t.Skipf("Cannot run test without non-lo host interface")
+	}
+
+	nt := networkTemplateT{
+		Name:   "ptp0",
+		Type:   "ptp",
+		IpMasq: true,
+		Master: iface.Name,
+		Ipam: ipamTemplateT{
+			Type:   "host-local",
+			Subnet: "192.168.0.0/24",
+			Routes: []map[string]string{
+				{"dst": "0.0.0.0/0"},
+			},
+		},
+	}
+
+	netDir := prepareTestNet(t, ctx, nt)
+	defer os.RemoveAll(netDir)
+
+	port, err := randomFreePort(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	echoImage := patchTestACI("rkt-inspect-echo.aci",
+		"--exec=/echo-socket-activated",
+		"--ports=test-port,protocol=tcp,port=80,socketActivated=true")
+	defer os.Remove(echoImage)
+
+	conn, err := sd_dbus.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rktTestingEchoService := `
+	[Unit]
+	Description=Socket-activated echo server
+
+	[Service]
+	ExecStart=%s
+	KillMode=process
+	`
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rnd := r.Int()
+
+	// Write unit files directly to runtime system units directory
+	// (/run/systemd/system) to avoid calling LinkUnitFiles - it is buggy in
+	// systemd v219 as it does not work with absolute paths.
+	unitsDir := "/run/systemd/system"
+	containerIP := "192.168.0.101"
+
+	cmd := fmt.Sprintf("%s --insecure-options=image --debug run --net=\"%s:IP=%s\" --port=test-port:%d --mds-register=false %s",
+		ctx.Cmd(), nt.Name, containerIP, port, echoImage)
+
+	serviceContent := fmt.Sprintf(rktTestingEchoService, cmd)
+	serviceTargetBase := fmt.Sprintf("rkt-testing-socket-activation-%d.service", rnd)
+	serviceTarget := filepath.Join(unitsDir, serviceTargetBase)
+
+	if err := ioutil.WriteFile(serviceTarget, []byte(serviceContent), 0666); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(serviceTarget)
+
+	rktTestingEchoSocket := `
+	[Unit]
+	Description=Socket-activated netcat server socket
+
+	[Socket]
+	ListenStream=%d
+
+	[Install]
+	WantedBy=sockets.target
+	`
+
+	socketContent := fmt.Sprintf(rktTestingEchoSocket, port)
+	socketTargetBase := fmt.Sprintf("proxy-to-rkt-testing-socket-activation-%d.socket", rnd)
+	socketTarget := filepath.Join(unitsDir, socketTargetBase)
+
+	if err := ioutil.WriteFile(socketTarget, []byte(socketContent), 0666); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(socketTarget)
+
+	proxyToRktTestingEchoService := `
+	[Unit]
+	Requires=%s
+	After=%s
+
+	[Service]
+	ExecStart=/lib/systemd/systemd-socket-proxyd %s:%d
+	`
+
+	proxyContent := fmt.Sprintf(proxyToRktTestingEchoService, serviceTargetBase, serviceTargetBase, containerIP, port)
+	proxyContentBase := fmt.Sprintf("proxy-to-rkt-testing-socket-activation-%d.service", rnd)
+	proxyTarget := filepath.Join(unitsDir, proxyContentBase)
+
+	if err := ioutil.WriteFile(proxyTarget, []byte(proxyContent), 0666); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(proxyTarget)
+
+	reschan := make(chan string)
+	doJob := func() {
+		job := <-reschan
+		if job != "done" {
+			t.Fatal("Job is not done:", job)
+		}
+	}
+
+	if _, err := conn.StartUnit(socketTargetBase, "replace", reschan); err != nil {
+		t.Fatal(err)
+	}
+	doJob()
+
+	defer func() {
+		if _, err := conn.StopUnit(socketTargetBase, "replace", reschan); err != nil {
+			t.Fatal(err)
+		}
+		doJob()
+
+		if _, err := conn.StopUnit(serviceTargetBase, "replace", reschan); err != nil {
+			t.Fatal(err)
+		}
+		doJob()
+
+		if _, err := conn.StopUnit(proxyContentBase, "replace", reschan); err != nil {
+			t.Fatal(err)
+		}
+		doJob()
+	}()
+
+	expected := "HELO\n"
+	sockConn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := fmt.Fprintf(sockConn, expected); err != nil {
+		t.Fatal(err)
+	}
+
+	answer, err := bufio.NewReader(sockConn).ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if answer != expected {
+		t.Fatalf("Expected %q, Got %q", expected, answer)
+	}
+
+	return
+}


### PR DESCRIPTION
Setting `ptp` template network and IP address in systemd unit during
test. Updated also docs with example.