### PR TITLE
docs: remove leftover enter subcmd section

### DIFF
--- a/Documentation/subcommands/enter.md
+++ b/Documentation/subcommands/enter.md
@@ -16,10 +16,6 @@ bin   data  entrypoint.sh  home  lib64  mnt  proc  run   selinux  sys  usr
 boot  dev   etc            lib   media  opt  root  sbin  srv      tmp  var
 ```
 
-## Run a Pod in the Background
-
-Work in progress. Please contribute!
-
 ## Options
 
 | Flag | Default | Options | Description |


### PR DESCRIPTION
Remove irrelevant section from the enter subcommand documentation.

Background doesn't make sense here. Probably an oversight from here: a63e496e647