### PR TITLE
stage1: restrict access to procfs and sysfs paths

### DIFF
--- a/stage1/init/common/pod.go
+++ b/stage1/init/common/pod.go
@@ -454,6 +454,43 @@ func appToSystemd(p *stage1commontypes.Pod, ra *schema.RuntimeApp, interactive b
 		unit.NewUnitOption("Service", "SyslogIdentifier", appName.String()),
 	}
 
+	// Restrict access to some security-sensitive paths under /proc and /sys.
+	// Those entries can be hidden or just made read-only to app.
+	roPaths := []string{
+		"/proc/sys/kernel/core_pattern",
+		"/proc/sys/kernel/modprobe",
+		"/proc/sys/vm/panic_on_oom",
+		"/proc/sysrq-trigger",
+		"/sys/block/",
+		"/sys/bus/",
+		"/sys/class/",
+		"/sys/dev/",
+		"/sys/devices/",
+		"/sys/kernel/",
+	}
+	hiddenPaths := []string{
+		// TODO(lucab): file-paths restrictions need support in systemd first
+		//"/proc/config.gz",
+		//"/proc/kallsyms",
+		//"/proc/sched_debug",
+		//"/proc/kcore",
+		//"/proc/kmem",
+		//"/proc/mem",
+		"/sys/firmware/",
+		"/sys/fs/",
+		"/sys/hypervisor/",
+		"/sys/module/",
+		"/sys/power/",
+	}
+	// Paths prefixed with "-" are ignored if they do not exist:
+	// [https://www.freedesktop.org/software/systemd/man/systemd.exec.html#ReadWriteDirectories=]
+	for _, p := range hiddenPaths {
+		opts = append(opts, unit.NewUnitOption("Service", "InaccessibleDirectories", fmt.Sprintf("-%s", filepath.Join(common.RelAppRootfsPath(appName), p))))
+	}
+	for _, p := range roPaths {
+		opts = append(opts, unit.NewUnitOption("Service", "ReadOnlyDirectories", fmt.Sprintf("-%s", filepath.Join(common.RelAppRootfsPath(appName), p))))
+	}
+
 	if ra.ReadOnlyRootFS {
 		opts = append(opts, unit.NewUnitOption("Service", "ReadOnlyDirectories", common.RelAppRootfsPath(appName)))
 	}

--- a/tests/rkt_mount_test.go
+++ b/tests/rkt_mount_test.go
@@ -102,3 +102,35 @@ func TestMountSymlink(t *testing.T) {
 		}
 	}
 }
+
+// TestProcFSRestrictions checks that access to sensitive paths under
+// /proc and /sys is correctly restricted:
+// https://github.com/coreos/rkt/issues/2484
+func TestProcFSRestrictions(t *testing.T) {
+	// check access to read-only paths
+	roEntry := "/proc/sysrq-trigger"
+	testContent := "h"
+	roImage := patchTestACI("rkt-inspect-write-procfs.aci", fmt.Sprintf("--exec=/inspect --write-file --file-name %s --content %s", roEntry, testContent))
+	defer os.Remove(roImage)
+
+	roCtx := testutils.NewRktRunCtx()
+	defer roCtx.Cleanup()
+
+	roCmd := fmt.Sprintf("%s --insecure-options=image run %s", roCtx.Cmd(), roImage)
+
+	roExpectedLine := fmt.Sprintf("Cannot write to file \"%s\"", roEntry)
+	runRktAndCheckOutput(t, roCmd, roExpectedLine, true)
+
+	// check access to inaccessible paths
+	hiddenEntry := "/sys/firmware/"
+	hiddenImage := patchTestACI("rkt-inspect-stat-procfs.aci", fmt.Sprintf("--exec=/inspect --stat-file --file-name %s", hiddenEntry))
+	defer os.Remove(hiddenImage)
+
+	hiddenCtx := testutils.NewRktRunCtx()
+	defer hiddenCtx.Cleanup()
+
+	hiddenCmd := fmt.Sprintf("%s --insecure-options=image run %s", hiddenCtx.Cmd(), hiddenImage)
+
+	hiddenExpectedLine := fmt.Sprintf("%s: mode: d---------", hiddenEntry)
+	runRktAndCheckOutput(t, hiddenCmd, hiddenExpectedLine, false)
+}


### PR DESCRIPTION
Many procfs and sysfs endpoints are currently not namespace-aware
and can be used by malicious pods to manipulate host state
and escape the sandboxing.
This commit introduces an initial mitigation, by marking those
paths as read-only or inaccessible to containers.

(Partially) Fixes #2484