### PR TITLE
build: only ignore specific sub-directories in `dist`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@
 /config.log
 /config.status
 /configure
-/dist
+/dist/bash_completion
+/dist/manpages
 /tags


### PR DESCRIPTION
Refine `.gitignore` to only ignore bash_completion and manpages
artifacts. Reinstate the toplevel `dist` directory, as it contains
some other tracked data.