### PR TITLE
gc: Add flag 'mark-only' to mark garbage pods without deleting them.

### DIFF
--- a/Documentation/subcommands/gc.md
+++ b/Documentation/subcommands/gc.md
@@ -29,6 +29,7 @@ Garbage collecting pod "f07a4070-79a9-4db0-ae65-a090c9c393a3"
 | --- | --- | --- | --- |
 | `--expire-prepared` |  `24h0m0s` | A time | Duration to wait before expiring prepared pods |
 | `--grace-period` |  `30m0s` | A time | Duration to wait before discarding inactive pods from garbage |
+| `--mark-only` | `false` | If set to true, then the exited/aborted pods will be moved to the garbage directories without actually deleting them, this is useful for marking the exit time of a pod |
 
 ## Global options
 

--- a/tests/rkt_gc_test.go
+++ b/tests/rkt_gc_test.go
@@ -1,0 +1,74 @@
+// Copyright 2015 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+func TestGC(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	// Finished pods.
+	patchImportAndRun("inspect-gc-test-run.aci", []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=0"}, t, ctx)
+
+	// Prepared pods.
+	patchImportAndPrepare("inspect-gc-test-prepare.aci", []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=0"}, t, ctx)
+
+	// Abort prepare.
+	imagePath := patchTestACI("inspect-gc-test-abort.aci", []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=0"}...)
+	defer os.Remove(imagePath)
+	cmd := fmt.Sprintf("%s --insecure-options=image prepare %s %s", ctx.Cmd(), imagePath, imagePath)
+	spawnAndWaitOrFail(t, cmd, 1)
+
+	gcCmd := fmt.Sprintf("%s gc --mark-only=true --expire-prepared=0 --grace-period=0", ctx.Cmd())
+	spawnAndWaitOrFail(t, gcCmd, 0)
+
+	gcDirs := []string{
+		filepath.Join(ctx.DataDir(), "pods", "exited-garbage"),
+		filepath.Join(ctx.DataDir(), "pods", "prepared"),
+		filepath.Join(ctx.DataDir(), "pods", "garbage"),
+	}
+
+	for _, dir := range gcDirs {
+		pods, err := ioutil.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("cannot read gc directory %q: %v", dir, err)
+		}
+		if len(pods) == 0 {
+			t.Fatalf("pods should still exist in directory %q", dir)
+		}
+	}
+
+	gcCmd = fmt.Sprintf("%s gc --mark-only=false --expire-prepared=0 --grace-period=0", ctx.Cmd())
+	spawnAndWaitOrFail(t, gcCmd, 0)
+
+	for _, dir := range gcDirs {
+		pods, err := ioutil.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("cannot read gc directory %q: %v", dir, err)
+		}
+		if len(pods) != 0 {
+			t.Fatalf("no pods should exist in directory %q, but found: %v", dir, pods)
+		}
+	}
+}

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -238,6 +238,14 @@ func patchImportAndRun(image string, patches []string, t *testing.T, ctx *testut
 	spawnAndWaitOrFail(t, cmd, 0)
 }
 
+func patchImportAndPrepare(image string, patches []string, t *testing.T, ctx *testutils.RktRunCtx) {
+	imagePath := patchTestACI(image, patches...)
+	defer os.Remove(imagePath)
+
+	cmd := fmt.Sprintf("%s --insecure-options=image prepare %s", ctx.Cmd(), imagePath)
+	spawnAndWaitOrFail(t, cmd, 0)
+}
+
 func runGC(t *testing.T, ctx *testutils.RktRunCtx) {
 	cmd := fmt.Sprintf("%s gc --grace-period=0s", ctx.Cmd())
 	spawnAndWaitOrFail(t, cmd, 0)


### PR DESCRIPTION
If this flag is set to true, then we move the exited/aborted pods
to exited-garbage/garbage directory, but do not deleting them.
    
For prepared pods, if the flag is true, we don't move them to garbage
even the pods are expired.
    
A third party application can use 'rkt gc --mark-only=true' to
marks the time when the pods is not running.

Follows https://github.com/coreos/rkt/issues/1789#issuecomment-207111814

Next, will need `rkt list/status` and `rkt api-service` to return the timestamp.

cc @alban @jonboulle @iaguis @sjpotter @euank 