### PR TITLE
stage1: exit code: use systemctl exit on coreos flavor

### DIFF
--- a/stage1/init/common/pod.go
+++ b/stage1/init/common/pod.go
@@ -472,7 +472,7 @@ func appToSystemd(p *stage1commontypes.Pod, ra *schema.RuntimeApp, interactive b
 }
 
 func writeShutdownService(p *stage1commontypes.Pod) error {
-	_, systemdVersion, err := GetFlavor(p)
+	flavor, systemdVersion, err := GetFlavor(p)
 	if err != nil {
 		return err
 	}
@@ -493,7 +493,10 @@ func writeShutdownService(p *stage1commontypes.Pod) error {
 	// This can happen, for example, when building rkt with:
 	//
 	// ./configure --with-stage1-flavors=src --with-stage1-systemd-version=master
-	if systemdVersion != 0 && systemdVersion < 227 {
+	//
+	// The patches for the "exit" verb are backported to the "coreos" flavor, so
+	// don't rely on the systemd version on the "coreos" flavor.
+	if flavor != "coreos" && systemdVersion != 0 && systemdVersion < 227 {
 		shutdownVerb = "halt"
 	}
 

--- a/tests/rkt_api_service_bench_test.go
+++ b/tests/rkt_api_service_bench_test.go
@@ -32,7 +32,7 @@ func setup() (*testutils.RktRunCtx, *gexpect.ExpectSubprocess, v1alpha.PublicAPI
 	ctx := testutils.NewRktRunCtx()
 	svc := startAPIService(t, ctx)
 	c, conn := newAPIClientOrFail(t, "localhost:15441")
-	imagePath := patchTestACI("rkt-inspect-print.aci", "--exec=/inspect --print-msg=HELLO_API --exit-code=42")
+	imagePath := patchTestACI("rkt-inspect-print.aci", "--exec=/inspect --print-msg=HELLO_API")
 
 	return ctx, svc, c, conn, imagePath
 }

--- a/tests/rkt_api_service_test.go
+++ b/tests/rkt_api_service_test.go
@@ -284,7 +284,7 @@ func TestAPIServiceListInspectPods(t *testing.T) {
 		t.Errorf("Unexpected result: %v, should see zero pods", resp.Pods)
 	}
 
-	patches := []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=42"}
+	patches := []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=0"}
 	imageHash := patchImportAndFetchHash("rkt-inspect-print.aci", patches, t, ctx)
 	imgID, err := types.NewHash(imageHash)
 	if err != nil {

--- a/tests/rkt_dns_test.go
+++ b/tests/rkt_dns_test.go
@@ -30,38 +30,45 @@ func TestDNS(t *testing.T) {
 	defer ctx.Cleanup()
 
 	for _, tt := range []struct {
-		paramDNS     string
-		expectedLine string
+		paramDNS      string
+		expectedLine  string
+		expectedError bool
 	}{
 		{
-			paramDNS:     "",
-			expectedLine: "Cannot read file",
+			paramDNS:      "",
+			expectedLine:  "Cannot read file",
+			expectedError: true,
 		},
 		{
-			paramDNS:     "--dns=8.8.4.4",
-			expectedLine: "nameserver 8.8.4.4",
+			paramDNS:      "--dns=8.8.4.4",
+			expectedLine:  "nameserver 8.8.4.4",
+			expectedError: false,
 		},
 		{
-			paramDNS:     "--dns=8.8.8.8 --dns=8.8.4.4",
-			expectedLine: "nameserver 8.8.8.8",
+			paramDNS:      "--dns=8.8.8.8 --dns=8.8.4.4",
+			expectedLine:  "nameserver 8.8.8.8",
+			expectedError: false,
 		},
 		{
-			paramDNS:     "--dns=8.8.8.8 --dns=8.8.4.4 --dns-search=search.com --dns-opt=debug",
-			expectedLine: "nameserver 8.8.4.4",
+			paramDNS:      "--dns=8.8.8.8 --dns=8.8.4.4 --dns-search=search.com --dns-opt=debug",
+			expectedLine:  "nameserver 8.8.4.4",
+			expectedError: false,
 		},
 		{
-			paramDNS:     "--dns-search=foo.com --dns-search=bar.com",
-			expectedLine: "search foo.com bar.com",
+			paramDNS:      "--dns-search=foo.com --dns-search=bar.com",
+			expectedLine:  "search foo.com bar.com",
+			expectedError: false,
 		},
 		{
-			paramDNS:     "--dns-opt=debug --dns-opt=use-vc --dns-opt=rotate",
-			expectedLine: "options debug use-vc rotate",
+			paramDNS:      "--dns-opt=debug --dns-opt=use-vc --dns-opt=rotate",
+			expectedLine:  "options debug use-vc rotate",
+			expectedError: false,
 		},
 	} {
 
 		rktCmd := fmt.Sprintf(`%s --insecure-options=image run --set-env=FILE=/etc/resolv.conf %s %s`,
 			ctx.Cmd(), tt.paramDNS, imageFile)
 		t.Logf("%s\n", rktCmd)
-		runRktAndCheckOutput(t, rktCmd, tt.expectedLine, false)
+		runRktAndCheckOutput(t, rktCmd, tt.expectedLine, tt.expectedError)
 	}
 }

--- a/tests/rkt_exit_test.go
+++ b/tests/rkt_exit_test.go
@@ -35,7 +35,7 @@ func TestExitCodeSimple(t *testing.T) {
 		cmd := fmt.Sprintf(`%s --debug --insecure-options=image run --mds-register=false %s`,
 			ctx.Cmd(), imageFile)
 		t.Logf("%s\n", cmd)
-		spawnAndWaitOrFail(t, cmd, 0)
+		spawnAndWaitOrFail(t, cmd, i)
 		checkAppStatus(t, ctx, false, "rkt-inspect", fmt.Sprintf("status=%d", i))
 	}
 }
@@ -71,10 +71,8 @@ func TestExitCodeWithSeveralApps(t *testing.T) {
 	}
 
 	t.Logf("Waiting pod termination\n")
-	// Currently we have systemd v222 in the coreos flavor which doesn't
-	// include the exit status propagation code.
-	// TODO(iaguis): we should expect 5 as the exit status when we update to v229
-	waitOrFail(t, child, 0)
+	// Since systend v227, the exit status is propagated from the app to rkt
+	waitOrFail(t, child, 5)
 
 	t.Logf("Check final status\n")
 

--- a/tests/rkt_list_test.go
+++ b/tests/rkt_list_test.go
@@ -139,7 +139,7 @@ func getCreationStartTime(t *testing.T, ctx *testutils.RktRunCtx, imageID string
 func TestRktListCreatedStarted(t *testing.T) {
 	const imgName = "rkt-list-creation-start-time-test"
 
-	image := patchTestACI(fmt.Sprintf("%s.aci", imgName), fmt.Sprintf("--exec=/inspect "))
+	image := patchTestACI(fmt.Sprintf("%s.aci", imgName), fmt.Sprintf("--exec=/inspect --exit-code=0"))
 	defer os.Remove(image)
 
 	imageHash := getHashOrPanic(image)

--- a/tests/rkt_non_root_test.go
+++ b/tests/rkt_non_root_test.go
@@ -47,19 +47,18 @@ func TestNonRootReadInfo(t *testing.T) {
 
 	// Launch some pods, this creates the environment for later testing.
 	imgs := []struct {
-		name     string
-		msg      string
-		exitCode string
-		imgFile  string
+		name    string
+		msg     string
+		imgFile string
 	}{
-		{name: "inspect-1", msg: "foo-1", exitCode: "1"},
-		{name: "inspect-2", msg: "foo-2", exitCode: "2"},
-		{name: "inspect-3", msg: "foo-3", exitCode: "3"},
+		{name: "inspect-1", msg: "foo-1"},
+		{name: "inspect-2", msg: "foo-2"},
+		{name: "inspect-3", msg: "foo-3"},
 	}
 
 	for i, img := range imgs {
 		imgName := fmt.Sprintf("rkt-%s.aci", img.name)
-		imgs[i].imgFile = patchTestACI(imgName, fmt.Sprintf("--name=%s", img.name), fmt.Sprintf("--exec=/inspect --print-msg=%s --exit-code=%s", img.msg, img.exitCode))
+		imgs[i].imgFile = patchTestACI(imgName, fmt.Sprintf("--name=%s", img.name), fmt.Sprintf("--exec=/inspect --print-msg=%s --exit-code=0", img.msg))
 		defer os.Remove(imgs[i].imgFile)
 	}
 


### PR DESCRIPTION
The exit status can be propagated from apps by using "systemctl exit"
since systemd v227. rkt checks the systemd version to know whether it
can use "systemctl exit". However, systemd from coreos is back porting
the patches, so we skip the systemd version check on the coreos flavor.

See https://github.com/coreos/rkt/issues/1460

------------------------

Do not merge yet: the systemd patches are actually not yet back ported in CoreOS Linux.