### PR TITLE
networking: Add flags to specify net config and net plugin binary dirs.

### DIFF
--- a/networking/net_plugin.go
+++ b/networking/net_plugin.go
@@ -30,8 +30,6 @@ import (
 	"github.com/coreos/rkt/common"
 )
 
-// TODO(eyakubovich): make this configurable in rkt.conf
-const UserNetPluginsPath = "/usr/lib/rkt/plugins/net"
 const BuiltinNetPluginsPath = "usr/lib/rkt/plugins/net"
 
 func pluginErr(err error, output []byte) error {
@@ -81,7 +79,7 @@ func (e *podEnv) pluginPaths() []string {
 	// try 3rd-party path first
 	return []string{
 		filepath.Join(e.localConfig, UserNetPathSuffix),
-		UserNetPluginsPath,
+		e.netPlugin,
 		filepath.Join(common.Stage1RootfsPath(e.podRoot), BuiltinNetPluginsPath),
 	}
 }

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -68,7 +68,7 @@ var stderr *log.Logger
 
 // Setup creates a new networking namespace and executes network plugins to
 // set up networking. It returns in the new pod namespace
-func Setup(podRoot string, podID types.UUID, fps []ForwardedPort, netList common.NetList, localConfig, flavor string, debug bool) (*Networking, error) {
+func Setup(podRoot string, podID types.UUID, fps []ForwardedPort, netList common.NetList, localConfig, flavor string, netConfig string, netPlugin string, debug bool) (*Networking, error) {
 
 	stderr = log.New(os.Stderr, "networking", debug)
 
@@ -84,6 +84,8 @@ func Setup(podRoot string, podID types.UUID, fps []ForwardedPort, netList common
 			podID:        podID,
 			netsLoadList: netList,
 			localConfig:  localConfig,
+			netConfig:    netConfig,
+			netPlugin:    netPlugin,
 		},
 	}
 

--- a/networking/podenv.go
+++ b/networking/podenv.go
@@ -49,6 +49,8 @@ type podEnv struct {
 	podID        types.UUID
 	netsLoadList common.NetList
 	localConfig  string
+	netConfig    string
+	netPlugin    string
 }
 
 type activeNet struct {
@@ -59,7 +61,7 @@ type activeNet struct {
 
 // Loads nets specified by user and default one from stage1
 func (e *podEnv) loadNets() ([]activeNet, error) {
-	nets, err := loadUserNets(e.localConfig, e.netsLoadList)
+	nets, err := loadUserNets(e.localConfig, e.netConfig, e.netsLoadList)
 	if err != nil {
 		return nil, err
 	}
@@ -221,13 +223,16 @@ func copyFileToDir(src, dstdir string) (string, error) {
 	return dst, err
 }
 
-func loadUserNets(localConfig string, netsLoadList common.NetList) ([]activeNet, error) {
+func loadUserNets(localConfig string, netConfig string, netsLoadList common.NetList) ([]activeNet, error) {
 	if netsLoadList.None() {
 		stderr.Printf("networking namespace with loopback only")
 		return nil, nil
 	}
 
 	userNetPath := filepath.Join(localConfig, UserNetPathSuffix)
+	if netConfig != "" {
+		userNetPath = netConfig
+	}
 	stderr.Printf("loading networks from %v", userNetPath)
 
 	files, err := listFiles(userNetPath)

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -67,6 +67,8 @@ image arguments with a lone "---" to resume argument parsing.`,
 	flagPodManifest  string
 	flagMDSRegister  bool
 	flagUUIDFileSave string
+	flagNetConfig    string
+	flagNetPlugin    string
 )
 
 func init() {
@@ -76,6 +78,8 @@ func init() {
 	cmdRun.Flags().Var(&flagPorts, "port", "ports to expose on the host (requires contained network). Syntax: --port=NAME:HOSTPORT")
 	cmdRun.Flags().Var(&flagNet, "net", "configure the pod's networking. Optionally, pass a list of user-configured networks to load and set arguments to pass to each network, respectively. Syntax: --net[=n[:args], ...]")
 	cmdRun.Flags().Lookup("net").NoOptDefVal = "default"
+	cmdRun.Flags().StringVar(&flagNetConfig, "net-config", "", "the directory to find the network configuration")
+	cmdRun.Flags().StringVar(&flagNetPlugin, "net-plugin", "/usr/lib/rkt/plugins/net", "the directory to find the network plugin binaries")
 	cmdRun.Flags().BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	cmdRun.Flags().BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
 	cmdRun.Flags().BoolVar(&flagPrivateUsers, "private-users", false, "run within user namespaces (experimental).")
@@ -279,15 +283,21 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 
 	rcfg := stage0.RunConfig{
 		CommonConfig: &cfg,
-		Net:          flagNet,
-		LockFd:       lfd,
-		Interactive:  flagInteractive,
-		DNS:          flagDNS,
-		DNSSearch:    flagDNSSearch,
-		DNSOpt:       flagDNSOpt,
-		MDSRegister:  flagMDSRegister,
-		LocalConfig:  globalFlags.LocalConfigDir,
-		RktGid:       rktgid,
+
+		NetConfig: &stage0.NetConfig{
+			ConfigDir: flagNetConfig,
+			PluginDir: flagNetPlugin,
+			Net:       flagNet,
+			DNS:       flagDNS,
+			DNSSearch: flagDNSSearch,
+			DNSOpt:    flagDNSOpt,
+		},
+
+		LockFd:      lfd,
+		Interactive: flagInteractive,
+		MDSRegister: flagMDSRegister,
+		LocalConfig: globalFlags.LocalConfigDir,
+		RktGid:      rktgid,
 	}
 
 	apps, err := p.getApps()

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -41,6 +41,8 @@ func init() {
 
 	cmdRunPrepared.Flags().Var(&flagNet, "net", "configure the pod's networking. Optionally, pass a list of user-configured networks to load and set arguments to pass to each network, respectively. Syntax: --net[=n[:args]][,]")
 	cmdRunPrepared.Flags().Lookup("net").NoOptDefVal = "default"
+	cmdRunPrepared.Flags().StringVar(&flagNetConfig, "net-config", "", "the directory to find the network configuration")
+	cmdRunPrepared.Flags().StringVar(&flagNetPlugin, "net-plugin", "/usr/lib/rkt/plugins/net", "the directory to find the network plugin binaries")
 	cmdRunPrepared.Flags().Var(&flagDNS, "dns", "name servers to write in /etc/resolv.conf")
 	cmdRunPrepared.Flags().Var(&flagDNSSearch, "dns-search", "DNS search domains to write in /etc/resolv.conf")
 	cmdRunPrepared.Flags().Var(&flagDNSOpt, "dns-opt", "DNS options to write in /etc/resolv.conf")
@@ -123,12 +125,18 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 			UUID:  p.uuid,
 			Debug: globalFlags.Debug,
 		},
-		Net:         flagNet,
+
+		NetConfig: &stage0.NetConfig{
+			ConfigDir: flagNetConfig,
+			PluginDir: flagNetPlugin,
+			Net:       flagNet,
+			DNS:       flagDNS,
+			DNSSearch: flagDNSSearch,
+			DNSOpt:    flagDNSOpt,
+		},
+
 		LockFd:      lfd,
 		Interactive: flagInteractive,
-		DNS:         flagDNS,
-		DNSSearch:   flagDNSSearch,
-		DNSOpt:      flagDNSOpt,
 		MDSRegister: flagMDSRegister,
 		Apps:        apps,
 		RktGid:      rktgid,

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -82,16 +82,13 @@ type PrepareConfig struct {
 // configuration parameters needed by Run
 type RunConfig struct {
 	*CommonConfig
-	Net         common.NetList // pod should have its own network stack
+	*NetConfig
 	LockFd      int            // lock file descriptor
 	Interactive bool           // whether the pod is interactive or not
 	MDSRegister bool           // whether to register with metadata service or not
 	Apps        schema.AppList // applications (prepare gets them via Apps)
 	LocalConfig string         // Path to local configuration
 	RktGid      int            // group id of the 'rkt' group, -1 if there's no rkt group.
-	DNS         []string       // DNS name servers to write in /etc/resolv.conf
-	DNSSearch   []string       // DNS search domains to write in /etc/resolv.conf
-	DNSOpt      []string       // DNS options to write in /etc/resolv.conf
 }
 
 // configuration shared by both Run and Prepare
@@ -104,6 +101,16 @@ type CommonConfig struct {
 	Debug        bool
 	MountLabel   string // selinux label to use for fs
 	ProcessLabel string // selinux label to use for process
+}
+
+// configuration for networking
+type NetConfig struct {
+	ConfigDir string         // directory to find the network configuration.
+	PluginDir string         // directory to find the network plugin binaries.
+	Net       common.NetList // pod should have its own network stack
+	DNS       []string       // DNS name servers to write in /etc/resolv.conf
+	DNSSearch []string       // DNS search domains to write in /etc/resolv.conf
+	DNSOpt    []string       // DNS options to write in /etc/resolv.conf
 }
 
 func init() {
@@ -471,6 +478,14 @@ func Run(cfg RunConfig, dir string, dataDir string) {
 	}
 
 	args = append(args, "--net="+cfg.Net.String())
+
+	if cfg.ConfigDir != "" {
+		args = append(args, "--net-config="+cfg.ConfigDir)
+	}
+
+	if cfg.PluginDir != "" {
+		args = append(args, "--net-plugin="+cfg.PluginDir)
+	}
 
 	if cfg.Interactive {
 		args = append(args, "--interactive")

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -98,6 +98,8 @@ func mirrorLocalZoneInfo(root string) {
 var (
 	debug        bool
 	netList      common.NetList
+	netConfig    string
+	netPlugin    string
 	interactive  bool
 	privateUsers string
 	mdsToken     string
@@ -110,6 +112,8 @@ var (
 func init() {
 	flag.BoolVar(&debug, "debug", false, "Run in debug mode")
 	flag.Var(&netList, "net", "Setup networking")
+	flag.StringVar(&netConfig, "net-config", "", "Directory to find the network configuration")
+	flag.StringVar(&netPlugin, "net-plugin", "", "Directory to find the network plugin binaries")
 	flag.BoolVar(&interactive, "interactive", false, "The pod is interactive")
 	flag.StringVar(&privateUsers, "private-users", "", "Run within user namespace. Can be set to [=UIDBASE[:NUIDS]]")
 	flag.StringVar(&mdsToken, "mds-token", "", "MDS auth token")
@@ -516,7 +520,7 @@ func stage1() int {
 			return 6
 		}
 
-		n, err = networking.Setup(root, p.UUID, fps, netList, localConfig, flavor, debug)
+		n, err = networking.Setup(root, p.UUID, fps, netList, localConfig, flavor, netConfig, netPlugin, debug)
 		if err != nil {
 			log.PrintE("failed to setup network", err)
 			return 6

--- a/tests/testutils/ctx.go
+++ b/tests/testutils/ctx.go
@@ -105,7 +105,7 @@ func (ctx *RktRunCtx) SetupDataDir() error {
 }
 
 func (ctx *RktRunCtx) LaunchMDS() error {
-	ctx.mds = exec.Command(ctx.rktBin(), "metadata-service")
+	ctx.mds = exec.Command(ctx.RktBin(), "metadata-service")
 	return ctx.mds.Start()
 }
 
@@ -174,14 +174,14 @@ func (ctx *RktRunCtx) RunGC() {
 		"gc",
 		"--grace-period=0s",
 	)
-	if err := exec.Command(ctx.rktBin(), rktArgs...).Run(); err != nil {
+	if err := exec.Command(ctx.RktBin(), rktArgs...).Run(); err != nil {
 		panic(fmt.Sprintf("Failed to run gc: %v", err))
 	}
 }
 
 func (ctx *RktRunCtx) Cmd() string {
 	return fmt.Sprintf("%s %s",
-		ctx.rktBin(),
+		ctx.RktBin(),
 		strings.Join(ctx.rktOptions(), " "),
 	)
 }
@@ -189,12 +189,12 @@ func (ctx *RktRunCtx) Cmd() string {
 // TODO(jonboulle): clean this up
 func (ctx *RktRunCtx) CmdNoConfig() string {
 	return fmt.Sprintf("%s %s",
-		ctx.rktBin(),
+		ctx.RktBin(),
 		ctx.directories[0].rktOption(),
 	)
 }
 
-func (ctx *RktRunCtx) rktBin() string {
+func (ctx *RktRunCtx) RktBin() string {
 	rkt := GetValueFromEnvOrPanic("RKT")
 	abs, err := filepath.Abs(rkt)
 	if err != nil {


### PR DESCRIPTION
Add `--net-config` for net config dir.
Add `--net-plugin` for net plugin binary dir.

Also did minor refactoring that groups networking related flags together.

cc @iaguis @alban @jonboulle 
