### PR TITLE
Doc/subcmd/run: Add docker port name convention

### DIFF
--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -342,7 +342,7 @@ For more details see the [hacking documentation](../hacking.md).
 | `--no-overlay` |  `false` | `true` or `false` | Disable overlay filesystem |
 | `--no-store` |  `false` | `true` or `false` | Fetch images, ignoring the local store. See [image fetching behavior](../image-fetching-behavior.md) |
 | `--pod-manifest` |  `` | A path | The path to the pod manifest. If it's non-empty, then only `--net`, `--no-overlay` and `--interactive` will have effect |
-| `--port` |  `` | A port number | Ports to expose on the host (requires [contained network](https://github.com/coreos/rkt/blob/master/Documentation/networking.md#contained-mode)). Syntax: --port=NAME:HOSTPORT |
+| `--port` |  `` | A port number | Ports to expose on the host (requires [contained network](https://github.com/coreos/rkt/blob/master/Documentation/networking/overview.md#contained-mode)). Syntax: `--port=NAME:HOSTPORT` The NAME is that given in the ACI. By convention, Docker containers' EXPOSEd ports are given a name formed from the port number, a hyphen, and the protocol, e.g., `80-tcp`, giving something like `--port=80-tcp:8080` |
 | `--private-users` |  `false` | `true` or `false` | Run within user namespaces (experimental) |
 | `--set-env` |  `` | An environment variable. Syntax `NAME=VALUE` | An environment variable to set for apps |
 | `--signature` |  `` | A file path | Local signature file to use in validating the preceding image |


### PR DESCRIPTION
Add docker port name convention.
Update link to contained network doc#heading.
<strike>Be explicit about false, at least in this row for now</strike> D'oh. :blush:

Ref #2113.