### PR TITLE
config: add config subcommand

### DIFF
--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -63,6 +63,7 @@ The API service allows clients to list and inspect pods and images running under
 ## Misc
 
 * [version](subcommands/version.md)
+* [config](subcommands/config.md)
 
 ## Global Options
 

--- a/Documentation/subcommands/config.md
+++ b/Documentation/subcommands/config.md
@@ -1,0 +1,125 @@
+# rkt config
+
+The `config` subcommand prints the configuration of each rkt stage in JSON on the standard output.
+
+## Structure
+
+The general structure is a simple hierarchy consisting of the following top-level element:
+
+```
+{
+	"stage0": [...]
+}
+```
+
+The entry "stage0" refers to stage-specific configuration; "stage1" is currently left out intentionally because its configuration subsystem is subject to change. The generated output are valid configuration entries as specified in the configuration documentation.
+
+The "stage0" entry contains subentries of rktKind "auth", "dockerAuth", "paths", and "stage1". Note that the `config` subcommand will output separate entries per "auth" domain and separate entries per "dockerAuth" registry. While it is possible to specify an array of strings in the input configuration rkt internally merges configuration state from different directories potentially creating multiple entries.
+
+Consider the following system configuration:
+```
+$ cat /etc/rkt/auth.d/basic.json
+{
+  "rktKind": "auth",
+  "rktVersion": "v1",
+  "domains": [
+    "foo.com",
+    "bar.com",
+    "baz.com"
+  ],
+  "type": "basic",
+  "credentials": { "user": "sysUser", "password": "sysPassword" }
+}
+```
+
+And the following user configuration:
+```
+$ ~/.config/rkt/auth.d/basic.json
+{
+  "rktKind": "auth",
+  "rktVersion": "v1",
+  "domains": [
+    "foo.com"
+  ],
+  "type": "basic",
+  "credentials": { "user": "user", "password": "password" }
+}
+```
+
+The `config` subcommand would generate the following separate merged entries:
+```
+{
+  "stage0": [
+    {
+      "rktVersion": "v1",
+      "rktKind": "auth",
+      "domains": [ "bar.com" ],
+      "type": "basic",
+      "credentials": { "user": "sysUser", "password": "sysPassword" }
+    },
+    {
+      "rktVersion": "v1",
+      "rktKind": "auth",
+      "domains": [ "baz.com" ],
+      "type": "basic",
+      "credentials": { "user": "sysUser", "password": "sysPassword" }
+    },
+    {
+      "rktVersion": "v1",
+      "rktKind": "auth",
+      "domains": [ "foo.com" ],
+      "type": "basic",
+      "credentials": { "user": "user", "password": "password" }
+    }
+  ]
+}
+```
+
+In the example given above the user configuration entry for the domain "foo.com" overrides the system configuration entry leaving the entries "bar.com" and "baz.com" unchanged. The `config` subcommand output creates three separate entries for "foo.com", "bar.com", and "baz.com".
+
+Note: While the "bar.com", and "baz.com" entries in the example given above could be merged into one entry they are still being printed separate. This behavior is subject to change, future implementations may provide a merged output.
+
+## Example
+
+```
+$ rkt config
+{
+  "stage0": [
+    {
+      "rktVersion": "v1",
+      "rktKind": "auth",
+      "domains": [
+        "bar.com"
+      ],
+      "type": "oauth",
+      "credentials": {
+        "token": "someToken"
+      }
+    },
+    {
+      "rktVersion": "v1",
+      "rktKind": "auth",
+      "domains": [
+        "foo.com"
+      ],
+      "type": "basic",
+      "credentials": {
+        "user": "user",
+        "password": "userPassword"
+      }
+    },
+    {
+      "rktVersion": "v1",
+      "rktKind": "paths",
+      "data": "/var/lib/rkt",
+      "stage1-images": "/usr/lib/rkt"
+    },
+    {
+      "rktVersion": "v1",
+      "rktKind": "stage1",
+      "name": "coreos.com/rkt/stage1-coreos",
+      "version": "0.15.0+git",
+      "location": "/usr/libexec/rkt/stage1-coreos.aci"
+    }
+  ]
+}

--- a/rkt/config.go
+++ b/rkt/config.go
@@ -1,0 +1,51 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdConfig = &cobra.Command{
+		Use:   "config",
+		Short: "Print configuration for each stage in JSON format",
+		Long: `The output will be parsable JSON with "stage0" and stage1" as keys and rkt configuration entries as values.
+The generated configuration entries resemble the original rkt configuration format.`,
+		Run: runWrapper(runConfig),
+	}
+)
+
+func init() {
+	cmdRkt.AddCommand(cmdConfig)
+}
+
+func runConfig(cmd *cobra.Command, args []string) int {
+	config, err := getConfig()
+	if err != nil {
+		stderr.PrintE("cannot get configuration", err)
+		return 1
+	}
+
+	b, err := json.Marshal(config)
+	if err != nil {
+		stderr.PanicE("error marshaling configuration", err)
+	}
+
+	stdout.Print(string(b))
+	return 0
+}

--- a/rkt/config/auth.go
+++ b/rkt/config/auth.go
@@ -56,13 +56,12 @@ func init() {
 }
 
 type basicAuthHeaderer struct {
-	user     string
-	password string
+	auth basicV1
 }
 
 func (h *basicAuthHeaderer) Header() http.Header {
 	headers := make(http.Header)
-	creds := []byte(fmt.Sprintf("%s:%s", h.user, h.password))
+	creds := []byte(fmt.Sprintf("%s:%s", h.auth.User, h.auth.Password))
 	encodedCreds := base64.StdEncoding.EncodeToString(creds)
 	headers.Add(authHeader, "Basic "+encodedCreds)
 
@@ -70,12 +69,12 @@ func (h *basicAuthHeaderer) Header() http.Header {
 }
 
 type oAuthBearerTokenHeaderer struct {
-	token string
+	auth oauthV1
 }
 
 func (h *oAuthBearerTokenHeaderer) Header() http.Header {
 	headers := make(http.Header)
-	headers.Add(authHeader, "Bearer "+h.token)
+	headers.Add(authHeader, "Bearer "+h.auth.Token)
 
 	return headers
 }
@@ -124,8 +123,7 @@ func (p *authV1JsonParser) getBasicV1Headerer(raw json.RawMessage) (Headerer, er
 		return nil, err
 	}
 	return &basicAuthHeaderer{
-		user:     basic.User,
-		password: basic.Password,
+		auth: basic,
 	}, nil
 }
 
@@ -138,7 +136,7 @@ func (p *authV1JsonParser) getOAuthV1Headerer(raw json.RawMessage) (Headerer, er
 		return nil, fmt.Errorf("no oauth bearer token specified")
 	}
 	return &oAuthBearerTokenHeaderer{
-		token: oauth.Token,
+		auth: oauth,
 	}, nil
 }
 

--- a/rkt/config/config.go
+++ b/rkt/config/config.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -37,8 +38,8 @@ type Headerer interface {
 // BasicCredentials holds typical credentials used for authentication
 // (user and password). Used for fetching docker images.
 type BasicCredentials struct {
-	User     string
-	Password string
+	User     string `json:"user"`
+	Password string `json:"password"`
 }
 
 // ConfigurablePaths holds various paths defined in the configuration.
@@ -62,6 +63,90 @@ type Config struct {
 	DockerCredentialsPerRegistry map[string]BasicCredentials
 	Paths                        ConfigurablePaths
 	Stage1                       Stage1Data
+}
+
+// MarshalJSON marshals the config for user output.
+func (c *Config) MarshalJSON() ([]byte, error) {
+	stage0 := []interface{}{}
+
+	for host, auth := range c.AuthPerHost {
+		var typ string
+		var credentials interface{}
+
+		switch h := auth.(type) {
+		case *basicAuthHeaderer:
+			typ = "basic"
+			credentials = h.auth
+		case *oAuthBearerTokenHeaderer:
+			typ = "oauth"
+			credentials = h.auth
+		default:
+			return nil, errors.New("unknown headerer type")
+		}
+
+		auth := struct {
+			RktVersion  string      `json:"rktVersion"`
+			RktKind     string      `json:"rktKind"`
+			Domains     []string    `json:"domains"`
+			Type        string      `json:"type"`
+			Credentials interface{} `json:"credentials"`
+		}{
+			RktVersion:  "v1",
+			RktKind:     "auth",
+			Domains:     []string{host},
+			Type:        typ,
+			Credentials: credentials,
+		}
+
+		stage0 = append(stage0, auth)
+	}
+
+	for registry, credentials := range c.DockerCredentialsPerRegistry {
+		dockerAuth := struct {
+			RktVersion  string           `json:"rktVersion"`
+			RktKind     string           `json:"rktKind"`
+			Registries  []string         `json:"registries"`
+			Credentials BasicCredentials `json:"credentials"`
+		}{
+			RktVersion:  "v1",
+			RktKind:     "dockerAuth",
+			Registries:  []string{registry},
+			Credentials: credentials,
+		}
+
+		stage0 = append(stage0, dockerAuth)
+	}
+
+	paths := struct {
+		RktVersion   string `json:"rktVersion"`
+		RktKind      string `json:"rktKind"`
+		Data         string `json:"data"`
+		Stage1Images string `json:"stage1-images"`
+	}{
+		RktVersion:   "v1",
+		RktKind:      "paths",
+		Data:         c.Paths.DataDir,
+		Stage1Images: c.Paths.Stage1ImagesDir,
+	}
+
+	stage1 := struct {
+		RktVersion string `json:"rktVersion"`
+		RktKind    string `json:"rktKind"`
+		Name       string `json:"name"`
+		Version    string `json:"version"`
+		Location   string `json:"location"`
+	}{
+		RktVersion: "v1",
+		RktKind:    "stage1",
+		Name:       c.Stage1.Name,
+		Version:    c.Stage1.Version,
+		Location:   c.Stage1.Location,
+	}
+
+	stage0 = append(stage0, paths, stage1)
+
+	data := map[string]interface{}{"stage0": stage0}
+	return json.Marshal(data)
 }
 
 type configParser interface {

--- a/rkt/config/config_test.go
+++ b/rkt/config/config_test.go
@@ -85,6 +85,10 @@ func TestAuthConfigFormat(t *testing.T) {
 				t.Error("Got unexpected results\nResult:\n", result, "\n\nExpected:\n", tt.expected)
 			}
 		}
+
+		if _, err := json.Marshal(cfg); err != nil {
+			t.Errorf("error marshaling config %v", err)
+		}
 	}
 }
 
@@ -117,6 +121,10 @@ func TestDockerAuthConfigFormat(t *testing.T) {
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Error("Got unexpected results\nResult:\n", result, "\n\nExpected:\n", tt.expected)
 			}
+		}
+
+		if _, err := json.Marshal(cfg); err != nil {
+			t.Errorf("error marshaling config %v", err)
 		}
 	}
 }


### PR DESCRIPTION
This command adds the config subcommand.

TODOs:
- [x] ~~add `paths` entries~~ (removed)
- [x] add `stage0` `auth` entries
- [x] add `stage0` `paths` entries
- [x] add `stage1` entries (currently only one)
- [x] add unit tests

Fixes #2368