### PR TITLE
doc: stage1-implementors-guide.md: clarify pid vs ppid

### DIFF
--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -50,10 +50,10 @@ An alternative stage 1 could forego systemd-nspawn and systemd altogether, or re
 All that is required is an executable at the place indicated by the `coreos.com/rkt/stage1/run` entrypoint that knows how to apply the pod manifest and prepared ACI file-systems to good effect.
 
 The resolved entrypoint must inform rkt of its PID for the benefit of `rkt enter`.
-Stage 1 must write the host PIDs of the pod's process #1 and that process's parent to these two files, respectively:
+Stage 1 implementors have two options for doing so; only one must be implemented:
 
-* `/var/lib/rkt/pods/run/$uuid/pid`: the PID of the process that is PID 1 in the container.
-* `/var/lib/rkt/pods/run/$uuid/ppid`: the PID of the parent of the process that is PID 1 in the container.
+* `/var/lib/rkt/pods/run/$uuid/pid`: the PID of the process that will be given to the "enter" entrypoint.
+* `/var/lib/rkt/pods/run/$uuid/ppid`: the PID of the parent of the process that will be given to the "enter" entrypoint. That parent process must have exactly one child process.
 
 #### Arguments
 

--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -909,8 +909,9 @@ func (p *pod) getPID() (int, error) {
 
 // getContainerPID1 returns the pid of the process with pid 1 in the pod.
 func (p *pod) getContainerPID1() (pid int, err error) {
-	// rkt supports two methods to find the container's PID 1:
-	// the pid file and the ppid file.
+	// rkt supports two methods to find the container's PID 1: the pid
+	// file and the ppid file.
+	// The ordering is not important and only one of them must be supplied.
 	// See Documentation/devel/stage1-implementors-guide.md
 	for {
 		var ppid int


### PR DESCRIPTION
Clarify that only one file must be written among pid / ppid.

Reword the description. With the kvm flavor, the pid 1 of the container
was not visible on the host. The new wording does not make that
assumption.

/cc @jellonek @jonboulle @s-urbaniak PTAL

Related to: https://github.com/coreos/rkt/issues/2389 