### PR TITLE
Add libtspi dev to install script update docker build cmd

### DIFF
--- a/Documentation/hacking.md
+++ b/Documentation/hacking.md
@@ -33,7 +33,7 @@ Alternatively, you can build rkt in a Docker container with the following comman
 Replace `$SRC` with the absolute path to your rkt source code:
 
 ```
-# docker run -v $SRC:/opt/rkt debian:sid /bin/bash -c "cd /opt/rkt && ./scripts/install-deps-debian-sid.sh go get github.com/appc/spec/... && ./autogen.sh && ./configure && make"
+# docker run -v $SRC:/opt/rkt debian:sid /bin/bash -c "cd /opt/rkt && ./scripts/install-deps-debian-sid.sh && go get github.com/appc/spec/... && ./autogen.sh && ./configure && make"
 ```
 
 ### Building systemd in stage1 from source

--- a/Documentation/hacking.md
+++ b/Documentation/hacking.md
@@ -33,7 +33,7 @@ Alternatively, you can build rkt in a Docker container with the following comman
 Replace `$SRC` with the absolute path to your rkt source code:
 
 ```
-# docker run -v $SRC:/opt/rkt -i -t golang:1.5 /bin/bash -c "apt-get update && apt-get install -y coreutils cpio squashfs-tools realpath autoconf file xz-utils patch bc libacl1-dev libtspi-dev libssl-dev && cd /opt/rkt && go get github.com/appc/spec/... && ./autogen.sh && ./configure && make"
+# docker run -v $SRC:/opt/rkt debian:sid /bin/bash -c "cd /opt/rkt && ./scripts/install-deps-debian-sid.sh go get github.com/appc/spec/... && ./autogen.sh && ./configure && make"
 ```
 
 ### Building systemd in stage1 from source

--- a/scripts/install-deps-debian-sid.sh
+++ b/scripts/install-deps-debian-sid.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-DEBIAN_SID_DEPS="ca-certificates gcc libc6-dev make automake wget git golang-go coreutils cpio squashfs-tools realpath autoconf file xz-utils patch bc locales libacl1-dev libssl-dev"
+DEBIAN_SID_DEPS="ca-certificates gcc libc6-dev make automake wget git golang-go coreutils cpio squashfs-tools realpath autoconf file xz-utils patch bc locales libacl1-dev libssl-dev libtspi-dev"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update


### PR DESCRIPTION
This pull request adds the dependency `libtspi-dev` to `scripts/install-deps-debian-sid.sh` to reuse this install script for the [Building rkt with Docker](https://github.com/coreos/rkt/blob/master/Documentation/hacking.md#building-rkt-with-docker) section. Also i changed the image of this part to `debian:sid`. Now it uses the same image and dependencies like the [Building rkt in rkt](https://github.com/coreos/rkt/blob/master/Documentation/rkt-build-rkt.md#debian-sid) section.

@alban @iaguis @jellonek Can somebody please take a look? Thanks!