### PR TITLE
stage1/init: interpret "root" as UID/GID 0

### DIFF
--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -612,6 +612,28 @@ func TestPodManifest(t *testing.T) {
 			"",
 		},
 		{
+			// Set "root", it should work without it being present in
+			// /etc/{passwd,group}
+			[]imagePatch{
+				{"rkt-test-run-pod-manifest-root-user-group.aci", []string{}},
+			},
+			&schema.PodManifest{
+				Apps: []schema.RuntimeApp{
+					{
+						Name: baseAppName,
+						App: &types.App{
+							Exec:  []string{"/inspect", "--print-user"},
+							User:  "root",
+							Group: "root",
+						},
+					},
+				},
+			},
+			0,
+			"User: uid=0 euid=0 gid=0 egid=0",
+			"",
+		},
+		{
 			// Set invalid non-numerical app user.
 			[]imagePatch{
 				{"rkt-test-run-pod-manifest-invalid-user.aci", []string{}},

--- a/tests/rkt_run_user_group_test.go
+++ b/tests/rkt_run_user_group_test.go
@@ -78,6 +78,18 @@ func TestAppUserGroup(t *testing.T) {
 			rktParams:   "--user=user1 --group=group1",
 			expected:    "User: uid=1000 euid=1000 gid=100 egid=100",
 		},
+		{
+			imageParams: []string{"--user=root", "--group=root"},
+			expected:    "User: uid=0 euid=0 gid=0 egid=0",
+		},
+		{
+			rktParams: "--user=root --group=root",
+			expected:  "User: uid=0 euid=0 gid=0 egid=0",
+		},
+		{
+			rktParams: "--user=/inspect --group=/inspect",
+			expected:  "User: uid=0 euid=0 gid=0 egid=0",
+		},
 	} {
 		func() {
 			ctx := testutils.NewRktRunCtx()


### PR DESCRIPTION
This is a special case and it should work even if the image doesn't have
/etc/passwd or /etc/group.

Fixes #2411 