### PR TITLE
Implement composable uid/gid generators

### DIFF
--- a/pkg/aci/render.go
+++ b/pkg/aci/render.go
@@ -17,7 +17,7 @@ package aci
 import (
 	"errors"
 
-	"github.com/coreos/rkt/pkg/uid"
+	"github.com/coreos/rkt/pkg/user"
 	"github.com/hashicorp/errwrap"
 
 	ptar "github.com/coreos/rkt/pkg/tar"
@@ -28,7 +28,7 @@ import (
 
 // Given an imageID, start with the matching image available in the store,
 // build its dependency list and render it inside dir
-func RenderACIWithImageID(imageID types.Hash, dir string, ap acirenderer.ACIRegistry, uidRange *uid.UidRange) error {
+func RenderACIWithImageID(imageID types.Hash, dir string, ap acirenderer.ACIRegistry, uidRange *user.UidRange) error {
 	renderedACI, err := acirenderer.GetRenderedACIWithImageID(imageID, ap)
 	if err != nil {
 		return err
@@ -38,7 +38,7 @@ func RenderACIWithImageID(imageID types.Hash, dir string, ap acirenderer.ACIRegi
 
 // Given an image app name and optional labels, get the best matching image
 // available in the store, build its dependency list and render it inside dir
-func RenderACI(name types.ACIdentifier, labels types.Labels, dir string, ap acirenderer.ACIRegistry, uidRange *uid.UidRange) error {
+func RenderACI(name types.ACIdentifier, labels types.Labels, dir string, ap acirenderer.ACIRegistry, uidRange *user.UidRange) error {
 	renderedACI, err := acirenderer.GetRenderedACI(name, labels, ap)
 	if err != nil {
 		return err
@@ -48,7 +48,7 @@ func RenderACI(name types.ACIdentifier, labels types.Labels, dir string, ap acir
 
 // Given an already populated dependency list, it will extract, under the provided
 // directory, the rendered ACI
-func RenderACIFromList(imgs acirenderer.Images, dir string, ap acirenderer.ACIProvider, uidRange *uid.UidRange) error {
+func RenderACIFromList(imgs acirenderer.Images, dir string, ap acirenderer.ACIProvider, uidRange *user.UidRange) error {
 	renderedACI, err := acirenderer.GetRenderedACIFromList(imgs, ap)
 	if err != nil {
 		return err
@@ -61,7 +61,7 @@ func RenderACIFromList(imgs acirenderer.Images, dir string, ap acirenderer.ACIPr
 // The manifest will be extracted from the upper ACI.
 // No file overwriting is done as it should usually be called
 // providing an empty directory.
-func renderImage(renderedACI acirenderer.RenderedACI, dir string, ap acirenderer.ACIProvider, uidRange *uid.UidRange) error {
+func renderImage(renderedACI acirenderer.RenderedACI, dir string, ap acirenderer.ACIProvider, uidRange *user.UidRange) error {
 	for _, ra := range renderedACI {
 		rs, err := ap.ReadStream(ra.Key)
 		if err != nil {

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -22,7 +22,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/coreos/rkt/pkg/uid"
+	"github.com/coreos/rkt/pkg/user"
 
 	"github.com/appc/spec/pkg/device"
 )
@@ -60,7 +60,7 @@ func CopySymlink(src, dest string) error {
 	return nil
 }
 
-func CopyTree(src, dest string, uidRange *uid.UidRange) error {
+func CopyTree(src, dest string, uidRange *user.UidRange) error {
 	cleanSrc := filepath.Clean(src)
 
 	dirs := make(map[string][]syscall.Timespec)

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/coreos/rkt/pkg/uid"
+	"github.com/coreos/rkt/pkg/user"
 )
 
 const tstprefix = "fileutil-test"
@@ -95,7 +95,7 @@ func TestCopyTree(t *testing.T) {
 	createTree(t, src, tr)
 
 	// absolute paths
-	if err := CopyTree(src, dst, uid.NewBlankUidRange()); err != nil {
+	if err := CopyTree(src, dst, user.NewBlankUidRange()); err != nil {
 		t.Fatal(err)
 	}
 	checkTree(t, dst, tr)
@@ -106,13 +106,13 @@ func TestCopyTree(t *testing.T) {
 	}
 
 	dst = "dst-rel1"
-	if err := CopyTree("././src/", dst, uid.NewBlankUidRange()); err != nil {
+	if err := CopyTree("././src/", dst, user.NewBlankUidRange()); err != nil {
 		t.Fatal(err)
 	}
 	checkTree(t, dst, tr)
 
 	dst = "./dst-rel2"
-	if err := CopyTree("./src", dst, uid.NewBlankUidRange()); err != nil {
+	if err := CopyTree("./src", dst, user.NewBlankUidRange()); err != nil {
 		t.Fatal(err)
 	}
 	checkTree(t, dst, tr)

--- a/pkg/tar/chroot.go
+++ b/pkg/tar/chroot.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/coreos/rkt/pkg/multicall"
 	"github.com/coreos/rkt/pkg/sys"
-	"github.com/coreos/rkt/pkg/uid"
+	"github.com/coreos/rkt/pkg/user"
 	"github.com/hashicorp/errwrap"
 )
 
@@ -68,7 +68,7 @@ func extractTarCommand() error {
 		return errwrap.Wrap(errors.New("error parsing uidShift argument"), err)
 	}
 
-	uidRange := &uid.UidRange{Shift: uint32(us), Count: uint32(uc)}
+	uidRange := &user.UidRange{Shift: uint32(us), Count: uint32(uc)}
 
 	if err := syscall.Chroot(dir); err != nil {
 		return errwrap.Wrap(fmt.Errorf("failed to chroot in %s", dir), err)
@@ -101,7 +101,7 @@ func extractTarCommand() error {
 // If overwrite is true, existing files will be overwritten.
 // The extraction is executed by fork/exec()ing a new process. The new process
 // needs the CAP_SYS_CHROOT capability.
-func ExtractTar(rs io.Reader, dir string, overwrite bool, uidRange *uid.UidRange, pwl PathWhitelistMap) error {
+func ExtractTar(rs io.Reader, dir string, overwrite bool, uidRange *user.UidRange, pwl PathWhitelistMap) error {
 	r, w, err := os.Pipe()
 	if err != nil {
 		return err

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/appc/spec/pkg/device"
 	"github.com/coreos/rkt/pkg/fileutil"
-	"github.com/coreos/rkt/pkg/uid"
+	"github.com/coreos/rkt/pkg/user"
 	"github.com/hashicorp/errwrap"
 )
 
@@ -41,7 +41,7 @@ type PathWhitelistMap map[string]struct{}
 
 type FilePermissionsEditor func(string, int, int, byte, os.FileInfo) error
 
-func NewUidShiftingFilePermEditor(uidRange *uid.UidRange) (FilePermissionsEditor, error) {
+func NewUidShiftingFilePermEditor(uidRange *user.UidRange) (FilePermissionsEditor, error) {
 	if os.Geteuid() != 0 {
 		return func(_ string, _, _ int, _ byte, _ os.FileInfo) error {
 			// The files are owned by the current user on creation.

--- a/pkg/tar/tar_test.go
+++ b/pkg/tar/tar_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/coreos/rkt/pkg/multicall"
 	"github.com/coreos/rkt/pkg/sys"
-	"github.com/coreos/rkt/pkg/uid"
+	"github.com/coreos/rkt/pkg/user"
 )
 
 func init() {
@@ -792,7 +792,7 @@ func extractTarHelper(rdr io.Reader, target string) error {
 }
 
 func extractTarHelperPWL(rdr io.Reader, target string, pwl PathWhitelistMap) error {
-	return ExtractTar(rdr, target, false, uid.NewBlankUidRange(), pwl)
+	return ExtractTar(rdr, target, false, user.NewBlankUidRange(), pwl)
 }
 
 func extractTarInsecureHelper(rdr io.Reader, target string) error {
@@ -800,7 +800,7 @@ func extractTarInsecureHelper(rdr io.Reader, target string) error {
 }
 
 func extractTarInsecureHelperPWL(rdr io.Reader, target string, pwl PathWhitelistMap) error {
-	editor, err := NewUidShiftingFilePermEditor(uid.NewBlankUidRange())
+	editor, err := NewUidShiftingFilePermEditor(user.NewBlankUidRange())
 	if err != nil {
 		return err
 	}

--- a/pkg/user/doc.go
+++ b/pkg/user/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package user allows resolving user UIDs/GIDs using various methods.
+// It also provides an implementation for shifting UIDs/GIDs.
+package user

--- a/pkg/user/resolver.go
+++ b/pkg/user/resolver.go
@@ -1,0 +1,143 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package user
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/coreos/rkt/pkg/group"
+	"github.com/coreos/rkt/pkg/passwd"
+	"github.com/hashicorp/errwrap"
+)
+
+// Resolver defines the interface for resolving a UID/GID.
+type Resolver interface {
+	IDs() (uid int, gid int, err error)
+}
+
+type idsFromEtc struct {
+	rootPath string
+	username string
+	group    string
+}
+
+// IDsFromEtc returns a new UID/GID resolver by parsing etc/passwd, and etc/group
+// relative from the given rootPath looking for the given username, or group.
+// If username is empty string the etc/passwd lookup will be ommitted.
+// If group is empty string the etc/group lookup will be ommitted.
+func IDsFromEtc(rootPath, username, group string) (Resolver, error) {
+	return idsFromEtc{
+		rootPath: rootPath,
+		username: username,
+		group:    group,
+	}, nil
+}
+
+func (e idsFromEtc) IDs() (uid int, gid int, err error) {
+	uid, gid = -1, -1
+
+	uid, err = passwd.LookupUidFromFile(
+		e.username,
+		filepath.Join(e.rootPath, "etc/passwd"),
+	)
+
+	if e.username != "" && err != nil {
+		return
+	}
+
+	gid, err = group.LookupGidFromFile(
+		e.group,
+		filepath.Join(e.rootPath, "etc/group"),
+	)
+
+	if e.group != "" && err != nil {
+		return
+	}
+
+	return uid, gid, nil
+}
+
+type idsFromStat struct {
+	path string
+	r    *UidRange
+}
+
+// IDsFromStat returns a new UID/GID resolver deriving the UID/GID from file attributes
+// and unshifts the UID/GID if the given range is not nil.
+// If the given id does not start with a slash "/" an error is returned.
+func IDsFromStat(rootPath, file string, r *UidRange) (Resolver, error) {
+	if strings.HasPrefix(file, "/") {
+		return idsFromStat{filepath.Join(rootPath, file), r}, nil
+	}
+
+	return nil, fmt.Errorf("invalid filename %q", file)
+}
+
+func (s idsFromStat) IDs() (int, int, error) {
+	var stat syscall.Stat_t
+
+	if err := syscall.Lstat(s.path, &stat); err != nil {
+		return -1, -1, errwrap.Wrap(
+			fmt.Errorf("unable to stat file %q", s.path),
+			err,
+		)
+	}
+
+	if s.r == nil {
+		return int(stat.Uid), int(stat.Gid), nil
+	}
+
+	uid, _, err := s.r.UnshiftRange(stat.Uid, stat.Gid)
+	if err != nil {
+		return -1, -1, errwrap.Wrap(errors.New("unable to determine real uid"), err)
+	}
+
+	_, gid, err := s.r.UnshiftRange(stat.Uid, stat.Gid)
+	if err != nil {
+		return -1, -1, errwrap.Wrap(errors.New("unable to determine real gid"), err)
+	}
+
+	return int(uid), int(gid), nil
+}
+
+// numericIDs is the struct that always resolves to uid=i and gid=i.
+type numericIDs struct {
+	i int
+}
+
+// NumericIDs returns a resolver that will resolve constant UID/GID values.
+// If the given id equals to "root" the resolver always resolves UID=0 and GID=0.
+// If the given id is a numeric literal i it always resolves UID=i and GID=i.
+// If the given id is neither "root" nor a numeric literal an error is returned.
+func NumericIDs(id string) (Resolver, error) {
+	if id == "root" {
+		return numericIDs{0}, nil
+	}
+
+	if i, err := strconv.Atoi(id); err == nil {
+		return numericIDs{i}, nil
+	}
+
+	return nil, fmt.Errorf("invalid id %q", id)
+}
+
+func (n numericIDs) IDs() (int, int, error) {
+	return n.i, n.i, nil
+}

--- a/pkg/user/resolver_test.go
+++ b/pkg/user/resolver_test.go
@@ -1,0 +1,350 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package user_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	osuser "os/user"
+
+	"github.com/coreos/rkt/pkg/user"
+)
+
+const (
+	maxInt = int(^uint(0) >> 1)
+	minInt = -maxInt - 1
+)
+
+func TestNumeric(t *testing.T) {
+	for i, tt := range []struct {
+		id string
+
+		// expected
+		err      bool
+		uid, gid int
+	}{
+		{
+			id:  "foo",
+			err: true,
+		},
+		{
+			id:  "",
+			err: true,
+		},
+		{
+			id:  "root",
+			uid: 0, gid: 0,
+		},
+		{
+			id:  "0",
+			uid: 0, gid: 0,
+		},
+		{
+			id:  "1",
+			uid: 1, gid: 1,
+		},
+		{
+			id:  strconv.Itoa(minInt),
+			uid: minInt, gid: minInt,
+		},
+		{
+			id:  strconv.Itoa(maxInt),
+			uid: maxInt, gid: maxInt,
+		},
+		{
+			id:  "9223372036854775808", // overflow (64bit) int by one
+			err: true,
+		},
+		{
+			id:  "-9223372036854775809", // overflow (64bit) int by one
+			err: true,
+		},
+		{
+			id:  "-1",
+			uid: -1, gid: -1,
+		},
+	} {
+		gen, err := user.NumericIDs(tt.id)
+		if err == nil && tt.err {
+			t.Errorf("test %d: expected err but got none", i)
+		}
+
+		if err != nil {
+			continue
+		}
+
+		uid, gid, err := gen.IDs()
+		if err != nil {
+			panic(err) // must not happen
+		}
+
+		if uid != tt.uid {
+			t.Errorf("test %d: expected uid %d but got %d", i, tt.uid, uid)
+		}
+
+		if gid != tt.gid {
+			t.Errorf("test %d: expected gid %d but got %d", i, tt.gid, gid)
+		}
+	}
+}
+
+func TestFromEtc(t *testing.T) {
+	root, err := ioutil.TempDir("", "rkt-TestFromEtc-")
+	if err != nil {
+		panic(err)
+	}
+
+	defer os.RemoveAll(root)
+
+	if err := os.Mkdir(
+		filepath.Join(root, "etc"),
+		0700,
+	); err != nil {
+		panic(err)
+	}
+
+	if err := ioutil.WriteFile(
+		filepath.Join(root, "etc/passwd"),
+		[]byte(`u1:xxx:1000:100:::`),
+		0600,
+	); err != nil {
+		panic(err)
+	}
+
+	if err := ioutil.WriteFile(
+		filepath.Join(root, "etc/group"),
+		[]byte(`g1:xxx:100:u1`),
+		0600,
+	); err != nil {
+		panic(err)
+	}
+
+	for i, tt := range []struct {
+		username, group string
+
+		// expected
+		err      bool
+		uid, gid int
+	}{
+		{
+			uid: -1,
+			gid: -1,
+			err: false,
+		},
+		{
+			username: "unknown",
+
+			uid: -1,
+			gid: -1,
+			err: true,
+		},
+		{
+			group: "unknown",
+
+			uid: -1,
+			gid: -1,
+			err: true,
+		},
+		{
+			username: "u1",
+
+			uid: 1000,
+			gid: -1,
+			err: false,
+		},
+		{
+			username: "u1",
+			group:    "unknown",
+
+			uid: 1000,
+			gid: -1,
+			err: true,
+		},
+		{
+			group: "g1",
+
+			uid: -1,
+			gid: 100,
+			err: false,
+		},
+		{
+			username: "unknown",
+			group:    "g1",
+
+			uid: -1,
+			gid: -1,
+			err: true,
+		},
+		{
+			username: "u1",
+			group:    "g1",
+
+			uid: 1000,
+			gid: 100,
+			err: false,
+		},
+	} {
+		gen, err := user.IDsFromEtc(root, tt.username, tt.group)
+		if err != nil {
+			panic(err)
+		}
+
+		uid, gid, err := gen.IDs()
+		if err == nil && tt.err {
+			t.Errorf("test %d: expected err but got none", i)
+		}
+
+		if err != nil && !tt.err {
+			t.Errorf("test %d: expected no err but got one", i)
+		}
+
+		if uid != tt.uid {
+			t.Errorf("test %d: expected uid %d but got %d", i, tt.uid, uid)
+		}
+
+		if gid != tt.gid {
+			t.Errorf("test %d: expected gid %d but got %d", i, tt.gid, gid)
+		}
+	}
+}
+
+func TestStat(t *testing.T) {
+	tmp, err := ioutil.TempFile("", "rkt-TestStat-")
+	if err != nil {
+		panic(err)
+	}
+
+	defer os.Remove(tmp.Name())
+
+	rng := user.NewBlankUidRange()
+	rng.SetRandomUidRange(100)
+
+	u, err := osuser.Current()
+	if err != nil {
+		panic(err)
+	}
+
+	procUid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		panic(err)
+	}
+
+	procGid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		panic(err)
+	}
+
+	for i, tt := range []struct {
+		root, path string
+
+		// expected
+		errIDs, err bool
+		uid, gid    int
+	}{
+		{
+			root: "",
+			path: "",
+
+			err: true,
+		},
+		{
+			root: "unknown",
+			path: "",
+
+			err: true,
+		},
+		{
+			root: "",
+			path: "unknown",
+
+			err: true,
+		},
+		{
+			root: "",
+			path: tmp.Name(),
+
+			uid: procUid,
+			gid: procGid,
+		},
+		{
+			root: "/",
+			path: tmp.Name(),
+
+			uid: procUid,
+			gid: procGid,
+		},
+		{
+			root: "unknown",
+			path: tmp.Name(),
+
+			errIDs: true,
+			uid:    -1,
+			gid:    -1,
+		},
+		{
+			root: filepath.Dir(tmp.Name()),
+			path: "",
+
+			err: true,
+		},
+		{
+			root: filepath.Dir(tmp.Name()),
+			path: "/" + filepath.Base(tmp.Name()),
+
+			uid: procUid,
+			gid: procGid,
+		},
+		{
+			root: filepath.Dir(tmp.Name()),
+			path: "/unknown",
+
+			errIDs: true,
+			uid:    -1,
+			gid:    -1,
+		},
+		{
+			root: filepath.Dir(tmp.Name()),
+			path: "unknown",
+
+			err: true,
+		},
+	} {
+		gen, err := user.IDsFromStat(tt.root, tt.path, nil)
+		if err == nil && tt.err {
+			t.Errorf("test %d: expected error but got one", i)
+		}
+
+		if err != nil {
+			continue
+		}
+
+		uid, gid, err := gen.IDs()
+		if err == nil && tt.errIDs {
+			t.Errorf("test %d: expected err but got none", i)
+		}
+
+		if uid != tt.uid {
+			t.Errorf("test %d: expected uid %d but got %d", i, tt.uid, uid)
+		}
+
+		if gid != tt.gid {
+			t.Errorf("test %d: expected gid %d but got %d", i, tt.gid, gid)
+		}
+	}
+}

--- a/pkg/user/uid_range.go
+++ b/pkg/user/uid_range.go
@@ -15,7 +15,7 @@
 // For how the uidshift and uidcount are generated please check:
 // http://cgit.freedesktop.org/systemd/systemd/commit/?id=03cfe0d51499e86b1573d1
 
-package uid
+package user
 
 import (
 	"errors"

--- a/rkt/image_extract.go
+++ b/rkt/image_extract.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/coreos/rkt/pkg/fileutil"
 	"github.com/coreos/rkt/pkg/tar"
-	"github.com/coreos/rkt/pkg/uid"
+	"github.com/coreos/rkt/pkg/user"
 	"github.com/coreos/rkt/store"
 
 	"github.com/spf13/cobra"
@@ -124,7 +124,7 @@ func runImageExtract(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	if err := tar.ExtractTar(aci, extractDir, false, uid.NewBlankUidRange(), nil); err != nil {
+	if err := tar.ExtractTar(aci, extractDir, false, user.NewBlankUidRange(), nil); err != nil {
 		stderr.PrintE("error extracting ACI", err)
 		return 1
 	}
@@ -134,7 +134,7 @@ func runImageExtract(cmd *cobra.Command, args []string) (exit int) {
 		if err := os.Rename(rootfsDir, absOutputDir); err != nil {
 			if e, ok := err.(*os.LinkError); ok && e.Err == syscall.EXDEV {
 				// it's on a different device, fall back to copying
-				if err := fileutil.CopyTree(rootfsDir, absOutputDir, uid.NewBlankUidRange()); err != nil {
+				if err := fileutil.CopyTree(rootfsDir, absOutputDir, user.NewBlankUidRange()); err != nil {
 					stderr.PrintE("error copying ACI rootfs", err)
 					return 1
 				}

--- a/rkt/image_render.go
+++ b/rkt/image_render.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/coreos/rkt/pkg/fileutil"
-	"github.com/coreos/rkt/pkg/uid"
+	"github.com/coreos/rkt/pkg/user"
 	"github.com/coreos/rkt/store"
 
 	"github.com/spf13/cobra"
@@ -127,7 +127,7 @@ func runImageRender(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	cachedTreePath := s.GetTreeStoreRootFS(id)
-	if err := fileutil.CopyTree(cachedTreePath, rootfsOutDir, uid.NewBlankUidRange()); err != nil {
+	if err := fileutil.CopyTree(cachedTreePath, rootfsOutDir, user.NewBlankUidRange()); err != nil {
 		stderr.PrintE("error copying ACI rootfs", err)
 		return 1
 	}

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -22,7 +22,7 @@ import (
 	"github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/pkg/lock"
-	"github.com/coreos/rkt/pkg/uid"
+	"github.com/coreos/rkt/pkg/user"
 	"github.com/coreos/rkt/rkt/image"
 	"github.com/coreos/rkt/stage0"
 	"github.com/coreos/rkt/store"
@@ -81,7 +81,7 @@ func init() {
 func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	var err error
 	origStdout := os.Stdout
-	privateUsers := uid.NewBlankUidRange()
+	privateUsers := user.NewBlankUidRange()
 	if flagQuiet {
 		if os.Stdout, err = os.Open("/dev/null"); err != nil {
 			stderr.PrintE("unable to open /dev/null", err)
@@ -99,7 +99,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 			stderr.Print("--private-users is not supported, kernel compiled without user namespace support")
 			return 1
 		}
-		privateUsers.SetRandomUidRange(uid.DefaultRangeCount)
+		privateUsers.SetRandomUidRange(user.DefaultRangeCount)
 	}
 
 	if err = parseApps(&rktApps, args, cmd.Flags(), true); err != nil {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -25,7 +25,7 @@ import (
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/pkg/label"
 	"github.com/coreos/rkt/pkg/lock"
-	"github.com/coreos/rkt/pkg/uid"
+	"github.com/coreos/rkt/pkg/user"
 	"github.com/coreos/rkt/rkt/image"
 	"github.com/coreos/rkt/stage0"
 	"github.com/coreos/rkt/store"
@@ -114,7 +114,7 @@ func init() {
 }
 
 func runRun(cmd *cobra.Command, args []string) (exit int) {
-	privateUsers := uid.NewBlankUidRange()
+	privateUsers := user.NewBlankUidRange()
 	err := parseApps(&rktApps, args, cmd.Flags(), true)
 	if err != nil {
 		stderr.PrintE("error parsing app image arguments", err)
@@ -131,7 +131,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 			stderr.Print("--private-users is not supported, kernel compiled without user namespace support")
 			return 1
 		}
-		privateUsers.SetRandomUidRange(uid.DefaultRangeCount)
+		privateUsers.SetRandomUidRange(user.DefaultRangeCount)
 	}
 
 	if len(flagPorts) > 0 && flagNet.None() {

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -47,7 +47,7 @@ import (
 	"github.com/coreos/rkt/pkg/label"
 	"github.com/coreos/rkt/pkg/sys"
 	"github.com/coreos/rkt/pkg/tpm"
-	"github.com/coreos/rkt/pkg/uid"
+	"github.com/coreos/rkt/pkg/user"
 	"github.com/coreos/rkt/store"
 	"github.com/coreos/rkt/version"
 	"github.com/hashicorp/errwrap"
@@ -76,7 +76,7 @@ type PrepareConfig struct {
 	UseOverlay         bool                // prepare pod with overlay fs
 	SkipTreeStoreCheck bool                // skip checking the treestore before rendering
 	PodManifest        string              // use the pod manifest specified by the user, this will ignore flags such as '--volume', '--port', etc.
-	PrivateUsers       *uid.UidRange       // User namespaces
+	PrivateUsers       *user.UidRange      // User namespaces
 }
 
 // configuration parameters needed by Run

--- a/stage1/init/common/mount.go
+++ b/stage1/init/common/mount.go
@@ -21,7 +21,7 @@ import (
 	"syscall"
 
 	"github.com/coreos/rkt/pkg/fileutil"
-	"github.com/coreos/rkt/pkg/uid"
+	"github.com/coreos/rkt/pkg/user"
 
 	"github.com/appc/spec/schema"
 	"github.com/appc/spec/schema/types"
@@ -158,7 +158,7 @@ func PrepareMountpoints(volPath string, targetPath string, vol *types.Volume, do
 			Uid = int(fi.Sys().(*syscall.Stat_t).Uid)
 			Gid = int(fi.Sys().(*syscall.Stat_t).Gid)
 
-			if err := fileutil.CopyTree(targetPath, volPath, uid.NewBlankUidRange()); err != nil {
+			if err := fileutil.CopyTree(targetPath, volPath, user.NewBlankUidRange()); err != nil {
 				return errwrap.Wrap(fmt.Errorf("error copying image files to empty volume %q", volPath), err)
 			}
 		}

--- a/store/backup.go
+++ b/store/backup.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 
 	"github.com/coreos/rkt/pkg/fileutil"
-	"github.com/coreos/rkt/pkg/uid"
+	"github.com/coreos/rkt/pkg/user"
 )
 
 // createBackup backs a database up in a given directory. It basically
@@ -37,7 +37,7 @@ func createBackup(dbDir, backupsDir string, limit int) error {
 	if err := os.MkdirAll(backupsDir, defaultPathPerm); err != nil {
 		return err
 	}
-	if err := fileutil.CopyTree(dbDir, tmpBackupDir, uid.NewBlankUidRange()); err != nil {
+	if err := fileutil.CopyTree(dbDir, tmpBackupDir, user.NewBlankUidRange()); err != nil {
 		return err
 	}
 	defer os.RemoveAll(tmpBackupDir)

--- a/store/tree.go
+++ b/store/tree.go
@@ -33,7 +33,7 @@ import (
 	"github.com/coreos/rkt/pkg/aci"
 	"github.com/coreos/rkt/pkg/fileutil"
 	"github.com/coreos/rkt/pkg/sys"
-	"github.com/coreos/rkt/pkg/uid"
+	"github.com/coreos/rkt/pkg/user"
 	"github.com/hashicorp/errwrap"
 )
 
@@ -66,7 +66,7 @@ func (ts *TreeStore) Write(id string, key string, s *Store) (string, error) {
 	if err := os.MkdirAll(treepath, 0755); err != nil {
 		return "", errwrap.Wrap(fmt.Errorf("cannot create treestore directory %s", treepath), err)
 	}
-	err = aci.RenderACIWithImageID(*imageID, treepath, s, uid.NewBlankUidRange())
+	err = aci.RenderACIWithImageID(*imageID, treepath, s, user.NewBlankUidRange())
 	if err != nil {
 		return "", errwrap.Wrap(errors.New("cannot render aci"), err)
 	}


### PR DESCRIPTION
This cleans up the code a bit and provides the necessary uid/gid functionality for implementing user/groups for rkt fly, see #2439