### PR TITLE
build: fix build failures on manpages/bash-completion target due to missing GOPATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,14 @@
 *~
 
+.vagrant
+/.config.args
 /Makefile
+/acbuild
 /autom4te.cache
+/build-rir*
+/build-rkt*
 /config.log
 /config.status
-/.config.args
 /configure
-/build-rkt*
-/build-rir*
-.vagrant
+/dist
 /tags
-/acbuild

--- a/rkt/rkt.mk
+++ b/rkt/rkt.mk
@@ -31,11 +31,11 @@ include makelib/build_go_bin.mk
 
 manpages: | $(GOPATH_TO_CREATE)/src/$(REPO_PATH)
 	mkdir -p dist/manpages/
-	ls rkt/*.go | grep -vE '_test.go|main.go|_gen.go' | xargs go run rkt/manpages_gen.go
+	ls rkt/*.go | grep -vE '_test.go|main.go|_gen.go' | $(GO_ENV) xargs "$(GO)" run rkt/manpages_gen.go
 
 bash-completion: | $(GOPATH_TO_CREATE)/src/$(REPO_PATH)
 	mkdir -p dist/bash_completion/
-	ls rkt/*.go | grep -vE '_test.go|main.go|_gen.go' | xargs go run rkt/bash_completion_gen.go
+	ls rkt/*.go | grep -vE '_test.go|main.go|_gen.go' | $(GO_ENV) xargs "$(GO)" run rkt/bash_completion_gen.go
 
 protobuf:
 	scripts/genproto.sh


### PR DESCRIPTION
Pass expected variables to build commands and prefer them over hardcoded ones. Also, git ignore `dist` directory with build artifacts.