### PR TITLE
stage1/usr_from_coreos: use CoreOS 1032.0.0 with systemd v229

### DIFF
--- a/stage1/usr_from_coreos/coreos-common.mk
+++ b/stage1/usr_from_coreos/coreos-common.mk
@@ -9,9 +9,9 @@ _CCN_INCLUDED_ := x
 $(call setup-tmp-dir,CCN_TMPDIR)
 
 # systemd version in coreos image
-CCN_SYSTEMD_VERSION := v225
+CCN_SYSTEMD_VERSION := v229
 # coreos image version
-CCN_IMG_RELEASE := 991.0.0
+CCN_IMG_RELEASE := 1032.0.0
 # coreos image URL
 CCN_IMG_URL := https://alpha.release.core-os.net/amd64-usr/$(CCN_IMG_RELEASE)/coreos_production_pxe_image.cpio.gz
 # path to downloaded pxe image

--- a/stage1/usr_from_coreos/manifest.d/systemd.manifest
+++ b/stage1/usr_from_coreos/manifest.d/systemd.manifest
@@ -61,6 +61,9 @@ lib64/libmount.so.1
 lib64/libmount.so.1.1.0
 lib64/libnss_files-2.21.so
 lib64/libnss_files.so.2
+lib64/libpam.so
+lib64/libpam.so.0
+lib64/libpam.so.0.84.1
 lib64/libpcre.so
 lib64/libpcre.so.1
 lib64/libpcre.so.1.2.4


### PR DESCRIPTION
Now that [systemd v229 is in CoreOS](https://github.com/coreos/coreos-overlay/pull/1833) we can bump it in stage1.

Fixes https://github.com/coreos/rkt/issues/1759