### PR TITLE
stage1: Fix segfault in enterexec

### DIFF
--- a/stage1/enterexec/enterexec.c
+++ b/stage1/enterexec/enterexec.c
@@ -214,7 +214,15 @@ static void load_env(const char *env_file, const char *keep_env_file, int enteri
 
 	set_env(env_file);
 	set_env(keep_env_file);
-	if (entering) setenv("TERM", term, 1);
+	if (entering) {
+		// enter is typically interactive; ensure we always have a sane enough term
+		// variable.
+		if (term == NULL) {
+			setenv("TERM", "vt100", 1);
+		} else {
+			setenv("TERM", term, 1);
+		}
+	}
 }
 
 /* Parse a comma-separated list of numeric gids from str, returns an malloc'd


### PR DESCRIPTION
Prior to this commit, if `rkt enter` was executed without the `TERM`
environment variable set, a segfault could occur.
This commit treats an unset TERM environment variable as meaning 'xterm'
and avoids the segfault.

This is more noticeable in environments where rkt is the child of some non-terminal process (e.g. the kubelet).

Related to https://github.com/kubernetes/kubernetes/issues/25430

I reproduced this via `sudo sh -c 'unset TERM && rkt enter $uid ls'` on my machine, though I'm not certain that it reproduces consistently on all machines. I could not reproduce it after this change.

I wasn't sure if it was preferable to leave `TERM` blank when it is unset for the caller and I'm open for any discussion / arguments there.

cc @dgonyeo 