### PR TITLE
tests: TestServiceFile: increase timeout to 15s

### DIFF
--- a/tests/rkt_service_file_test.go
+++ b/tests/rkt_service_file_test.go
@@ -88,8 +88,8 @@ func TestServiceFile(t *testing.T) {
 		t.Fatalf("Test unit not found in list")
 	}
 
-	// Run the unit for 10 seconds. You can check the logs manually in journalctl
-	time.Sleep(10 * time.Second)
+	// Run the unit for 15 seconds. You can check the logs manually in journalctl
+	time.Sleep(15 * time.Second)
 
 	// Stop the unit
 	_, err = conn.StopUnit(target, "replace", reschan)


### PR DESCRIPTION
TestServiceFile was previously waiting 10 seconds. In our test on Fedora
23, it was taking 11 seconds. This made the test fail. This patch
increases the delay to 15 seconds. It should be enough.

/cc @iaguis 