### PR TITLE
stage1: capabilities: implement both remain set and remove set

### DIFF
--- a/tests/inspect/inspect.go
+++ b/tests/inspect/inspect.go
@@ -42,6 +42,7 @@ var (
 		CheckTty           bool
 		PrintExec          bool
 		PrintMsg           string
+		SuffixMsg          string
 		PrintEnv           string
 		PrintCapsPid       int
 		PrintUser          bool
@@ -81,6 +82,7 @@ func init() {
 	globalFlagset.BoolVar(&globalFlags.CheckTty, "check-tty", false, "Check if stdin is a terminal")
 	globalFlagset.BoolVar(&globalFlags.PrintExec, "print-exec", false, "Print the command we were execed as (i.e. argv[0])")
 	globalFlagset.StringVar(&globalFlags.PrintMsg, "print-msg", "", "Print the message given as parameter")
+	globalFlagset.StringVar(&globalFlags.SuffixMsg, "suffix-msg", "", "Print this suffix after some commands")
 	globalFlagset.StringVar(&globalFlags.CheckCwd, "check-cwd", "", "Check if the current working directory is the one specified")
 	globalFlagset.StringVar(&globalFlags.PrintEnv, "print-env", "", "Print the specified environment variable")
 	globalFlagset.IntVar(&globalFlags.PrintCapsPid, "print-caps-pid", -1, "Print capabilities of the specified pid (or current process if pid=0)")
@@ -188,10 +190,10 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Cannot get caps: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Printf("Capability set: effective: %s\n", caps.StringCap(capability.EFFECTIVE))
-		fmt.Printf("Capability set: permitted: %s\n", caps.StringCap(capability.PERMITTED))
-		fmt.Printf("Capability set: inheritable: %s\n", caps.StringCap(capability.INHERITABLE))
-		fmt.Printf("Capability set: bounding: %s\n", caps.StringCap(capability.BOUNDING))
+		fmt.Printf("Capability set: effective: %s (%s)\n", caps.StringCap(capability.EFFECTIVE), globalFlags.SuffixMsg)
+		fmt.Printf("Capability set: permitted: %s (%s)\n", caps.StringCap(capability.PERMITTED), globalFlags.SuffixMsg)
+		fmt.Printf("Capability set: inheritable: %s (%s)\n", caps.StringCap(capability.INHERITABLE), globalFlags.SuffixMsg)
+		fmt.Printf("Capability set: bounding: %s (%s)\n", caps.StringCap(capability.BOUNDING), globalFlags.SuffixMsg)
 
 		if capStr := os.Getenv("CAPABILITY"); capStr != "" {
 			capInt, err := strconv.Atoi(capStr)
@@ -201,9 +203,9 @@ func main() {
 			}
 			c := capability.Cap(capInt)
 			if caps.Get(capability.BOUNDING, c) {
-				fmt.Printf("%v=enabled\n", c.String())
+				fmt.Printf("%v=enabled (%s)\n", c.String(), globalFlags.SuffixMsg)
 			} else {
-				fmt.Printf("%v=disabled\n", c.String())
+				fmt.Printf("%v=disabled (%s)\n", c.String(), globalFlags.SuffixMsg)
 			}
 		}
 	}

--- a/tests/rkt_caps_test.go
+++ b/tests/rkt_caps_test.go
@@ -19,11 +19,309 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/coreos/rkt/tests/testutils"
 	"github.com/syndtr/gocapability/capability"
 )
+
+func TestCapsSeveralApp(t *testing.T) {
+	// All the following images are launched together in the same pod
+	var appCapsTests = []struct {
+		// constants
+		testName     string // name of the image
+		capRemainSet string // if != "x", value passed to actool patch-manifest --capability=
+		capRemoveSet string // if != "x", value passed to actool patch-manifest --revoke-capability=
+		expected     string // caps bounding set as printed by gocapability
+
+		// set during the test
+		imageFile string
+	}{
+		// Testing without isolators
+		{
+			testName:     "image-none",
+			capRemainSet: "x",
+			capRemoveSet: "x",
+			expected: strings.Join([]string{
+				"chown",
+				"dac_override",
+				"fowner",
+				"fsetid",
+				"kill",
+				"setgid",
+				"setuid",
+				"setpcap",
+				"net_bind_service",
+				"net_raw",
+				"sys_chroot",
+				"mknod",
+				"audit_write",
+				"setfcap",
+			}, ", "),
+		},
+		// Testing remain set
+		{
+			testName:     "image-only-one-cap",
+			capRemainSet: "CAP_NET_ADMIN",
+			capRemoveSet: "x",
+			expected:     "net_admin",
+		},
+		{
+			testName:     "image-only-one-cap-from-default",
+			capRemainSet: "CAP_CHOWN",
+			capRemoveSet: "x",
+			expected:     "chown",
+		},
+		{
+			testName: "image-some-caps",
+			capRemainSet: strings.Join([]string{
+				"CAP_CHOWN",
+				"CAP_FOWNER",
+				"CAP_SYS_ADMIN",
+				"CAP_NET_ADMIN",
+			}, ","),
+			capRemoveSet: "x",
+			expected: strings.Join([]string{
+				"chown",
+				"fowner",
+				"net_admin",
+				"sys_admin",
+			}, ", "),
+		},
+		{
+			testName: "image-caps-from-nspawn-default",
+			capRemainSet: strings.Join([]string{
+				"CAP_CHOWN",
+				"CAP_DAC_OVERRIDE",
+				"CAP_DAC_READ_SEARCH",
+				"CAP_FOWNER",
+				"CAP_FSETID",
+				"CAP_IPC_OWNER",
+				"CAP_KILL",
+				"CAP_LEASE",
+				"CAP_LINUX_IMMUTABLE",
+				"CAP_NET_BIND_SERVICE",
+				"CAP_NET_BROADCAST",
+				"CAP_NET_RAW",
+				"CAP_SETGID",
+				"CAP_SETFCAP",
+				"CAP_SETPCAP",
+				"CAP_SETUID",
+				"CAP_SYS_ADMIN",
+				"CAP_SYS_CHROOT",
+				"CAP_SYS_NICE",
+				"CAP_SYS_PTRACE",
+				"CAP_SYS_TTY_CONFIG",
+				"CAP_SYS_RESOURCE",
+				"CAP_SYS_BOOT",
+				"CAP_AUDIT_WRITE",
+				"CAP_AUDIT_CONTROL",
+			}, ","),
+			capRemoveSet: "x",
+			expected: strings.Join([]string{
+				"chown",
+				"dac_override",
+				"dac_read_search",
+				"fowner",
+				"fsetid",
+				"kill",
+				"setgid",
+				"setuid",
+				"setpcap",
+				"linux_immutable",
+				"net_bind_service",
+				"net_broadcast",
+				"net_raw",
+				"ipc_owner",
+				"sys_chroot",
+				"sys_ptrace",
+				"sys_admin",
+				"sys_boot",
+				"sys_nice",
+				"sys_resource",
+				"sys_tty_config",
+				"lease",
+				"audit_write",
+				"audit_control",
+				"setfcap",
+			}, ", "),
+		},
+		// Testing revoke set
+		{
+			testName:     "image-revoke-one-from-default",
+			capRemainSet: "x",
+			capRemoveSet: "CAP_CHOWN",
+			expected: strings.Join([]string{
+				"dac_override, fowner, fsetid, kill, setgid, setuid, setpcap, net_bind_service, net_raw, sys_chroot, mknod, audit_write, setfcap",
+			}, ", "),
+		},
+		{
+			testName:     "image-revoke-one-already-revoked",
+			capRemainSet: "x",
+			capRemoveSet: "CAP_SYS_ADMIN",
+			expected: strings.Join([]string{
+				"chown",
+				"dac_override",
+				"fowner",
+				"fsetid",
+				"kill",
+				"setgid",
+				"setuid",
+				"setpcap",
+				"net_bind_service",
+				"net_raw",
+				"sys_chroot",
+				"mknod",
+				"audit_write",
+				"setfcap",
+			}, ", "),
+		},
+		{
+			testName:     "image-revoke-two",
+			capRemainSet: "x",
+			capRemoveSet: "CAP_CHOWN,CAP_SYS_ADMIN",
+			expected: strings.Join([]string{
+				"dac_override",
+				"fowner",
+				"fsetid",
+				"kill",
+				"setgid",
+				"setuid",
+				"setpcap",
+				"net_bind_service",
+				"net_raw",
+				"sys_chroot",
+				"mknod",
+				"audit_write",
+				"setfcap",
+			}, ", "),
+		},
+		{
+			testName:     "image-revoke-all",
+			capRemainSet: "x",
+			capRemoveSet: strings.Join([]string{
+				"CAP_AUDIT_WRITE",
+				"CAP_CHOWN",
+				"CAP_DAC_OVERRIDE",
+				"CAP_FSETID",
+				"CAP_FOWNER",
+				"CAP_KILL",
+				"CAP_MKNOD",
+				"CAP_NET_RAW",
+				"CAP_NET_BIND_SERVICE",
+				"CAP_SETUID",
+				"CAP_SETGID",
+				"CAP_SETPCAP",
+				"CAP_SETFCAP",
+				"CAP_SYS_CHROOT",
+			}, ","),
+			expected: "",
+		},
+		{
+			testName:     "image-revoke-all-but-one",
+			capRemainSet: "x",
+			capRemoveSet: strings.Join([]string{
+				"CAP_AUDIT_WRITE",
+				"CAP_CHOWN",
+				"CAP_DAC_OVERRIDE",
+				"CAP_FSETID",
+				"CAP_FOWNER",
+				"CAP_KILL",
+				"CAP_MKNOD",
+				"CAP_NET_RAW",
+				"CAP_NET_BIND_SERVICE",
+				"CAP_SETUID",
+				"CAP_SETGID",
+				"CAP_SETPCAP",
+				"CAP_SETFCAP",
+			}, ","),
+			expected: "sys_chroot",
+		},
+		{
+			testName:     "image-revoke-all-plus-one",
+			capRemainSet: "x",
+			capRemoveSet: strings.Join([]string{
+				"CAP_AUDIT_WRITE",
+				"CAP_CHOWN",
+				"CAP_DAC_OVERRIDE",
+				"CAP_FSETID",
+				"CAP_FOWNER",
+				"CAP_KILL",
+				"CAP_MKNOD",
+				"CAP_NET_RAW",
+				"CAP_NET_BIND_SERVICE",
+				"CAP_SETUID",
+				"CAP_SETGID",
+				"CAP_SETPCAP",
+				"CAP_SETFCAP",
+				"CAP_SYS_CHROOT",
+				"CAP_SYS_ADMIN",
+			}, ","),
+			expected: "",
+		},
+		// Testing with an empty remain set or an empty remove set
+		// TODO(alban): "actool patch-manifest" cannot generate those images for now
+		//{
+		//	testName:     "image-remain-set-empty",
+		//	capRemainSet: "",
+		//	capRemoveSet: "x",
+		//	expected:     "",
+		//},
+		//{
+		//	testName:     "image-revoke-none",
+		//	capRemainSet: "x",
+		//	capRemoveSet: "",
+		//	expected:     "TODO(alban)",
+		//},
+	}
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	for i, tt := range appCapsTests {
+		patches := []string{
+			fmt.Sprintf("--name=%s", tt.testName),
+			fmt.Sprintf("--exec=/inspect --print-caps-pid=0 --suffix-msg=%s", tt.testName),
+		}
+		if tt.capRemainSet != "x" {
+			patches = append(patches, "--capability="+tt.capRemainSet)
+		}
+		if tt.capRemoveSet != "x" {
+			patches = append(patches, "--revoke-capability="+tt.capRemoveSet)
+		}
+		imageFile := patchTestACI(tt.testName+".aci", patches...)
+		defer os.Remove(imageFile)
+		appCapsTests[i].imageFile = imageFile
+		t.Logf("Built image %q", imageFile)
+	}
+
+	// Generate the rkt arguments to launch all the apps in the same pod
+	rktArgs := ""
+	for _, tt := range appCapsTests {
+		rktArgs += " " + tt.imageFile
+	}
+	cmd := fmt.Sprintf("%s --insecure-options=image run %s", ctx.Cmd(), rktArgs)
+
+	// Ideally, the test would run the pod only one time, but all
+	// apps' output is mixed together without ordering guarantees, so
+	// it makes it impossible to call all the expectWithOutput() in
+	// the correct order.
+	for _, tt := range appCapsTests {
+		t.Logf("Checking caps for %q", tt.testName)
+		child := spawnOrFail(t, cmd)
+
+		expected := fmt.Sprintf("Capability set: bounding: %s (%s)",
+			tt.expected, tt.testName)
+		if err := expectWithOutput(child, expected); err != nil {
+			t.Fatalf("Expected %q but not found: %v", expected, err)
+		}
+
+		waitOrFail(t, child, 0)
+
+		ctx.RunGC()
+	}
+}
 
 var capsTests = []struct {
 	testName            string


### PR DESCRIPTION
It follows the [Linux Isolators semantics from the App Container Executor spec](https://github.com/appc/spec/blob/master/spec/ace.md#linux-isolators), as modified by https://github.com/appc/spec/pull/600.

The new functional test TestCapsSeveralApp runs a pod with 12 apps with various capability definitions and tests that each app is executed with the correct caps. The 12 images are generated by `actool patch-manifest --capability=|--revoke-capability=` implemented by https://github.com/appc/spec/pull/601.

This PR depends on https://github.com/appc/spec/pull/601.

Fixes https://github.com/coreos/rkt/issues/2348