### PR TITLE
docs: added benchmarks folder, benchmarks for v1.4.0

### DIFF
--- a/Documentation/benchmarks/README.md
+++ b/Documentation/benchmarks/README.md
@@ -1,0 +1,29 @@
+# Benchmarks
+
+rkt has a utility called rkt-monitor that will run rkt with an example
+workload, and track the memory and CPU usage. It does this by exec'ing rkt with
+an ACI or pod manifest, watching the resource consumption for rkt and all
+children processes, and after a timeout killing rkt and printing the results.
+
+## Running the Benchmarks
+
+To run the benchmarks, one must have both a built version of rkt-monitor and an
+ACI or pod manifest. Additionally, rkt must be available on the `PATH`.
+
+To build rkt-monitor, `cd` to `tests/rkt-monitor` and run the `build` script in
+that directory.
+
+To build one of the provided workloads, run any of the `build-*` scripts in
+`tests/rkt-monitor`. All scripts require acbuild to be available on the current
+`PATH`. The script will produce either an ACI, or a directory with multiple
+ACIs and a pod manifest. In the case of the latter, the ACIs in the created
+directory must be imported into rkt's cas before running rkt-monitor, via the
+command `rkt fetch --insecure-options=image <newDirectory>/*`.
+
+With rkt-monitor and an ACI or a pod manifest, now the benchmarks can be run
+via `./rkt-monitor <workload>`.
+
+There are two flags available to influence how rkt-monitor runs. `-v` will
+print out the current resource usage of each process every second. `-d` can be
+used to specify a duration to run the tests for (default of 10s). For example,
+`-d 30s` will run the tests for 30 seconds.

--- a/Documentation/benchmarks/rkt-1-4-0-benchmarks.md
+++ b/Documentation/benchmarks/rkt-1-4-0-benchmarks.md
@@ -1,0 +1,49 @@
+```
+derek@proton ~> cat /proc/cpuinfo | grep "model name"
+model name  : Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz
+model name  : Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz
+model name  : Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz
+model name  : Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz
+derek@proton ~> uname -a                             
+Linux proton 4.4.6 #1-NixOS SMP Wed Mar 16 15:43:17 UTC 2016 x86_64 GNU/Linux
+```
+
+## v1.4.0
+
+### log-stresser.aci
+```
+derek@proton ~/go/src/github.com/coreos/rkt/tests/rkt-monitor> sudo ./rkt-monitor log-stresser.aci
+rkt(18493): seconds alive: 10  avg CPU: 28.314541%  avg Mem: 2 mB  peak Mem: 2 mB
+systemd(18515): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB
+systemd-journal(18517): seconds alive: 9  avg CPU: 88.397098%  avg Mem: 7 mB  peak Mem: 7 mB
+worker(18521): seconds alive: 9  avg CPU: 7.330367%  avg Mem: 5 mB  peak Mem: 6 mB
+```
+
+### mem-stresser.aci
+```
+derek@proton ~/go/src/github.com/coreos/rkt/tests/rkt-monitor> sudo ./rkt-monitor mem-stresser.aci 
+worker(18634): seconds alive: 9  avg CPU: 98.550401%  avg Mem: 318 mB  peak Mem: 555 mB
+rkt(18599): seconds alive: 10  avg CPU: 3.583814%  avg Mem: 2 mB  peak Mem: 2 mB
+systemd(18628): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB
+systemd-journal(18630): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 6 mB  peak Mem: 6 mB
+```
+
+### cpu-stresser.aci
+```
+derek@proton ~/go/src/github.com/coreos/rkt/tests/rkt-monitor> sudo ./rkt-monitor cpu-stresser.aci 
+rkt(18706): seconds alive: 10  avg CPU: 3.587050%  avg Mem: 2 mB  peak Mem: 2 mB
+systemd(18736): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB
+systemd-journal(18740): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 6 mB  peak Mem: 6 mB
+worker(18744): seconds alive: 9  avg CPU: 88.937493%  avg Mem: 808 kB  peak Mem: 808 kB
+```
+
+### too-many-apps.podmanifest
+```
+derek@proton ~/go/src/github.com/coreos/rkt/tests/rkt-monitor> sudo ./rkt-monitor too-many-apps.podmanifest -d 30s
+# Identical (aside from PID) worker-binary lines removed
+rkt(17227): seconds alive: 20  avg CPU: 9.595387%  avg Mem: 3 mB  peak Mem: 20 mB
+systemd(17253): seconds alive: 17  avg CPU: 0.329028%  avg Mem: 16 mB  peak Mem: 16 mB
+systemd-journal(17255): seconds alive: 17  avg CPU: 0.000000%  avg Mem: 6 mB  peak Mem: 6 mB
+worker-binary(17883): seconds alive: 17  avg CPU: 0.000000%  avg Mem: 840 kB  peak Mem: 840 kB
+```
+


### PR DESCRIPTION
Added the `Documentation/benchmarks` folder which includes a README that
describes how rkt-monitor works and how to use it, and a file detailing
the results of running rkt-monitor on each current workload with rkt
v1.4.0.

Fixes https://github.com/coreos/rkt/issues/1788