### PR TITLE
Rename semaphore to semaphoreci

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -3,14 +3,14 @@
 This directory contains a set of functional tests for rkt.
 The tests use [gexpect](https://github.com/coreos/gexpect) to spawn various `rkt run` commands and look for expected output.
 
-## Semaphore
+## Semaphore Continuous Integration System
 
-The tests run on the [Semaphore](https://semaphoreci.com/) CI system through the [`rktbot`](https://semaphoreci.com/rktbot) user, which is part of the [`coreos`](https://semaphoreci.com/coreos/) org on Semaphore.
+The tests run on the [Semaphore CI system](https://semaphoreci.com/) through the [`rktbot`](https://semaphoreci.com/rktbot) user, which is part of the [`coreos`](https://semaphoreci.com/coreos/) org on Semaphore CI system.
 This user is authorized against the corresponding [`rktbot`](https://github.com/rktbot) GitHub account.
 The credentials for `rktbot` are currently managed by CoreOS.
 
-The tests are executed on Semaphore at each Pull Request (PR).
-Each GitHub PR page should have a link to the [test results on Semaphore](https://semaphoreci.com/coreos/rkt).
+The tests are executed on Semaphore CI system at each Pull Request (PR).
+Each GitHub PR page should have a link to the [test results on Semaphore CI](https://semaphoreci.com/coreos/rkt).
 
 Developers can disable the tests by adding `[skip ci]` in the last commit message of the PR.
 

--- a/tests/build-and-run-tests.sh
+++ b/tests/build-and-run-tests.sh
@@ -28,16 +28,16 @@ function ciSkip {
     exit 0
 }
 
-# Configure SemaphoreCI environment.
-function semaphoreConfiguration {
+# Configure Semaphore CI system environment.
+function semaphoreCIConfiguration {
     # We might not need to run functional tests or process docs.
     # This is best-effort; || true ensures this does not affect test outcome
-    # First, ensure origin is updated - semaphore can do some weird caching
+    # First, ensure origin is updated - Semaphore CI system can do some weird caching
     git fetch || true
     SRC_CHANGES=$(git diff-tree --no-commit-id --name-only -r HEAD..origin/master | grep -cEv ${DOC_CHANGE_PATTERN}) || true
     DOC_CHANGES=$(git diff-tree --no-commit-id --name-only -r HEAD..origin/master | grep -cE ${DOC_CHANGE_PATTERN}) || true
 
-    # Set up go environment on semaphore
+    # Set up go environment on Semaphore CI
     if [ -f /opt/change-go-version.sh ]; then
         . /opt/change-go-version.sh
         change-go-version 1.5
@@ -232,7 +232,7 @@ function main {
 
     # https://semaphoreci.com/docs/available-environment-variables.html
     if [ "${SEMAPHORE-}" == true ] ; then
-        semaphoreConfiguration
+        semaphoreCIConfiguration
     fi
 
     prepareBuildEnv

--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -15,10 +15,10 @@ fi
 if [ "${CI-}" == true ] ; then
 	# https://semaphoreci.com/
 	if [ "${SEMAPHORE-}" == true ] ; then
-		# Most dependencies are already installed on Semaphore.
+		# Most dependencies are already installed on Semaphore CI system.
 		# Here we can install any missing dependencies. Whenever
-		# Semaphore installs more dependencies on their platform,
-		# they should be removed from here to save time.
+		# Semaphore CI system installs more dependencies on their
+		# platform, they should be removed from here to save time.
 
 		# If there is some dependency to install then
 		# uncomment the following line and add "sudo apt-get

--- a/tests/rkt_userns_test.go
+++ b/tests/rkt_userns_test.go
@@ -46,7 +46,7 @@ var usernsTests = []struct {
 		"", // no check: it could be 0 but also the gid of 'rkt', see https://github.com/coreos/rkt/pull/1452
 	},
 	// TODO test with overlay fs too. We don't test it for now because
-	// Semaphore doesn't support it.
+	// Semaphore CI system doesn't support it.
 }
 
 func TestUserns(t *testing.T) {


### PR DESCRIPTION
To prevent confusion, usage of "Semaphore" is changed to "SemaphoreCI"