### PR TITLE
stage1/init: create a new mount ns for each app

### DIFF
--- a/stage1/init/common/pod.go
+++ b/stage1/init/common/pod.go
@@ -457,6 +457,9 @@ func appToSystemd(p *stage1commontypes.Pod, ra *schema.RuntimeApp, interactive b
 		unit.NewUnitOption("Service", "Restart", "no"),
 		unit.NewUnitOption("Service", "ExecStart", execStartString),
 		unit.NewUnitOption("Service", "RootDirectory", common.RelAppRootfsPath(appName)),
+		// MountFlags=shared creates a new mount namespace and (as unintuitive
+		// as it might seem) makes sure the mount is slave+shared.
+		unit.NewUnitOption("Service", "MountFlags", "shared"),
 		unit.NewUnitOption("Service", "WorkingDirectory", workDir),
 		unit.NewUnitOption("Service", "EnvironmentFile", RelEnvFilePathSystemd(appName)),
 		unit.NewUnitOption("Service", "User", strconv.Itoa(u)),

--- a/tests/rkt_mountns_test.go
+++ b/tests/rkt_mountns_test.go
@@ -1,0 +1,41 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build host coreos src kvm
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+func TestMountNSApp(t *testing.T) {
+	image := patchTestACI("rkt-test-mount-ns-app.aci", "--exec=/inspect --check-mountns", "--capability=CAP_SYS_PTRACE")
+	defer os.Remove(image)
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	rktCmd := fmt.Sprintf("%s --insecure-options=image run %s", ctx.Cmd(), image)
+
+	expectedLine := "check-mountns: DIFFERENT"
+	runRktAndCheckOutput(t, rktCmd, expectedLine, false)
+}
+
+func TestSharedSlave(t *testing.T) {
+}

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -94,6 +94,11 @@ var volTests = []struct {
 		`<<<1>>>`,
 		0,
 	},
+	{
+		`/bin/sh -c "export FILE=/dir1/file CONTENT=1 ; ^RKT_BIN^ --debug --insecure-options=image run --mds-register=false --volume=dir1,kind=host,source=^TMPDIR^ --inherit-env=true ^VOL_RW_WRITE_FILE_ONLY^ ^VOL_RO_READ_FILE_ONLY^ --exec /inspect -- --pre-sleep=1 --read-file"`,
+		`<<<1>>>`,
+		0,
+	},
 }
 
 func NewVolumesTest() testutils.Test {
@@ -106,6 +111,10 @@ func NewVolumesTest() testutils.Test {
 		defer os.Remove(volRwReadFileImage)
 		volRwWriteFileImage := patchTestACI("rkt-inspect-vol-rw-write-file.aci", "--exec=/inspect --write-file --read-file", "--mounts=dir1,path=/dir1,readOnly=false")
 		defer os.Remove(volRwWriteFileImage)
+		volRwWriteFileOnlyImage := patchTestACI("rkt-inspect-vol-rw-write-file-only.aci", "--exec=/inspect --write-file", "--mounts=dir1,path=/dir1,readOnly=false")
+		defer os.Remove(volRwWriteFileOnlyImage)
+		volRoReadFileOnlyImage := patchTestACI("rkt-inspect-vol-ro-read-file-only.aci", "--name=coreos.com/rkt-inspect-2", "--exec=/inspect --read-file", "--mounts=dir1,path=/dir1,readOnly=true")
+		defer os.Remove(volRoReadFileOnlyImage)
 		volRoReadFileImage := patchTestACI("rkt-inspect-vol-ro-read-file.aci", "--exec=/inspect --read-file", "--mounts=dir1,path=/dir1,readOnly=true")
 		defer os.Remove(volRoReadFileImage)
 		volRoWriteFileImage := patchTestACI("rkt-inspect-vol-ro-write-file.aci", "--exec=/inspect --write-file --read-file", "--mounts=dir1,path=/dir1,readOnly=true")
@@ -134,6 +143,8 @@ func NewVolumesTest() testutils.Test {
 			cmd = strings.Replace(cmd, "^VOL_RO_WRITE_FILE^", volRoWriteFileImage, -1)
 			cmd = strings.Replace(cmd, "^VOL_RW_READ_FILE^", volRwReadFileImage, -1)
 			cmd = strings.Replace(cmd, "^VOL_RW_WRITE_FILE^", volRwWriteFileImage, -1)
+			cmd = strings.Replace(cmd, "^VOL_RW_WRITE_FILE_ONLY^", volRwWriteFileOnlyImage, -1)
+			cmd = strings.Replace(cmd, "^VOL_RO_READ_FILE_ONLY^", volRoReadFileOnlyImage, -1)
 			cmd = strings.Replace(cmd, "^VOL_ADD_MOUNT_RW^", volAddMountRwImage, -1)
 			cmd = strings.Replace(cmd, "^VOL_ADD_MOUNT_RO^", volAddMountRoImage, -1)
 


### PR DESCRIPTION
Up to this point, you could escape the app's chroot easily by using a
simple program downloaded from the internet [[1]][1]. To avoid this, we now
create a new mount namespace per each app.

You can still escape the chroot if you have CAP_SYS_PTRACE and access
`/proc/1/root` but this fixes the issue for images that don't need this
capability.

[1]: http://www.unixwiz.net/techtips/chroot-practices.html