### PR TITLE
Use lowercase for UID & GID options in run example

### DIFF
--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -170,7 +170,7 @@ Syntax:
  In the following example, we create an empty volume for app1's `/var/data`:
 
  ```
- # rkt run --volume data,kind=empty,mode=0700,UID=0,GID=0
+ # rkt run --volume data,kind=empty,mode=0700,uid=0,gid=0
  ```
 
 ### Mounting Volumes without Mount Points


### PR DESCRIPTION
The syntax description for the --volume option uses lowercase for the uid and gid parameters; whereas the example uses uppercase. Change the example to conform to the implemented behaviour.