### PR TITLE
rkt/image: render images only if we're root

### DIFF
--- a/rkt/image/fetcher.go
+++ b/rkt/image/fetcher.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"runtime"
 
 	"github.com/coreos/rkt/common"
@@ -52,7 +53,9 @@ func (f *Fetcher) FetchImage(img string, ascPath string, imgType apps.AppImageTy
 			return "", err
 		}
 	}
-	if common.SupportsOverlay() {
+	// we need to be able to do a chroot and access to the tree store
+	// directories, check if we're root
+	if common.SupportsOverlay() && os.Geteuid() == 0 {
 		if _, _, err := f.S.RenderTreeStore(hash, false); err != nil {
 			return "", errwrap.Wrap(errors.New("error rendering tree store"), err)
 		}


### PR DESCRIPTION
To render images, we need access to the tree store directories and
capabilities to do a chroot.

We could allow the rkt group to access the tree store directories and
not do a chroot when rendering but since this rendering-on-fetch is just
an optimization, it's simpler to just skip the rendering if we fetch as
non-root.

Fixes https://github.com/coreos/rkt/issues/2521