### PR TITLE
doc: dependencies: linux 3.18

### DIFF
--- a/Documentation/dependencies.md
+++ b/Documentation/dependencies.md
@@ -60,7 +60,7 @@ For the most part the codebase is self-contained (e.g. all dependencies are vend
 
 ## Run-time dependencies
 
-* Linux 3.8+ (ideally 4.3+ to have overlay-on-overlay working), with the following options configured:
+* Linux 3.18+ (ideally 4.3+ to have overlay-on-overlay working), with the following options configured:
   * CONFIG_CGROUPS
   * CONFIG_NAMESPACES
   * CONFIG_UTS_NS

--- a/README.md
+++ b/README.md
@@ -72,4 +72,8 @@ Some portions of the codebase are derived from other projects under different li
 
 ## Known issues
 
-Due to a bug in the Linux kernel, using rkt's overlay support on top of an overlay filesystem requires Linux 4.3+.
+Due to a bug in the Linux kernel, using rkt's overlay support on top of an overlay filesystem requires Linux 4.3+ (see the [stacked overlay fix](https://github.com/torvalds/linux/commit/1c8a47d) and [#1537](https://github.com/coreos/rkt/issues/1537)).
+
+Due to a bug in the Linux kernel, rkt will not work when /var/lib/rkt is on btrfs ([#2175](https://github.com/coreos/rkt/issues/2175)).
+
+Linux 3.18+ is required to successfully garbage collect rkt pods when system services such as udevd are in a slave mount namespace (see [lazy umounts on unlinked files and directories](https://github.com/torvalds/linux/commit/8ed936b) and [#1922](https://github.com/coreos/rkt/issues/1922)).


### PR DESCRIPTION
Linux 3.18 introduced the fix for unlinking files and directories that
are mount points in another mount namespace. Before Linux 3.18,
unlinking could return EBUSY:
https://github.com/torvalds/linux/commit/8ed936b

With the introduction of rkt-fly, this becomes a visible issue with rkt
gc, see discussion on:
https://github.com/coreos/rkt/issues/1922#issuecomment-196914006

This patch bumps the run-time dependency to Linux 3.18

-----

/cc @jellonek @BrianHicks @jcollie