### PR TITLE
stage1: allow pid1 to be moved to init.scope

### DIFF
--- a/common/cgroup/cgroup.go
+++ b/common/cgroup/cgroup.go
@@ -384,8 +384,11 @@ func RemountCgroupsRO(root string, enabledCgroups map[int][]string, subcgroup st
 
 		// Create cgroup directories and mount the files we need over
 		// themselves so they stay read-write
+		appCgroups := []string{filepath.Join(subcgroupPath, "init.scope")}
 		for _, serviceName := range serviceNames {
-			appCgroup := filepath.Join(subcgroupPath, serviceName)
+			appCgroups = append(appCgroups, filepath.Join(subcgroupPath, "system.slice", serviceName))
+		}
+		for _, appCgroup := range appCgroups {
 			if err := os.MkdirAll(appCgroup, 0755); err != nil {
 				return err
 			}

--- a/stage1/aci/aci-install.mk
+++ b/stage1/aci/aci-install.mk
@@ -14,6 +14,7 @@ AMI_ACIROOTFSDIR := $(STAGE1_ACIROOTFSDIR_$(AMI_FLAVOR))
 AMI_ACI_DIRS_BASE := $(AMI_ACIROOTFSDIR)
 AMI_ACI_DIRS_RESTS := \
 	etc \
+	etc/systemd \
 	opt/stage2 \
 	rkt/status \
 	rkt/env
@@ -25,6 +26,8 @@ AMI_ACI_DIR_CHAINS := \
 AMI_ACI_INSTALLED_DIRS := $(addprefix $(AMI_ACI_DIRS_BASE)/,$(AMI_ACI_DIRS_RESTS))
 # os-release in /etc in the ACI rootfs
 AMI_ACI_OS_RELEASE := $(AMI_ACI_DIRS_BASE)/etc/os-release
+# /etc/systemd/system.conf in the ACI rootfs
+AMI_ACI_SYSTEMD_CONF := $(AMI_ACI_DIRS_BASE)/etc/systemd/system.conf
 # manifest in the ACI directory
 AMI_ACI_MANIFEST := $(STAGE1_ACIDIR_$(AMI_FLAVOR))/manifest
 # generated manifest to be copied to the ACI directory
@@ -35,6 +38,7 @@ AMI_SRC_MANIFEST := $(MK_SRCDIR)/aci-manifest.in
 AMI_NAME := coreos.com/rkt/stage1-$(AMI_FLAVOR)
 # list of installed files
 AMI_INSTALLED_FILES := \
+	$(AMI_ACI_SYSTEMD_CONF) \
 	$(AMI_ACI_OS_RELEASE) \
 	$(AMI_ACI_MANIFEST)
 
@@ -110,7 +114,8 @@ $(call generate-kv-deps,$(AMI_INSTALLED_KV_DEPMK_STAMP),$(AMI_RMDIR_STAMP),$(AMI
 STAGE1_INSTALL_DIRS_$(AMI_FLAVOR) += $(addsuffix :0755,$(AMI_ACI_DIR_CHAINS))
 STAGE1_INSTALL_FILES_$(AMI_FLAVOR) += \
 	$(AMI_GEN_MANIFEST):$(AMI_ACI_MANIFEST):0644 \
-	$(MK_SRCDIR)/os-release:$(AMI_ACI_OS_RELEASE):0644
+	$(MK_SRCDIR)/os-release:$(AMI_ACI_OS_RELEASE):0644 \
+	$(MK_SRCDIR)/system.conf:$(AMI_ACI_SYSTEMD_CONF):0644
 STAGE1_SECONDARY_STAMPS_$(AMI_FLAVOR) += $(AMI_STAMP)
 CLEAN_FILES += $(AMI_GEN_MANIFEST)
 

--- a/stage1/aci/system.conf
+++ b/stage1/aci/system.conf
@@ -1,0 +1,7 @@
+# /etc/systemd/system.conf
+# See systemd-system.conf(5) for details.
+
+[Manager]
+DefaultCPUAccounting=yes
+DefaultBlockIOAccounting=yes
+DefaultMemoryAccounting=yes

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -729,7 +729,7 @@ func getContainerSubCgroup(machineID string) (string, error) {
 		if err != nil {
 			return "", errwrap.Wrap(errors.New("could not get unit name"), err)
 		}
-		subcgroup = filepath.Join(slicePath, unit, "system.slice")
+		subcgroup = filepath.Join(slicePath, unit)
 	} else {
 		escapedmID := strings.Replace(machineID, "-", "\\x2d", -1)
 		machineDir := "machine-" + escapedmID + ".scope"
@@ -737,7 +737,7 @@ func getContainerSubCgroup(machineID string) (string, error) {
 			// we are not in the final cgroup yet: systemd-nspawn will move us
 			// to the correct cgroup later during registration so we can't
 			// look it up in /proc/self/cgroup
-			subcgroup = filepath.Join("machine.slice", machineDir, "system.slice")
+			subcgroup = filepath.Join("machine.slice", machineDir)
 		} else {
 			// when registration is disabled the container will be directly
 			// under the current cgroup so we can look it up in /proc/self/cgroup
@@ -752,7 +752,7 @@ func getContainerSubCgroup(machineID string) (string, error) {
 			if err := cgroup.JoinSubcgroup("systemd", ownCgroupPath); err != nil {
 				return "", errwrap.Wrap(fmt.Errorf("error joining %s subcgroup", ownCgroupPath), err)
 			}
-			subcgroup = filepath.Join(ownCgroupPath, "system.slice")
+			subcgroup = ownCgroupPath
 		}
 	}
 


### PR DESCRIPTION
pid1 was moved to init.scope in the systemd hierarchy but not in the
other cgroup hierarchies. This was because systemd-nspawn does not
delegate the other cgroup hierarchies and mount them read-only. rkt
make parts of the other cgroup hierarchies read-write but this was not
extended to init.scope. This patch extends that logic to init.scope.

Also add /etc/systemd/system.conf: we want to enable accounting features.

---

/cc @sjpotter 
