### PR TITLE
rkt: check signatures on --stage1-* options

### DIFF
--- a/Documentation/hacking.md
+++ b/Documentation/hacking.md
@@ -85,6 +85,12 @@ However, a default value can be set for this parameter at build time by setting 
 It can be set with the `paths` kind of configuration.
 For more details, see [configure script parameters documentation](build-configure.md) and [configuration documentation](configuration.md).
 
+rkt expects stage1 images to be signed except in the following cases:
+
+* it is the default stage1 image and it's in the same directory as the rkt binary
+* `--stage1-{name,hash}` is used and the image is already in the store
+* `--stage1-{url,path,from-dir}` is used and the image is in the default directory configured at build time
+
 ## Managing Dependencies
 
 rkt uses [`godep`](https://github.com/tools/godep) to manage third-party dependencies.

--- a/Documentation/running-fly-stage1.md
+++ b/Documentation/running-fly-stage1.md
@@ -64,18 +64,13 @@ This will build the rkt binary and the stage1-fly.aci in `build-rkt-1.2.1+git/bi
 
 ### Selecting stage1 at runtime
 
-Here is a quick example of how to use a container stage1 named `stage1-fly.aci` in `/usr/share/rkt/`:
+Here is a quick example of how to use a container with the official fly stage1:
 
 ```
-# rkt run --stage1-path=/usr/share/rkt/stage1-fly.aci coreos.com/etcd:v2.2.5
+# rkt run --stage1-name=coreos.com/rkt/stage1-fly:1.2.1 coreos.com/etcd:v2.2.5
 ```
 
-When the image is already in the store, the `--stage1-name` or `--stage1-hash` flags can be used instead for a faster startup:
-
-```
-# rkt run --stage1-name=coreos.com/rkt/stage1-fly coreos.com/etcd:v2.2.5
-# rkt run --stage1-hash=<hash> coreos.com/etcd:v2.2.5
-```
+If the image is not in the store, `--stage1-name` will perform discovery and fetch the image.
 
 ## Notes on isolation and security
 

--- a/Documentation/running-lkvm-stage1.md
+++ b/Documentation/running-lkvm-stage1.md
@@ -79,33 +79,16 @@ Currently, the memory allocated to the virtual machine is a sum of memory requir
 
 ### Selecting stage1 at runtime
 
-If you want to run software that requires hypervisor isolation along with trusted software that only needs container isolation, you can [choose which stage1.aci to use at runtime](https://github.com/coreos/rkt/blob/master/Documentation/commands.md#use-a-custom-stage-1).
+If you want to run software that requires hypervisor isolation along with trusted software that only needs container isolation, you can [choose which stage1 to use at runtime](https://github.com/coreos/rkt/blob/master/Documentation/subcommands/run.md#use-a-custom-stage-1).
 
-For example, if you have a container stage1 named `stage1-coreos.aci` and a lkvm stage1 named `stage1-kvm.aci` in `/usr/local/rkt/`:
+For example, to use the official lkvm stage1:
 
 ```
-# rkt run --stage1-path=/usr/local/rkt/stage1-coreos.aci coreos.com/etcd:v2.0.9
-...
-# rkt run --stage1-path=/usr/local/rkt/stage1-kvm.aci coreos.com/etcd:v2.0.9
+# rkt run --stage1-name=coreos.com/rkt/stage1-kvm:1.2.1 coreos.com/etcd:v2.0.9
 ...
 ```
 
-These images can be installed in the default stage1 images directory.
-In this case, the stage1 image can be selected with a different flag:
-
-```
-# rkt run --stage1-from-dir=stage1-coreos.aci coreos.com/etcd:v2.0.9
-...
-# rkt run --stage1-from-dir=stage1-kvm.aci coreos.com/etcd:v2.0.9
-...
-```
-
-When the image is already in the store, the `--stage1-name` or `--stage1-hash` flags can be used instead for a faster startup:
-
-```
-# rkt run --stage1-name=coreos.com/rkt/stage1-kvm coreos.com/etcd:v2.0.9
-# rkt run --stage1-hash=<hash> coreos.com/etcd:v2.0.9
-```
+If the image is not in the store, `--stage1-name` will perform discovery and fetch the image.
 
 ## How does it work?
 

--- a/Documentation/subcommands/enter.md
+++ b/Documentation/subcommands/enter.md
@@ -16,18 +16,6 @@ bin   data  entrypoint.sh  home  lib64  mnt  proc  run   selinux  sys  usr
 boot  dev   etc            lib   media  opt  root  sbin  srv      tmp  var
 ```
 
-## Use a Custom Stage 1
-
-rkt is designed and intended to be modular, using a [staged architecture](../devel/architecture.md).
-
-You can use a custom stage1 by using the `--stage1-{url,path,name,hash,from-dir}` flags.
-
-```
-# rkt --stage1-path=/tmp/stage1.aci run coreos.com/etcd:v2.0.0
-```
-
-For more details see the [hacking documentation](../hacking.md).
-
 ## Run a Pod in the Background
 
 Work in progress. Please contribute!

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -305,6 +305,24 @@ For example, if you use systemd, you can [run rkt using `systemd-run`](https://g
 
 If you don't use systemd, you can use [daemon](http://www.libslack.org/daemon/) as an alternative.
 
+## Use a Custom Stage 1
+
+rkt is designed and intended to be modular, using a [staged architecture](../devel/architecture.md).
+
+You can use a custom stage1 by using the `--stage1-{url,path,name,hash,from-dir}` flags.
+
+```
+# rkt --stage1-path=/tmp/stage1.aci run coreos.com/etcd:v2.0.0
+```
+
+rkt expects stage1 images to be signed except in the following cases:
+
+* it is the default stage1 image and it's in the same directory as the rkt binary
+* `--stage1-{name,hash}` is used and the image is already in the store
+* `--stage1-{url,path,from-dir}` is used and the image is in the default directory configured at build time
+
+For more details see the [hacking documentation](../hacking.md).
+
 ## Options
 
 | Flag | Default | Options | Description |

--- a/rkt/stage1hash.go
+++ b/rkt/stage1hash.go
@@ -353,6 +353,8 @@ func getStage1HashFromPath(fn *image.Finder, imgLoc, imgFileName string) (*types
 		if err != nil {
 			fallbackErr = err
 		} else {
+			// using stage1 image in rkt's path, don't check the signature
+			fn.Ks = nil
 			rktDir := filepath.Dir(exePath)
 			imgPath := filepath.Join(rktDir, imgFileName)
 			hash, err := fn.FindImage(imgPath, "", apps.AppImagePath)


### PR DESCRIPTION
We were not checking signatures when the uses passes `--stage1-*`
options.

The new behavior is like so:

- If the user doesn't pass any flag, stage1 images will be taken from the default stage1 directory or from the directory where the rkt binary is. In that case, we don't check any signatures.
- If the user passes any `--stage1-*` flag, we always check the signature unless the resulting path is the one configured at build time.
- If the user uses rkt's configuration to configure a different stage1 we assume they know what they're doing and we'll check the signature.

Does this make sense? // @krnowak 