### PR TITLE
rkt/pods.go: Fix a bug in getContainerPID1().

### DIFF
--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -893,14 +893,15 @@ func (p *pod) getContainerPID1() (pid int, err error) {
 		}
 
 		ppid, err = p.readIntFromFile("ppid")
+		if err != nil && !os.IsNotExist(err) {
+			return -1, err
+		}
 		if err == nil {
 			pid, err = getChildPID(ppid)
 			if err == nil {
 				return pid, nil
 			}
-			if _, ok := err.(ErrChildNotReady); ok {
-				err = nil
-			} else {
+			if _, ok := err.(ErrChildNotReady); !ok {
 				return -1, err
 			}
 		}
@@ -914,8 +915,8 @@ func (p *pod) getContainerPID1() (pid int, err error) {
 			return -1, err
 		}
 
-		if !os.IsNotExist(err) || !p.isRunning() {
-			return -1, err
+		if !p.isRunning() {
+			return -1, fmt.Errorf("pod %v is not running anymore", p.uuid)
 		}
 	}
 }


### PR DESCRIPTION
If 'getChildPID()' returns an 'ErrChildNotReady' error,
then the variable 'err' will be set to nil, which causes the last
If statement's condition to be true, and returns '-1, nil'.


cc @alban @iaguis @sjpotter 