### PR TITLE
docs: fix duplicate word

### DIFF
--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -295,7 +295,7 @@ The `run` subcommand features the `--net` argument which takes options to config
 
 ### Default contained networking
 
-When the argument is not given, `--net=default` is automatically assumed and the default contained network network will be loaded.
+When the argument is not given, `--net=default` is automatically assumed and the default contained network will be loaded.
 
 ### Host networking
 


### PR DESCRIPTION
Fixes the word "network" appearing twice instead of once when explaining the default contained network argument.