### PR TITLE
stage1: prepare-app: mount a new sysfs instead of bind mount

### DIFF
--- a/stage1/prepare-app/prepare-app.c
+++ b/stage1/prepare-app/prepare-app.c
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
 	};
 	static const mount_point dirs_mount_table[] = {
 		{ "/proc", "/proc", "bind", NULL, MS_BIND|MS_REC },
-		{ "/sys", "/sys", "bind", NULL, MS_BIND|MS_REC },
+		{ "sysfs", "/sys", "sysfs", NULL, MS_NOSUID|MS_NODEV|MS_NOEXEC },
 		{ "/dev/shm", "/dev/shm", "bind", NULL, MS_BIND },
 		{ "/dev/pts", "/dev/pts", "bind", NULL, MS_BIND },
 		{ "/run/systemd/journal", "/run/systemd/journal", "bind", NULL, MS_BIND },


### PR DESCRIPTION
Avoid a recursive bind mount that would be slow with a lot of apps in the pod.

See https://github.com/coreos/rkt/issues/2351

-----

Do not merge yet: I would like to test it more.