### PR TITLE
tests/net: cover too long net names

### DIFF
--- a/tests/rkt_net_test.go
+++ b/tests/rkt_net_test.go
@@ -743,3 +743,19 @@ func TestNetOverride(t *testing.T) {
 		t.Fatalf("overriding IP did not work: Got %q but expected %q", containerIP, expectedIP)
 	}
 }
+
+func TestNetLongName(t *testing.T) {
+	nt := networkTemplateT{
+		Name:   "thisnameiswaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaytoolong",
+		Type:   "ptp",
+		IpMasq: true,
+		Ipam: ipamTemplateT{
+			Type:   "host-local",
+			Subnet: "11.11.6.0/24",
+			Routes: []map[string]string{
+				{"dst": "0.0.0.0/0"},
+			},
+		},
+	}
+	testNetCustomNatConnectivity(t, nt)
+}


### PR DESCRIPTION
Closes #2314.
It should work by now (fixed in CNI) so adding a test case.