### PR TITLE
scripts: Add bc to common dependencies

### DIFF
--- a/scripts/install-common.sh
+++ b/scripts/install-common.sh
@@ -4,7 +4,7 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates gcc libc6-dev make automake wget git coreutils cpio squashfs-tools realpath autoconf file libacl1-dev libtspi-dev
+apt-get install -y --no-install-recommends ca-certificates gcc libc6-dev make automake wget git coreutils cpio squashfs-tools realpath autoconf file libacl1-dev libtspi-dev bc
 
 ./scripts/install-go.sh
 . /etc/profile


### PR DESCRIPTION
I just tried setting up a development environment from scratch with `vagrant up`, but building failed during the provision step. Looks like it fails because `bc` isn't installed inside the Vagrant box:

```
$ cat rkt-build.log
----------------------------------------------------------------
Initialized build system. For a common configuration please run:
----------------------------------------------------------------

./configure 

checking for bash... /bin/bash
checking for git... git
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking for cat... cat
checking for cpio... cpio
checking for gzip... gzip
checking for md5sum... md5sum
checking for mktemp... mktemp
checking for sort... sort
checking for touch... touch
checking for unsquashfs... unsquashfs
checking for wget... wget
configure: WARNING: * kvm is an experimental stage1 implementation, some features are missing
configure: will build linux kernel and lkvm from source, make sure that all their build requirements are fulfilled
checking for patch... patch
checking for tar... tar
checking for xz... xz
configure: WARNING: * fly is an experimental stage1 implementation with almost no isolation and less features
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking for acl/libacl.h... yes
checking for dlfcn.h... yes
checking for printf in -lc... yes
checking whether C library provides setns function... yes
checking for gpg... gpg
checking for fork in -lc... yes
checking for trousers/tss.h... yes
checking for a BSD-compatible install... /usr/bin/install -c
checking for file... file
checking for go... go
checking for gofmt... gofmt
checking for go... /usr/local/go/bin/go
checking whether we have go 1.5 or newer... yes
checking whether we have a go version without CVE-2015-8618... yes
configure: creating ./config.status
config.status: creating Makefile

        rkt 1.1.0+git7b07bf2-dirty

        stage1 setup

        type:                                   'flavor'
        default stage1 location:                '/usr/lib/rkt/stage1-images/stage1-coreos.aci'
        default stage1 images directory:        '/usr/lib/rkt/stage1-images'

        built stage1 flavors:                   'coreos,kvm,fly'
        default stage1 flavor:                  'coreos'
        implied default stage1 name:            'coreos.com/rkt/stage1-coreos'
        implied default stage1 version:         '1.1.0+git7b07bf2-dirty'

        coreos/kvm flavor specific build parameters

        local CoreOS PXE image path:            ''
        local CoreOS PXE image systemd version: ''

        other build parameters

        functional tests enabled:               'no'
        features:                               '-TPM'
        go version:                             '1.5.3'
  CC           build-rkt-1.1.0+git/tools/appexec
  CC           build-rkt-1.1.0+git/tools/prepare-app
  CC           build-rkt-1.1.0+git/tools/enter
  WGET         http://alpha.release.core-os.net/amd64-usr/794.1.0/coreos_production_pxe_image.cpio.gz => build-rkt-1.1.0+git/tmp/coreos-common/pxe.img
  MANIFEST     coreos
  WGET         https://www.kernel.org/pub/linux/kernel/v4.x/linux-4.3.1.tar.xz => build-rkt-1.1.0+git/tmp/usr_from_kvm/kernel/linux-4.3.1.tar.xz
  MANIFEST     kvm
  MANIFEST     fly
  GIT CLONE    https://kernel.googlesource.com/pub/scm/linux/kernel/git/will/kvmtool (3c8aec9e2b5066412390559629dabeb7816ee8f2) => build-rkt-1.1.0+git/tmp/usr_from_kvm/lkvm/src
  GO           github.com/coreos/rkt/stage1/enter_kvm
  GIT RESET    build-rkt-1.1.0+git/tmp/usr_from_kvm/lkvm/src => 3c8aec9e2b5066412390559629dabeb7816ee8f2
  GIT CLEAN    build-rkt-1.1.0+git/tmp/usr_from_kvm/lkvm/src
  GO           github.com/coreos/rkt/stage1_fly/run
  WGET         http://alpha.release.core-os.net/amd64-usr/794.1.0/coreos_production_pxe_image.cpio.gz.sig => build-rkt-1.1.0+git/tmp/coreos-common/pxe.img.777fe7ac43d67d052f89e0ce5f10cb9b.sig
  GO           github.com/coreos/rkt/stage1_fly/gc
  GO           github.com/coreos/rkt/stage1_fly/enter
  GO           github.com/coreos/rkt/rkt
  GO           github.com/coreos/rkt/tools/depsgen
  GO           <Godeps>/github.com/appc/spec/actool
  EXTRACT      build-rkt-1.1.0+git/tmp/coreos-common/pxe.img => build-rkt-1.1.0+git/tmp/coreos-common/usr.squashfs
  GO           github.com/coreos/rkt/tools/filelistgen
  GO           github.com/coreos/rkt/tools/cleangen
  GO           <Godeps>/github.com/appc/cni/plugins/main/ptp
  GO           <Godeps>/github.com/appc/cni/plugins/main/bridge
  GO           <Godeps>/github.com/appc/cni/plugins/main/macvlan
  GO           <Godeps>/github.com/appc/cni/plugins/main/ipvlan
  GO           <Godeps>/github.com/appc/cni/plugins/ipam/host-local
  GO           <Godeps>/github.com/appc/cni/plugins/ipam/dhcp
  GO           <Godeps>/github.com/appc/cni/plugins/meta/flannel
  GO           <Godeps>/github.com/appc/cni/plugins/meta/tuning
  GO           github.com/coreos/rkt/stage1/init
  GO           github.com/coreos/rkt/stage1/gc
  UNTAR        build-rkt-1.1.0+git/tmp/usr_from_kvm/kernel/linux-4.3.1.tar.xz => build-rkt-1.1.0+git/tmp/usr_from_kvm/kernel
  UNSQUASHFS   build-rkt-1.1.0+git/tmp/coreos-common/usr.squashfs => build-rkt-1.1.0+git/tmp/usr_from_kvm/cbu/rootfs/usr
  UNSQUASHFS   build-rkt-1.1.0+git/tmp/coreos-common/usr.squashfs => build-rkt-1.1.0+git/tmp/usr_from_coreos/cbu/rootfs/usr
  BUILD EXT    bzImage
  BUILD EXT    lkvm
  ACTOOL       build-rkt-1.1.0+git/bin/stage1-fly.aci
Makefile:310: Skipping optional libraries: bfd GTK3 vncserver SDL aio
KVMTOOLS_VERSION = 3.18.0
Makefile:310: Skipping optional libraries: bfd GTK3 vncserver SDL aio
  ACTOOL       build-rkt-1.1.0+git/bin/stage1-coreos.aci
/bin/sh: 1: bc: not found
make[3]: *** [include/generated/timeconst.h] Error 127
make[2]: *** [prepare0] Error 2
make[1]: *** [sub-make] Error 2
stage1/usr_from_kvm/kernel.mk:46: recipe for target '/vagrant/build-rkt-1.1.0+git/stamps/__stage1_usr_from_kvm_kernel_mk_bzimage.stamp' failed
make: *** [/vagrant/build-rkt-1.1.0+git/stamps/__stage1_usr_from_kvm_kernel_mk_bzimage.stamp] Error 2
make: *** Waiting for unfinished jobs....
```

After installing `bc`, it builds successfully.