### PR TITLE
Allow passing existing network namespace to --net as a net name

### DIFF
--- a/networking/podenv.go
+++ b/networking/podenv.go
@@ -46,6 +46,7 @@ const (
 // is running in
 type podEnv struct {
 	podRoot      string
+	nsPath       string
 	podID        types.UUID
 	netsLoadList common.NetList
 	localConfig  string
@@ -92,6 +93,9 @@ func (e *podEnv) loadNets() ([]activeNet, error) {
 }
 
 func (e *podEnv) podNSPath() string {
+	if e.nsPath != "" {
+		return e.nsPath
+	}
 	return filepath.Join(e.podRoot, "netns")
 }
 


### PR DESCRIPTION
For some reference, see https://github.com/kubernetes/kubernetes/issues/24672#issuecomment-215152231.  The capability of passing an existing network namespace into rkt would allow kubernetes pod containers to share the same network namespace like they do with the docker runtime.

Untested PR, mostly for discussion.