### PR TITLE
disable OverlayFS by default when working on ZFS

### DIFF
--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -170,7 +170,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 
 	pcfg := stage0.PrepareConfig{
 		CommonConfig:       &cfg,
-		UseOverlay:         !flagNoOverlay && common.SupportsOverlay(),
+		UseOverlay:         !flagNoOverlay && common.SupportsOverlay() && common.FSSupportsOverlay(getDataDir()),
 		PrivateUsers:       privateUsers,
 		SkipTreeStoreCheck: globalFlags.InsecureFlags.SkipOnDiskCheck(),
 	}

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -235,7 +235,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 
 	pcfg := stage0.PrepareConfig{
 		CommonConfig:       &cfg,
-		UseOverlay:         !flagNoOverlay && common.SupportsOverlay(),
+		UseOverlay:         !flagNoOverlay && common.SupportsOverlay() && common.FSSupportsOverlay(getDataDir()),
 		PrivateUsers:       privateUsers,
 		SkipTreeStoreCheck: globalFlags.InsecureFlags.SkipOnDiskCheck(),
 	}


### PR DESCRIPTION
OverlayFS doesn't work on top of ZFS, thus using ZFS under `/var/lib/rkt` requires passing `--no-overlay` flag every time. This code detects ZFS and disables overlay automatically.