### PR TITLE
net: fix port forwarding behavior with custom CNI ipMasq'ed networks different and allow different hostPort:podPort combinations

### DIFF
--- a/Documentation/networking/overview.md
+++ b/Documentation/networking/overview.md
@@ -332,6 +332,14 @@ The pod's TCP port 80 can be mapped to an arbitrary port on the host during rkt 
 
 Now, any traffic arriving on host's TCP port 8888 will be forwarded to the pod on port 80.
 
+### Network used for forwarded ports
+
+The network that will be chosen for the port forwarding depends on the _ipMasq_ setting of the configured networks.
+If at least one of them has _ipMasq_ enabled, the forwarded traffic will be passed through the first loaded network that has IP masquerading enabled.
+If no network is masqueraded, the last loaded network will be used.
+As a reminder, the sort order of the loaded networks is detailed in the chapter about [setting up additional networks](#setting-up-additional-networks).
+
+### Socket Activation
 rkt also supports socket activation.
 This is documented in [Socket-activated service](../using-rkt-with-systemd.md#socket-activated-service).
 

--- a/networking/kvm.go
+++ b/networking/kvm.go
@@ -552,7 +552,11 @@ func kvmSetup(podRoot string, podID types.UUID, fps []ForwardedPort, netList com
 		}
 		network.nets[i] = n
 	}
-	err := network.forwardPorts(fps, network.GetDefaultIP())
+	defaultIP, err := network.GetDefaultIP()
+	if err != nil {
+		return nil, err
+	}
+	err = network.forwardPorts(fps, defaultIP)
 	if err != nil {
 		return nil, err
 	}

--- a/networking/kvm.go
+++ b/networking/kvm.go
@@ -552,12 +552,11 @@ func kvmSetup(podRoot string, podID types.UUID, fps []ForwardedPort, netList com
 		}
 		network.nets[i] = n
 	}
-	defaultIP, err := network.GetDefaultIP()
+	podIP, err := network.GetForwardableNetPodIP()
 	if err != nil {
 		return nil, err
 	}
-	err = network.forwardPorts(fps, defaultIP)
-	if err != nil {
+	if err := network.forwardPorts(fps, podIP); err != nil {
 		return nil, err
 	}
 

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -532,7 +532,7 @@ func stage1() int {
 		}
 
 		if len(mdsToken) > 0 {
-			hostIP, err := n.GetDefaultHostIP()
+			hostIP, err := n.GetForwardableNetHostIP()
 			if err != nil {
 				log.PrintE("failed to get default Host IP", err)
 				return 1

--- a/tests/rkt_net_kvm_test.go
+++ b/tests/rkt_net_kvm_test.go
@@ -18,9 +18,9 @@ package main
 
 import "testing"
 
-func TestNetDefaultPortFwdConnectivity(t *testing.T) {
-	NewNetDefaultPortFwdConnectivityTest(
-		PortFwdCase{"172.16.28.1", "--net=default", true},
+func TestNetPortFwdConnectivity(t *testing.T) {
+	NewNetPortFwdConnectivityTest(
+		defaultSamePortFwdCase,
 	).Execute(t)
 }
 

--- a/tests/rkt_net_nspawn_test.go
+++ b/tests/rkt_net_nspawn_test.go
@@ -26,10 +26,16 @@ func TestNetHostConnectivity(t *testing.T) {
 	NewNetHostConnectivityTest().Execute(t)
 }
 
-func TestNetDefaultPortFwdConnectivity(t *testing.T) {
-	NewNetDefaultPortFwdConnectivityTest(
-		PortFwdCase{"172.16.28.1", "--net=default", true},
-		PortFwdCase{"127.0.0.1", "--net=default", true},
+func TestNetPortFwdConnectivity(t *testing.T) {
+	NewNetPortFwdConnectivityTest(
+		defaultSamePortFwdCase,
+		defaultDiffPortFwdCase,
+		defaultLoSamePortFwdCase,
+		defaultLoDiffPortFwdCase,
+		bridgeSamePortFwdCase,
+		bridgeDiffPortFwdCase,
+		bridgeLoSamePortFwdCase,
+		bridgeLoDiffPortFwdCase,
 	).Execute(t)
 }
 


### PR DESCRIPTION
This PR fixes port forwarding functionality when a pod is run with custom ipMasq'ed CNI networks.
It also fixes #2283: port forwarding where hostPort and podPort are different

---
Post-Merge Checklist
- [ ] Create ticket for KVM to implement the extended port forwarding features