### PR TITLE
docs: Change getting started guide to build a static binary

### DIFF
--- a/Documentation/getting-started-guide.md
+++ b/Documentation/getting-started-guide.md
@@ -28,7 +28,7 @@ Next we need to build our application.
 We are going to statically link our app so we can ship an App Container Image with no external dependencies.
 
 ```
-$ CGO_ENABLED=0 GOOS=linux go build -o hello -a -tags netgo -ldflags '-w' .
+$ CGO_ENABLED=0 go build -ldflags '-extldflags "-static"'
 ```
 
 Before proceeding, verify that the produced binary is statically linked:


### PR DESCRIPTION
Current build command would not work after #2506

Fixes #2584

@alban Can you please take a look at my PR. I am not sure if this is what you wanted, but i tried to build `hello` with the new build command an it worked for me. Please let me know if there is something wrong with my PR. Thanks!