### PR TITLE
Remove 'get' from method names in 'rkt/image' pkg

### DIFF
--- a/rkt/image/dockerfetcher.go
+++ b/rkt/image/dockerfetcher.go
@@ -46,9 +46,9 @@ type dockerFetcher struct {
 	Debug         bool
 }
 
-// GetHash uses docker2aci to download the image and convert it to
+// Hash uses docker2aci to download the image and convert it to
 // ACI, then stores it in the store and returns the hash.
-func (f *dockerFetcher) GetHash(u *url.URL) (string, error) {
+func (f *dockerFetcher) Hash(u *url.URL) (string, error) {
 	ensureLogger(f.Debug)
 	dockerURL, err := d2acommon.ParseDockerURL(path.Join(u.Host, u.Path))
 	if err != nil {

--- a/rkt/image/downloader.go
+++ b/rkt/image/downloader.go
@@ -26,21 +26,21 @@ import (
 // downloadSession is an interface used by downloader for controlling
 // the downloading process.
 type downloadSession interface {
-	// GetClient returns a client used for handling the
+	// Client returns a client used for handling the
 	// requests. It is a good place for e.g. setting up a redirect
 	// handling.
-	GetClient() (*http.Client, error)
-	// GetRequest returns an HTTP request. Is is a good place to
+	Client() (*http.Client, error)
+	// Request returns an HTTP request. It is a good place to
 	// add some headers to a request.
-	GetRequest(u *url.URL) (*http.Request, error)
+	Request(u *url.URL) (*http.Request, error)
 	// HandleStatus is mostly used to check if the response has
 	// the required HTTP status. When this function returns either
 	// an error or a false value, then the downloader will skip
 	// getting contents of the response body.
 	HandleStatus(res *http.Response) (bool, error)
-	// GetBodyReader returns a reader used to get contents of the
+	// BodyReader returns a reader used to get contents of the
 	// response body.
-	GetBodyReader(*http.Response) (io.Reader, error)
+	BodyReader(*http.Response) (io.Reader, error)
 }
 
 // downloader has a rather obvious purpose - it downloads stuff.
@@ -53,11 +53,11 @@ type downloader struct {
 // a given writeSyncer instance.
 func (d *downloader) Download(u *url.URL, out writeSyncer) error {
 	d.ensureSession()
-	client, err := d.Session.GetClient()
+	client, err := d.Session.Client()
 	if err != nil {
 		return err
 	}
-	req, err := d.Session.GetRequest(u)
+	req, err := d.Session.Request(u)
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func (d *downloader) Download(u *url.URL, out writeSyncer) error {
 		return err
 	}
 
-	reader, err := d.Session.GetBodyReader(res)
+	reader, err := d.Session.BodyReader(res)
 	if err != nil {
 		return err
 	}
@@ -98,15 +98,15 @@ func (d *downloader) ensureSession() {
 // response other than 200 as an error.
 type defaultDownloadSession struct{}
 
-func (s *defaultDownloadSession) GetBodyReader(res *http.Response) (io.Reader, error) {
+func (s *defaultDownloadSession) BodyReader(res *http.Response) (io.Reader, error) {
 	return res.Body, nil
 }
 
-func (s *defaultDownloadSession) GetClient() (*http.Client, error) {
+func (s *defaultDownloadSession) Client() (*http.Client, error) {
 	return http.DefaultClient, nil
 }
 
-func (s *defaultDownloadSession) GetRequest(u *url.URL) (*http.Request, error) {
+func (s *defaultDownloadSession) Request(u *url.URL) (*http.Request, error) {
 	req := &http.Request{
 		Method:     "GET",
 		URL:        u,

--- a/rkt/image/fetcher.go
+++ b/rkt/image/fetcher.go
@@ -239,7 +239,7 @@ func (f *Fetcher) maybeFetchHTTPURLFromRemote(rem *store.Remote, u *url.URL, a *
 			Debug:         f.Debug,
 			Headers:       f.Headers,
 		}
-		return hf.GetHash(u, a)
+		return hf.Hash(u, a)
 	}
 	return "", nil
 }
@@ -253,7 +253,7 @@ func (f *Fetcher) maybeFetchDockerURLFromRemote(u *url.URL) (string, error) {
 			S:             f.S,
 			Debug:         f.Debug,
 		}
-		return df.GetHash(u)
+		return df.Hash(u)
 	}
 	return "", nil
 }
@@ -266,7 +266,7 @@ func (f *Fetcher) fetchSingleImageByPath(path string, a *asc) (string, error) {
 		Ks:            f.Ks,
 		Debug:         f.Debug,
 	}
-	return ff.GetHash(path, a)
+	return ff.Hash(path, a)
 }
 
 type appBundle struct {
@@ -353,7 +353,7 @@ func (f *Fetcher) maybeFetchImageFromRemote(app *appBundle, a *asc) (string, err
 			Headers:            f.Headers,
 			TrustKeysFromHTTPS: f.TrustKeysFromHTTPS,
 		}
-		return nf.GetHash(app.App, a)
+		return nf.Hash(app.App, a)
 	}
 	return "", nil
 }

--- a/rkt/image/filefetcher.go
+++ b/rkt/image/filefetcher.go
@@ -34,9 +34,9 @@ type fileFetcher struct {
 	Debug         bool
 }
 
-// GetHash opens a file, optionally verifies it against passed asc,
+// Hash opens a file, optionally verifies it against passed asc,
 // stores it in the store and returns the hash.
-func (f *fileFetcher) GetHash(aciPath string, a *asc) (string, error) {
+func (f *fileFetcher) Hash(aciPath string, a *asc) (string, error) {
 	ensureLogger(f.Debug)
 	absPath, err := filepath.Abs(aciPath)
 	if err != nil {
@@ -98,7 +98,7 @@ func (f *fileFetcher) getVerifiedFile(aciPath string, a *asc) (*os.File, error) 
 
 	entity, err := validator.ValidateWithSignature(f.Ks, ascFile)
 	if err != nil {
-		return nil, errwrap.Wrap(fmt.Errorf("image %q verification failed", validator.GetImageName()), err)
+		return nil, errwrap.Wrap(fmt.Errorf("image %q verification failed", validator.ImageName()), err)
 	}
 	printIdentities(entity)
 

--- a/rkt/image/httpops.go
+++ b/rkt/image/httpops.go
@@ -106,8 +106,8 @@ func (o *httpOps) DownloadImageWithETag(u *url.URL, etag string) (readSeekCloser
 	return retAciFile, session.Cd, nil
 }
 
-// GetAscRemoteFetcher provides a remoteAscFetcher for asc.
-func (o *httpOps) GetAscRemoteFetcher() *remoteAscFetcher {
+// AscRemoteFetcher provides a remoteAscFetcher for asc.
+func (o *httpOps) AscRemoteFetcher() *remoteAscFetcher {
 	ensureLogger(o.Debug)
 	f := func(u *url.URL, file *os.File) error {
 		switch u.Scheme {

--- a/rkt/image/namefetcher.go
+++ b/rkt/image/namefetcher.go
@@ -43,9 +43,9 @@ type nameFetcher struct {
 	TrustKeysFromHTTPS bool
 }
 
-// GetHash runs the discovery, fetches the image, optionally verifies
+// Hash runs the discovery, fetches the image, optionally verifies
 // it against passed asc, stores it in the store and returns the hash.
-func (f *nameFetcher) GetHash(app *discovery.App, a *asc) (string, error) {
+func (f *nameFetcher) Hash(app *discovery.App, a *asc) (string, error) {
 	ensureLogger(f.Debug)
 	name := app.Name.String()
 	log.Printf("searching for app image %s", name)
@@ -140,7 +140,7 @@ func (f *nameFetcher) fetch(app *discovery.App, aciURL string, a *asc) (readSeek
 	}
 
 	if f.InsecureFlags.SkipImageCheck() || f.Ks == nil {
-		o := f.getHTTPOps()
+		o := f.httpOps()
 		aciFile, cd, err := o.DownloadImage(u)
 		if err != nil {
 			return nil, nil, err
@@ -155,7 +155,7 @@ func (f *nameFetcher) fetchVerifiedURL(app *discovery.App, u *url.URL, a *asc) (
 	appName := app.Name.String()
 	f.maybeFetchPubKeys(appName)
 
-	o := f.getHTTPOps()
+	o := f.httpOps()
 	ascFile, retry, err := o.DownloadSignature(a)
 	if err != nil {
 		return nil, nil, err
@@ -281,10 +281,10 @@ func (f *nameFetcher) maybeOverrideAscFetcherWithRemote(ascURL string, a *asc) {
 		return
 	}
 	a.Location = ascURL
-	a.Fetcher = f.getHTTPOps().GetAscRemoteFetcher()
+	a.Fetcher = f.httpOps().AscRemoteFetcher()
 }
 
-func (f *nameFetcher) getHTTPOps() *httpOps {
+func (f *nameFetcher) httpOps() *httpOps {
 	return &httpOps{
 		InsecureSkipTLSVerify: f.InsecureFlags.SkipTLSCheck(),
 		S:       f.S,

--- a/rkt/image/resumablesession.go
+++ b/rkt/image/resumablesession.go
@@ -81,12 +81,12 @@ type resumableSession struct {
 	byteRangeSupported bool
 }
 
-func (s *resumableSession) GetClient() (*http.Client, error) {
+func (s *resumableSession) Client() (*http.Client, error) {
 	s.ensureClient()
 	return s.client, nil
 }
 
-func (s *resumableSession) GetRequest(u *url.URL) (*http.Request, error) {
+func (s *resumableSession) Request(u *url.URL) (*http.Request, error) {
 	s.u = u
 	if err := s.maybeSetupDownloadResume(u); err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func (s *resumableSession) HandleStatus(res *http.Response) (bool, error) {
 	}
 }
 
-func (s *resumableSession) GetBodyReader(res *http.Response) (io.Reader, error) {
+func (s *resumableSession) BodyReader(res *http.Response) (io.Reader, error) {
 	reader := getIoProgressReader(s.Label, res)
 	return reader, nil
 }

--- a/rkt/image/validator.go
+++ b/rkt/image/validator.go
@@ -49,15 +49,15 @@ func newValidator(image io.ReadSeeker) (*validator, error) {
 	return v, nil
 }
 
-// GetImageName returns image name as it is in the image manifest.
-func (v *validator) GetImageName() string {
+// ImageName returns image name as it is in the image manifest.
+func (v *validator) ImageName() string {
 	return v.manifest.Name.String()
 }
 
 // ValidateName checks if desired image name is actually the same as
 // the one in the image manifest.
 func (v *validator) ValidateName(imageName string) error {
-	name := v.GetImageName()
+	name := v.ImageName()
 	if name != imageName {
 		return fmt.Errorf("error when reading the app name: %q expected but %q found",
 			imageName, name)
@@ -92,7 +92,7 @@ func (v *validator) ValidateWithSignature(ks *keystore.Keystore, sig io.ReadSeek
 	if _, err := sig.Seek(0, 0); err != nil {
 		return nil, errwrap.Wrap(errors.New("error seeking signature file"), err)
 	}
-	entity, err := ks.CheckSignature(v.GetImageName(), v.image, sig)
+	entity, err := ks.CheckSignature(v.ImageName(), v.image, sig)
 	if err == pgperrors.ErrUnknownIssuer {
 		log.Print("If you expected the signing key to change, try running:")
 		log.Print("    rkt trust --prefix <image>")


### PR DESCRIPTION
Refactors 'rkt/image' to remove 'Get' from the method names.

Related to #2450