### PR TITLE
docs, image, rkt: Make printing progress bars optional

### DIFF
--- a/Documentation/subcommands/fetch.md
+++ b/Documentation/subcommands/fetch.md
@@ -88,6 +88,7 @@ Note that the configuration kind for images downloaded via https:// and images d
 | `--full` |  `false` | `true` or `false` | Print the full image hash after fetching |
 | `--no-store` |  `false` | `true` or `false` | Fetch images ignoring the local store. See [image fetching behavior](../image-fetching-behavior.md) |
 | `--signature` |  `` | A file path | Local signature file to use in validating the preceding image |
+| `--simple-output` |  `false` | `true` or `false` | Print simple messages when downloading data (images or signatures) instead of progress bars |
 | `--store-only` |  `false` | `true` or `false` | Use only available images in the store (do not discover or download from remote URLs). See [image fetching behavior](../image-fetching-behavior.md) |
 
 ## Global options

--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -44,6 +44,7 @@ c9fad0e6-8236-4fc2-ad17-55d0a4c7d742
 | `--private-users` |  `false` | `true` or `false` | Run within user namespaces (experimental) |
 | `--quiet` |  `false` | `true` or `false` | Suppress superfluous output on stdout, print only the UUID on success |
 | `--set-env` |  `` | An environment variable. Syntax `NAME=VALUE` | An environment variable to set for apps |
+| `--simple-output` |  `false` | `true` or `false` | Print simple messages when downloading data (images or signatures) instead of progress bars |
 | `--stage1-url` |  `` | A URL to a stage1 image. HTTP/HTTPS/File/Docker URLs are supported | Image to use as stage1 |
 | `--stage1-path` |  `` | A path to a stage1 image. Absolute and relative paths are supported | Image to use as stage1 |
 | `--stage1-name` |  `` | A name of a stage1 image. Will perform a discovery if the image is not in the store | Image to use as stage1 |

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -327,6 +327,7 @@ If you don't use systemd, you can use [daemon](http://www.libslack.org/daemon/) 
 | `--private-users` |  `false` | `true` or `false` | Run within user namespaces (experimental) |
 | `--set-env` |  `` | An environment variable. Syntax `NAME=VALUE` | An environment variable to set for apps |
 | `--signature` |  `` | A file path | Local signature file to use in validating the preceding image |
+| `--simple-output` |  `false` | `true` or `false` | Print simple messages when downloading data (images or signatures) instead of progress bars |
 | `--stage1-url` |  `` | A URL to a stage1 image. HTTP/HTTPS/File/Docker URLs are supported | Image to use as stage1 |
 | `--stage1-path` |  `` | A path to a stage1 image. Absolute and relative paths are supported | Image to use as stage1 |
 | `--stage1-name` |  `` | A name of a stage1 image. Will perform a discovery if the image is not in the store | Image to use as stage1 |

--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -54,6 +54,8 @@ func init() {
 	cmdFetch.Flags().BoolVar(&flagStoreOnly, "store-only", false, "use only available images in the store (do not discover or download from remote URLs)")
 	cmdFetch.Flags().BoolVar(&flagNoStore, "no-store", false, "fetch images ignoring the local store")
 	cmdFetch.Flags().BoolVar(&flagFullHash, "full", false, "print the full image hash after fetching")
+
+	addSimpleOutputFlag(cmdFetch.Flags())
 }
 
 func runFetch(cmd *cobra.Command, args []string) (exit int) {
@@ -95,6 +97,8 @@ func runFetch(cmd *cobra.Command, args []string) (exit int) {
 		StoreOnly: flagStoreOnly,
 		NoStore:   flagNoStore,
 		WithDeps:  true,
+
+		SimpleOutput: flagSimpleOutput,
 	}
 
 	err = rktApps.Walk(func(app *apps.App) error {

--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -275,6 +275,8 @@ func TestDownloading(t *testing.T) {
 			S:             s,
 			Headers:       headers,
 			InsecureFlags: insecureFlags,
+
+			SimpleOutput: true,
 		}
 		_, err = ft.FetchImage(tt.ACIURL, "", apps.AppImageURL)
 		if err != nil && !tt.authFail {
@@ -348,6 +350,8 @@ func TestFetchImage(t *testing.T) {
 		S:             s,
 		Ks:            ks,
 		InsecureFlags: secureFlags,
+
+		SimpleOutput: true,
 	}
 	_, err = ft.FetchImage(fmt.Sprintf("%s/app.aci", ts.URL), "", apps.AppImageURL)
 	if err != nil {
@@ -537,6 +541,8 @@ func TestFetchImageCache(t *testing.T) {
 			InsecureFlags: secureFlags,
 			// Skip local store
 			NoStore: true,
+
+			SimpleOutput: true,
 		}
 		_, err = ft.FetchImage(aciURL, "", apps.AppImageURL)
 		if err != nil {

--- a/rkt/image/common.go
+++ b/rkt/image/common.go
@@ -70,6 +70,10 @@ type action struct {
 	// WithDeps tells whether image dependencies should be
 	// downloaded too.
 	WithDeps bool
+
+	// SimpleOutput tells fetcher to print simple messages instead
+	// of progress bars.
+	SimpleOutput bool
 }
 
 var (

--- a/rkt/image/fetcher.go
+++ b/rkt/image/fetcher.go
@@ -231,6 +231,7 @@ func (f *Fetcher) maybeFetchHTTPURLFromRemote(rem *store.Remote, u *url.URL, a *
 			Rem:           rem,
 			Debug:         f.Debug,
 			Headers:       f.Headers,
+			SimpleOutput:  f.SimpleOutput,
 		}
 		return hf.GetHash(u, a)
 	}
@@ -345,6 +346,7 @@ func (f *Fetcher) maybeFetchImageFromRemote(app *appBundle, a *asc) (string, err
 			Debug:              f.Debug,
 			Headers:            f.Headers,
 			TrustKeysFromHTTPS: f.TrustKeysFromHTTPS,
+			SimpleOutput:       f.SimpleOutput,
 		}
 		return nf.GetHash(app.App, a)
 	}

--- a/rkt/image/httpfetcher.go
+++ b/rkt/image/httpfetcher.go
@@ -35,6 +35,7 @@ type httpFetcher struct {
 	Rem           *store.Remote
 	Debug         bool
 	Headers       map[string]config.Headerer
+	SimpleOutput  bool
 }
 
 // GetHash fetches the URL, optionally verifies it against passed asc,
@@ -151,9 +152,10 @@ func (f *httpFetcher) fetchVerifiedURL(u *url.URL, a *asc, etag string) (readSee
 func (f *httpFetcher) getHTTPOps() *httpOps {
 	return &httpOps{
 		InsecureSkipTLSVerify: f.InsecureFlags.SkipTLSCheck(),
-		S:       f.S,
-		Headers: f.Headers,
-		Debug:   f.Debug,
+		S:            f.S,
+		Headers:      f.Headers,
+		Debug:        f.Debug,
+		SimpleOutput: f.SimpleOutput,
 	}
 }
 

--- a/rkt/image/httpops.go
+++ b/rkt/image/httpops.go
@@ -35,6 +35,7 @@ type httpOps struct {
 	S                     *store.Store
 	Headers               map[string]config.Headerer
 	Debug                 bool
+	SimpleOutput          bool
 }
 
 // DownloadSignature takes an asc instance and tries to get the
@@ -140,6 +141,7 @@ func (o *httpOps) getSession(u *url.URL, file *os.File, label, etag string) *res
 		File:                  file,
 		ETagFilePath:          eTagFilePath,
 		Label:                 label,
+		SimpleOutput:          o.SimpleOutput,
 	}
 }
 

--- a/rkt/image/namefetcher.go
+++ b/rkt/image/namefetcher.go
@@ -41,6 +41,7 @@ type nameFetcher struct {
 	Debug              bool
 	Headers            map[string]config.Headerer
 	TrustKeysFromHTTPS bool
+	SimpleOutput       bool
 }
 
 // GetHash runs the discovery, fetches the image, optionally verifies
@@ -277,8 +278,9 @@ func (f *nameFetcher) maybeOverrideAscFetcherWithRemote(ascURL string, a *asc) {
 func (f *nameFetcher) getHTTPOps() *httpOps {
 	return &httpOps{
 		InsecureSkipTLSVerify: f.InsecureFlags.SkipTLSCheck(),
-		S:       f.S,
-		Headers: f.Headers,
-		Debug:   f.Debug,
+		S:            f.S,
+		Headers:      f.Headers,
+		Debug:        f.Debug,
+		SimpleOutput: f.SimpleOutput,
 	}
 }

--- a/rkt/image/resumablesession.go
+++ b/rkt/image/resumablesession.go
@@ -70,6 +70,9 @@ type resumableSession struct {
 	// Label is used for printing the type of the downloaded data
 	// when printing a pretty progress bar.
 	Label string
+	// SimpleOutput tells the downloader to print a simple message
+	// when downloading data, instead of a progress bar.
+	SimpleOutput bool
 
 	// Cd is a cache data returned by HTTP server. It is an output
 	// value.
@@ -117,7 +120,12 @@ func (s *resumableSession) HandleStatus(res *http.Response) (bool, error) {
 }
 
 func (s *resumableSession) GetBodyReader(res *http.Response) (io.Reader, error) {
-	reader := getIoProgressReader(s.Label, res)
+	var reader io.Reader
+	if s.SimpleOutput {
+		reader = getSimpleReader(s.Label, res)
+	} else {
+		reader = getIoProgressReader(s.Label, res)
+	}
 	return reader, nil
 }
 

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -69,6 +69,8 @@ func init() {
 	cmdPrepare.Flags().Var((*appExec)(&rktApps), "exec", "override the exec command for the preceding image")
 	cmdPrepare.Flags().Var((*appMount)(&rktApps), "mount", "mount point binding a volume to a path within an app")
 
+	addSimpleOutputFlag(cmdPrepare.Flags())
+
 	// Disable interspersed flags to stop parsing after the first non flag
 	// argument. This is need to permit to correctly handle
 	// multiple "IMAGE -- imageargs ---"  options
@@ -144,6 +146,8 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		StoreOnly: flagStoreOnly,
 		NoStore:   flagNoStore,
 		WithDeps:  true,
+
+		SimpleOutput: flagSimpleOutput,
 	}
 	if err := fn.FindImages(&rktApps); err != nil {
 		stderr.PrintE("error finding images", err)

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -31,6 +31,7 @@ import (
 	"github.com/coreos/rkt/store"
 	"github.com/hashicorp/errwrap"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -67,7 +68,12 @@ image arguments with a lone "---" to resume argument parsing.`,
 	flagPodManifest  string
 	flagMDSRegister  bool
 	flagUUIDFileSave string
+	flagSimpleOutput bool
 )
+
+func addSimpleOutputFlag(flags *pflag.FlagSet) {
+	flags.BoolVar(&flagSimpleOutput, "simple-output", false, "print simple messages when downloading data instead of a progressbar")
+}
 
 func init() {
 	cmdRkt.AddCommand(cmdRun)
@@ -97,6 +103,8 @@ func init() {
 	cmdRun.Flags().Var((*appMount)(&rktApps), "mount", "mount point binding a volume to a path within an app")
 	cmdRun.Flags().Var((*appMemoryLimit)(&rktApps), "memory", "memory limit for the preceding image (example: '--memory=16Mi', '--memory=50M', '--memory=1G')")
 	cmdRun.Flags().Var((*appCPULimit)(&rktApps), "cpu", "cpu limit for the preceding image (example: '--cpu=500m')")
+
+	addSimpleOutputFlag(cmdRun.Flags())
 
 	flagPorts = portList{}
 	flagDNS = flagStringList{}
@@ -189,6 +197,8 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		StoreOnly: flagStoreOnly,
 		NoStore:   flagNoStore,
 		WithDeps:  true,
+
+		SimpleOutput: flagSimpleOutput,
 	}
 	if err := fn.FindImages(&rktApps); err != nil {
 		stderr.Error(err)

--- a/rkt/stage1hash.go
+++ b/rkt/stage1hash.go
@@ -296,6 +296,8 @@ func getStage1Finder(s *store.Store) *image.Finder {
 		StoreOnly: false,
 		NoStore:   false,
 		WithDeps:  false,
+
+		SimpleOutput: flagSimpleOutput,
 	}
 }
 


### PR DESCRIPTION
This adds a `--simple-output` boolean flag to all the commands that may fetch images (`run`, `fetch`, `prepare`), so we will print some simple messages about downloading stuff instead of progress bars. I added that because it was sometimes randomly botching the output from gexpect on semaphore and some strings weren't found. This is not a complete fix - there are bugs in gexpect too, that needs to be addressed or already were at upstream, I'll have to see.