### PR TITLE
rkt: add command to export a pod to an aci

### DIFF
--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -38,6 +38,7 @@ rkt provides subcommands to list, get status, and clean its pods.
 
 * [list](subcommands/list.md)
 * [status](subcommands/status.md)
+* [export](subcommands/export.md)
 * [gc](subcommands/gc.md)
 * [rm](subcommands/rm.md)
 * [cat-manifest](subcommands/cat-manifest.md)

--- a/Documentation/subcommands/export.md
+++ b/Documentation/subcommands/export.md
@@ -1,0 +1,17 @@
+# rkt export
+
+Exports an exited, single-app pod to an App Container Image (.aci)
+
+```
+$ rkt export UUID .aci
+```
+
+## Options
+
+| Flag | Default | Options | Description |
+| --- | --- | --- | --- |
+| `--overwrite` |  `false` | `true` or `false` | Overwrite the output aci if it exists  |
+
+## Global options
+
+See the table with [global options in general commands documentation](../commands.md#global-options).

--- a/common/common.go
+++ b/common/common.go
@@ -55,6 +55,15 @@ const (
 
 	DefaultLocalConfigDir  = "/etc/rkt"
 	DefaultSystemConfigDir = "/usr/lib/rkt"
+
+	// Default perm bits for the regular files
+	// within the stage1 directory. (e.g. image manifest,
+	// pod manifest, stage1ID, etc).
+	DefaultRegularFilePerm = os.FileMode(0640)
+
+	// Default perm bits for the regular directories
+	// within the stage1 directory.
+	DefaultRegularDirPerm = os.FileMode(0750)
 )
 
 const (

--- a/common/overlay/overlay.go
+++ b/common/overlay/overlay.go
@@ -1,0 +1,47 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package overlay
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/coreos/rkt/pkg/label"
+	"github.com/hashicorp/errwrap"
+)
+
+// MountCfg containes the needed data to construct the overlay mount syscall. The Lower and Upper fields
+// are paths to the filesystems to be merged. The Work field should be an empty directory. Dest is where
+// the mount will be located. Lbl is an syslinux label.
+type MountCfg struct {
+	Lower,
+	Upper,
+	Work,
+	Dest,
+	Lbl string
+}
+
+// Mount mounts the upper and lower directories to the destination directory. The MountCfg struct supplies
+// information required to build the mount system call. The path to the mounted files system is returned
+// upon success.
+func Mount(cfg *MountCfg) (string, error) {
+	opts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", cfg.Lower, cfg.Upper, cfg.Work)
+	opts = label.FormatMountLabel(opts, cfg.Lbl)
+	if err := syscall.Mount("overlay", cfg.Dest, "overlay", 0, opts); err != nil {
+		return "", errwrap.Wrap(fmt.Errorf("error mounting overlay with options '%s' and dest '%s'", opts, cfg.Dest), err)
+	}
+
+	return cfg.Dest, nil
+}

--- a/rkt/export.go
+++ b/rkt/export.go
@@ -1,0 +1,149 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/appc/spec/aci"
+	"github.com/appc/spec/schema"
+	"github.com/coreos/rkt/common"
+	"github.com/hashicorp/errwrap"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdExport = &cobra.Command{
+		Use:   "export UUID OUTPUT_ACI_FILE",
+		Short: "Export an exited pod to an ACI file",
+		Long: `UUID should be the uuid of an exited pod.
+
+Note that currently only pods with a single app and started with the --no-overlay option are supported.`,
+		Run: runWrapper(runExport),
+	}
+)
+
+func init() {
+	cmdRkt.AddCommand(cmdExport)
+	cmdExport.Flags().BoolVar(&flagOverwriteACI, "overwrite", false, "overwrite output ACI")
+}
+
+func runExport(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) != 2 {
+		cmd.Usage()
+		return 1
+	}
+
+	aci := args[1]
+	ext := filepath.Ext(aci)
+	if ext != schema.ACIExtension {
+		stderr.Printf("extension must be %s (given %s)", schema.ACIExtension, aci)
+		return 1
+	}
+
+	p, err := getPodFromUUIDString(args[0])
+	if err != nil {
+		stderr.PrintE("problem retrieving pod", err)
+		return 1
+	}
+	defer p.Close()
+
+	if !p.isExited {
+		stderr.Print("pod is not exited. Only exited pods are supported.")
+		return 1
+	}
+
+	if p.usesOverlay() {
+		stderr.Print("pod uses overlayfs. Only pods using the --no-overlay flag are supported.")
+		return 1
+	}
+
+	var apps schema.AppList
+	if apps, err = p.getApps(); err != nil {
+		stderr.PrintE("problem getting pod's app list", err)
+		return 1
+	}
+
+	if len(apps) != 1 {
+		stderr.Print("pod has more than one app. Only pods with one app are supported.")
+		return 1
+	}
+
+	root := common.AppPath(p.path(), apps[0].Name)
+	if err = buildAci(root, aci); err != nil {
+		stderr.PrintE("error building aci", err)
+		return 1
+	}
+
+	return 0
+}
+
+func buildAci(root, target string) (e error) {
+	mode := os.O_CREATE | os.O_WRONLY
+	if flagOverwriteACI {
+		mode |= os.O_TRUNC
+	} else {
+		mode |= os.O_EXCL
+	}
+	aciFile, err := os.OpenFile(target, mode, 0644)
+	if err != nil {
+		if os.IsExist(err) {
+			return errors.New("target file exists (try --overwrite)")
+		} else {
+			return errwrap.Wrap(fmt.Errorf("unable to open target %s", target), err)
+		}
+	}
+
+	gw := gzip.NewWriter(aciFile)
+	tr := tar.NewWriter(gw)
+
+	defer func() {
+		tr.Close()
+		gw.Close()
+		aciFile.Close()
+		// e is implicitly assigned by the return statement. As defer runs
+		// after return, but before actually returning, this works.
+		if e != nil {
+			os.Remove(target)
+		}
+	}()
+
+	mpath := filepath.Join(root, aci.ManifestFile)
+	b, err := ioutil.ReadFile(mpath)
+	if err != nil {
+		return errwrap.Wrap(errors.New("unable to read Image Manifest"), err)
+	}
+	var im schema.ImageManifest
+	if err := im.UnmarshalJSON(b); err != nil {
+		return errwrap.Wrap(errors.New("unable to load Image Manifest"), err)
+	}
+	iw := aci.NewImageWriter(im, tr)
+
+	if err := filepath.Walk(root, aci.BuildWalker(root, iw, nil)); err != nil {
+		return errwrap.Wrap(errors.New("error walking rootfs"), err)
+	}
+
+	if err = iw.Close(); err != nil {
+		return errwrap.Wrap(fmt.Errorf("unable to close image %s", target), err)
+	}
+
+	return
+}

--- a/rkt/export.go
+++ b/rkt/export.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"syscall"
 
@@ -28,9 +29,9 @@ import (
 	"github.com/appc/spec/schema"
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/common/overlay"
-	"github.com/hashicorp/errwrap"
-
+	"github.com/coreos/rkt/pkg/user"
 	"github.com/coreos/rkt/store"
+	"github.com/hashicorp/errwrap"
 	"github.com/spf13/cobra"
 )
 
@@ -110,12 +111,24 @@ func runExport(cmd *cobra.Command, args []string) (exit int) {
 		}()
 	}
 
+	// Check for user namespace (--private-user), if in use get uidRange
+	var uidRange *user.UidRange
+	privUserFile := path.Join(p.path(), common.PrivateUsersPreparedFilename)
+	privUserContent, err := ioutil.ReadFile(privUserFile)
+	if err == nil {
+		uidRange = user.NewBlankUidRange()
+		// The file was found, save uid & gid shift and count
+		if err := uidRange.Deserialize(privUserContent); err != nil {
+			stderr.PrintE(fmt.Sprintf("problem deserializing the content of %s", common.PrivateUsersPreparedFilename), err)
+			return 1
+		}
+	}
+
 	root := common.AppPath(p.path(), app.Name)
-	if err = buildAci(root, aci); err != nil {
+	if err = buildAci(root, aci, uidRange); err != nil {
 		stderr.PrintE("error building aci", err)
 		return 1
 	}
-
 	return 0
 }
 
@@ -156,7 +169,9 @@ func mountOverlay(pod *pod, app *schema.RuntimeApp, dest string) (string, error)
 	return mntDir, nil
 }
 
-func buildAci(root, target string) (e error) {
+// buildAci builds a target aci from the root directory using any uid schift
+// information from uidRange.
+func buildAci(root, target string, uidRange *user.UidRange) (e error) {
 	mode := os.O_CREATE | os.O_WRONLY
 	if flagOverwriteACI {
 		mode |= os.O_TRUNC
@@ -197,7 +212,20 @@ func buildAci(root, target string) (e error) {
 	}
 	iw := aci.NewImageWriter(im, tr)
 
-	if err := filepath.Walk(root, aci.BuildWalker(root, iw, nil)); err != nil {
+	// Unshift uid and gid when pod was started with --private-user (user namespace)
+	var walkerCb aci.TarHeaderWalkFunc = func(hdr *tar.Header) bool {
+		if uidRange != nil {
+			uid, gid, err := uidRange.UnshiftRange(uint32(hdr.Uid), uint32(hdr.Gid))
+			if err != nil {
+				stderr.PrintE("error unshifting gid and uid", err)
+				return false
+			}
+			hdr.Uid, hdr.Gid = int(uid), int(gid)
+		}
+		return true
+	}
+
+	if err := filepath.Walk(root, aci.BuildWalker(root, iw, walkerCb)); err != nil {
 		return errwrap.Wrap(errors.New("error walking rootfs"), err)
 	}
 

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -42,6 +42,7 @@ import (
 	"github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/common/apps"
+	"github.com/coreos/rkt/common/overlay"
 	"github.com/coreos/rkt/pkg/aci"
 	"github.com/coreos/rkt/pkg/fileutil"
 	"github.com/coreos/rkt/pkg/label"
@@ -51,17 +52,6 @@ import (
 	"github.com/coreos/rkt/store"
 	"github.com/coreos/rkt/version"
 	"github.com/hashicorp/errwrap"
-)
-
-const (
-	// Default perm bits for the regular files
-	// within the stage1 directory. (e.g. image manifest,
-	// pod manifest, stage1ID, etc).
-	defaultRegularFilePerm = os.FileMode(0640)
-
-	// Default perm bits for the regular directories
-	// within the stage1 directory.
-	defaultRegularDirPerm = os.FileMode(0750)
 )
 
 var debugEnabled bool
@@ -196,6 +186,7 @@ func generatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
 		if err != nil {
 			return errwrap.Wrap(errors.New("error converting image name to app name"), err)
 		}
+
 		if err := prepareAppImage(cfg, *appName, img, dir, cfg.UseOverlay); err != nil {
 			return errwrap.Wrap(fmt.Errorf("error setting up image %s", img), err)
 		}
@@ -342,7 +333,7 @@ func validatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
 
 // Prepare sets up a pod based on the given config.
 func Prepare(cfg PrepareConfig, dir string, uuid *types.UUID) error {
-	if err := os.MkdirAll(common.AppsInfoPath(dir), defaultRegularDirPerm); err != nil {
+	if err := os.MkdirAll(common.AppsInfoPath(dir), common.DefaultRegularDirPerm); err != nil {
 		return errwrap.Wrap(errors.New("error creating apps info directory"), err)
 	}
 	debug("Preparing stage1")
@@ -365,7 +356,7 @@ func Prepare(cfg PrepareConfig, dir string, uuid *types.UUID) error {
 
 	debug("Writing pod manifest")
 	fn := common.PodManifestPath(dir)
-	if err := ioutil.WriteFile(fn, pmb, defaultRegularFilePerm); err != nil {
+	if err := ioutil.WriteFile(fn, pmb, common.DefaultRegularFilePerm); err != nil {
 		return errwrap.Wrap(errors.New("error writing pod manifest"), err)
 	}
 
@@ -382,7 +373,7 @@ func Prepare(cfg PrepareConfig, dir string, uuid *types.UUID) error {
 		// mark the pod as prepared for user namespaces
 		uidrangeBytes := cfg.PrivateUsers.Serialize()
 
-		if err := ioutil.WriteFile(filepath.Join(dir, common.PrivateUsersPreparedFilename), uidrangeBytes, defaultRegularFilePerm); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(dir, common.PrivateUsersPreparedFilename), uidrangeBytes, common.DefaultRegularFilePerm); err != nil {
 			return errwrap.Wrap(errors.New("error writing userns marker file"), err)
 		}
 	}
@@ -439,7 +430,7 @@ func addResolvConf(cfg RunConfig, rootfs string) {
 	}
 	content += "\n"
 
-	if err := os.Mkdir(filepath.Join(rootfs, "etc"), defaultRegularDirPerm); err != nil {
+	if err := os.Mkdir(filepath.Join(rootfs, "etc"), common.DefaultRegularDirPerm); err != nil {
 		if !os.IsExist(err) {
 			log.Fatalf("error creating dir %q: %v\n", "/etc", err)
 		}
@@ -584,7 +575,7 @@ func prepareAppImage(cfg PrepareConfig, appName types.ACName, img types.Hash, cd
 	}
 
 	appInfoDir := common.AppInfoPath(cdir, appName)
-	if err := os.MkdirAll(appInfoDir, defaultRegularDirPerm); err != nil {
+	if err := os.MkdirAll(appInfoDir, common.DefaultRegularDirPerm); err != nil {
 		return errwrap.Wrap(errors.New("error creating apps info directory"), err)
 	}
 
@@ -610,12 +601,12 @@ func prepareAppImage(cfg PrepareConfig, appName types.ACName, img types.Hash, cd
 			cfg.CommonConfig.RootHash = hash
 		}
 
-		if err := ioutil.WriteFile(common.AppTreeStoreIDPath(cdir, appName), []byte(treeStoreID), defaultRegularFilePerm); err != nil {
+		if err := ioutil.WriteFile(common.AppTreeStoreIDPath(cdir, appName), []byte(treeStoreID), common.DefaultRegularFilePerm); err != nil {
 			return errwrap.Wrap(errors.New("error writing app treeStoreID"), err)
 		}
 	} else {
 		ad := common.AppPath(cdir, appName)
-		err := os.MkdirAll(ad, defaultRegularDirPerm)
+		err := os.MkdirAll(ad, common.DefaultRegularDirPerm)
 		if err != nil {
 			return errwrap.Wrap(errors.New("error creating image directory"), err)
 		}
@@ -645,7 +636,7 @@ func prepareAppImage(cfg PrepareConfig, appName types.ACName, img types.Hash, cd
 func setupAppImage(cfg RunConfig, appName types.ACName, img types.Hash, cdir string, useOverlay bool) error {
 	ad := common.AppPath(cdir, appName)
 	if useOverlay {
-		err := os.MkdirAll(ad, defaultRegularDirPerm)
+		err := os.MkdirAll(ad, common.DefaultRegularDirPerm)
 		if err != nil {
 			return errwrap.Wrap(errors.New("error creating image directory"), err)
 		}
@@ -669,7 +660,7 @@ func setupAppImage(cfg RunConfig, appName types.ACName, img types.Hash, cdir str
 // When useOverlay is false, it attempts to render and expand the stage1.
 func prepareStage1Image(cfg PrepareConfig, img types.Hash, cdir string, useOverlay bool) error {
 	s1 := common.Stage1ImagePath(cdir)
-	if err := os.MkdirAll(s1, defaultRegularDirPerm); err != nil {
+	if err := os.MkdirAll(s1, common.DefaultRegularDirPerm); err != nil {
 		return errwrap.Wrap(errors.New("error creating stage1 directory"), err)
 	}
 
@@ -704,7 +695,7 @@ func prepareStage1Image(cfg PrepareConfig, img types.Hash, cdir string, useOverl
 	}
 
 	fn := path.Join(cdir, common.Stage1TreeStoreIDFilename)
-	if err := ioutil.WriteFile(fn, []byte(treeStoreID), defaultRegularFilePerm); err != nil {
+	if err := ioutil.WriteFile(fn, []byte(treeStoreID), common.DefaultRegularFilePerm); err != nil {
 		return errwrap.Wrap(errors.New("error writing stage1 treeStoreID"), err)
 	}
 	return nil
@@ -745,7 +736,7 @@ func writeManifest(cfg CommonConfig, img types.Hash, dest string) error {
 	}
 
 	debug("Writing image manifest")
-	if err := ioutil.WriteFile(filepath.Join(dest, "manifest"), mb, defaultRegularFilePerm); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(dest, "manifest"), mb, common.DefaultRegularFilePerm); err != nil {
 		return errwrap.Wrap(errors.New("error writing image manifest"), err)
 	}
 
@@ -765,24 +756,40 @@ func copyAppManifest(cdir string, appName types.ACName, dest string) error {
 }
 
 // overlayRender renders the image that corresponds to the given hash using the
-// overlay filesystem.
-// It mounts an overlay filesystem from the cached tree of the image as rootfs.
+// overlay filesystem. It mounts an overlay filesystem from the cached tree of
+// the image as rootfs.
 func overlayRender(cfg RunConfig, treeStoreID string, cdir string, dest string, appName string) error {
 	cachedTreePath := cfg.Store.GetTreeStoreRootFS(treeStoreID)
-	fi, err := os.Stat(cachedTreePath)
+	mc, err := prepareOverlay(cachedTreePath, treeStoreID, cdir, dest, appName, cfg.MountLabel,
+		cfg.RktGid, common.DefaultRegularDirPerm)
 	if err != nil {
-		return err
+		return errwrap.Wrap(errors.New("problem preparing overlay directories"), err)
+	}
+	if _, err = overlay.Mount(mc); err != nil {
+		return errwrap.Wrap(errors.New("problem mounting overlay filesystem"), err)
+	}
+
+	return nil
+}
+
+// prepateOverlay sets up the needed directories, files and permissions for the
+// overlay-rendered pods
+func prepareOverlay(lower, treeStoreID, cdir, dest, appName, lbl string,
+	gid int, fm os.FileMode) (*overlay.MountCfg, error) {
+	fi, err := os.Stat(lower)
+	if err != nil {
+		return nil, err
 	}
 	imgMode := fi.Mode()
 
-	destRootfs := path.Join(dest, "rootfs")
-	if err := os.MkdirAll(destRootfs, imgMode); err != nil {
-		return err
+	dst := path.Join(dest, "rootfs")
+	if err := os.MkdirAll(dst, imgMode); err != nil {
+		return nil, err
 	}
 
 	overlayDir := path.Join(cdir, "overlay")
-	if err := os.MkdirAll(overlayDir, defaultRegularDirPerm); err != nil {
-		return err
+	if err := os.MkdirAll(overlayDir, fm); err != nil {
+		return nil, err
 	}
 
 	// Since the parent directory (rkt/pods/$STATE/$POD_UUID) has the 'S_ISGID' bit, here
@@ -790,43 +797,36 @@ func overlayRender(cfg RunConfig, treeStoreID string, cdir string, dest string, 
 	// directory so that it won't inherit the bit. Otherwise the files
 	// created by users within the pod will inherit the 'S_ISGID' bit
 	// as well.
-	if err := os.Chmod(overlayDir, defaultRegularDirPerm); err != nil {
-		return err
+	if err := os.Chmod(overlayDir, fm); err != nil {
+		return nil, err
 	}
 
 	imgDir := path.Join(overlayDir, treeStoreID)
-	if err := os.MkdirAll(imgDir, defaultRegularDirPerm); err != nil {
-		return err
+	if err := os.MkdirAll(imgDir, fm); err != nil {
+		return nil, err
 	}
-
 	// Also make 'rkt/pods/$STATE/$POD_UUID/overlay/$IMAGE_ID' to be readable by 'rkt' group
 	// As 'rkt' status will read the 'rkt/pods/$STATE/$POD_UUID/overlay/$IMAGE_ID/upper/rkt/status/$APP'
-	// to get exit status.
-	if err := os.Chown(imgDir, -1, cfg.RktGid); err != nil {
-		return err
+	// to get exgid
+	if err := os.Chown(imgDir, -1, gid); err != nil {
+		return nil, err
 	}
 
-	upperDir := path.Join(imgDir, "upper", appName)
-	if err := os.MkdirAll(upperDir, imgMode); err != nil {
-		return err
+	upper := path.Join(imgDir, "upper", appName)
+	if err := os.MkdirAll(upper, imgMode); err != nil {
+		return nil, err
 	}
-	if err := label.SetFileLabel(upperDir, cfg.MountLabel); err != nil {
-		return err
-	}
-
-	workDir := path.Join(imgDir, "work", appName)
-	if err := os.MkdirAll(workDir, defaultRegularDirPerm); err != nil {
-		return err
-	}
-	if err := label.SetFileLabel(workDir, cfg.MountLabel); err != nil {
-		return err
+	if err := label.SetFileLabel(upper, lbl); err != nil {
+		return nil, err
 	}
 
-	opts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", cachedTreePath, upperDir, workDir)
-	opts = label.FormatMountLabel(opts, cfg.MountLabel)
-	if err := syscall.Mount("overlay", destRootfs, "overlay", 0, opts); err != nil {
-		return errwrap.Wrap(errors.New("error mounting"), err)
+	work := path.Join(imgDir, "work", appName)
+	if err := os.MkdirAll(work, fm); err != nil {
+		return nil, err
+	}
+	if err := label.SetFileLabel(work, lbl); err != nil {
+		return nil, err
 	}
 
-	return nil
+	return &overlay.MountCfg{lower, upper, work, dst, lbl}, nil
 }

--- a/tests/rkt_export_test.go
+++ b/tests/rkt_export_test.go
@@ -1,0 +1,91 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+func TestExport(t *testing.T) {
+	const (
+		testAci     = "test.aci"
+		testFile    = "test.txt"
+		testContent = "ThisIsATest"
+		runInspect  = "%s %s %s %s --exec=/inspect -- %s"
+	)
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	tests := []struct {
+		runArgs        string
+		writeArgs      string
+		readArgs       string
+		expectedStatus int
+		expectedResult string
+	}{
+		{
+			"--no-overlay --insecure-options=image",
+			"--write-file --file-name=" + testFile + " --content=" + testContent,
+			"--read-file --file-name=" + testFile,
+			0,
+			testContent,
+		},
+	}
+	for _, tt := range tests {
+		tmpDir := createTempDirOrPanic("rkt-TestExport-tmp-")
+		defer os.RemoveAll(tmpDir)
+
+		tmpTestAci := filepath.Join(tmpDir, testAci)
+
+		// Prepare the image with modifications
+		prepareCmd := fmt.Sprintf(runInspect, ctx.Cmd(), "prepare", tt.runArgs, getInspectImagePath(), tt.writeArgs)
+		t.Logf("Preparing 'inspect --write-file'")
+		uuid := runRktAndGetUUID(t, prepareCmd)
+
+		runCmd := fmt.Sprintf("%s run-prepared %s", ctx.Cmd(), uuid)
+		t.Logf("Running 'inspect --write-file'")
+		child := spawnOrFail(t, runCmd)
+		waitOrFail(t, child, 0)
+
+		// Export the image
+		exportCmd := fmt.Sprintf("%s export %s %s", ctx.Cmd(), uuid, tmpTestAci)
+		t.Logf("Running 'export'")
+		child = spawnOrFail(t, exportCmd)
+		waitOrFail(t, child, tt.expectedStatus)
+
+		if tt.expectedStatus == 0 {
+			// Run the newly created ACI and check the output
+			readCmd := fmt.Sprintf(runInspect, ctx.Cmd(), "run", tt.runArgs, tmpTestAci, tt.readArgs)
+			t.Logf("Running 'inspect --read-file'")
+			child := spawnOrFail(t, readCmd)
+			if tt.expectedResult != "" {
+				if _, out, err := expectRegexWithOutput(child, tt.expectedResult); err != nil {
+					t.Fatalf("expected %q but not found: %v\n%s", tt.expectedResult, err, out)
+				}
+			}
+			waitOrFail(t, child, tt.expectedStatus)
+		}
+
+		// run garbage collector on pods and images
+		runGC(t, ctx)
+		runImageGC(t, ctx)
+	}
+}

--- a/tests/rkt_export_test.go
+++ b/tests/rkt_export_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/tests/testutils"
 )
 
@@ -28,27 +29,50 @@ func TestExport(t *testing.T) {
 		testAci     = "test.aci"
 		testFile    = "test.txt"
 		testContent = "ThisIsATest"
-		runInspect  = "%s %s %s %s --exec=/inspect -- %s"
 	)
 
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	tests := []struct {
+	type testCfg struct {
 		runArgs        string
 		writeArgs      string
 		readArgs       string
-		expectedStatus int
 		expectedResult string
-	}{
+	}
+
+	tests := []testCfg{
 		{
 			"--no-overlay --insecure-options=image",
 			"--write-file --file-name=" + testFile + " --content=" + testContent,
 			"--read-file --file-name=" + testFile,
-			0,
 			testContent,
 		},
 	}
+
+	// Need to do both checks
+	if common.SupportsUserNS() && checkUserNS() == nil {
+		tests = append(tests, []testCfg{
+			{
+				"--private-users --no-overlay --insecure-options=image",
+				"--write-file --file-name=" + testFile + " --content=" + testContent,
+				"--read-file --file-name=" + testFile,
+				testContent,
+			},
+		}...)
+	}
+
+	if common.SupportsOverlay() {
+		tests = append(tests, []testCfg{
+			{
+				"--insecure-options=image",
+				"--write-file --file-name=" + testFile + " --content=" + testContent,
+				"--read-file --file-name=" + testFile,
+				testContent,
+			},
+		}...)
+	}
+
 	for _, tt := range tests {
 		tmpDir := createTempDirOrPanic("rkt-TestExport-tmp-")
 		defer os.RemoveAll(tmpDir)
@@ -56,6 +80,7 @@ func TestExport(t *testing.T) {
 		tmpTestAci := filepath.Join(tmpDir, testAci)
 
 		// Prepare the image with modifications
+		const runInspect = "%s %s %s %s --exec=/inspect -- %s"
 		prepareCmd := fmt.Sprintf(runInspect, ctx.Cmd(), "prepare", tt.runArgs, getInspectImagePath(), tt.writeArgs)
 		t.Logf("Preparing 'inspect --write-file'")
 		uuid := runRktAndGetUUID(t, prepareCmd)
@@ -69,20 +94,18 @@ func TestExport(t *testing.T) {
 		exportCmd := fmt.Sprintf("%s export %s %s", ctx.Cmd(), uuid, tmpTestAci)
 		t.Logf("Running 'export'")
 		child = spawnOrFail(t, exportCmd)
-		waitOrFail(t, child, tt.expectedStatus)
+		waitOrFail(t, child, 0)
 
-		if tt.expectedStatus == 0 {
-			// Run the newly created ACI and check the output
-			readCmd := fmt.Sprintf(runInspect, ctx.Cmd(), "run", tt.runArgs, tmpTestAci, tt.readArgs)
-			t.Logf("Running 'inspect --read-file'")
-			child := spawnOrFail(t, readCmd)
-			if tt.expectedResult != "" {
-				if _, out, err := expectRegexWithOutput(child, tt.expectedResult); err != nil {
-					t.Fatalf("expected %q but not found: %v\n%s", tt.expectedResult, err, out)
-				}
+		// Run the newly created ACI and check the output
+		readCmd := fmt.Sprintf(runInspect, ctx.Cmd(), "run", tt.runArgs, tmpTestAci, tt.readArgs)
+		t.Logf("Running 'inspect --read-file'")
+		child = spawnOrFail(t, readCmd)
+		if tt.expectedResult != "" {
+			if _, out, err := expectRegexWithOutput(child, tt.expectedResult); err != nil {
+				t.Fatalf("expected %q but not found: %v\n%s", tt.expectedResult, err, out)
 			}
-			waitOrFail(t, child, tt.expectedStatus)
 		}
+		waitOrFail(t, child, 0)
 
 		// run garbage collector on pods and images
 		runGC(t, ctx)


### PR DESCRIPTION
Adds a new `export` command to rkt which generates an aci from a
pod; saving any changes made to the pod.

Usage is `rkt export POD_UUID my.aci`

This is currently restricted to only working with exited pods with a
single app.

Fixes #1197