### PR TITLE
stage1: clean up pod cgroups on GC

### DIFF
--- a/common/cgroup/cgroup.go
+++ b/common/cgroup/cgroup.go
@@ -375,7 +375,7 @@ func RemountCgroupsRO(root string, enabledCgroups map[int][]string, subcgroup st
 	// Mount RW knobs we need to make the enabled isolators work
 	for _, c := range controllers {
 		cPath := filepath.Join(cgroupTmpfs, c)
-		subcgroupPath := filepath.Join(cPath, subcgroup)
+		subcgroupPath := filepath.Join(cPath, subcgroup, "system.slice")
 
 		// Workaround for https://github.com/coreos/rkt/issues/1210
 		if c == "cpuset" {

--- a/tests/rkt_gc_nspawn_test.go
+++ b/tests/rkt_gc_nspawn_test.go
@@ -1,0 +1,76 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build host coreos src
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+func getPodCgroups(shortUUID string) ([]string, error) {
+	var podCgroups []string
+	walkCgroups := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsDir() && strings.Contains(path, shortUUID) {
+			podCgroups = append(podCgroups, path)
+		}
+		return nil
+	}
+	if err := filepath.Walk("/sys/fs/cgroup", walkCgroups); err != nil {
+		return nil, err
+	}
+	return podCgroups, nil
+}
+
+func TestGCCgroup(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	imagePath := patchImportAndFetchHash("inspect-gc-test-run.aci", []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=0"}, t, ctx)
+	defer os.Remove(imagePath)
+	cmd := fmt.Sprintf("%s --insecure-options=image prepare %s", ctx.Cmd(), imagePath)
+	uuid := runRktAndGetUUID(t, cmd)
+	shortUUID := strings.Split(uuid, "-")[0]
+
+	cmd = fmt.Sprintf("%s run-prepared %s", ctx.Cmd(), shortUUID)
+	runRktAndCheckOutput(t, cmd, "", false)
+
+	cgs, err := getPodCgroups(shortUUID)
+	if err != nil {
+		t.Fatalf("error getting pod cgroups: %v", err)
+	}
+	if len(cgs) == 0 {
+		t.Fatalf("expected pod cgroup directories after run, but found none")
+	}
+
+	runGC(t, ctx)
+
+	cgs, err = getPodCgroups(shortUUID)
+	if err != nil {
+		t.Fatalf("error getting pod cgroups: %v", err)
+	}
+	if len(cgs) > 0 {
+		t.Fatalf(fmt.Sprintf("expected no pod cgroup directories after GC, but found %d: %v", len(cgs), cgs))
+	}
+}

--- a/tests/rkt_rm_nspawn_test.go
+++ b/tests/rkt_rm_nspawn_test.go
@@ -1,0 +1,59 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build host coreos src
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+func TestRmCgroup(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	imagePath := patchImportAndFetchHash("inspect-rm-test-run.aci", []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=0"}, t, ctx)
+	defer os.Remove(imagePath)
+	cmd := fmt.Sprintf("%s --insecure-options=image prepare %s", ctx.Cmd(), imagePath)
+	uuid := runRktAndGetUUID(t, cmd)
+	shortUUID := strings.Split(uuid, "-")[0]
+
+	cmd = fmt.Sprintf("%s run-prepared %s", ctx.Cmd(), shortUUID)
+	runRktAndCheckOutput(t, cmd, "", false)
+
+	cgs, err := getPodCgroups(shortUUID)
+	if err != nil {
+		t.Fatalf("error getting pod cgroups: %v", err)
+	}
+	if len(cgs) == 0 {
+		t.Fatalf("expected pod cgroup directories after run, but found none")
+	}
+
+	rmCmd := fmt.Sprintf("%s rm %s", ctx.Cmd(), shortUUID)
+	spawnAndWaitOrFail(t, rmCmd, 0)
+
+	cgs, err = getPodCgroups(shortUUID)
+	if err != nil {
+		t.Fatalf("error getting pod cgroups: %v", err)
+	}
+	if len(cgs) > 0 {
+		t.Fatalf(fmt.Sprintf("expected no pod cgroup directories after GC, but found %d: %v", len(cgs), cgs))
+	}
+}

--- a/tests/rkt_rm_test.go
+++ b/tests/rkt_rm_test.go
@@ -1,0 +1,81 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build host coreos src kvm
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+func TestRm(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	var uuids []string
+
+	img := patchTestACI("inspect-rm-test-run.aci", []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=0"}...)
+	defer os.Remove(img)
+	prepareCmd := fmt.Sprintf("%s --insecure-options=image prepare %s", ctx.Cmd(), img)
+
+	// Finished pod.
+	uuid := runRktAndGetUUID(t, prepareCmd)
+	runPreparedCmd := fmt.Sprintf("%s --insecure-options=image run-prepared %s", ctx.Cmd(), uuid)
+	runRktAndCheckOutput(t, runPreparedCmd, "", false)
+
+	uuids = append(uuids, uuid)
+
+	// Prepared pod.
+	uuid = runRktAndGetUUID(t, prepareCmd)
+	uuids = append(uuids, uuid)
+
+	podDirs := []string{
+		filepath.Join(ctx.DataDir(), "pods", "run"),
+		filepath.Join(ctx.DataDir(), "pods", "prepared"),
+	}
+
+	for _, dir := range podDirs {
+		pods, err := ioutil.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("cannot read pods directory %q: %v", dir, err)
+		}
+		if len(pods) == 0 {
+			t.Fatalf("pods should still exist in directory %q: %v", dir, pods)
+		}
+	}
+
+	for _, u := range uuids {
+		cmd := fmt.Sprintf("%s rm %s", ctx.Cmd(), u)
+		spawnAndWaitOrFail(t, cmd, 0)
+	}
+
+	podDirs = append(podDirs, filepath.Join(ctx.DataDir(), "pods", "exited-garbage"))
+
+	for _, dir := range podDirs {
+		pods, err := ioutil.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("cannot read pods directory %q: %v", dir, err)
+		}
+		if len(pods) != 0 {
+			t.Errorf("no pods should exist in directory %q, but found: %v", dir, pods)
+		}
+	}
+}


### PR DESCRIPTION
After a pod exits, there'll be some leftover directories in
/sys/fs/cgroup.

This commit cleans them up on GC.

Fixes (partially) #2504