### PR TITLE
run: added alias for "launch"

### DIFF
--- a/rkt/run.go
+++ b/rkt/run.go
@@ -50,7 +50,8 @@ take precedence over global ones if they have the same path.
 An "--" may be used to inhibit rkt run's parsing of subsequent arguments, which
 will instead be appended to the preceding image app's exec arguments. End the
 image arguments with a lone "---" to resume argument parsing.`,
-		Run: ensureSuperuser(runWrapper(runRun)),
+		Aliases: []string{"launch"},
+		Run:     ensureSuperuser(runWrapper(runRun)),
 	}
 	flagPorts        portList
 	flagNet          common.NetList


### PR DESCRIPTION
Seeing as how rockets are launched, not run, this commit adds "launch"
as an alias for the run command.

Works like you'd expect it to:

```
derek@proton ~/go/src/github.com/coreos/rkt> sudo ./build-rkt-1.5.1/bin/rkt launch --interactive quay.io/coreos/alpine-sh
image: using image from file /home/derek/go/src/github.com/coreos/rkt/build-rkt-1.5.1/bin/stage1-coreos.aci
image: using image from local store for image name quay.io/coreos/alpine-sh
networking: loading networks from /etc/rkt/net.d
networking: loading network default with type ptp
stage1: warning: error setting journal ACLs, you'll need root to read the pod journal: unable to open a handle to libacl
stage1: warning: libsystemd not found even though systemd is running. Cgroup limits set by the environment (e.g. a systemd service) won't be enforced.
stage1: continuing with per-app isolators disabled: unable to open a handle to libsystemd
/ #
```