### PR TITLE
rkt: fix panic on rm a non-existing pod with uuid-file

### DIFF
--- a/rkt/rm.go
+++ b/rkt/rm.go
@@ -43,20 +43,23 @@ func runRm(cmd *cobra.Command, args []string) (exit int) {
 	var podUUIDs []*types.UUID
 	var err error
 
+	ret := 0
 	switch {
 	case len(args) == 0 && flagUUIDFile != "":
 		podUUID, err = readUUIDFromFile(flagUUIDFile)
 		if err != nil {
-			stderr.PrintE("unable to read UUID from file", err)
-			return 1
+			stderr.PrintE("unable to resolve UUID from file", err)
+			ret = 1
+		} else {
+			podUUIDs = append(podUUIDs, podUUID)
 		}
-		podUUIDs = append(podUUIDs, podUUID)
 
 	case len(args) > 0 && flagUUIDFile == "":
 		for _, uuid := range args {
 			podUUID, err := resolveUUID(uuid)
 			if err != nil {
 				stderr.PrintE("unable to resolve UUID", err)
+				ret = 1
 			} else {
 				podUUIDs = append(podUUIDs, podUUID)
 			}
@@ -67,7 +70,6 @@ func runRm(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	ret := 0
 	for _, podUUID = range podUUIDs {
 		p, err := getPod(podUUID)
 		if err != nil {

--- a/rkt/uuid.go
+++ b/rkt/uuid.go
@@ -77,7 +77,7 @@ func readUUIDFromFile(path string) (*types.UUID, error) {
 	}
 	uuid = bytes.TrimSpace(uuid)
 
-	return types.NewUUID(string(uuid))
+	return resolveUUID(string(uuid))
 }
 
 func writeUUIDToFile(uuid *types.UUID, path string) error {

--- a/tests/rkt_rm_test.go
+++ b/tests/rkt_rm_test.go
@@ -79,3 +79,24 @@ func TestRm(t *testing.T) {
 		}
 	}
 }
+
+func TestRmInvalid(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	nonexistentUUID := "0f746094-3438-42bc-ab37-3cf85f132e60"
+	tmpDir := createTempDirOrPanic("rkt_rm_test")
+	defer os.RemoveAll(tmpDir)
+	uuidFile := filepath.Join(tmpDir, "uuid-file")
+	if err := ioutil.WriteFile(uuidFile, []byte(nonexistentUUID), 0600); err != nil {
+		t.Fatalf("cannot write uuid-file: %v", err)
+	}
+
+	expected := fmt.Sprintf("no matches found for %q", nonexistentUUID)
+
+	cmd := fmt.Sprintf("%s rm %s", ctx.Cmd(), nonexistentUUID)
+	runRktAndCheckOutput(t, cmd, expected, true)
+
+	cmd = fmt.Sprintf("%s rm --uuid-file=%s", ctx.Cmd(), uuidFile)
+	runRktAndCheckOutput(t, cmd, expected, true)
+}


### PR DESCRIPTION
We were trusting that the value in the uuid file referred to an existing
pod, which caused a panic if that wasn't the case.

In this commit we resolve the UUID to check if the pod actually exists.

Also, make rm's behavior consistent between caling it with a pod UUID
and with `--uuid-file`:

* Print a similar error message
* Set the exit status to 1 if we fail to remove any pod

There's no tests for `rkt rm`. I add some in https://github.com/coreos/rkt/pull/2655. I can add a test-case for this there.

Fixes https://github.com/coreos/rkt/issues/2678