### PR TITLE
docs: systemd-run with kvm flavor

### DIFF
--- a/Documentation/using-rkt-with-systemd.md
+++ b/Documentation/using-rkt-with-systemd.md
@@ -65,6 +65,10 @@ MACHINE CLASS SERVICE
 0 machines listed.
 ```
 
+### KVM flavor with systemd-run
+
+`rkt` with KVM flavor requires to be runned with stdin/stdout connected to TTY so remember to add `--pty` into `systemd-run` parameters.
+
 ## Managing pods as systemd services
 
 ### Simple Unit File


### PR DESCRIPTION
closes #2650