### PR TITLE
stage0,stage1: add interface-version annotation

### DIFF
--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -96,6 +96,14 @@ For example, it removes the network namespace of a pod.
 * `--debug` to activate debugging
 * UUID of the pod
 
+Versioning
+----------
+
+The stage1 command line interface is versioned using an annotation with the name `coreos.com/rkt/stage1/interface-version`.
+If the annotation is not present, rkt assumes the version is 1.
+
+The current version of the stage1 interface is 1.
+
 Examples
 --------
 
@@ -132,6 +140,10 @@ Examples
         {
             "name": "coreos.com/rkt/stage1/gc",
             "value": "/ex/gc"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/interface-version",
+            "value": "1"
         }
     ]
 }

--- a/stage0/interface.go
+++ b/stage0/interface.go
@@ -1,0 +1,57 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+package stage0
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"strconv"
+
+	"github.com/appc/spec/schema"
+	"github.com/coreos/rkt/common"
+	"github.com/hashicorp/errwrap"
+)
+
+const (
+	interfaceVersion = "coreos.com/rkt/stage1/interface-version"
+)
+
+// getStage1InterfaceVersion retrieves the interface version from the stage1
+// manifest for a given pod
+func getStage1InterfaceVersion(cdir string) (int, error) {
+	b, err := ioutil.ReadFile(common.Stage1ManifestPath(cdir))
+	if err != nil {
+		return -1, errwrap.Wrap(errors.New("error reading pod manifest"), err)
+	}
+
+	s1m := schema.ImageManifest{}
+	if err := json.Unmarshal(b, &s1m); err != nil {
+		return -1, errwrap.Wrap(errors.New("error unmarshaling stage1 manifest"), err)
+	}
+
+	if iv, ok := s1m.Annotations.Get(interfaceVersion); ok {
+		v, err := strconv.Atoi(iv)
+		if err != nil {
+			return -1, errwrap.Wrap(errors.New("error parsing interface version"), err)
+		}
+		return v, nil
+	}
+
+	// "interface-version" annotation not found, assume version 1
+	return 1, nil
+}

--- a/stage1/aci/aci-manifest.in
+++ b/stage1/aci/aci-manifest.in
@@ -28,6 +28,10 @@
         {
             "name": "coreos.com/rkt/stage1/gc",
             "value": "/gc"
+        },
+        {
+            "name": "coreos.com/rkt/stage1/interface-version",
+            "value": "1"
         }
     ]
 }


### PR DESCRIPTION
So stage0 can check which features stage1 supports and pass flags
accordingly.

cc @krnowak