### PR TITLE
store: force removal of the tree store even if it's in a bad state

### DIFF
--- a/store/tree.go
+++ b/store/tree.go
@@ -153,14 +153,18 @@ func (ts *TreeStore) Remove(id string, s *Store) error {
 
 	key, err := ts.GetImageHash(id)
 	if err != nil {
-		return err
+		fmt.Fprintf(os.Stderr, "store: warning: tree store in a bad state, forcing removal\n")
 	}
 
 	if err := os.RemoveAll(treepath); err != nil {
 		return err
 	}
 
-	return s.UpdateTreeStoreSize(key, 0)
+	if key != "" {
+		return s.UpdateTreeStoreSize(key, 0)
+	}
+
+	return nil
 }
 
 // IsRendered checks if the tree store with the provided id is fully rendered


### PR DESCRIPTION
If the "image" file is not present in the tree store directory, that
tree store can't be removed. Don't error out if that happens, just print
a warning so it is removed.

This means that the image size will be overestimated because we can't
know which image the tree store refers to, but at least we can remove
the tree store.

Fixes #2180 (for real)

```
$ sudo rkt run docker://busybox --insecure-options=image
image: using image from local store for image name coreos.com/rkt/stage1-coreos:1.1.0+git4f50d4e
image: using image from local store for url docker://busybox
networking: loading networks from /etc/rkt/net.d
networking: loading network default with type ptp 
$ sudo rm /var/lib/rkt/cas/tree/deps-sha512-630c391429eff28aa9a18da5445848a9ad055d15b2979127f168abd7a52cd24b/{image,rendered} 
iaguis@locke-xps13: ~/temp/rkt  
$ sudo rkt run docker://busybox --insecure-options=image --interactive
image: using image from local store for image name coreos.com/rkt/stage1-coreos:1.1.0+git4f50d4e
image: using image from local store for url docker://busybox
warning: tree store in a bad state, forcing removal
networking: loading networks from /etc/rkt/net.d
networking: loading network default with type ptp
/ # exit
$
```