### PR TITLE
tests: update pattern to skip more doc/img files

### DIFF
--- a/tests/build-and-run-tests.sh
+++ b/tests/build-and-run-tests.sh
@@ -234,8 +234,10 @@ function main {
 
     DOC_CHANGE_PATTERN="\
             -e ^Documentation/ \
-            -e ^(README|ROADMAP|CONTRIBUTING|CHANGELOG)$ \
+            -e ^logos/ \
+            -e ^(MAINTAINERS|LICENSE|DCO)$ \
             -e \.md$\
+            -e \.(jpeg|jpg|png|svg)$\
     "
 
     buildFolder


### PR DESCRIPTION
This commit adds more patterns to DOC_CHANGE_PATTERN, skipping
testing on image changes and more top-level files.
Closes #2642

Signed-off-by: Luca Bruno <lucab@debian.org>