### PR TITLE
dist: Update tmpfiles to create /etc/rkt

### DIFF
--- a/dist/init/systemd/tmpfiles.d/rkt.conf
+++ b/dist/init/systemd/tmpfiles.d/rkt.conf
@@ -22,3 +22,5 @@ d /var/lib/rkt/pods/prepared 2750 root rkt
 d /var/lib/rkt/pods/run 2750 root rkt
 d /var/lib/rkt/pods/exited-garbage 2750 root rkt
 d /var/lib/rkt/pods/garbage 2750 root rkt
+
+d /etc/rkt 2770 root rkt-admin


### PR DESCRIPTION
By creating this directory, users can run `rkt trust` without being
root, if the user is in the rkt group.

If we want to treat `rkt trust` as a more privileged operation, than we could go one step further and create `/etc/rkt/trustedkeys` with a different set of permissions/groups.