### PR TITLE
build, stage1: Check squashfs manifest

### DIFF
--- a/Documentation/dependencies.md
+++ b/Documentation/dependencies.md
@@ -37,6 +37,7 @@ For the most part the codebase is self-contained (e.g. all dependencies are vend
 ### Specific dependencies for the coreos/kvm flavor
 
 * cat
+* comm
 * cpio
 * gzip
 * md5sum

--- a/configure.ac
+++ b/configure.ac
@@ -260,6 +260,7 @@ dnl gpg - it will be checked when we will actually download the image
 dnl from the network
 AC_DEFUN([RKT_COMMON_COREOS_PROGS],
          [RKT_REQ_PROG([CAT],[cat],[cat])
+          RKT_REQ_PROG([COMM],[comm],[comm])
           RKT_REQ_PROG([CPIO],[cpio],[cpio])
           RKT_REQ_PROG([GZIP],[gzip],[gzip])
           RKT_REQ_PROG([MD5SUM],[md5sum],[md5sum])

--- a/stage1/usr_from_kvm/manifest.d/ip.manifest
+++ b/stage1/usr_from_kvm/manifest.d/ip.manifest
@@ -1,1 +1,1 @@
-/bin/ip
+bin/ip


### PR DESCRIPTION
Since unsquashfs does not have a flag for ensuring that all the files from manifest were extracted, we have to do it on our own. We do this by making sure that the complete manifest is a subset of a list of the files in the squashfs file (acquired by the "unsquashfs -ls <file>" command). This requires doing some set operations, so we got a dependency on comm from coreutils.

This also fixes one manifest file. All other manifest files do not add the root slash to the path.

Fixes #2337.