### PR TITLE
tests: rkt-monitor add new statistics

### DIFF
--- a/Documentation/benchmarks/README.md
+++ b/Documentation/benchmarks/README.md
@@ -23,7 +23,9 @@ command `rkt fetch --insecure-options=image <newDirectory>/*`.
 With rkt-monitor and an ACI or a pod manifest, now the benchmarks can be run
 via `./rkt-monitor <workload>`.
 
-There are two flags available to influence how rkt-monitor runs. `-v` will
-print out the current resource usage of each process every second. `-d` can be
-used to specify a duration to run the tests for (default of 10s). For example,
-`-d 30s` will run the tests for 30 seconds.
+There are four flags available to influence how rkt-monitor runs. `-r ` set the
+number of benchmark experiment repetitions, `-f` save output to files in a
+temporary directory with `rkt_benchmark` prefix, `-v` will print out the current
+resource usage of each process every second. `-d` can be used to specify a
+duration to run the tests for (default of 10s). For example, `-d 30s` will run
+the tests for 30 seconds.

--- a/Documentation/benchmarks/rkt-1-4-0-benchmarks.md
+++ b/Documentation/benchmarks/rkt-1-4-0-benchmarks.md
@@ -17,7 +17,7 @@ rkt(18493): seconds alive: 10  avg CPU: 28.314541%  avg Mem: 2 mB  peak Mem: 2 m
 systemd(18515): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB
 systemd-journal(18517): seconds alive: 9  avg CPU: 88.397098%  avg Mem: 7 mB  peak Mem: 7 mB
 worker(18521): seconds alive: 9  avg CPU: 7.330367%  avg Mem: 5 mB  peak Mem: 6 mB
-load average in a container: Load1: 0.390000 Load5: 0.120000 Load15: 0.080000
+load average: Load1: 0.390000 Load5: 0.120000 Load15: 0.080000
 container start time: 250721ns
 container stop time: 17332926ns
 
@@ -30,7 +30,7 @@ worker(18634): seconds alive: 9  avg CPU: 98.550401%  avg Mem: 318 mB  peak Mem:
 rkt(18599): seconds alive: 10  avg CPU: 3.583814%  avg Mem: 2 mB  peak Mem: 2 mB
 systemd(18628): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB
 systemd-journal(18630): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 6 mB  peak Mem: 6 mB
-load average in a container: Load1: 0.310000 Load5: 0.150000 Load15: 0.090000
+load average: Load1: 0.310000 Load5: 0.150000 Load15: 0.090000
 container start time: 259746ns
 container stop time: 17593446ns
 ```
@@ -42,7 +42,7 @@ rkt(18706): seconds alive: 10  avg CPU: 3.587050%  avg Mem: 2 mB  peak Mem: 2 mB
 systemd(18736): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB
 systemd-journal(18740): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 6 mB  peak Mem: 6 mB
 worker(18744): seconds alive: 9  avg CPU: 88.937493%  avg Mem: 808 kB  peak Mem: 808 kB
-load average in a container: Load1: 0.310000 Load5: 0.130000 Load15: 0.080000
+load average: Load1: 0.310000 Load5: 0.130000 Load15: 0.080000
 container start time: 296570ns
 container stop time: 16124700ns
 ```

--- a/Documentation/benchmarks/rkt-1-4-0-benchmarks.md
+++ b/Documentation/benchmarks/rkt-1-4-0-benchmarks.md
@@ -17,6 +17,10 @@ rkt(18493): seconds alive: 10  avg CPU: 28.314541%  avg Mem: 2 mB  peak Mem: 2 m
 systemd(18515): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB
 systemd-journal(18517): seconds alive: 9  avg CPU: 88.397098%  avg Mem: 7 mB  peak Mem: 7 mB
 worker(18521): seconds alive: 9  avg CPU: 7.330367%  avg Mem: 5 mB  peak Mem: 6 mB
+load average in a container: Load1: 0.390000 Load5: 0.120000 Load15: 0.080000
+container start time: 250721ns
+container stop time: 17332926ns
+
 ```
 
 ### mem-stresser.aci
@@ -26,6 +30,9 @@ worker(18634): seconds alive: 9  avg CPU: 98.550401%  avg Mem: 318 mB  peak Mem:
 rkt(18599): seconds alive: 10  avg CPU: 3.583814%  avg Mem: 2 mB  peak Mem: 2 mB
 systemd(18628): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB
 systemd-journal(18630): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 6 mB  peak Mem: 6 mB
+load average in a container: Load1: 0.310000 Load5: 0.150000 Load15: 0.090000
+container start time: 259746ns
+container stop time: 17593446ns
 ```
 
 ### cpu-stresser.aci
@@ -35,6 +42,9 @@ rkt(18706): seconds alive: 10  avg CPU: 3.587050%  avg Mem: 2 mB  peak Mem: 2 mB
 systemd(18736): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB
 systemd-journal(18740): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 6 mB  peak Mem: 6 mB
 worker(18744): seconds alive: 9  avg CPU: 88.937493%  avg Mem: 808 kB  peak Mem: 808 kB
+load average in a container: Load1: 0.310000 Load5: 0.130000 Load15: 0.080000
+container start time: 296570ns
+container stop time: 16124700ns
 ```
 
 ### too-many-apps.podmanifest
@@ -45,5 +55,8 @@ rkt(17227): seconds alive: 20  avg CPU: 9.595387%  avg Mem: 3 mB  peak Mem: 20 m
 systemd(17253): seconds alive: 17  avg CPU: 0.329028%  avg Mem: 16 mB  peak Mem: 16 mB
 systemd-journal(17255): seconds alive: 17  avg CPU: 0.000000%  avg Mem: 6 mB  peak Mem: 6 mB
 worker-binary(17883): seconds alive: 17  avg CPU: 0.000000%  avg Mem: 840 kB  peak Mem: 840 kB
+load average: Load1: 0.480000 Load5: 0.350000 Load15: 0.300000
+container start time: 528476ns
+container stop time: 4522346ns
 ```
 

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -507,6 +507,11 @@
 			"Rev": "9ef341037b1bcadeeee79e77da4f6baf63de4feb"
 		},
 		{
+			"ImportPath": "github.com/shirou/gopsutil/load",
+			"Comment": "v2.0.0-10-g9ef3410",
+			"Rev": "9ef341037b1bcadeeee79e77da4f6baf63de4feb"
+		},
+		{
 			"ImportPath": "github.com/shirou/gopsutil/mem",
 			"Comment": "v2.0.0-10-g9ef3410",
 			"Rev": "9ef341037b1bcadeeee79e77da4f6baf63de4feb"

--- a/Godeps/_workspace/src/github.com/shirou/gopsutil/load/load.go
+++ b/Godeps/_workspace/src/github.com/shirou/gopsutil/load/load.go
@@ -1,0 +1,35 @@
+package load
+
+import (
+	"encoding/json"
+
+	"github.com/shirou/gopsutil/internal/common"
+)
+
+var invoke common.Invoker
+
+func init() {
+	invoke = common.Invoke{}
+}
+
+type AvgStat struct {
+	Load1  float64 `json:"load1"`
+	Load5  float64 `json:"load5"`
+	Load15 float64 `json:"load15"`
+}
+
+func (l AvgStat) String() string {
+	s, _ := json.Marshal(l)
+	return string(s)
+}
+
+type MiscStat struct {
+	ProcsRunning int `json:"procsRunning"`
+	ProcsBlocked int `json:"procsBlocked"`
+	Ctxt         int `json:"ctxt"`
+}
+
+func (m MiscStat) String() string {
+	s, _ := json.Marshal(m)
+	return string(s)
+}

--- a/Godeps/_workspace/src/github.com/shirou/gopsutil/load/load_darwin.go
+++ b/Godeps/_workspace/src/github.com/shirou/gopsutil/load/load_darwin.go
@@ -1,0 +1,67 @@
+// +build darwin
+
+package load
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/shirou/gopsutil/internal/common"
+)
+
+func Avg() (*AvgStat, error) {
+	values, err := common.DoSysctrl("vm.loadavg")
+	if err != nil {
+		return nil, err
+	}
+
+	load1, err := strconv.ParseFloat(values[0], 64)
+	if err != nil {
+		return nil, err
+	}
+	load5, err := strconv.ParseFloat(values[1], 64)
+	if err != nil {
+		return nil, err
+	}
+	load15, err := strconv.ParseFloat(values[2], 64)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &AvgStat{
+		Load1:  float64(load1),
+		Load5:  float64(load5),
+		Load15: float64(load15),
+	}
+
+	return ret, nil
+}
+
+// Misc returnes miscellaneous host-wide statistics.
+// darwin use ps command to get process running/blocked count.
+// Almost same as FreeBSD implementation, but state is different.
+// U means 'Uninterruptible Sleep'.
+func Misc() (*MiscStat, error) {
+	bin, err := exec.LookPath("ps")
+	if err != nil {
+		return nil, err
+	}
+	out, err := invoke.Command(bin, "axo", "state")
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(out), "\n")
+
+	ret := MiscStat{}
+	for _, l := range lines {
+		if strings.Contains(l, "R") {
+			ret.ProcsRunning++
+		} else if strings.Contains(l, "U") {
+			// uninterruptible sleep == blocked
+			ret.ProcsBlocked++
+		}
+	}
+
+	return &ret, nil
+}

--- a/Godeps/_workspace/src/github.com/shirou/gopsutil/load/load_freebsd.go
+++ b/Godeps/_workspace/src/github.com/shirou/gopsutil/load/load_freebsd.go
@@ -1,0 +1,65 @@
+// +build freebsd
+
+package load
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/shirou/gopsutil/internal/common"
+)
+
+func Avg() (*AvgStat, error) {
+	values, err := common.DoSysctrl("vm.loadavg")
+	if err != nil {
+		return nil, err
+	}
+
+	load1, err := strconv.ParseFloat(values[0], 64)
+	if err != nil {
+		return nil, err
+	}
+	load5, err := strconv.ParseFloat(values[1], 64)
+	if err != nil {
+		return nil, err
+	}
+	load15, err := strconv.ParseFloat(values[2], 64)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &AvgStat{
+		Load1:  float64(load1),
+		Load5:  float64(load5),
+		Load15: float64(load15),
+	}
+
+	return ret, nil
+}
+
+// Misc returnes miscellaneous host-wide statistics.
+// darwin use ps command to get process running/blocked count.
+// Almost same as Darwin implementation, but state is different.
+func Misc() (*MiscStat, error) {
+	bin, err := exec.LookPath("ps")
+	if err != nil {
+		return nil, err
+	}
+	out, err := invoke.Command(bin, "axo", "state")
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(out), "\n")
+
+	ret := MiscStat{}
+	for _, l := range lines {
+		if strings.Contains(l, "R") {
+			ret.ProcsRunning++
+		} else if strings.Contains(l, "D") {
+			ret.ProcsBlocked++
+		}
+	}
+
+	return &ret, nil
+}

--- a/Godeps/_workspace/src/github.com/shirou/gopsutil/load/load_linux.go
+++ b/Godeps/_workspace/src/github.com/shirou/gopsutil/load/load_linux.go
@@ -1,0 +1,78 @@
+// +build linux
+
+package load
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+
+	"github.com/shirou/gopsutil/internal/common"
+)
+
+func Avg() (*AvgStat, error) {
+	filename := common.HostProc("loadavg")
+	line, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	values := strings.Fields(string(line))
+
+	load1, err := strconv.ParseFloat(values[0], 64)
+	if err != nil {
+		return nil, err
+	}
+	load5, err := strconv.ParseFloat(values[1], 64)
+	if err != nil {
+		return nil, err
+	}
+	load15, err := strconv.ParseFloat(values[2], 64)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &AvgStat{
+		Load1:  load1,
+		Load5:  load5,
+		Load15: load15,
+	}
+
+	return ret, nil
+}
+
+// Misc returnes miscellaneous host-wide statistics.
+// Note: the name should be changed near future.
+func Misc() (*MiscStat, error) {
+	filename := common.HostProc("stat")
+	out, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &MiscStat{}
+	lines := strings.Split(string(out), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		v, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		switch fields[0] {
+		case "procs_running":
+			ret.ProcsRunning = int(v)
+		case "procs_blocked":
+			ret.ProcsBlocked = int(v)
+		case "ctxt":
+			ret.Ctxt = int(v)
+		default:
+			continue
+		}
+
+	}
+
+	return ret, nil
+}

--- a/Godeps/_workspace/src/github.com/shirou/gopsutil/load/load_windows.go
+++ b/Godeps/_workspace/src/github.com/shirou/gopsutil/load/load_windows.go
@@ -1,0 +1,19 @@
+// +build windows
+
+package load
+
+import (
+	"github.com/shirou/gopsutil/internal/common"
+)
+
+func Avg() (*AvgStat, error) {
+	ret := AvgStat{}
+
+	return &ret, common.ErrNotImplementedError
+}
+
+func Misc() (*MiscStat, error) {
+	ret := MiscStat{}
+
+	return &ret, common.ErrNotImplementedError
+}

--- a/tests/rkt-monitor/README.md
+++ b/tests/rkt-monitor/README.md
@@ -40,4 +40,7 @@ rkt(13261): seconds alive: 10  avg CPU: 33.113897%  avg Mem: 4 kB  peak Mem: 4 k
 systemd(13302): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB
 systemd-journal(13303): seconds alive: 9  avg CPU: 68.004584%  avg Mem: 7 mB  peak Mem: 7 mB
 worker(13307): seconds alive: 9  avg CPU: 13.004088%  avg Mem: 1 mB  peak Mem: 1 mB
+load average in a container: Load1: 0.280000 Load5: 0.250000 Load15: 0.200000
+container start time: 315621ns
+container stop time: 17280555ns
 ```

--- a/tests/rkt-monitor/README.md
+++ b/tests/rkt-monitor/README.md
@@ -14,8 +14,10 @@ Examples:
 rkt-monitor mem-stresser.aci -v -d 30s
 
 Flags:
+  -f, --to-file[=false]: Save benchmark results to files in a temp dir
   -d, --duration="10s": How long to run the ACI
   -h, --help[=false]: help for rkt-monitor
+  -r, --repetitions=1: Numbers of benchmark repetitions
   -o, --show-output[=false]: Display rkt's stdout and stderr
   -v, --verbose[=false]: Print current usage every second
 ```

--- a/tests/rkt-monitor/main.go
+++ b/tests/rkt-monitor/main.go
@@ -15,7 +15,9 @@
 package main
 
 import (
+	"encoding/csv"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -44,6 +46,7 @@ var (
 	flagVerbose    bool
 	flagDuration   string
 	flagShowOutput bool
+	saveToCsv      bool
 
 	cmdRktMonitor = &cobra.Command{
 		Use:     "rkt-monitor IMAGE",
@@ -59,6 +62,9 @@ func init() {
 	cmdRktMonitor.Flags().BoolVarP(&flagVerbose, "verbose", "v", false, "Print current usage every second")
 	cmdRktMonitor.Flags().StringVarP(&flagDuration, "duration", "d", "10s", "How long to run the ACI")
 	cmdRktMonitor.Flags().BoolVarP(&flagShowOutput, "show-output", "o", false, "Display rkt's stdout and stderr")
+	cmdRktMonitor.Flags().BoolVarP(&saveToCsv, "to-file", "f", false, "Save benchmark results to benchmark.csv file")
+
+	flag.Parse()
 }
 
 func main() {
@@ -119,7 +125,7 @@ func runRktMonitor(cmd *cobra.Command, args []string) {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	go func() {
-		for _ = range c {
+		for range c {
 			err := killAllChildren(int32(execCmd.Process.Pid))
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "cleanup failed: %v\n", err)
@@ -131,6 +137,9 @@ func runRktMonitor(cmd *cobra.Command, args []string) {
 	usages := make(map[int32][]*ProcessStatus)
 
 	timeToStop := time.Now().Add(d)
+
+	records := [][]string{{"Time", "PID name", "PID number", "RSS", "CPU"}} // csv headers
+
 	for time.Now().Before(timeToStop) {
 		usage, err := getUsage(int32(execCmd.Process.Pid))
 		if err != nil {
@@ -138,6 +147,10 @@ func runRktMonitor(cmd *cobra.Command, args []string) {
 		}
 		if flagVerbose {
 			printUsage(usage)
+		}
+
+		if saveToCsv {
+			records = addRecords(usage, records)
 		}
 
 		for _, ps := range usage {
@@ -181,6 +194,14 @@ func runRktMonitor(cmd *cobra.Command, args []string) {
 
 		fmt.Printf("%s(%d): seconds alive: %d  avg CPU: %f%%  avg Mem: %s  peak Mem: %s\n", processHistory[0].Name, processHistory[0].Pid, len(processHistory), avgCPU, formatSize(avgMem), formatSize(peakMem))
 	}
+
+	if saveToCsv {
+		saveRecords(records)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Can't write to a file: %v\n", err)
+		}
+	}
+
 	fmt.Printf("load average: Load1: %f Load5: %f Load15: %f\n", loadAvg.Load1, loadAvg.Load5, loadAvg.Load15)
 
 	fmt.Printf("container start time: %dns\n", containerStarted.Sub(containerStarting).Nanoseconds())
@@ -295,4 +316,27 @@ func printUsage(statuses []*ProcessStatus) {
 		fmt.Printf("%s(%d): Mem: %s CPU: %f\n", s.Name, s.Pid, formatSize(s.RSS), s.CPU)
 	}
 	fmt.Printf("\n")
+}
+
+func addRecords(statuses []*ProcessStatus, records [][]string) [][]string {
+	for _, s := range statuses {
+		records = append(records, []string{time.Now().String(), s.Name, strconv.Itoa(int(s.Pid)), formatSize(s.RSS), strconv.FormatFloat(s.CPU, 'g', 1, 64)})
+	}
+	return records
+}
+
+func saveRecords(records [][]string) error {
+	csvFile, err := os.Create("benchmark.csv")
+	defer csvFile.Close()
+	if err != nil {
+		return err
+	}
+
+	w := csv.NewWriter(csvFile)
+	w.WriteAll(records)
+	if err := w.Error(); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
New statistics for load average and boot/stop time measure of container.
Differences are measured in a nanoseconds. Godeps updated as well.