### PR TITLE
Check for openssl headers availability in kvm flavor

### DIFF
--- a/Documentation/dependencies.md
+++ b/Documentation/dependencies.md
@@ -52,7 +52,10 @@ For the most part the codebase is self-contained (e.g. all dependencies are vend
 * patch
 * tar
 * xz
-* build dependencies for kernel
+* [build dependencies for kernel](https://www.kernel.org/doc/Documentation/Changes)
+  * bc
+  * binutils
+  * openssl
 * build dependencies for lkvm
 
 ### Specific dependencies for the src flavor

--- a/Documentation/hacking.md
+++ b/Documentation/hacking.md
@@ -33,7 +33,7 @@ Alternatively, you can build rkt in a Docker container with the following comman
 Replace `$SRC` with the absolute path to your rkt source code:
 
 ```
-# docker run -v $SRC:/opt/rkt -i -t golang:1.5 /bin/bash -c "apt-get update && apt-get install -y coreutils cpio squashfs-tools realpath autoconf file xz-utils patch bc && cd /opt/rkt && go get github.com/appc/spec/... && ./autogen.sh && ./configure && make"
+# docker run -v $SRC:/opt/rkt -i -t golang:1.5 /bin/bash -c "apt-get update && apt-get install -y coreutils cpio squashfs-tools realpath autoconf file xz-utils patch bc libacl1-dev libtspi-dev libssl-dev && cd /opt/rkt && go get github.com/appc/spec/... && ./autogen.sh && ./configure && make"
 ```
 
 ### Building systemd in stage1 from source
@@ -69,6 +69,7 @@ If building with docker, these must be added to the `apt-get install` command.
 * xz-utils
 * patch
 * bc
+* libssl-dev
 
 ### Alternative stage1 paths
 

--- a/configure.ac
+++ b/configure.ac
@@ -289,7 +289,11 @@ RKT_ITERATE_FLAVORS([${RKT_STAGE1_FLAVORS}],[flavor],
                                       RKT_COMMON_COREOS_PROGS
                                       RKT_REQ_PROG([PATCH],[patch],[patch])
                                       RKT_REQ_PROG([TAR],[tar],[tar])
-                                      RKT_REQ_PROG([XZ],[xz],[xz])],
+                                      RKT_REQ_PROG([XZ],[xz],[xz])
+                                      AC_CHECK_HEADER([openssl/bio.h],
+                                                      [],
+                                                      [AC_MSG_ERROR([** No development headers for openssl found])],
+                                                      [AC_INCLUDES_DEFAULT])],
                              [host],
                                      [],
                              [fly],


### PR DESCRIPTION
To use kernel sources during kvm flavor build, openssl headers
are needed.

Signed-off-by: Michal Rostecki <michal.rostecki@gmail.com>