### PR TITLE
store: fix multi process with multi goroutines race on db.

### DIFF
--- a/store/db_test.go
+++ b/store/db_test.go
@@ -78,6 +78,9 @@ func createTable(db *DB, t *testing.T) {
 }
 
 func TestDBRace(t *testing.T) {
+	// TODO(sgotti) this will not find concurrenct accesses to ql db from
+	// multiple processes using multiple goroutines. A test that spawns at
+	// least two processes using multiple goroutines is needed.
 	oldGoMaxProcs := runtime.GOMAXPROCS(runtime.NumCPU())
 	defer runtime.GOMAXPROCS(oldGoMaxProcs)
 


### PR DESCRIPTION
When there are multiple OS processes concurrently accessing the ql
db and at least one of them has multiple goroutines using a shared store
instance the internal ql (camlistore based) locking error: `cannot
acquire lock: resource temporarily unavailable` can be triggered.

For example:

Process A, goroutine 1: takes the the flock, then takes the lock on the mutex, and does db.Open
Process A, goroutine 2: takes the flock, blocks on the lock on the mutex
Process A, goroutine 1: does something on db, calls db.Close, unlocks the flock, release the lock on the mutex
Process A, goroutine 2: takes the lock on the mutex, but now it has the flock UNLOCKED
Process B, goroutine 1: take the lock on the flock and then takes lock on the mutex (since it's another process): the ql internal camlistore lock will fail.

In the code there's already a locking made by a mutex, but looks like it
was put just there to make the go race detector happy and the
lock/unlock order is wrong. Instead this is really needed.

This patch fixes the lock/unlock order.

A future test to really test this problem will need to spawn two
processes with one at least using multiple goroutines using the same
store instance.

Here an example repro:

```
package main

import (
        "fmt"
        "os"

        "github.com/coreos/rkt/store"
)

func main() {
        s, err := store.NewStore("/tmp/test/rkt")
        if err != nil {
                fmt.Printf("cannot open store: %v", err)
                os.Exit(1)
        }

        runs := 10000
        for i := 0; i < runs; i++ {
                go func() {
                        _, err = s.GetAllACIInfos(nil, false)
                        if err != nil {
                                fmt.Printf("cannot query db: %v", err)
                                os.Exit(1)
                        }
                }()
        }

        s.Close()
}

```

compile and execute the above command with something like:

```
#!/bin/bash
while true; do
        for i in $(seq 0 2); do
                ./test01 &
        done
        wait
done
```

Should fix #2374 