### PR TITLE
selinux: relabel content under pods/run to match container image

### DIFF
--- a/rkt/run.go
+++ b/rkt/run.go
@@ -216,6 +216,8 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
+	p.mountLabel = mountLabel
+
 	cfg := stage0.CommonConfig{
 		MountLabel:   mountLabel,
 		ProcessLabel: processLabel,


### PR DESCRIPTION
We need to setup the containers runtime environment to match the label
of the container image.  The goal is to get any files that need to be
written by the container process to be the container label.

Not sure if the Relabel is the best way to handle this.  But it works
pretty well.  BTW The label/selinux code in opencontainers has been
updated with newer API then you have in RKT.  It should be updated.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>