### PR TITLE
rkt/image: render images on fetch

### DIFF
--- a/rkt/image/fetcher.go
+++ b/rkt/image/fetcher.go
@@ -16,10 +16,12 @@ package image
 
 import (
 	"container/list"
+	"errors"
 	"fmt"
 	"net/url"
 	"runtime"
 
+	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/common/apps"
 	"github.com/coreos/rkt/stage0"
 	"github.com/coreos/rkt/store"
@@ -48,6 +50,11 @@ func (f *Fetcher) FetchImage(img string, ascPath string, imgType apps.AppImageTy
 		err = f.fetchImageDeps(hash)
 		if err != nil {
 			return "", err
+		}
+	}
+	if common.SupportsOverlay() {
+		if _, _, err := f.S.RenderTreeStore(hash, false); err != nil {
+			return "", errwrap.Wrap(errors.New("error rendering tree store"), err)
 		}
 	}
 	return hash, nil


### PR DESCRIPTION
rkt was delaying rendering images to the tree store until they were
about to run for the first time which caused that first run to be slow
for big images.

This commit renders the image to the tree store at fetch time.

If the system doesn't support overlayfs, we don't render it because we
don't use the tree store when overlayfs is not used.

Startup time benchmark:

rkt run a Docker nginx image, pre-fetched. Size = 188MiB when unextracted
The insecure option `ondisk` was used.

command | time (rkt master) | time (rkt master + https://github.com/coreos/rkt/pull/2398)
--------|-------------------|---------------------------
1st time run | real 0m4.964s, user 0m3.570s, sys 0m0.813s | real 0m0.333s, user 0m0.097s, sys 0m0.050s
2nd time run | real 0m0.350s, user 0m0.063s, sys 0m0.077s | real 0m0.343s, user 0m0.073s, sys 0m0.070s

Fixes #2388 