### PR TITLE
functional tests: fix detectChanges function

### DIFF
--- a/tests/build-and-run-tests.sh
+++ b/tests/build-and-run-tests.sh
@@ -166,7 +166,7 @@ function buildFolder {
 function detectChanges {
     HEAD=`git rev-parse HEAD`
     MASTER=`git rev-parse origin/master`
-    if [[ ${HEAD} != ${MASTER} ]]; then
+    if [[ ${HEAD} == ${MASTER} ]]; then
         SRC_CHANGES=1
         DOC_CHANGES=1
     elif [[ ${SRC_CHANGES} -eq 0 && ${DOC_CHANGES} -eq 0 ]]; then


### PR DESCRIPTION
When we did the refactoring of the CI build script, we inverted the
condition that checks if we're in origin/master to always run the tests
in that case. That caused tests not running on the master branch
anymore.