### PR TITLE
rkt/image: check that discovery labels match manifest labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## vUNRELEASED
 
+#### New features and UX changes
+
+- Ensure that the initial name and labels used for discovery match the name and labels in the Image Manifest as specified in the appc spec ([#2311](https://github.com/coreos/rkt/pull/2311)). Users wanting the latest image should use `rkt prepare/run/fetch example.com/aci` without any labels. If the discovery server supports the "latest" pattern, the user can bypass a locally cached image in the store and fetch an updated image using `rkt prepare/run/fetch --no-store example.com/aci` option.
+
 #### Note for packagers
 
 Files generated from sources are no longer checked-in the git repository. Instead, packagers should build them:

--- a/rkt/image/namefetcher.go
+++ b/rkt/image/namefetcher.go
@@ -181,7 +181,7 @@ func (f *nameFetcher) fetchVerifiedURL(app *discovery.App, u *url.URL, a *asc) (
 		}
 	}
 
-	if err := f.validate(appName, aciFile, ascFile); err != nil {
+	if err := f.validate(app, aciFile, ascFile); err != nil {
 		return nil, nil, err
 	}
 	retAciFile := aciFile
@@ -249,13 +249,17 @@ func (f *nameFetcher) checkIdentity(appName string, ascFile io.ReadSeeker) error
 	return nil
 }
 
-func (f *nameFetcher) validate(appName string, aciFile, ascFile io.ReadSeeker) error {
+func (f *nameFetcher) validate(app *discovery.App, aciFile, ascFile io.ReadSeeker) error {
 	v, err := newValidator(aciFile)
 	if err != nil {
 		return err
 	}
 
-	if err := v.ValidateName(appName); err != nil {
+	if err := v.ValidateName(app.Name.String()); err != nil {
+		return err
+	}
+
+	if err := v.ValidateLabels(app.Labels); err != nil {
 		return err
 	}
 

--- a/rkt/image/validator.go
+++ b/rkt/image/validator.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/appc/spec/aci"
 	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
 	"golang.org/x/crypto/openpgp"
 	pgperrors "golang.org/x/crypto/openpgp/errors"
 )
@@ -60,6 +61,21 @@ func (v *validator) ValidateName(imageName string) error {
 	if name != imageName {
 		return fmt.Errorf("error when reading the app name: %q expected but %q found",
 			imageName, name)
+	}
+	return nil
+}
+
+// ValidateLabels checks if desired image labels are actually the same as
+// the ones in the image manifest.
+func (v *validator) ValidateLabels(labels map[types.ACIdentifier]string) error {
+	for n, rv := range labels {
+		if av, ok := v.manifest.GetLabel(n.String()); ok {
+			if rv != av {
+				return fmt.Errorf("requested value for label %q: %q differs from fetched aci label value: %q", n, rv, av)
+			}
+		} else {
+			return fmt.Errorf("requested label %q not provided by the image manifest", n)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
The spec in the discovery part says: "Implementations MUST ensure
that the initial name and labels used for discovery matches the name and
labels in the Image Manifest."

Actually rkt just checks that the names matches but ignore the labels.

This patch also check the labels. Like the other validation parts the
check is executed only if the user doesn't pass `--insecure-options=image`

A functional test is added.

With this patch users calling `rkt fetch example.com/aci:latest` but
receiving an aci with a different version (like v2.0) will receive a
validation error.

This will fix a part of #2305 (since it will error on users running `rkt fetch example.com/aci:latest` to get the latest image if they don't have image verification disabled)