### PR TITLE
kvm: skip kvm network tests

### DIFF
--- a/tests/rkt_net_kvm_test.go
+++ b/tests/rkt_net_kvm_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build kvm
+// +build skip
 
 package main
 

--- a/tests/rkt_socket_proxyd_test.go
+++ b/tests/rkt_socket_proxyd_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src kvm
+// +build coreos src
 
 package main
 


### PR DESCRIPTION
Remove network tests from test suite caused by #2007 and #2535