### PR TITLE
Add "pubkey" insecure flag.

### DIFF
--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -72,10 +72,10 @@ In addition to the flags used by individual `rkt` commands, `rkt` has a set of g
 | --- | --- | --- | --- |
 | `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
 | `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
+| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**pubkey**: Allow fetching pubkeys via insecure connections (via HTTP connections or from servers with unverified certificates). This slightly extends the meaning of the `--trust-keys-from-https` flag.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
 | `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
 | `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
+| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from HTTPS (or HTTP if the insecure `pubkey` option is also specified) |
 | `--user-config` |  `` | A directory path | Path to the user configuration directory |
 
 ## Logging

--- a/Documentation/subcommands/api-service.md
+++ b/Documentation/subcommands/api-service.md
@@ -26,12 +26,4 @@ Here is a small [Go program](../../api/v1alpha/client_example.go) that illustrat
 
 ## Global options
 
-| Flag | Default | Options | Description |
-| --- | --- | --- | --- |
-| `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
-| `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
-| `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
-| `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
-| `--user-config` |  `` | A directory path | Path to the user configuration directory |
+See the table with [global options in general commands documentation](../commands.md#global-options).

--- a/Documentation/subcommands/cat-manifest.md
+++ b/Documentation/subcommands/cat-manifest.md
@@ -18,12 +18,4 @@ For debugging or inspection you may want to extract the PodManifest to stdout.
 
 ## Global options
 
-| Flag | Default | Options | Description |
-| --- | --- | --- | --- |
-| `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
-| `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
-| `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
-| `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
-| `--user-config` |  `` | A directory path | Path to the user configuration directory |
+See the table with [global options in general commands documentation](../commands.md#global-options).

--- a/Documentation/subcommands/enter.md
+++ b/Documentation/subcommands/enter.md
@@ -28,12 +28,4 @@ Work in progress. Please contribute!
 
 ## Global options
 
-| Flag | Default | Options | Description |
-| --- | --- | --- | --- |
-| `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
-| `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
-| `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
-| `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
-| `--user-config` |  `` | A directory path | Path to the user configuration directory |
+See the table with [global options in general commands documentation](../commands.md#global-options).

--- a/Documentation/subcommands/fetch.md
+++ b/Documentation/subcommands/fetch.md
@@ -92,14 +92,6 @@ Note that the configuration kind for images downloaded via https:// and images d
 
 ## Global options
 
-| Flag | Default | Options | Description |
-| --- | --- | --- | --- |
-| `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
-| `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
-| `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
-| `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
-| `--user-config` |  `` | A directory path | Path to the user configuration directory |
+See the table with [global options in general commands documentation](../commands.md#global-options).
 
 [appc-discovery]: https://github.com/appc/spec/blob/master/spec/discovery.md

--- a/Documentation/subcommands/gc.md
+++ b/Documentation/subcommands/gc.md
@@ -32,12 +32,4 @@ Garbage collecting pod "f07a4070-79a9-4db0-ae65-a090c9c393a3"
 
 ## Global options
 
-| Flag | Default | Options | Description |
-| --- | --- | --- | --- |
-| `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
-| `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
-| `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
-| `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
-| `--user-config` |  `` | A directory path | Path to the user configuration directory |
+See the table with [global options in general commands documentation](../commands.md#global-options).

--- a/Documentation/subcommands/image.md
+++ b/Documentation/subcommands/image.md
@@ -143,12 +143,4 @@ rkt: 2 image(s) successfully removed
 
 ## Global options
 
-| Flag | Default | Options | Description |
-| --- | --- | --- | --- |
-| `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
-| `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
-| `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
-| `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
-| `--user-config` |  `` | A directory path | Path to the user configuration directory |
+See the table with [global options in general commands documentation](../commands.md#global-options).

--- a/Documentation/subcommands/list.md
+++ b/Documentation/subcommands/list.md
@@ -29,12 +29,4 @@ UUID                                   APP     IMAGE NAME              IMAGE ID 
 
 ## Global options
 
-| Flag | Default | Options | Description |
-| --- | --- | --- | --- |
-| `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
-| `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
-| `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
-| `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
-| `--user-config` |  `` | A directory path | Path to the user configuration directory |
+See the table with [global options in general commands documentation](../commands.md#global-options).

--- a/Documentation/subcommands/metadata-service.md
+++ b/Documentation/subcommands/metadata-service.md
@@ -34,12 +34,4 @@ See [App Container specification](https://github.com/appc/spec/blob/master/spec/
 
 ## Global options
 
-| Flag | Default | Options | Description |
-| --- | --- | --- | --- |
-| `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
-| `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
-| `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
-| `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
-| `--user-config` |  `` | A directory path | Path to the user configuration directory |
+See the table with [global options in general commands documentation](../commands.md#global-options).

--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -55,12 +55,4 @@ c9fad0e6-8236-4fc2-ad17-55d0a4c7d742
 
 ## Global options
 
-| Flag | Default | Options | Description |
-| --- | --- | --- | --- |
-| `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
-| `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
-| `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
-| `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
-| `--user-config` |  `` | A directory path | Path to the user configuration directory |
+See the table with [global options in general commands documentation](../commands.md#global-options).

--- a/Documentation/subcommands/rm.md
+++ b/Documentation/subcommands/rm.md
@@ -17,12 +17,4 @@ rkt rm --uuid-file=/run/rkt-uuids/mypod
 
 ### Global options
 
-| Flag | Default | Options | Description |
-| --- | --- | --- | --- |
-| `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
-| `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
-| `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
-| `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
-| `--user-config` |  `` | A directory path | Path to the user configuration directory |
+See the table with [global options in general commands documentation](../commands.md#global-options).

--- a/Documentation/subcommands/run-prepared.md
+++ b/Documentation/subcommands/run-prepared.md
@@ -55,12 +55,4 @@ c9fad0e6    etcd    coreos.com/etcd prepared
 
 ## Global options
 
-| Flag | Default | Options | Description |
-| --- | --- | --- | --- |
-| `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
-| `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
-| `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
-| `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
-| `--user-config` |  `` | A directory path | Path to the user configuration directory |
+See the table with [global options in general commands documentation](../commands.md#global-options).

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -357,12 +357,4 @@ For more details see the [hacking documentation](../hacking.md).
 
 ## Global options
 
-| Flag | Default | Options | Description |
-| --- | --- | --- | --- |
-| `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
-| `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
-| `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
-| `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
-| `--user-config` |  `` | A directory path | Path to the user configuration directory |
+See the table with [global options in general commands documentation](../commands.md#global-options).

--- a/Documentation/subcommands/status.md
+++ b/Documentation/subcommands/status.md
@@ -24,12 +24,4 @@ If the pod is still running, you can wait for it to finish and then get the stat
 
 ## Global options
 
-| Flag | Default | Options | Description |
-| --- | --- | --- | --- |
-| `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
-| `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
-| `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
-| `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
-| `--user-config` |  `` | A directory path | Path to the user configuration directory |
+See the table with [global options in general commands documentation](../commands.md#global-options).

--- a/Documentation/subcommands/trust.md
+++ b/Documentation/subcommands/trust.md
@@ -94,14 +94,6 @@ $ find /etc/rkt/trustedkeys/
 
 ## Global options
 
-| Flag | Default | Options | Description |
-| --- | --- | --- | --- |
-| `--debug` |  `false` | `true` or `false` | Prints out more debug information to `stderr` |
-| `--dir` | `/var/lib/rkt` | A directory path | Path to the `rkt` data directory |
-| `--insecure-options` |  none | **none**: All security features are enabled<br/>**http**: Allow HTTP connections. Be warned that this will send any credentials as clear text.<br/>**image**: Disables verifying image signatures<br/>**tls**: Accept any certificate from the server and any host name in that certificate<br/>**ondisk**: Disables verifying the integrity of the on-disk, rendered image before running. This significantly speeds up start time.<br/>**all**: Disables all security checks | Comma-separated list of security features to disable |
-| `--local-config` |  `/etc/rkt` | A directory path | Path to the local configuration directory |
-| `--system-config` |  `/usr/lib/rkt` | A directory path | Path to the system configuration directory |
-| `--trust-keys-from-https` |  `false` | `true` or `false` | Automatically trust gpg keys fetched from https |
-| `--user-config` |  `` | A directory path | Path to the user configuration directory |
+See the table with [global options in general commands documentation](../commands.md#global-options).
 
 [appc-discovery]: https://github.com/appc/spec/blob/master/spec/discovery.md

--- a/rkt/flag/secflags.go
+++ b/rkt/flag/secflags.go
@@ -20,12 +20,13 @@ const (
 	insecureTLS
 	insecureOnDisk
 	insecureHTTP
+	insecurePubKey
 
-	insecureAll = (insecureImage | insecureTLS | insecureOnDisk | insecureHTTP)
+	insecureAll = (insecureImage | insecureTLS | insecureOnDisk | insecureHTTP | insecurePubKey)
 )
 
 var (
-	insecureOptions = []string{"none", "image", "tls", "ondisk", "http", "all"}
+	insecureOptions = []string{"none", "image", "tls", "ondisk", "http", "pubkey", "all"}
 
 	insecureOptionsMap = map[string]int{
 		insecureOptions[0]: insecureNone,
@@ -33,7 +34,8 @@ var (
 		insecureOptions[2]: insecureTLS,
 		insecureOptions[3]: insecureOnDisk,
 		insecureOptions[4]: insecureHTTP,
-		insecureOptions[5]: insecureAll,
+		insecureOptions[5]: insecurePubKey,
+		insecureOptions[6]: insecureAll,
 	}
 )
 
@@ -67,6 +69,10 @@ func (sf *SecFlags) SkipOnDiskCheck() bool {
 
 func (sf *SecFlags) AllowHTTP() bool {
 	return sf.hasFlag(insecureHTTP)
+}
+
+func (sf *SecFlags) ConsiderInsecurePubKeys() bool {
+	return sf.hasFlag(insecurePubKey)
 }
 
 func (sf *SecFlags) SkipAllSecurityChecks() bool {


### PR DESCRIPTION
This adds a new, "pubkey" insecure option, so we can temporarily (by creating a second keystore in /tmp) trust keys from HTTP(S). We need this for testing, because local ACI server uses an invalid certificate (apparently for example.com, not for localhost), so to be able to download anything from it, we need to pass a "tls" insecure option. But then, the keys from discovery weren't downloaded at all.

It also deduplicates global flags documentation.