### PR TITLE
tests: enable tests on the 'host' flavor

### DIFF
--- a/tests/rkt_ace_validator_test.go
+++ b/tests/rkt_ace_validator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build host coreos src
 
 package main
 

--- a/tests/rkt_api_service_bench_test.go
+++ b/tests/rkt_api_service_bench_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_api_service_nspawn_test.go
+++ b/tests/rkt_api_service_nspawn_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build host coreos src
 
 package main
 

--- a/tests/rkt_api_service_test.go
+++ b/tests/rkt_api_service_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_app_isolator_nspawn_test.go
+++ b/tests/rkt_app_isolator_nspawn_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build host coreos src
 
 package main
 

--- a/tests/rkt_app_isolator_test.go
+++ b/tests/rkt_app_isolator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_auth_test.go
+++ b/tests/rkt_auth_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_caps_nspawn_test.go
+++ b/tests/rkt_caps_nspawn_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build host coreos src
 
 package main
 

--- a/tests/rkt_caps_test.go
+++ b/tests/rkt_caps_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_cat_manifest_test.go
+++ b/tests/rkt_cat_manifest_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_dns_test.go
+++ b/tests/rkt_dns_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build host coreos src
 
 package main
 

--- a/tests/rkt_env_test.go
+++ b/tests/rkt_env_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_error_output_test.go
+++ b/tests/rkt_error_output_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_etc_hosts_test.go
+++ b/tests/rkt_etc_hosts_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build host coreos src
 
 package main
 

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_exit_test.go
+++ b/tests/rkt_exit_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build host coreos src
 
 package main
 

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_gc_test.go
+++ b/tests/rkt_gc_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_hostname_test.go
+++ b/tests/rkt_hostname_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_image_cat_manifest_test.go
+++ b/tests/rkt_image_cat_manifest_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_image_dependencies_test.go
+++ b/tests/rkt_image_dependencies_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_image_extract_test.go
+++ b/tests/rkt_image_extract_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_image_gc_test.go
+++ b/tests/rkt_image_gc_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_image_list_test.go
+++ b/tests/rkt_image_list_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_image_rm_test.go
+++ b/tests/rkt_image_rm_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_interactive_test.go
+++ b/tests/rkt_interactive_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_list_test.go
+++ b/tests/rkt_list_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_metadata_service_test.go
+++ b/tests/rkt_metadata_service_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_mount_test.go
+++ b/tests/rkt_mount_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build host coreos src
 
 package main
 

--- a/tests/rkt_net_nspawn_test.go
+++ b/tests/rkt_net_nspawn_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build host coreos src
 
 package main
 

--- a/tests/rkt_net_test.go
+++ b/tests/rkt_net_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_non_root_test.go
+++ b/tests/rkt_non_root_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_pid_file_nspawn_test.go
+++ b/tests/rkt_pid_file_nspawn_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build host coreos src
 
 package main
 

--- a/tests/rkt_pid_file_test.go
+++ b/tests/rkt_pid_file_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_root_commands_test.go
+++ b/tests/rkt_root_commands_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build host coreos src
 
 package main
 

--- a/tests/rkt_run_user_group_test.go
+++ b/tests/rkt_run_user_group_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build host coreos src
 
 package main
 

--- a/tests/rkt_service_file_test.go
+++ b/tests/rkt_service_file_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_socket_activation_test.go
+++ b/tests/rkt_socket_activation_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_socket_proxyd_test.go
+++ b/tests/rkt_socket_proxyd_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_stage1_loading_test.go
+++ b/tests/rkt_stage1_loading_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_supplementary_gids_test.go
+++ b/tests/rkt_supplementary_gids_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_trust_test.go
+++ b/tests/rkt_trust_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build host coreos src kvm
 
 package main
 

--- a/tests/rkt_userns_test.go
+++ b/tests/rkt_userns_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build host coreos src
 
 package main
 

--- a/tests/rkt_volume_nspawn_test.go
+++ b/tests/rkt_volume_nspawn_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build host coreos src
 
 package main
 

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // TODO: fix TestDockerVolumeSemantics on KVM and add the "kvm" build tag again
-// +build coreos src
+// +build host coreos src
 
 package main
 


### PR DESCRIPTION
The flavor "host" is tested by `tests/aws.sh` on Fedora-Rawhide.

Symptoms:
```
  GO TEST      github.com/coreos/rkt/tests
# github.com/coreos/rkt/tests
runtime.main: call to external function main.main
runtime.main: main.main: not defined
runtime.main: undefined: main.main
tests/functional.mk:82: recipe for target '/var/tmp/rkt/builds/build-rkt-host/build-rkt-1.4.0+git/stamps/__tests_functional_mk_functional_tests.stamp' failed
make: *** [/var/tmp/rkt/builds/build-rkt-host/build-rkt-1.4.0+git/stamps/__tests_functional_mk_functional_tests.stamp] Error 2
```

/cc @steveeJ 