### PR TITLE
pkg/sys: add SYS_SYNCFS definition for ppc64/ppc64le

### DIFF
--- a/pkg/sys/sys_linux_ppc64.go
+++ b/pkg/sys/sys_linux_ppc64.go
@@ -1,0 +1,21 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux,ppc64
+
+package sys
+
+const (
+	SYS_SYNCFS = 348
+)

--- a/pkg/sys/sys_linux_ppc64le.go
+++ b/pkg/sys/sys_linux_ppc64le.go
@@ -1,0 +1,21 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux,ppc64le
+
+package sys
+
+const (
+	SYS_SYNCFS = 348
+)


### PR DESCRIPTION
Added missing SYS_SYNCFS definition for ppc64 and ppc64le,
fixing build failures on those architectures.

Closes: coreos/rkt#2441
Signed-off-by: Luca Bruno <lucab@debian.org>