### PR TITLE
store: check the ACI file's UID instead of the diskv dir

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -538,16 +538,16 @@ func (s *Store) RemoveACI(key string) error {
 	// Try to see if we are the owner of the images, if not, returns not enough permission error.
 	for _, ds := range s.stores {
 		// XXX: The construction of 'path' depends on the implementation of diskv.
-		path := filepath.Join(ds.BasePath, filepath.Join(ds.Transform(key)...))
+		path := filepath.Join(ds.BasePath, filepath.Join(ds.Transform(key)...), key)
 		fi, err := os.Stat(path)
 		if err != nil {
-			return errwrap.Wrap(errors.New("cannot get the stat of the image directory"), err)
+			return errwrap.Wrap(errors.New("cannot stat the image"), err)
 		}
 
 		uid := os.Getuid()
-		dirUid := int(fi.Sys().(*syscall.Stat_t).Uid)
+		aciUid := int(fi.Sys().(*syscall.Stat_t).Uid)
 
-		if uid != dirUid && uid != 0 {
+		if uid != aciUid && uid != 0 {
 			return fmt.Errorf("permission denied, are you root or the owner of the image?")
 		}
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/coreos/rkt/pkg/sys"
 
 	"github.com/appc/spec/schema/types"
+	"github.com/hashicorp/errwrap"
 )
 
 const tstprefix = "store-test"
@@ -564,8 +565,8 @@ func TestRemoveACI(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error: %v", err)
 	}
-	if _, ok := err.(*StoreRemovalError); !ok {
-		t.Fatalf("expected StoreRemovalError got: %v", err)
+	expectedErr := "cannot stat the image"
+	if !errwrap.Contains(err, expectedErr) {
+		t.Fatalf("expected %s got: %v", expectedErr, err)
 	}
-
 }


### PR DESCRIPTION
To check if we can remove an image we were checking the UID of the
diskv directory where the image is located.

This is wrong because several images can end up in the same diskv
directory and be fetched by different users, so we would be checking
against the first user that imported an image there.