### PR TITLE
stage1: implement docker volume semantics

### DIFF
--- a/stage1/init/common/mount.go
+++ b/stage1/init/common/mount.go
@@ -92,8 +92,9 @@ func generateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume
 			defaultMode := "0755"
 			defaultUID := 0
 			defaultGID := 0
+			uniqName := ra.Name + "-" + mp.Name
 			emptyVol := types.Volume{
-				Name: mp.Name,
+				Name: uniqName,
 				Kind: "empty",
 				Mode: &defaultMode,
 				UID:  &defaultUID,
@@ -106,11 +107,11 @@ func generateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume
 				log.Printf("Docker converted image, initializing implicit volume with data contained at the mount point %q.", mp.Name)
 			}
 
-			volumes[mp.Name] = emptyVol
+			volumes[uniqName] = emptyVol
 			genMnts = append(genMnts,
 				mountWrapper{
 					Mount: schema.Mount{
-						Volume: mp.Name,
+						Volume: uniqName,
 						Path:   mp.Path,
 					},
 					dockerImplicit: dockerImplicit,

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -56,6 +56,10 @@
     },
     "annotations": [
         {
+            "name": "appc.io/docker/repository",
+            "value": "whatever"
+        },
+        {
             "name": "coreos.com/rkt/stage1/run",
             "value": "/ex/run"
         },

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -141,3 +141,16 @@ func TestVolumes(t *testing.T) {
 		}
 	}
 }
+
+func TestDockerVolumeSemantics(t *testing.T) {
+	dockerVolImage := patchTestACI("rkt-volume-image.aci", fmt.Sprintf("--mounts=dir1,path=/dir1,readOnly=false"))
+	defer os.Remove(dockerVolImage)
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	cmd := fmt.Sprintf(`/bin/sh -c "export FILE=/dir1/file ; %s --debug --insecure-options=image run --inherit-env %s --exec /inspect -- --read-file"`, ctx.Cmd(), dockerVolImage)
+
+	expected := "<<<dir1>>>"
+	runRktAndCheckOutput(t, cmd, expected, false)
+}


### PR DESCRIPTION
Docker volumes are initialized with the files in the image if they
exist, unless a host directory is mounted there (see
https://docs.docker.com/engine/userguide/containers/dockervolumes/#data-volumes).

However, when we convert docker images with docker2aci, we convert
docker volumes to mount points, and if the user doesn't specify a host
path for mounting, we mount an empty volume, effectively masking the
files in the image.

To fix this, we create a special case for the case when application uses
an image converted from docker and we mount an implicit empty volume.
In that case, we copy the files from the image to the volume, so docker
images work correctly.

Note that we won't do this if the user explicitly specifies an empty
volume or if they mount a host directory.

TODO:

- ~~What if the user runs a pod with several docker images with the same mount point, then the files that end up in the volume are not defined. Maybe we should make implicit empty volumes unique.~~ Prepended the app name which is unique.
- ~~Tests~~