### PR TITLE
tests: fix TestVolumes on systemd-git-master

### DIFF
--- a/tests/inspect/inspect.go
+++ b/tests/inspect/inspect.go
@@ -230,8 +230,9 @@ func main() {
 
 		err := ioutil.WriteFile(fileName, []byte(content), 0600)
 		if err != nil {
+			// This error message is tested in TestVolumes
 			fmt.Fprintf(os.Stderr, "Cannot write to file %q: %v\n", fileName, err)
-			os.Exit(1)
+			os.Exit(0)
 		}
 	}
 


### PR DESCRIPTION
One test in TestVolumes attempts to write on a read-only volume and
checks that the error message passed by the "inspect" app is as follows:

> Cannot write to file "/dir1/file": open /dir1/file: read-only file
> system

The "inspect" app returned the return code 1 in that case.

With new versions of systemd, the app return code is propagated to
systemd-nspawn and the rkt command returns that return code. See
https://github.com/coreos/rkt/issues/1460

But TestVolumes was expecting the return code 0. In order to make the
test work both on old systemd versions and newer systemd versions, this
patch changes the "inspect" app return code to 0. TestVolumes checks the
error message anyway.

Fixes https://github.com/coreos/rkt/issues/2219