### PR TITLE
docs, rkt: Add missing --signature parameter

### DIFF
--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -44,6 +44,7 @@ c9fad0e6-8236-4fc2-ad17-55d0a4c7d742
 | `--private-users` |  `false` | `true` or `false` | Run within user namespaces (experimental) |
 | `--quiet` |  `false` | `true` or `false` | Suppress superfluous output on stdout, print only the UUID on success |
 | `--set-env` |  `` | An environment variable. Syntax `NAME=VALUE` | An environment variable to set for apps |
+| `--signature` |  `` | A file path | Local signature file to use in validating the preceding image |
 | `--stage1-url` |  `` | A URL to a stage1 image. HTTP/HTTPS/File/Docker URLs are supported | Image to use as stage1 |
 | `--stage1-path` |  `` | A path to a stage1 image. Absolute and relative paths are supported | Image to use as stage1 |
 | `--stage1-name` |  `` | A name of a stage1 image. Will perform a discovery if the image is not in the store | Image to use as stage1 |

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -68,6 +68,7 @@ func init() {
 	// per-app flags
 	cmdPrepare.Flags().Var((*appExec)(&rktApps), "exec", "override the exec command for the preceding image")
 	cmdPrepare.Flags().Var((*appMount)(&rktApps), "mount", "mount point binding a volume to a path within an app")
+	cmdPrepare.Flags().Var((*appAsc)(&rktApps), "signature", "local signature file to use in validating the preceding image")
 
 	// Disable interspersed flags to stop parsing after the first non flag
 	// argument. This is need to permit to correctly handle


### PR DESCRIPTION
It is rather expected to be able to pass a custom signature to prepare
command too, as it may fetch the image from the network.