### PR TITLE
Some simple arg doc string fixes

### DIFF
--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -59,7 +59,7 @@ func init() {
 	cmdPrepare.Flags().BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	cmdPrepare.Flags().BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
 	cmdPrepare.Flags().BoolVar(&flagPrivateUsers, "private-users", false, "run within user namespaces.")
-	cmdPrepare.Flags().Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
+	cmdPrepare.Flags().Var(&flagExplicitEnv, "set-env", "environment variable to set for apps in the form name=value")
 	cmdPrepare.Flags().BoolVar(&flagStoreOnly, "store-only", false, "use only available images in the store (do not discover or download from remote URLs)")
 	cmdPrepare.Flags().BoolVar(&flagNoStore, "no-store", false, "fetch images ignoring the local store")
 	cmdPrepare.Flags().StringVar(&flagPodManifest, "pod-manifest", "", "the path to the pod manifest. If it's non-empty, then only '--quiet' and '--no-overlay' will have effect")

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -80,7 +80,7 @@ func init() {
 	cmdRun.Flags().BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	cmdRun.Flags().BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
 	cmdRun.Flags().BoolVar(&flagPrivateUsers, "private-users", false, "run within user namespaces.")
-	cmdRun.Flags().Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
+	cmdRun.Flags().Var(&flagExplicitEnv, "set-env", "environment variable to set for apps in the form name=value")
 	cmdRun.Flags().BoolVar(&flagInteractive, "interactive", false, "run pod interactively. If true, only one image may be supplied.")
 	cmdRun.Flags().Var(&flagDNS, "dns", "name servers to write in /etc/resolv.conf")
 	cmdRun.Flags().Var(&flagDNSSearch, "dns-search", "DNS search domains to write in /etc/resolv.conf")

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -44,7 +44,7 @@ func init() {
 	cmdRunPrepared.Flags().Var(&flagDNS, "dns", "name servers to write in /etc/resolv.conf")
 	cmdRunPrepared.Flags().Var(&flagDNSSearch, "dns-search", "DNS search domains to write in /etc/resolv.conf")
 	cmdRunPrepared.Flags().Var(&flagDNSOpt, "dns-opt", "DNS options to write in /etc/resolv.conf")
-	cmdRunPrepared.Flags().BoolVar(&flagInteractive, "interactive", false, "the pod is interactive")
+	cmdRunPrepared.Flags().BoolVar(&flagInteractive, "interactive", false, "run pod interactively")
 	cmdRunPrepared.Flags().BoolVar(&flagMDSRegister, "mds-register", false, "register pod with metadata service")
 	cmdRunPrepared.Flags().StringVar(&flagHostname, "hostname", "", `pod's hostname. If empty, it will be "rkt-$PODUUID"`)
 }

--- a/rkt/stage1hash.go
+++ b/rkt/stage1hash.go
@@ -114,35 +114,35 @@ var (
 			kind: stage1ImageLocationURL,
 			flag: "stage1-url",
 			name: "stage1URL",
-			help: "a URL to an image to use as stage1",
+			help: "URL to an image to use as stage1",
 		},
 
 		stage1ImageLocationPath: {
 			kind: stage1ImageLocationPath,
 			flag: "stage1-path",
 			name: "stage1Path",
-			help: "an absolute or a relative path to an image to use as stage1",
+			help: "absolute or relative path to an image to use as stage1",
 		},
 
 		stage1ImageLocationName: {
 			kind: stage1ImageLocationName,
 			flag: "stage1-name",
 			name: "stage1Name",
-			help: "a name of an image to use as stage1",
+			help: "name of an image to use as stage1",
 		},
 
 		stage1ImageLocationHash: {
 			kind: stage1ImageLocationHash,
 			flag: "stage1-hash",
 			name: "stage1Hash",
-			help: "a hash of an image to use as stage1",
+			help: "hash of an image to use as stage1",
 		},
 
 		stage1ImageLocationFromDir: {
 			kind: stage1ImageLocationFromDir,
 			flag: "stage1-from-dir",
 			name: "stage1FromDir",
-			help: "a filename of an image in stage1 images directory to use as stage1",
+			help: "filename of an image in stage1 images directory to use as stage1",
 		},
 	}
 	// location to stage1 image overridden by one of --stage1-*


### PR DESCRIPTION
This removes some unnecessary indefinite articles from the start of argument doc strings and fixes the arg doc string for run-prepared's --interactive flag.