### PR TITLE
scripts: generate a Debian Sid ACI instead of using the Docker hub

### DIFF
--- a/Documentation/rkt-build-rkt.md
+++ b/Documentation/rkt-build-rkt.md
@@ -1,35 +1,19 @@
 # coreos.com/rkt/builder
 
 This container contains all build-time dependencies in order to build rkt.
-It currently can be built in one of two flavors: _Debian Sid_ or _Fedora 22_.
+It currently can be built in: _Debian Sid_.
 
 All commands assume you are running them in your local git checkout of rkt.
 
 ## Building coreos.com/rkt/builder using acbuild
 
 Requirements:
-- Go or `docker2aci`
 - rkt
 
-The file `scripts/acbuild-rkt-builder.sh` contains a simple bash script which will download a base docker image which is then converted into an ACI.
-Once the ACI has been downloaded, the manifest is patched.
-Next acbuild is run which creates an ACI that has all the required build dependencies for compiling `rkt`.
-
-If you want to change the base OS you can set it by using one of the following sets of variables:
-
-```
-export IMG=fedora
-export IMGVERSION=22
-```
-
-Or (default):
-
-```
-export IMG=debian
-export IMGVERSION=sid
-```
+The file `scripts/acbuild-rkt-builder.sh` contains a simple bash script which generates a Debian Sid tree and creates an ACI ready to build `rkt`.
 
 Running the build script:
+
 ```
 ./scripts/acbuild-rkt-builder.sh
 ```
@@ -41,6 +25,7 @@ Once that is finished there should be a `rkt-builder.aci` file in the current di
 Now that `rkt-builder.aci` has been built you have a container which will compile `rkt`.
 
 Put it into the rkt CAS:
+
 ```
 rkt fetch --insecure-options=image ./rkt-builder.aci
 ```
@@ -63,6 +48,7 @@ You should see rkt building in your rkt container, and once it's finished, the o
 # Building rkt in rkt one liners (sort of)
 
 If you don't want to bother with acbuild and want a simple one liner that uses rkt to build rkt,  you can install all the dependencies and build rkt from source in one line using bash in a container.
+Note that this fetches images from the Docker hub and doesn't check signatures.
 
 Set `SRC_DIR` to the absolute path to your git checkout of `rkt`:
 


### PR DESCRIPTION
Instead of getting the Debian Sid image from the Docker hub (we don't
check its signature) we generate a Debian Sid ACI using debootstrap.

This is an intermediate step to having the rkt builder hosted by CoreOS
with a proper official signature.