### PR TITLE
tests: install bc on Semaphore for kvm

### DIFF
--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -25,7 +25,7 @@ if [ "${CI-}" == true ] ; then
 		# install -y <dep>" after it.
 
 		sudo apt-get update -qq || true
-		sudo apt-get install -y libacl1-dev
+		sudo apt-get install -y libacl1-dev bc
 
 		# libmount: https://github.com/systemd/systemd/pull/986#issuecomment-138451264
 		sudo add-apt-repository --yes ppa:pitti/systemd-semaphore


### PR DESCRIPTION
The kvm flavor needs 'bc' to build and 'bc' is not installed by default
on Semaphore. This was introduced by https://github.com/coreos/rkt/pull/2007