### PR TITLE
stage1/prepare-app: Do not error out if symlinks exits.

### DIFF
--- a/Documentation/app-environment.md
+++ b/Documentation/app-environment.md
@@ -21,4 +21,4 @@ Since rkt v1.2.0, rkt gives access to systemd-journald's sockets in the /run/sys
 
 #### /dev/log
 
-Since rkt v1.2.0, /dev/log is created as a symlink to /run/systemd/journal/dev-log.
+Since rkt v1.2.0, if /dev/log does not exist in the image, it will be created as a symlink to /run/systemd/journal/dev-log.

--- a/stage1/prepare-app/prepare-app.c
+++ b/stage1/prepare-app/prepare-app.c
@@ -283,13 +283,13 @@ int main(int argc, char *argv[])
 	/* /dev/ptmx -> /dev/pts/ptmx */
 	exit_if(snprintf(to, sizeof(to), "%s/dev/ptmx", root) >= sizeof(to),
 		"Path too long: \"%s\"", to);
-	pexit_if(symlink("/dev/pts/ptmx", to) == -1,
+	pexit_if(symlink("/dev/pts/ptmx", to) == -1 && errno != EEXIST,
 		"Failed to create /dev/ptmx symlink");
 
 	/* /dev/log -> /run/systemd/journal/dev-log */
 	exit_if(snprintf(to, sizeof(to), "%s/dev/log", root) >= sizeof(to),
 		"Path too long: \"%s\"", to);
-	pexit_if(symlink("/run/systemd/journal/dev-log", to) == -1,
+	pexit_if(symlink("/run/systemd/journal/dev-log", to) == -1 && errno != EEXIST,
 		"Failed to create /dev/log symlink");
 
 	return EXIT_SUCCESS;


### PR DESCRIPTION
If /dev/ptmx or /dev/log already exists in the image,
leave it as is instead of overriding it.

Fix #2301 