### PR TITLE
stage0: complain and abort on conflicting CLI flags

### DIFF
--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -107,7 +107,9 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	if len(flagPodManifest) > 0 && (len(flagPorts) > 0 || flagInheritEnv || !flagExplicitEnv.IsEmpty() || flagStoreOnly || flagNoStore) {
+	if len(flagPodManifest) > 0 && (len(flagPorts) > 0 || flagInheritEnv || !flagExplicitEnv.IsEmpty() || flagStoreOnly || flagNoStore ||
+		(*appsVolume)(&rktApps).String() != "" || (*appMount)(&rktApps).String() != "" || (*appExec)(&rktApps).String() != "" ||
+		(*appUser)(&rktApps).String() != "" || (*appGroup)(&rktApps).String() != "") {
 		stderr.Print("conflicting flags set with --pod-manifest (see --help)")
 		return 1
 	}

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -148,7 +148,9 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	if len(flagPodManifest) > 0 && (len(flagPorts) > 0 || flagInheritEnv || !flagExplicitEnv.IsEmpty() || rktApps.Count() > 0 || flagStoreOnly || flagNoStore) {
+	if len(flagPodManifest) > 0 && (len(flagPorts) > 0 || flagInheritEnv || !flagExplicitEnv.IsEmpty() || rktApps.Count() > 0 || flagStoreOnly || flagNoStore ||
+		(*appsVolume)(&rktApps).String() != "" || (*appMount)(&rktApps).String() != "" || (*appExec)(&rktApps).String() != "" ||
+		(*appUser)(&rktApps).String() != "" || (*appGroup)(&rktApps).String() != "") {
 		stderr.Print("conflicting flags set with --pod-manifest (see --help)")
 		return 1
 	}

--- a/tests/rkt_prepare_test.go
+++ b/tests/rkt_prepare_test.go
@@ -1,0 +1,63 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build host coreos src kvm
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+// TestPrepareConflictingFlags tests that 'rkt prepare' will complain and abort
+// if conflicting flags are specified together with a pod manifest.
+func TestPrepareConflictingFlags(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	prepareConflictingFlagsMsg := "conflicting flags set with --pod-manifest (see --help)"
+	podManifestFlag := "--pod-manifest=/dev/null"
+	conflictingFlags := []struct {
+		flag string
+		args string
+	}{
+		{"--inherit-env", ""},
+		{"--no-store", ""},
+		{"--store-only", ""},
+		{"--port=", "foo:80"},
+		{"--set-env=", "foo=bar"},
+		{"--volume=", "foo,kind=host,source=/tmp"},
+		{"--mount=", "volume=foo,target=/tmp --volume=foo,kind=host,source=/tmp"},
+	}
+	imageConflictingFlags := []struct {
+		flag string
+		args string
+	}{
+		{"--exec=", "/bin/sh"},
+		{"--user=", "user_foo"},
+		{"--group=", "group_foo"},
+	}
+
+	for _, cf := range conflictingFlags {
+		cmd := fmt.Sprintf("%s prepare %s %s%s", ctx.Cmd(), podManifestFlag, cf.flag, cf.args)
+		runRktAndCheckOutput(t, cmd, prepareConflictingFlagsMsg, true)
+	}
+	for _, icf := range imageConflictingFlags {
+		cmd := fmt.Sprintf("%s prepare dummy-image.aci %s %s%s", ctx.Cmd(), podManifestFlag, icf.flag, icf.args)
+		runRktAndCheckOutput(t, cmd, prepareConflictingFlagsMsg, true)
+	}
+}

--- a/tests/rkt_run_test.go
+++ b/tests/rkt_run_test.go
@@ -1,0 +1,63 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build host coreos src kvm
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+// TestRunConflictingFlags tests that 'rkt run' will complain and abort
+// if conflicting flags are specified together with a pod manifest.
+func TestRunConflictingFlags(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	runConflictingFlagsMsg := "conflicting flags set with --pod-manifest (see --help)"
+	podManifestFlag := "--pod-manifest=/dev/null"
+	conflictingFlags := []struct {
+		flag string
+		args string
+	}{
+		{"--inherit-env", ""},
+		{"--no-store", ""},
+		{"--store-only", ""},
+		{"--port=", "foo:80"},
+		{"--set-env=", "foo=bar"},
+		{"--volume=", "foo,kind=host,source=/tmp"},
+		{"--mount=", "volume=foo,target=/tmp --volume=foo,kind=host,source=/tmp"},
+	}
+	imageConflictingFlags := []struct {
+		flag string
+		args string
+	}{
+		{"--exec=", "/bin/sh"},
+		{"--user=", "user_foo"},
+		{"--group=", "group_foo"},
+	}
+
+	for _, cf := range conflictingFlags {
+		cmd := fmt.Sprintf("%s run %s %s%s", ctx.Cmd(), podManifestFlag, cf.flag, cf.args)
+		runRktAndCheckOutput(t, cmd, runConflictingFlagsMsg, true)
+	}
+	for _, icf := range imageConflictingFlags {
+		cmd := fmt.Sprintf("%s run dummy-image.aci %s %s%s", ctx.Cmd(), podManifestFlag, icf.flag, icf.args)
+		runRktAndCheckOutput(t, cmd, runConflictingFlagsMsg, true)
+	}
+}


### PR DESCRIPTION
When a pod manifest is passed to rkt-prepare other conflicting
CLI flags are discarded, so far in a silent way.
This commit makes the issue explicit and abort when conflicting
flags are specified together with `--pod-manifest`.

Fixes #2418