### PR TITLE
functional tests: capture SIGTERM in inspect

### DIFF
--- a/tests/rkt_service_file_test.go
+++ b/tests/rkt_service_file_test.go
@@ -50,7 +50,10 @@ func TestServiceFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	opts := "-- --print-msg=HelloWorld --sleep=1000"
+	// we need to add --silent-sigterm so inspect terminates correctly and the
+	// transient service exits successfully so it disappears from the list of
+	// units
+	opts := "-- --silent-sigterm --print-msg=HelloWorld --sleep=1000"
 
 	cmd := fmt.Sprintf("%s --insecure-options=image run --mds-register=false --set-env=MESSAGE_LOOP=1000 %s %s", ctx.Cmd(), image, opts)
 	props := []sd_dbus.Property{


### PR DESCRIPTION
In TestService, we start a systemd service running a rkt image that
prints a message every second. Then we stop the unit and check it's not
in the service list.

This was working before because we weren't propagating the exit status
of apps in the pod to the outside.

Now that we do it, stopping the unit file means that SIGTERM will be
sent to nspawn, which will trigger a shutdown of systemd inside the pod,
which means SIGTERM will be sent to all the apps and that makes the
inspect binary exit with a non-zero status. Transient units that exit
with a failed status remain on the services list, so our test fails.

Capture SIGTERM in inspect and return 0 in that case, so the test
passes.

Fixes https://github.com/coreos/rkt/issues/2323