### PR TITLE
stage0/trust: change error message if prefix/root flag missing

### DIFF
--- a/Documentation/subcommands/trust.md
+++ b/Documentation/subcommands/trust.md
@@ -16,7 +16,7 @@ A few examples:
 # rkt trust --prefix=coreos.com/etcd
 ```
 
-To trust a key for an entire root domain, you must use the `--root` flag, with a path to a local key file (no discovery).
+To trust a key for an entire root domain, you must use the `--root` flag, with a path to a key file (no discovery).
 
 ```
 # rkt trust --root ~/aci-pubkeys.gpg

--- a/rkt/trust.go
+++ b/rkt/trust.go
@@ -59,7 +59,12 @@ func init() {
 func runTrust(cmd *cobra.Command, args []string) (exit int) {
 	if flagPrefix == "" && !flagRoot {
 		if len(args) != 0 {
-			stderr.Print("--root required for non-prefixed (root) keys")
+			stderr.Print(`aborting due to implicit unbounded trust (root domain)
+Please provide a specific domain prefix to trust:
+    rkt trust --prefix "example.com/foo" [PUBKEY]
+    rkt trust --prefix "example.com/foo/*" [PUBKEY]
+Otherwise, trust at the root domain (not recommended) must be explicitly requested:
+    rkt trust --root PUBKEY`)
 		} else {
 			cmd.Usage()
 		}


### PR DESCRIPTION
Error message is not helpful at the moment for the user

Fixes #480 

@jonboulle can you please take a look at this. I am not sure if this is ok so, this is my first code change in a golang project and rkt :)

The result is:

````
$ ./build-rkt-1.6.0+git/bin/rkt trust coreos.com
trust: Prevented potentially dangerous unbounded trust of all containers signed by keys from coreos.com
To continue trusting this root domain:
	rkt trust --root PUBKEY (local key file, no discovery)
Or, establish a smaller scope with a prefix:
	rkt trust --prefix "example.com/hello"
	rkt trust --prefix "example.com/foo/*"
````