### PR TITLE
stage1: Temporary fix for symlink mount issue.

### DIFF
--- a/tests/functional.mk
+++ b/tests/functional.mk
@@ -58,6 +58,9 @@ CLEAN_FILES += \
 	$(FTST_INSPECT_BINARY) \
 	$(FTST_EMPTY_IMAGE) \
 	$(FTST_IMAGE_ROOTFSDIR)/dir1/file \
+	$(FTST_IMAGE_ROOTFSDIR)/dir1/link_abs_dir2 \
+	$(FTST_IMAGE_ROOTFSDIR)/dir1/link_rel_dir2 \
+	$(FTST_IMAGE_ROOTFSDIR)/dir1/link_invalid \
 	$(FTST_IMAGE_ROOTFSDIR)/dir2/file \
 	$(FTST_IMAGE_ROOTFSDIR)/etc/group \
 	$(FTST_IMAGE_ROOTFSDIR)/etc/passwd \
@@ -87,6 +90,12 @@ $(FTST_IMAGE): $(FTST_IMAGE_MANIFEST) $(FTST_ACI_INSPECT) $(FTST_ACI_ECHO_SERVER
 	set -e; \
 	$(call vb,v2,GEN,$(call vsp,$(FTST_IMAGE_ROOTFSDIR)/dir1/file)) \
 	echo -n dir1 >$(FTST_IMAGE_ROOTFSDIR)/dir1/file; \
+	$(call vb,v2,GEN,$(call vsp,$(FTST_IMAGE_ROOTFSDIR)/dir1/link_abs_dir2)) \
+	ln -sf /dir2 $(FTST_IMAGE_ROOTFSDIR)/dir1/link_abs_dir2; \
+	$(call vb,v2,GEN,$(call vsp,$(FTST_IMAGE_ROOTFSDIR)/dir1/link_rel_dir2)) \
+	ln -sf ../dir2 $(FTST_IMAGE_ROOTFSDIR)/dir1/link_rel_dir2; \
+	$(call vb,v2,GEN,$(call vsp,$(FTST_IMAGE_ROOTFSDIR)/dir1/link_invalid)) \
+	ln -sf /../dir2 $(FTST_IMAGE_ROOTFSDIR)/dir1/link_invalid; \
 	$(call vb,v2,GEN,$(call vsp,$(FTST_IMAGE_ROOTFSDIR)/dir2/file)) \
 	echo -n dir2 >$(FTST_IMAGE_ROOTFSDIR)/dir2/file; \
 	$(call vb,v2,GEN,$(call vsp,$(FTST_IMAGE_ROOTFSDIR)/etc/group)) \

--- a/tests/rkt_mount_test.go
+++ b/tests/rkt_mount_test.go
@@ -1,0 +1,101 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+func TestMountSymlink(t *testing.T) {
+	mountSrcFile := filepath.Join(os.TempDir(), "hello")
+	if err := ioutil.WriteFile(mountSrcFile, []byte("world"), 0666); err != nil {
+		t.Fatalf("Cannot write file: %v", err)
+	}
+	defer os.Remove(mountSrcFile)
+
+	image := patchTestACI("rkt-test-mount-symlink.aci", "--exec=/inspect --read-file")
+	defer os.Remove(image)
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	tests := []struct {
+		linkFile     string
+		actualFile   string
+		expectedLine string
+		exitCode     int
+	}{
+		// '/dir1/link_abs_dir2' links to '/dir2'.
+		{
+			"/dir1/link_abs_dir2/foo",
+			"/dir2/foo",
+			"world",
+			0,
+		},
+		// '/dir1/link_rel_dir2' links to '/dir2'.
+		{
+			"/dir1/link_rel_dir2/bar",
+			"/dir2/bar",
+			"world",
+			0,
+		},
+		// '/dir1/../dir1/.//link_rel_dir2' links to '/dir2'.
+		{
+			"/dir1/../dir1/.//link_rel_dir2/foo",
+			"/dir2/foo",
+			"world",
+			0,
+		},
+		// '/dir1/../../../foo' is invalid because it tries to escape rootfs.
+		{
+			"/dir1/../../../foo",
+			"/dir2/foo",
+			"path escapes app's root",
+			3,
+		},
+		// '/dir1/link_invalid' is an invalid link because it tries to escape rootfs.
+		{
+			"/dir1/link_invalid/foo",
+			"/dir2/foo",
+			"escapes app's root with value",
+			3,
+		},
+	}
+
+	for _, tt := range tests {
+		paramMount := fmt.Sprintf("--volume=test,kind=host,source=%s --mount volume=test,target=%s", mountSrcFile, tt.linkFile)
+
+		// Read the actual file.
+		rktCmd := fmt.Sprintf("%s --insecure-options=image run %s --set-env=FILE=%s %s", ctx.Cmd(), paramMount, tt.actualFile, image)
+		t.Logf("%s\n", rktCmd)
+
+		if tt.exitCode == 0 {
+			runRktAndCheckOutput(t, rktCmd, tt.expectedLine, false)
+		} else {
+			child := spawnOrFail(t, rktCmd)
+			result, out, err := expectRegexWithOutput(child, tt.expectedLine)
+			if err != nil || len(result) != 1 {
+				t.Errorf("%q regex must be found one time, Error: %v\nOutput: %v", tt.expectedLine, err, out)
+			}
+			waitOrFail(t, child, tt.exitCode)
+		}
+	}
+}


### PR DESCRIPTION
nspawn doesn't handle a mount operation correctly if the container path contains a symlink.
This tries to fix the problem in rkt by evaluating the mount path and resolve any symlinks before passing the mount path to nspawn.

cc @alban @iaguis @jonboulle @sjpotter