### PR TITLE
stage1_fly: mount /etc/ before chrooting

### DIFF
--- a/stage1_fly/run/main.go
+++ b/stage1_fly/run/main.go
@@ -269,6 +269,9 @@ func stage1() int {
 			{"", "", "/sys", "none", syscall.MS_REC | syscall.MS_SHARED},
 			{"/sys", rfs, "/sys", "none", syscall.MS_BIND | syscall.MS_REC},
 
+			{"", "", "/etc", "none", syscall.MS_REC | syscall.MS_SHARED},
+			{"/etc", rfs, "/etc", "none", syscall.MS_BIND | syscall.MS_REC},
+
 			{"tmpfs", rfs, "/tmp", "tmpfs", 0},
 		},
 		argFlyMounts...,


### PR DESCRIPTION
Adds /etc to fly volumes that are mounted before chrooting to the root
filesystem.

Related to #2256
Related to coreos/bugs#1228

Fixes #2141