### PR TITLE
Refactor store pkg API and its tests

### DIFF
--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -66,7 +66,7 @@ type v1AlphaAPIServer struct {
 var _ v1alpha.PublicAPIServer = &v1AlphaAPIServer{}
 
 func newV1AlphaAPIServer() (*v1AlphaAPIServer, error) {
-	s, err := store.NewStore(getDataDir())
+	s, err := store.New(getDataDir())
 	if err != nil {
 		return nil, err
 	}

--- a/rkt/enter.go
+++ b/rkt/enter.go
@@ -94,7 +94,7 @@ func runEnter(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(getDataDir())
+	s, err := store.New(getDataDir())
 	if err != nil {
 		stderr.PrintE("cannot open store", err)
 		return 1

--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -72,7 +72,7 @@ func runFetch(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(getDataDir())
+	s, err := store.New(getDataDir())
 	if err != nil {
 		stderr.PrintE("cannot open store", err)
 		return 1

--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -253,7 +253,7 @@ func TestDownloading(t *testing.T) {
 		{denyAuthTS.URL, true, noAuth, false},
 	}
 
-	s, err := store.NewStore(dir)
+	s, err := store.New(dir)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -299,7 +299,7 @@ func TestFetchImage(t *testing.T) {
 		t.Fatalf("error creating tempdir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	s, err := store.NewStore(dir)
+	s, err := store.New(dir)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -366,7 +366,7 @@ func TestGetStoreKeyFromApp(t *testing.T) {
 		t.Fatalf("error creating tempdir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	s, err := store.NewStore(dir)
+	s, err := store.New(dir)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -437,7 +437,7 @@ func TestFetchImageCache(t *testing.T) {
 		t.Fatalf("error creating tempdir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	s, err := store.NewStore(dir)
+	s, err := store.New(dir)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}

--- a/rkt/gc.go
+++ b/rkt/gc.go
@@ -200,7 +200,7 @@ func deletePod(p *pod) {
 	}
 
 	if p.isExitedGarbage {
-		s, err := store.NewStore(getDataDir())
+		s, err := store.New(getDataDir())
 		if err != nil {
 			stderr.PrintE("cannot open store", err)
 			return

--- a/rkt/image_cat_manifest.go
+++ b/rkt/image_cat_manifest.go
@@ -43,7 +43,7 @@ func runImageCatManifest(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(getDataDir())
+	s, err := store.New(getDataDir())
 	if err != nil {
 		stderr.PrintE("cannot open store", err)
 		return 1

--- a/rkt/image_export.go
+++ b/rkt/image_export.go
@@ -48,7 +48,7 @@ func runImageExport(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(getDataDir())
+	s, err := store.New(getDataDir())
 	if err != nil {
 		stderr.PrintE("cannot open store", err)
 		return 1

--- a/rkt/image_extract.go
+++ b/rkt/image_extract.go
@@ -55,7 +55,7 @@ func runImageExtract(cmd *cobra.Command, args []string) (exit int) {
 	}
 	outputDir := args[1]
 
-	s, err := store.NewStore(getDataDir())
+	s, err := store.New(getDataDir())
 	if err != nil {
 		stderr.PrintE("cannot open store", err)
 		return 1

--- a/rkt/image_gc.go
+++ b/rkt/image_gc.go
@@ -49,7 +49,7 @@ func init() {
 }
 
 func runGCImage(cmd *cobra.Command, args []string) (exit int) {
-	s, err := store.NewStore(getDataDir())
+	s, err := store.New(getDataDir())
 	if err != nil {
 		stderr.PrintE("cannot open store", err)
 		return 1

--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -154,7 +154,7 @@ func runImages(cmd *cobra.Command, args []string) int {
 		fmt.Fprintf(tabOut, "%s\n", strings.Join(headerFields, "\t"))
 	}
 
-	s, err := store.NewStore(getDataDir())
+	s, err := store.New(getDataDir())
 	if err != nil {
 		stderr.PrintE("cannot open store", err)
 		return 1

--- a/rkt/image_render.go
+++ b/rkt/image_render.go
@@ -57,7 +57,7 @@ func runImageRender(cmd *cobra.Command, args []string) (exit int) {
 	}
 	outputDir := args[1]
 
-	s, err := store.NewStore(getDataDir())
+	s, err := store.New(getDataDir())
 	if err != nil {
 		stderr.PrintE("cannot open store", err)
 		return 1

--- a/rkt/image_rm.go
+++ b/rkt/image_rm.go
@@ -131,7 +131,7 @@ func runRmImage(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(getDataDir())
+	s, err := store.New(getDataDir())
 	if err != nil {
 		stderr.PrintE("cannot open store", err)
 		return 1

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -119,7 +119,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(getDataDir())
+	s, err := store.New(getDataDir())
 	if err != nil {
 		stderr.PrintE("cannot open store", err)
 		return 1

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -165,7 +165,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	s, err := store.NewStore(getDataDir())
+	s, err := store.New(getDataDir())
 	if err != nil {
 		stderr.PrintE("cannot open store", err)
 		return 1

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -62,7 +62,7 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 	}
 	defer p.Close()
 
-	s, err := store.NewStore(getDataDir())
+	s, err := store.New(getDataDir())
 	if err != nil {
 		stderr.PrintE("cannot open store", err)
 		return 1

--- a/store/backup_test.go
+++ b/store/backup_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package store
+package store_test
 
 import (
 	"fmt"

--- a/store/db_test.go
+++ b/store/db_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package store
+package store_test
 
 import (
 	"database/sql"
@@ -22,6 +22,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/coreos/rkt/store"
 	"github.com/coreos/rkt/tests/testutils"
 )
 
@@ -42,7 +43,7 @@ func queryValue(query string, tx *sql.Tx) (int, error) {
 	return value, nil
 }
 
-func insertValue(db *DB) error {
+func insertValue(db *store.DB) error {
 	return db.Do(func(tx *sql.Tx) error {
 		// Get the current count.
 		count, err := queryValue("SELECT count(*) FROM rkt_db_test", tx)
@@ -55,7 +56,7 @@ func insertValue(db *DB) error {
 	})
 }
 
-func getMaxCount(db *DB, t *testing.T) int {
+func getMaxCount(db *store.DB, t *testing.T) int {
 	var maxCount int
 	var err error
 	if err := db.Do(func(tx *sql.Tx) error {
@@ -68,7 +69,7 @@ func getMaxCount(db *DB, t *testing.T) int {
 	return maxCount
 }
 
-func createTable(db *DB, t *testing.T) {
+func createTable(db *store.DB, t *testing.T) {
 	if err := db.Do(func(tx *sql.Tx) error {
 		_, err := tx.Exec("CREATE TABLE rkt_db_test (counts int)")
 		return err
@@ -91,7 +92,7 @@ func TestDBRace(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	db, err := NewDB(dir)
+	db, err := store.NewDB(dir)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/store/main_test.go
+++ b/store/main_test.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE.BSD file,
 // or at https://opensource.org/licenses/BSD-3-Clause
 
-package store
+package store_test
 
 import (
 	"fmt"

--- a/store/remote_test.go
+++ b/store/remote_test.go
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package store
+package store_test
 
 import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/coreos/rkt/store"
 )
 
 func TestNewRemote(t *testing.T) {
@@ -31,13 +33,13 @@ func TestNewRemote(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
-	s, err := NewStore(dir)
+	s, err := store.New(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Create our first Remote, and simulate Store() to create row in the table
-	na := NewRemote(u1, "")
+	na := store.NewRemote(u1, "")
 	na.BlobKey = data
 	s.WriteRemote(na)
 

--- a/store/store.go
+++ b/store/store.go
@@ -104,7 +104,7 @@ type Store struct {
 	// storeLock is a lock on the whole store. It's used for store migration. If
 	// a previous version of rkt is using the store and in the meantime a
 	// new version is installed and executed it will try migrate the store
-	// during NewStore. This means that the previous running rkt will fail
+	// during New. This means that the previous running rkt will fail
 	// or behave badly after the migration as it's expecting another db format.
 	// For this reason, before executing migration, an exclusive lock must
 	// be taken on the whole store.
@@ -189,7 +189,8 @@ func (s *Store) populateSize() error {
 	return nil
 }
 
-func NewStore(baseDir string) (*Store, error) {
+// New creates a store using the given base directory path.
+func New(baseDir string) (*Store, error) {
 	// We need to allow the store's setgid bits (if any) to propagate, so
 	// disable umask
 	um := syscall.Umask(0)
@@ -305,7 +306,7 @@ func NewStore(baseDir string) (*Store, error) {
 	return s, nil
 }
 
-// Close closes a Store opened with NewStore().
+// Close closes a Store opened with New().
 func (s *Store) Close() error {
 	return s.storeLock.Close()
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package store
+package store_test
 
 import (
 	"archive/tar"
@@ -28,6 +28,7 @@ import (
 	"github.com/coreos/rkt/pkg/aci"
 	"github.com/coreos/rkt/pkg/multicall"
 	"github.com/coreos/rkt/pkg/sys"
+	"github.com/coreos/rkt/store"
 
 	"github.com/appc/spec/schema/types"
 )
@@ -44,7 +45,7 @@ func TestBlobStore(t *testing.T) {
 		t.Fatalf("error creating tempdir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	s, err := NewStore(dir)
+	s, err := store.New(dir)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -64,7 +65,7 @@ func TestResolveKey(t *testing.T) {
 		t.Fatalf("error creating tempdir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	s, err := NewStore(dir)
+	s, err := store.New(dir)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -157,7 +158,7 @@ func TestGetImageManifest(t *testing.T) {
 		t.Fatalf("error creating tempdir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	s, err := NewStore(dir)
+	s, err := store.New(dir)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -215,7 +216,7 @@ func TestGetAci(t *testing.T) {
 		t.Fatalf("error creating tempdir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	s, err := NewStore(dir)
+	s, err := store.New(dir)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -356,7 +357,7 @@ func TestTreeStore(t *testing.T) {
 		t.Fatalf("error creating tempdir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	s, err := NewStore(dir)
+	s, err := store.New(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -480,7 +481,7 @@ func TestRemoveACI(t *testing.T) {
 		t.Fatalf("error creating tempdir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	s, err := NewStore(dir)
+	s, err := store.New(dir)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/store/tree_test.go
+++ b/store/tree_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package store
+package store_test
 
 import (
 	"archive/tar"
@@ -22,9 +22,10 @@ import (
 
 	"github.com/coreos/rkt/pkg/aci"
 	"github.com/coreos/rkt/pkg/sys"
+	"github.com/coreos/rkt/store"
 )
 
-func treeStoreWriteACI(dir string, s *Store) (string, error) {
+func treeStoreWriteACI(dir string, s *store.Store) (string, error) {
 	imj := `
 		{
 		    "acKind": "ImageManifest",
@@ -99,7 +100,7 @@ func TestTreeStoreWrite(t *testing.T) {
 		t.Fatalf("error creating tempdir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	s, err := NewStore(dir)
+	s, err := store.New(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -134,7 +135,7 @@ func TestTreeStoreRemove(t *testing.T) {
 		t.Fatalf("error creating tempdir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	s, err := NewStore(dir)
+	s, err := store.New(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/store/utils_test.go
+++ b/store/utils_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package store
+package store_test
 
 import (
 	"testing"


### PR DESCRIPTION
Suffixes the test packages with `_test`, which helps see the API usage
from the package user's perspective and discourages testing unexported constructs.

Removes `Store` from the name store.NewStore of a function in store
package. Since the usage is `store.NewStore` outside of the package.