### PR TITLE
kvm: fix mounts regression

### DIFF
--- a/stage1/init/kvm.go
+++ b/stage1/init/kvm.go
@@ -97,7 +97,7 @@ func mountSharedVolumes(root string, p *stage1commontypes.Pod, ra *schema.Runtim
 		default:
 			return fmt.Errorf(`invalid volume kind %q. Must be one of "host" or "empty"`, vol.Kind)
 		}
-		absAppRootfs, err := filepath.Abs(common.AppRootfsPath(root, appName))
+		absAppRootfs, err := filepath.Abs(common.AppRootfsPath(".", appName))
 		if err != nil {
 			return fmt.Errorf(`could not evaluate absolute path for application rootfs in app: %v`, appName)
 		}


### PR DESCRIPTION
Cause - AppRootfsPath called with local "root" value was adding
stage1/rootfs twice. After this change this is made properly.

Fixes regression made in df53308, closes #2469