### PR TITLE
test: TestAPIServiceCgroup: increase timeout

### DIFF
--- a/tests/rkt_api_service_test.go
+++ b/tests/rkt_api_service_test.go
@@ -467,7 +467,7 @@ func TestAPIServiceCgroup(t *testing.T) {
 		}
 	}()
 
-	testutils.WaitOrTimeout(t, time.Second*10, done)
+	testutils.WaitOrTimeout(t, time.Second*30, done)
 
 	var cgroups []string
 


### PR DESCRIPTION
A timeout of 10 seconds is not enough for slow machines.

https://github.com/coreos/rkt/issues/2357

-----

/cc @yifan-gu 