### PR TITLE
stage1: implement read-only rootfs

### DIFF
--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -361,11 +361,11 @@ For more details see the [hacking documentation](../hacking.md).
 | `--private-users` |  `false` | `true` or `false` | Run within user namespaces. |
 | `--set-env` | none | An environment variable (ex. `--set-env=NAME=VALUE`) | An environment variable to set for apps. |
 | `--signature` | none | A file path | Local signature file to use in validating the preceding image |
-| `--stage1-url` | none | URL with protocol | A URL to a stage1 image. HTTP/HTTPS/File/Docker URLs are supported. |
-| `--stage1-path` | none | Absolute or relative path | A path to a stage1 image. |
-| `--stage1-name` | none | Image name (ex. `--stage1-name=coreos.com/rkt/stage1-coreos`) | A name of a stage1 image. Will perform a discovery if the image is not in the store. |
-| `--stage1-hash` | none | Image hash (ex. `--stage1-hash=sha512-dedce9f5ea50`) | A hash of a stage1 image. The image must exist in the store. |
 | `--stage1-from-dir` | none | Image name (ex. `--stage1-name=coreos.com/rkt/stage1-coreos`) | A stage1 image file name to search for inside the default stage1 images directory. |
+| `--stage1-hash` | none | Image hash (ex. `--stage1-hash=sha512-dedce9f5ea50`) | A hash of a stage1 image. The image must exist in the store. |
+| `--stage1-name` | none | Image name (ex. `--stage1-name=coreos.com/rkt/stage1-coreos`) | A name of a stage1 image. Will perform a discovery if the image is not in the store. |
+| `--stage1-path` | none | Absolute or relative path | A path to a stage1 image. |
+| `--stage1-url` | none | URL with protocol | A URL to a stage1 image. HTTP/HTTPS/File/Docker URLs are supported. |
 | `--store-only` | `false` | `true` or `false` | Use only available images in the store (do not discover or download from remote URLs). See [image fetching behavior](../image-fetching-behavior.md). |
 | `--uuid-file-save` | none | A file path | Write out the pod UUID to a file. |
 | `--volume` |  none | Volume syntax (ex. `--volume NAME,kind=KIND,source=PATH,readOnly=BOOL`) | Volumes to make available in the pod. See [Mount Volumes into a Pod](#mount-volumes-into-a-pod). |

--- a/stage1/init/common/pod.go
+++ b/stage1/init/common/pod.go
@@ -450,7 +450,7 @@ func appToSystemd(p *stage1commontypes.Pod, ra *schema.RuntimeApp, interactive b
 	}
 
 	if ra.ReadOnlyRootFS {
-		opts = append(opts, unit.NewUnitOption("Service", "ReadOnlyDirectories", "/"))
+		opts = append(opts, unit.NewUnitOption("Service", "ReadOnlyDirectories", common.RelAppRootfsPath(appName)))
 	}
 
 	// TODO(tmrts): Extract this logic into a utility function.
@@ -474,7 +474,7 @@ func appToSystemd(p *stage1commontypes.Pod, ra *schema.RuntimeApp, interactive b
 		}
 
 		if !IsMountReadOnly(vols[m.Volume], app.MountPoints) {
-			rwDirs = append(rwDirs, mntPath)
+			rwDirs = append(rwDirs, filepath.Join(common.RelAppRootfsPath(appName), mntPath))
 		}
 	}
 

--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -1068,7 +1068,8 @@ func TestPodManifest(t *testing.T) {
 
 		if tt.expectedResult != "" {
 			if _, out, err := expectRegexWithOutput(child, tt.expectedResult); err != nil {
-				t.Fatalf("Expected %q but not found: %v\n%s", tt.expectedResult, err, out)
+				t.Errorf("Expected %q but not found: %v\n%s", tt.expectedResult, err, out)
+				continue
 			}
 		}
 		waitOrFail(t, child, tt.expectedExit)
@@ -1085,7 +1086,8 @@ func TestPodManifest(t *testing.T) {
 
 		if tt.expectedResult != "" {
 			if _, out, err := expectRegexWithOutput(child, tt.expectedResult); err != nil {
-				t.Fatalf("Expected %q but not found: %v\n%s", tt.expectedResult, err, out)
+				t.Errorf("Expected %q but not found: %v\n%s", tt.expectedResult, err, out)
+				continue
 			}
 		}
 

--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -580,7 +580,7 @@ func TestPodManifest(t *testing.T) {
 				{
 					"rkt-test-run-pod-manifest-vol-rw-no-app.aci",
 					[]string{
-						"--exec=/inspect --write-file --read-file --file-name=/dir1/file --content=host:baz",
+						"--exec=/inspect --write-file --read-file --file-name=/dir1/file --content=host:baw",
 						"--mounts=dir1,path=/dir1,readOnly=false",
 					},
 				},
@@ -594,7 +594,7 @@ func TestPodManifest(t *testing.T) {
 				},
 			},
 			0,
-			"host:baz",
+			"host:baw",
 			"",
 		},
 		{
@@ -619,14 +619,14 @@ func TestPodManifest(t *testing.T) {
 					{"dir1", "host", tmpdir, nil, nil, nil, nil},
 				},
 			},
-			1,
-			`Cannot write to file "/dir1/host": open /dir1/host: read-only file system`,
+			0,
+			"host:baz",
 			"",
 		},
 		{
 			// Simple read after write with volume mounted, no apps in pod manifest.
 			// This should succeed even the mount point in image manifest is readOnly,
-			// because it is overrided by the volume's readOnly.
+			// because it is overriden by the volume's readOnly.
 			[]imagePatch{
 				{
 					"rkt-test-run-pod-manifest-vol-ro-no-app.aci",


### PR DESCRIPTION
Using the Pod manifest readOnlyRootFS option mounts the rootfs of the app
as read-only using systemd-exec unit option ReadOnlyDirectories.

Fixes #2487 
Supersedes #2612