### PR TITLE
docs: distributions: Fedora

### DIFF
--- a/Documentation/distributions.md
+++ b/Documentation/distributions.md
@@ -34,15 +34,18 @@ Or permanently disabled by editing `/etc/selinux/config`:
 SELINUX=permissive
 ```
 
-#### Caveat: firewall
+#### Caveat: firewalld
 
-The default firewall rules can block the traffic from rkt pods.
-See [#2206](https://github.com/coreos/rkt/issues/2206).
-As a workaround, they can be removed:
+Fedora uses [firewalld](https://fedoraproject.org/wiki/FirewallD) to dynamically define firewall zones.
+rkt is [not yet fully integrated with firewalld](https://github.com/coreos/rkt/issues/2206).
+The default firewalld rules may interfere with the network connectivity of rkt pods.
+To work around this, add a firewalld rule to allow pod traffic:
 ```
-sudo iptables -F
-sudo iptables -F -t nat
+sudo firewall-cmd --add-source=172.16.28.0/24 --zone=trusted
 ```
+
+172.16.28.0/24 is the subnet of the [default pod network](https://github.com/coreos/rkt/blob/master/Documentation/networking/overview.md#the-default-network). The command must be adapted when rkt is configured to use a [different network](https://github.com/coreos/rkt/blob/master/Documentation/networking/overview.md#setting-up-additional-networks) with a different subnet.
+
 
 ## Arch
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Check out the [roadmap](ROADMAP.md) for more details on the future of rkt.
 ## Trying out rkt
 
 To get started quickly using rkt for the first time, start with the ["trying out rkt" document](Documentation/trying-out-rkt.md).
+Also check [rkt support on your Linux distribution](Documentation/distributions.md).
 For an end-to-end example of building an application from scratch and running it with rkt, check out the [getting started guide](Documentation/getting-started-guide.md).
 
 ## Getting help with rkt


### PR DESCRIPTION
Improve documentation on the Fedora caveat with FirewallD. Add a link from README.md.

Addresses a part of https://github.com/coreos/rkt/issues/2202

@joshix PTAL