### PR TITLE
stage1/init: fix docker volume semantics

### DIFF
--- a/stage1/init/common/mount.go
+++ b/stage1/init/common/mount.go
@@ -56,8 +56,8 @@ func IsMountReadOnly(vol types.Volume, mountPoints []types.MountPoint) bool {
 	return isMPReadOnly(mountPoints, vol.Name)
 }
 
-func convertedFromDocker(ra *schema.RuntimeApp) bool {
-	ann := ra.Annotations
+func convertedFromDocker(im *schema.ImageManifest) bool {
+	ann := im.Annotations
 	_, ok := ann.Get("appc.io/docker/repository")
 	return ok
 }
@@ -65,7 +65,7 @@ func convertedFromDocker(ra *schema.RuntimeApp) bool {
 // GenerateMounts maps MountPoint paths to volumes, returning a list of mounts,
 // each with a parameter indicating if it's an implicit empty volume from a
 // Docker image.
-func GenerateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume) []mountWrapper {
+func GenerateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume, imageManifest *schema.ImageManifest) []mountWrapper {
 	app := ra.App
 
 	var genMnts []mountWrapper
@@ -101,7 +101,7 @@ func GenerateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume
 				GID:  &defaultGID,
 			}
 
-			dockerImplicit := convertedFromDocker(ra)
+			dockerImplicit := convertedFromDocker(imageManifest)
 			log.Printf("warning: no volume specified for mount point %q, implicitly creating an \"empty\" volume. This volume will be removed when the pod is garbage-collected.", mp.Name)
 			if dockerImplicit {
 				log.Printf("Docker converted image, initializing implicit volume with data contained at the mount point %q.", mp.Name)

--- a/stage1/init/common/mount.go
+++ b/stage1/init/common/mount.go
@@ -162,11 +162,10 @@ func PrepareMountpoints(volPath string, targetPath string, vol *types.Volume, do
 				return errwrap.Wrap(fmt.Errorf("error copying image files to empty volume %q", volPath), err)
 			}
 		}
-	} else {
-		if err := os.MkdirAll(volPath, 0770); err != nil {
-			return errwrap.Wrap(fmt.Errorf("error creating %q", volPath), err)
-		}
+	}
 
+	if err := os.MkdirAll(volPath, 0770); err != nil {
+		return errwrap.Wrap(fmt.Errorf("error creating %q", volPath), err)
 	}
 	if err := os.Chown(volPath, Uid, Gid); err != nil {
 		return errwrap.Wrap(fmt.Errorf("could not change owner of %q", volPath), err)

--- a/stage1/init/common/pod.go
+++ b/stage1/init/common/pod.go
@@ -629,7 +629,8 @@ func appToNspawnArgs(p *stage1commontypes.Pod, ra *schema.RuntimeApp) ([]string,
 		vols[v.Name] = v
 	}
 
-	mounts := GenerateMounts(ra, vols)
+	imageManifest := p.Images[appName.String()]
+	mounts := GenerateMounts(ra, vols, imageManifest)
 	for _, m := range mounts {
 		vol := vols[m.Volume]
 

--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -41,23 +41,6 @@ func stringP(s string) *string {
 	return &s
 }
 
-func generatePodManifestFile(t *testing.T, manifest *schema.PodManifest) string {
-	tmpDir := testutils.GetValueFromEnvOrPanic("FUNCTIONAL_TMP")
-	f, err := ioutil.TempFile(tmpDir, "rkt-test-manifest-")
-	if err != nil {
-		t.Fatalf("Cannot create tmp pod manifest: %v", err)
-	}
-
-	data, err := json.Marshal(manifest)
-	if err != nil {
-		t.Fatalf("Cannot marshal pod manifest: %v", err)
-	}
-	if err := ioutil.WriteFile(f.Name(), data, 0600); err != nil {
-		t.Fatalf("Cannot write pod manifest file: %v", err)
-	}
-	return f.Name()
-}
-
 func verifyHostFile(t *testing.T, tmpdir, filename string, i int, expectedResult string) {
 	filePath := path.Join(tmpdir, filename)
 	defer os.Remove(filePath)

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -679,6 +679,23 @@ func runRktTrust(t *testing.T, ctx *testutils.RktRunCtx, prefix string, keyIndex
 	}
 }
 
+func generatePodManifestFile(t *testing.T, manifest *schema.PodManifest) string {
+	tmpDir := testutils.GetValueFromEnvOrPanic("FUNCTIONAL_TMP")
+	f, err := ioutil.TempFile(tmpDir, "rkt-test-manifest-")
+	if err != nil {
+		t.Fatalf("Cannot create tmp pod manifest: %v", err)
+	}
+
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("Cannot marshal pod manifest: %v", err)
+	}
+	if err := ioutil.WriteFile(f.Name(), data, 0600); err != nil {
+		t.Fatalf("Cannot write pod manifest file: %v", err)
+	}
+	return f.Name()
+}
+
 func checkUserNS() error {
 	// CentOS 7 pretends to support user namespaces, but does not.
 	// See https://bugzilla.redhat.com/show_bug.cgi?id=1168776#c5

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -169,8 +169,8 @@ func TestDockerVolumeSemantics(t *testing.T) {
 	defer ctx.Cleanup()
 
 	var dockerVolImage []string
-	for _, tt := range volDockerTests {
-		img := patchTestACI("rkt-volume-image.aci", fmt.Sprintf("--mounts=mydir,path=%s,readOnly=false", tt.dir))
+	for i, tt := range volDockerTests {
+		img := patchTestACI(fmt.Sprintf("rkt-volume-image-%d.aci", i), fmt.Sprintf("--mounts=mydir,path=%s,readOnly=false", tt.dir))
 		defer os.Remove(img)
 		dockerVolImage = append(dockerVolImage, img)
 	}


### PR DESCRIPTION
To detect if we're running an image that was converted from docker, we
were getting annotations from the RuntimeApp. This doesn't work for the
case where the user runs rkt directly with a pod manifest, since they
can omit the annotations there.

Instead, use the ImageManifest, which is the right place to look for
annotations.

Also, fix a bug in the tests introduced by https://github.com/coreos/rkt/pull/2394 and another bug when the image is converted from docker, has a mountpoint, but the mountpoint directory is not actually included in the image. 