### PR TITLE
store: add support for multiple hashAlgorithms.

### DIFF
--- a/store/hash.go
+++ b/store/hash.go
@@ -1,0 +1,187 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"fmt"
+	"hash"
+	"reflect"
+	"strings"
+)
+
+type HashAlgorithm interface {
+	// ValidateHashString checks that a given input hash string is valid
+	ValidateHashString(hashStr string) error
+	// NormalizeHashString, given an input hash string, returns the
+	//normalized hash string depending on the hash algorithm implementation
+	NormalizeHashString(hashStr string) (string, error)
+	// HashToHashString takes a hash.Hash and returns a hash string. The
+	// hash.Hash must be of the supported type.
+	HashToHashString(h hash.Hash) (string, error)
+	// NewHash returns a new hash.Hash of the supported hashAlgorithm type
+	NewHash() hash.Hash
+}
+
+// SHA512HashAlgorithm is a hash algorithm that uses sha512 sums
+// To ameliorate excessively long hash string, hash strings use only the first
+// half of a sha512 rather than the entire hash.
+type SHA512HashAlgorithm struct {
+	hashPrefix              string
+	lenHash                 int
+	lenSum                  int
+	lenHashString           int
+	lenNormalizedSum        int
+	lenNormalizedHashString int
+	minlenHashString        int
+}
+
+func NewSHA512HashAlgorithm() *SHA512HashAlgorithm {
+	hashPrefix := "sha512"
+	lenHash := sha512.Size  // raw byte size
+	lenSum := (lenHash) * 2 // in hex characters
+	lenHashString := len(hashPrefix) + 1 + lenSum
+	lenNormalizedSum := (lenHash / 2) * 2 // half length, in hex characters
+	lenNormalizedHashString := len(hashPrefix) + 1 + lenNormalizedSum
+	minlenHashString := len(hashPrefix) + 1 + 2 // at least sha512-aa
+
+	return &SHA512HashAlgorithm{
+		hashPrefix:              hashPrefix,
+		lenHash:                 lenHash,
+		lenSum:                  lenSum,
+		lenHashString:           lenHashString,
+		lenNormalizedSum:        lenNormalizedSum,
+		lenNormalizedHashString: lenNormalizedHashString,
+		minlenHashString:        minlenHashString,
+	}
+}
+
+func (ha *SHA512HashAlgorithm) ValidateHashString(hashStr string) error {
+	elems := strings.Split(hashStr, "-")
+	if len(elems) != 2 {
+		return fmt.Errorf("badly formatted hash string")
+	}
+	hashPrefix := elems[0]
+	if hashPrefix != ha.hashPrefix {
+		return fmt.Errorf("wrong hash string prefix %q", hashPrefix)
+	}
+	if len(hashStr) > ha.lenHashString {
+		return fmt.Errorf("hash string too long")
+	}
+	if len(hashStr) < ha.minlenHashString {
+		return fmt.Errorf("hash string too short")
+	}
+	return nil
+}
+
+// NormalizeHashString, given an input hashstring, returns the hash string
+// cutted to lenNormalizedHashString if it's longer or an error if the hash
+// string is not valid
+func (ha *SHA512HashAlgorithm) NormalizeHashString(hashStr string) (string, error) {
+	if err := ha.ValidateHashString(hashStr); err != nil {
+		return "", err
+	}
+	if len(hashStr) > ha.lenNormalizedHashString {
+		hashStr = hashStr[:ha.lenNormalizedHashString]
+	}
+	return hashStr, nil
+}
+
+func (ha *SHA512HashAlgorithm) HashToHashString(h hash.Hash) (string, error) {
+	if reflect.TypeOf(h) != reflect.TypeOf(sha512.New()) {
+		return "", fmt.Errorf("wrong hash alghoritm")
+	}
+	s := h.Sum(nil)
+	return ha.sumToHashString(s), nil
+}
+
+// sumToHashString takes the hash sum and returns a shortened and prefixed
+// hexadecimal string version
+func (ha *SHA512HashAlgorithm) sumToHashString(k []byte) string {
+	return fmt.Sprintf("%s-%x", ha.hashPrefix, k)[0:ha.lenNormalizedHashString]
+}
+
+func (ha *SHA512HashAlgorithm) NewHash() hash.Hash {
+	return sha512.New()
+}
+
+// SHA256HashAlgorithm is a hash algorithm that uses sha256 sum
+type SHA256HashAlgorithm struct {
+	hashPrefix       string
+	lenHash          int
+	lenSum           int
+	lenHashString    int
+	minlenHashString int
+}
+
+func NewSHA256HashAlgorithm() *SHA256HashAlgorithm {
+	hashPrefix := "sha256"
+	lenHash := sha256.Size  // raw byte size
+	lenSum := (lenHash) * 2 // in hex characters
+	lenHashString := len(hashPrefix) + 1 + lenSum
+	minlenHashString := len(hashPrefix) + 1 + 2 // at least sha256-aa
+
+	return &SHA256HashAlgorithm{
+		hashPrefix:       hashPrefix,
+		lenHash:          lenHash,
+		lenSum:           lenSum,
+		lenHashString:    lenHashString,
+		minlenHashString: minlenHashString,
+	}
+}
+
+func (ha *SHA256HashAlgorithm) ValidateHashString(hashStr string) error {
+	elems := strings.Split(hashStr, "-")
+	if len(elems) != 2 {
+		return fmt.Errorf("badly formatted hash string")
+	}
+	hashPrefix := elems[0]
+	if hashPrefix != ha.hashPrefix {
+		return fmt.Errorf("wrong hash string prefix %q", hashPrefix)
+	}
+	if len(hashStr) > ha.lenHashString {
+		return fmt.Errorf("hash string too long")
+	}
+	if len(hashStr) < ha.minlenHashString {
+		return fmt.Errorf("hash string too short")
+	}
+	return nil
+}
+
+func (ha *SHA256HashAlgorithm) NormalizeHashString(hashStr string) (string, error) {
+	if err := ha.ValidateHashString(hashStr); err != nil {
+		return "", err
+	}
+	return hashStr, nil
+}
+
+func (ha *SHA256HashAlgorithm) HashToHashString(h hash.Hash) (string, error) {
+	if reflect.TypeOf(h) != reflect.TypeOf(sha256.New()) {
+		return "", fmt.Errorf("wrong hash alghoritm")
+	}
+	s := h.Sum(nil)
+	return ha.sumToHashString(s), nil
+}
+
+// sumToHashString takes the hash sum and returns a prefixed hexadecimal string
+// version
+func (ha *SHA256HashAlgorithm) sumToHashString(sum []byte) string {
+	return fmt.Sprintf("%s-%x", ha.hashPrefix, sum)[0:ha.lenHashString]
+}
+
+func (ha *SHA256HashAlgorithm) NewHash() hash.Hash {
+	return sha256.New()
+}

--- a/store/hash_test.go
+++ b/store/hash_test.go
@@ -1,0 +1,202 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import "testing"
+
+func TestSHA512NormalizeHashString(t *testing.T) {
+	// This also checks ValidateHashString since it's called but NormalizeHashString
+
+	tests := []struct {
+		input          string
+		expectedErr    string
+		expectedOutput string
+	}{
+		{
+			input:       "sha512-a-a",
+			expectedErr: "badly formatted hash string",
+		},
+		{
+			input:       "",
+			expectedErr: "badly formatted hash string",
+		},
+		{
+			input:       "00000000000000000000000000000000000000000000000000",
+			expectedErr: "badly formatted hash string",
+		},
+		{
+			input:       "sha256-00000000000000000000000000000000000000000000000000",
+			expectedErr: `wrong hash string prefix "sha256"`,
+		},
+		{
+			input:       "sha512-1",
+			expectedErr: "hash string too short",
+		},
+		{
+			input:       "sha512-67147019a5b56f5e2ee01e989a8aa4787f56b8445960be2d8678391cf111009bc0780f31001fd181a2b61507547aee4caa44cda4b8bdb238d0e4ba830069ed2c1",
+			expectedErr: "hash string too long",
+		},
+		{
+			input:          "sha512-67147019a5b56f5e2ee01e989a8aa4787f56b8445960be2d8678391cf111009bc0780f31001fd181a2b61507547aee4caa44cda4b8bdb238d0e4ba830069ed2c",
+			expectedOutput: "sha512-67147019a5b56f5e2ee01e989a8aa4787f56b8445960be2d8678391cf111009b",
+		},
+		{
+			input:          "sha512-67147019a5b56f5e2ee01e989a8aa4787f56b8445960be2d8678391cf111009b",
+			expectedOutput: "sha512-67147019a5b56f5e2ee01e989a8aa4787f56b8445960be2d8678391cf111009b",
+		},
+		{
+			input:          "sha512-67",
+			expectedOutput: "sha512-67",
+		},
+	}
+	for _, tt := range tests {
+		ha := NewSHA512HashAlgorithm()
+		out, err := ha.NormalizeHashString(tt.input)
+		if err != nil {
+			if tt.expectedErr != "" {
+				if err.Error() != tt.expectedErr {
+					t.Fatalf("got err: %v, expecting: %v", err, tt.expectedErr)
+				}
+			} else {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		} else {
+			if tt.expectedErr != "" {
+				t.Fatalf("got nil error, expecting: %v", tt.expectedErr)
+			}
+			if out != tt.expectedOutput {
+				t.Fatalf("got normalized hash string: %q, expected: %q", out, tt.expectedOutput)
+			}
+		}
+	}
+}
+
+func TestSHA512HashToHashString(t *testing.T) {
+	tests := []struct {
+		input          string
+		expectedOutput string
+	}{
+		{
+			input:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expectedOutput: "sha512-ad9e7ae1f68786c33ca713d4632b29ebcc9c9c040fc176ead8acb395a14c0832",
+		},
+	}
+	for _, tt := range tests {
+		ha := NewSHA512HashAlgorithm()
+		h := ha.NewHash()
+		_, err := h.Write([]byte(tt.input))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out, err := ha.HashToHashString(h)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != tt.expectedOutput {
+			t.Fatalf("got hash string: %q, expected: %q", out, tt.expectedOutput)
+		}
+	}
+}
+
+func TestSHA256NormalizeHashString(t *testing.T) {
+	// This also checks ValidateHashString since it's called but NormalizeHashString
+
+	tests := []struct {
+		input          string
+		expectedErr    string
+		expectedOutput string
+	}{
+		{
+			input:       "sha256-a-a",
+			expectedErr: "badly formatted hash string",
+		},
+		{
+			input:       "",
+			expectedErr: "badly formatted hash string",
+		},
+		{
+			input:       "00000000000000000000000000000000000000000000000000",
+			expectedErr: "badly formatted hash string",
+		},
+		{
+			input:       "sha512-00000000000000000000000000000000000000000000000000",
+			expectedErr: `wrong hash string prefix "sha512"`,
+		},
+		{
+			input:       "sha256-1",
+			expectedErr: "hash string too short",
+		},
+		{
+			input:       "sha256-67147019a5b56f5e2ee01e989a8aa4787f56b8445960be2d8678391cf111009bc",
+			expectedErr: "hash string too long",
+		},
+		{
+			input:          "sha256-67147019a5b56f5e2ee01e989a8aa4787f56b8445960be2d8678391cf111009b",
+			expectedOutput: "sha256-67147019a5b56f5e2ee01e989a8aa4787f56b8445960be2d8678391cf111009b",
+		},
+		{
+			input:          "sha256-67",
+			expectedOutput: "sha256-67",
+		},
+	}
+	for _, tt := range tests {
+		ha := NewSHA256HashAlgorithm()
+		out, err := ha.NormalizeHashString(tt.input)
+		if err != nil {
+			if tt.expectedErr != "" {
+				if err.Error() != tt.expectedErr {
+					t.Fatalf("got err: %v, expecting: %v", err, tt.expectedErr)
+				}
+			} else {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		} else {
+			if tt.expectedErr != "" {
+				t.Fatalf("got nil error, expecting: %v", tt.expectedErr)
+			}
+			if out != tt.expectedOutput {
+				t.Fatalf("got normalized hash string: %q, expected: %q", out, tt.expectedOutput)
+			}
+		}
+	}
+}
+
+func TestSHA256HashToHashString(t *testing.T) {
+	tests := []struct {
+		input          string
+		expectedOutput string
+	}{
+		{
+			input:          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expectedOutput: "sha256-61c60b487d1a921e0bcc9bf853dda0fb159b30bf57b2e2d2c753b00be15b5a09",
+		},
+	}
+	for _, tt := range tests {
+		ha := NewSHA256HashAlgorithm()
+		h := ha.NewHash()
+		_, err := h.Write([]byte(tt.input))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out, err := ha.HashToHashString(h)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if out != tt.expectedOutput {
+			t.Fatalf("got hash string: %q, expected: %q", out, tt.expectedOutput)
+		}
+	}
+}

--- a/store/tree.go
+++ b/store/tree.go
@@ -16,7 +16,6 @@ package store
 
 import (
 	"archive/tar"
-	"crypto/sha512"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -202,16 +201,14 @@ func (ts *TreeStore) GetRootFS(id string) string {
 func (ts *TreeStore) Hash(id string) (string, error) {
 	treepath := ts.GetPath(id)
 
-	hash := sha512.New()
+	hash := hashAlgorithms["sha512"].NewHash()
 	iw := NewHashWriter(hash)
 	err := filepath.Walk(treepath, buildWalker(treepath, iw))
 	if err != nil {
 		return "", errwrap.Wrap(errors.New("error walking rootfs"), err)
 	}
 
-	hashstring := hashToKey(hash)
-
-	return hashstring, nil
+	return hashAlgorithms["sha512"].HashToHashString(hash)
 }
 
 // Check calculates the actual rendered ACI's hash and verifies that it matches

--- a/tests/rkt_image_list_test.go
+++ b/tests/rkt_image_list_test.go
@@ -191,7 +191,7 @@ func TestShortHash(t *testing.T) {
 		{
 			fmt.Sprintf("image cat-manifest %s", hash0[:len("sha512-")+1]),
 			true,
-			"image ID too short",
+			"hash string too short",
 		},
 		// Try short hash that collides
 		{


### PR DESCRIPTION
I'm not sure how in future multiple image formats (like to OCI image spec) will be implemented.
Based on #2313 my initial idea was to use different kind of stores (for example ACIStore and OCIStore) since they have different peculiarities and logics.

This patch is the first part of a store refactor to support multiple kind of stores and adds support for multiple hash algorithms.

/cc @philips 

--
**store: add support for multiple hashAlgorithms.**

Actually the store just uses sha512 hash keys (half sized) since the
appc/spec only uses this kind of hash.

This patch adds a hashAlgorithm interface and implements two
hash algorithms (the current sha512 with half sized keys like the one
currently used, and a sha256) and converts the store to use this
interface.

This will be useful for future implementations where multiple hash types
should be supported (like OCI image digests).

Related to #2313 
