### PR TITLE
run: add user/group app flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### New features and UX changes
 
+- Add `--user`/`--group` option to rkt run/prepare ([#2419](https://github.com/coreos/rkt/pull/2419)). This option allows overriding the user/group specified in the image manifest.
+
 - Ensure that the initial name and labels used for discovery match the name and labels in the Image Manifest as specified in the appc spec ([#2311](https://github.com/coreos/rkt/pull/2311)). Users wanting the latest image should use `rkt prepare/run/fetch example.com/aci` without any labels. If the discovery server supports the "latest" pattern, the user can bypass a locally cached image in the store and fetch an updated image using `rkt prepare/run/fetch --no-store example.com/aci` option.
 
 #### Note for packagers

--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -52,6 +52,8 @@ c9fad0e6-8236-4fc2-ad17-55d0a4c7d742
 | `--stage1-from-dir` |  `` | A stage1 image file inside the default stage1 images directory | Image to use as stage1 |
 | `--store-only` |  `false` | `true` or `false` | Use only available images in the store (do not discover or download from remote URLs). See [image fetching behavior](../image-fetching-behavior.md) |
 | `--volume` |  `` | Volume syntax (`NAME,kind=KIND,source=PATH,readOnly=BOOL`). See [Mount Volumes into a Pod](run.md#mount-volumes-into-a-pod) | Volumes to make available in the pod |
+| `--user` | none | username or UID | user override for the preceding image (example: '--user=user') |
+| `--group` | none | group or GID | group override for the preceding image (example: '--group=group') |
 
 ## Global options
 

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -44,6 +44,14 @@ In the following example, the CPU isolator is defined to 750 milli-cores and the
 # rkt run coreos.com/etcd:v2.0.0 --cpu=750m --memory=128M
 ```
 
+## Overriding User/Group
+
+Application images must specify the username/group or the UID/GID the app is to be run as as specified in the [Image Manifest Schema](https://github.com/appc/spec/blob/master/spec/aci.md#image-manifest-schema). The user/group can be overridden by rkt using the `--user` and `--group` flags:
+
+```
+# rkt --insecure-options=image run docker://busybox --user=1000 --group=100 --exec id
+```
+
 ## Passing Arguments
 
 To pass additional arguments to images use the pattern of `image1 -- [image1 flags] --- image2 -- [image2 flags]`.

--- a/common/apps/apps.go
+++ b/common/apps/apps.go
@@ -46,6 +46,7 @@ type App struct {
 	Mounts      []schema.Mount        // mounts for this app (superseding any mounts in rktApps.mounts of same MountPoint)
 	MemoryLimit *types.ResourceMemory // memory isolator override
 	CPULimit    *types.ResourceCPU    // cpu isolator override
+	User, Group string                // user, group overrides
 
 	// TODO(jonboulle): These images are partially-populated hashes, this should be clarified.
 	ImageID types.Hash // resolved image identifier

--- a/rkt/cli_apps.go
+++ b/rkt/cli_apps.go
@@ -305,3 +305,51 @@ func (aml *appCPULimit) String() string {
 func (aml *appCPULimit) Type() string {
 	return "appCPULimit"
 }
+
+// appUser is for --user flags in the form of: --user=user
+type appUser apps.Apps
+
+func (au *appUser) Set(s string) error {
+	app := (*apps.Apps)(au).Last()
+	if app == nil {
+		return fmt.Errorf("--user must follow an image")
+	}
+	app.User = s
+	return nil
+}
+
+func (au *appUser) String() string {
+	app := (*apps.Apps)(au).Last()
+	if app == nil {
+		return ""
+	}
+	return app.User
+}
+
+func (au *appUser) Type() string {
+	return "appUser"
+}
+
+// appGroup is for --group flags in the form of: --group=group
+type appGroup apps.Apps
+
+func (ag *appGroup) Set(s string) error {
+	app := (*apps.Apps)(ag).Last()
+	if app == nil {
+		return fmt.Errorf("--group must follow an image")
+	}
+	app.Group = s
+	return nil
+}
+
+func (ag *appGroup) String() string {
+	app := (*apps.Apps)(ag).Last()
+	if app == nil {
+		return ""
+	}
+	return app.Group
+}
+
+func (ag *appGroup) Type() string {
+	return "appGroup"
+}

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -69,6 +69,8 @@ func init() {
 	cmdPrepare.Flags().Var((*appExec)(&rktApps), "exec", "override the exec command for the preceding image")
 	cmdPrepare.Flags().Var((*appMount)(&rktApps), "mount", "mount point binding a volume to a path within an app")
 	cmdPrepare.Flags().Var((*appAsc)(&rktApps), "signature", "local signature file to use in validating the preceding image")
+	cmdPrepare.Flags().Var((*appUser)(&rktApps), "user", "user override for the preceding image (example: '--user=user')")
+	cmdPrepare.Flags().Var((*appGroup)(&rktApps), "group", "group override for the preceding image (example: '--group=group')")
 
 	// Disable interspersed flags to stop parsing after the first non flag
 	// argument. This is need to permit to correctly handle

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -99,6 +99,8 @@ func init() {
 	cmdRun.Flags().Var((*appMount)(&rktApps), "mount", "mount point binding a volume to a path within an app")
 	cmdRun.Flags().Var((*appMemoryLimit)(&rktApps), "memory", "memory limit for the preceding image (example: '--memory=16Mi', '--memory=50M', '--memory=1G')")
 	cmdRun.Flags().Var((*appCPULimit)(&rktApps), "cpu", "cpu limit for the preceding image (example: '--cpu=500m')")
+	cmdRun.Flags().Var((*appUser)(&rktApps), "user", "user override for the preceding image (example: '--user=user')")
+	cmdRun.Flags().Var((*appGroup)(&rktApps), "group", "group override for the preceding image (example: '--group=group')")
 
 	flagPorts = portList{}
 	flagDNS = flagStringList{}

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -248,6 +248,14 @@ func generatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
 			ra.App.Isolators = append(ra.App.Isolators, isolator)
 		}
 
+		if user := app.User; user != "" {
+			ra.App.User = user
+		}
+
+		if group := app.Group; group != "" {
+			ra.App.Group = group
+		}
+
 		if cfg.InheritEnv || len(cfg.ExplicitEnv) > 0 {
 			MergeEnvs(&ra.App.Environment, cfg.InheritEnv, cfg.ExplicitEnv)
 		}

--- a/tests/rkt_run_user_group_test.go
+++ b/tests/rkt_run_user_group_test.go
@@ -1,0 +1,109 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+func TestAppUserGroup(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	imageDummy := patchTestACI("rkt-inspect-dummy.aci", "--name=dummy")
+	defer os.Remove(imageDummy)
+
+	for _, tt := range []struct {
+		imageParams []string
+		rktParams   string
+		expected    string
+	}{
+		{
+			expected: "User: uid=0 euid=0 gid=0 egid=0",
+		},
+		{
+			rktParams: "--user=200",
+			expected:  "User: uid=200 euid=200 gid=0 egid=0",
+		},
+		{
+			rktParams: "--group=300",
+			expected:  "User: uid=0 euid=0 gid=300 egid=300",
+		},
+		{
+			rktParams: "--user=200 --group=300",
+			expected:  "User: uid=200 euid=200 gid=300 egid=300",
+		},
+		{
+			rktParams: "--user=user1 --group=300",
+			expected:  "User: uid=1000 euid=1000 gid=300 egid=300",
+		},
+		{
+			rktParams: "--user=200 --group=group1",
+			expected:  "User: uid=200 euid=200 gid=100 egid=100",
+		},
+		{
+			imageParams: []string{"--user=400", "--group=500"},
+			expected:    "User: uid=400 euid=400 gid=500 egid=500",
+		},
+		{
+			imageParams: []string{"--user=400", "--group=500"},
+			rktParams:   "--user=200",
+			expected:    "User: uid=200 euid=200 gid=500 egid=500",
+		},
+		{
+			imageParams: []string{"--user=400", "--group=500"},
+			rktParams:   "--group=300",
+			expected:    "User: uid=400 euid=400 gid=300 egid=300",
+		},
+		{
+			imageParams: []string{"--user=400", "--group=500"},
+			rktParams:   "--user=200 --group=300",
+			expected:    "User: uid=200 euid=200 gid=300 egid=300",
+		},
+		{
+			imageParams: []string{"--user=400", "--group=500"},
+			rktParams:   "--user=user1 --group=group1",
+			expected:    "User: uid=1000 euid=1000 gid=100 egid=100",
+		},
+	} {
+		func() {
+			tt.imageParams = append(tt.imageParams, "--exec=/inspect --print-user")
+			image := patchTestACI("rkt-inspect-user-group.aci", tt.imageParams...)
+			defer os.Remove(image)
+
+			// run the user/group overriden app first
+			rktCmd := fmt.Sprintf(
+				"%s --insecure-options=image run %s %s %s",
+				ctx.Cmd(),
+				image, tt.rktParams,
+				imageDummy,
+			)
+			runRktAndCheckOutput(t, rktCmd, tt.expected, false)
+
+			// run the user/group overriden app last
+			rktCmd = fmt.Sprintf(
+				"%s --insecure-options=image run %s %s %s",
+				ctx.Cmd(),
+				imageDummy,
+				image, tt.rktParams,
+			)
+			runRktAndCheckOutput(t, rktCmd, tt.expected, false)
+		}()
+	}
+}


### PR DESCRIPTION
This adds --user and --group app flags to override the user and/or the
group for the run subcommand.

Fixes #1920