### PR TITLE
prepare: Support 'ondisk' verification skip

### DIFF
--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -165,9 +165,10 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	pcfg := stage0.PrepareConfig{
-		CommonConfig: &cfg,
-		UseOverlay:   !flagNoOverlay && common.SupportsOverlay(),
-		PrivateUsers: privateUsers,
+		CommonConfig:       &cfg,
+		UseOverlay:         !flagNoOverlay && common.SupportsOverlay(),
+		PrivateUsers:       privateUsers,
+		SkipTreeStoreCheck: globalFlags.InsecureFlags.SkipOnDiskCheck(),
 	}
 
 	if len(flagPodManifest) > 0 {


### PR DESCRIPTION
Prior to this commit, `rkt prepare` would check the ondisk image even if
the `--insecure-options=ondisk` flag was provided.

This commit corrects that.

I wasn't sure if there was an appropriate way to unit/functional test this. It didn't seem that there was a good framework inplace for unit testing run/prepare commands, and a functional test would be nontrivial (probably corrupt the ondisk data to see that it doesn't verify?).

I'd be happy to look into this a bit more if you feel it's prudent.