### PR TITLE
Add additional options for developers in build-and-run-tests.sh script

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -66,11 +66,13 @@ It would be possible to add more tests with the following commands:
 #### build-and-run-tests.sh parameters description
 
 The build script has the following parameters:
-- `-f` - Select flavor for rkt. You can choose only one from the following list: "`coreos`, `host`, `kvm`, `none`, `src`".
-- `-s` - Systemd version. You can choose `master` or a tag from the [systemd GitHub repository](https://github.com/systemd/systemd).
 - `-c` - Run cleanup. Cleanup has two phases: *after build* and *after tests*. In the *after build* phase, this script removes artifacts from external dependencies (like kernel sources in the `kvm` flavor). In the  *after tests* phase, it removes `rkt` build artifacts and (if the build is running on CI or if the `-x` flag is used) it unmounts the remaining `rkt` mountpoints, removes unused `rkt` NICs and flushes the current state of IPAM IP reservation.
-- `-x` - Force after-test cleanup on a non-CI system. **WARNING: This flag can affect your system. Use with caution.**
+- `-d` - Run build based on current state of local rkt repository instead of commited changes.
+- `-f` - Select flavor for rkt. You can choose only one from the following list: "`coreos`, `host`, `kvm`, `none`, `src`".
+- `-j` - Build without running unit and functional tests. Artifacts are available after build.
+- `-s` - Systemd version. You can choose `master` or a tag from the [systemd GitHub repository](https://github.com/systemd/systemd).
 - `-u` - Show usage message and exit.
+- `-x` - Force after-test cleanup on a non-CI system. **WARNING: This flag can affect your system. Use with caution.**
 
 ### Platform
 

--- a/tests/build-and-run-tests.sh
+++ b/tests/build-and-run-tests.sh
@@ -74,7 +74,7 @@ function checkFlavorValue {
 
 # Parse user provided parameters
 function parseParameters {
-    while getopts "f:s:cxu" option; do
+    while getopts "f:s:cxujd" option; do
         case ${option} in
         f)
             RKT_STAGE1_USR_FROM="${OPTARG}"
@@ -97,6 +97,12 @@ function parseParameters {
         c)
             PRECLEANUP=true
             POSTCLEANUP=true
+            ;;
+        j)
+            JUSTBUILD=true
+            ;;
+        d)
+            DIRTYBUILD=true
             ;;
         \?)
             set -
@@ -158,9 +164,10 @@ function build {
     if [[ ${PRECLEANUP} == true ]]; then
         rm -rf "${BUILD_DIR}/tmp/usr_from_${RKT_STAGE1_USR_FROM}"
     fi
-
-    make check
-    make "-j${CORES}" clean
+    if [[ ${JUSTBUILD} != true ]]; then
+        make check
+        make "-j${CORES}" clean
+    fi
 }
 
 # Prepare build directory name
@@ -185,21 +192,35 @@ function detectChanges {
     fi
 }
 
-# Clone source code into build directory
-function cloneCode {
-    detectChanges
-    git clone ../ "${BUILD_DIR}"
+# Copy source code into build directory
+function copyCode {
+    if [[ $(whereis -b rsync | awk '{print $2}') != "" ]]; then
+        rsync -aq ../ ${BUILD_DIR} --exclude=".git*" --exclude=builds --exclude-from=../.gitignore
+    else
+        echo "Cannot find `rsync`, which is required by this shell script"
+        exit 1
+    fi
+}
+
+# Set source code into build directory and enter into it
+function setCodeInBuildEnv {
+    if [[ ${DIRTYBUILD} == '' ]]; then
+        detectChanges
+    fi
+    copyCode
     pushd "${BUILD_DIR}"
 }
 
 # Show usage
 function usage {
     echo "build-and-run-tests.sh usage:"
-    echo -e "-f\tSelect flavor"
-    echo -e "-s\tSystemd version"
     echo -e "-c\tCleanup"
-    echo -e "-x\tUse with '-c' to force cleanup on non-CI systems"
+    echo -e "-d\tUse unsaved changes for build"
+    echo -e "-f\tSelect flavor"
+    echo -e "-j\tDon't run tests after build"
+    echo -e "-s\tSystemd version"
     echo -e "-u\tShow this message"
+    echo -e "-x\tUse with '-c' to force cleanup on non-CI systems"
 }
 
 # Prepare build environment
@@ -247,7 +268,7 @@ function main {
 
     prepareBuildEnv
     cd builds
-    cloneCode
+    setCodeInBuildEnv
 
     if [ ${SRC_CHANGES} -gt 0 ]; then
         build


### PR DESCRIPTION
This patch enables running builds w/o testing and using not commited changes for builds