### PR TITLE
KVM: Hypervisor support for KVM flavor

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -19,7 +19,7 @@ ABS_GO := @ABS_GO@
 # [STAGE1] build settings
 
 # selinux tags for rkt and functional tests
-RKT_TAGS := -tags "selinux @TPM_TAGS@ @SDJOURNAL_TAGS@"
+RKT_TAGS := -tags "selinux @TPM_TAGS@ @SDJOURNAL_TAGS@ @KVM_HV_TAG@"
 # stage1 build mode
 
 RKT_VERSION := @RKT_VERSION@

--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,13 @@ AC_ARG_WITH([stage1-systemd-version],
             [RKT_STAGE1_SYSTEMD_VER="${withval}"],
             [RKT_STAGE1_SYSTEMD_VER='auto'])
 
+# STAGE1 - KVM hypervisor. LKVM is the only choice for now
+AC_ARG_WITH([stage1-kvm-hypervisor],
+            [AS_HELP_STRING([--with-stage1-kvm-hypervisor],
+                            [hypervisor used by 'kvm' flavor; default and only option for now: 'lkvm'])],
+            [RKT_STAGE1_KVM_HV="${withval}"],
+            [RKT_STAGE1_KVM_HV='lkvm'])
+
 ## STAGE1 - path to coreos pxe and its systemd version for kvm and coreos flavors
 
 AC_ARG_WITH([coreos-local-pxe-image-path],
@@ -306,7 +313,7 @@ RKT_ITERATE_FLAVORS([${RKT_STAGE1_FLAVORS}],[flavor],
                              [coreos],
                                      [RKT_COMMON_COREOS_PROGS],
                              [kvm],
-                                     [AC_MSG_NOTICE([will build linux kernel and lkvm from source, make sure that all their build requirements are fulfilled])
+                                     [AC_MSG_NOTICE([will build linux kernel and ${RKT_STAGE1_KVM_HV} from source, make sure that all their build requirements are fulfilled])
                                       RKT_COMMON_COREOS_PROGS
                                       RKT_REQ_PROG([PATCH],[patch],[patch])
                                       RKT_REQ_PROG([TAR],[tar],[tar])
@@ -407,6 +414,14 @@ dnl Warn if version is HEAD, just use master.
 AS_VAR_IF([RKT_STAGE1_SYSTEMD_VER], [HEAD],
           [AC_MSG_WARN([* 'HEAD' is not a systemd version, setting it to 'master' instead])
            RKT_STAGE1_SYSTEMD_VER='master'])
+
+KVM_HV_TAG='hv_none'
+RKT_IF_HAS_FLAVOR([${RKT_STAGE1_FLAVORS}], [kvm],
+                  dnl for kvm check hypervisor
+                  AS_CASE([${RKT_STAGE1_KVM_HV}],
+                          [lkvm],
+                                  KVM_HV_TAG='hv_lkvm',
+                          [AC_MSG_ERROR([*** Invalid value passed to --with-stage1-kvm-hypervisor; lkvm is the only supported tool right now])]))
 
 ## Options specific to coreos/kvm flavors
 
@@ -736,6 +751,7 @@ AC_SUBST(RKT_STAGE1_DEFAULT_IMAGES_DIRECTORY_LDFLAGS)
 AC_SUBST(RKT_VERSION_LDFLAGS)
 AC_SUBST(RKT_FEATURES_LDFLAGS)
 
+AC_SUBST(KVM_HV_TAG)
 AC_SUBST(TPM_TAGS)
 AC_SUBST(SDJOURNAL_TAGS)
 
@@ -786,6 +802,13 @@ RKT_IF_HAS_FLAVOR([${RKT_STAGE1_FLAVORS}], [src],
 
         systemd git repo:                       '${RKT_STAGE1_SYSTEMD_SRC}'
         systemd version:                        '${RKT_STAGE1_SYSTEMD_VER}'])])
+
+RKT_IF_HAS_FLAVOR([${RKT_STAGE1_FLAVORS}], [kvm],
+                  [AC_MSG_RESULT([
+        kvm flavor specific build parameters
+
+        hypervisor:                             '${RKT_STAGE1_KVM_HV}'])])
+
 
 AC_MSG_RESULT([
         other build parameters

--- a/stage1/init/init.mk
+++ b/stage1/init/init.mk
@@ -1,1 +1,2 @@
+BGB_GO_FLAGS := $(strip $(RKT_TAGS))
 include stage1/makelib/aci_simple_go_bin.mk

--- a/stage1/init/kvm/hypervisor/hypervisor.go
+++ b/stage1/init/kvm/hypervisor/hypervisor.go
@@ -1,0 +1,46 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisor
+
+// KvmHypervisor structure describes KVM hypervisor binary and its parameters
+type KvmHypervisor struct {
+	Bin          string
+	KernelParams []string
+}
+
+// InitKernelParams sets debug and common parameters passed to the kernel
+func (hv *KvmHypervisor) InitKernelParams(isDebug bool) {
+	hv.KernelParams = append(hv.KernelParams, []string{
+		"console=hvc0",
+		"init=/usr/lib/systemd/systemd",
+		"no_timer_check",
+		"noreplace-smp",
+		"tsc=reliable"}...)
+
+	if isDebug {
+		hv.KernelParams = append(hv.KernelParams, []string{
+			"debug",
+			"systemd.log_level=debug",
+			"systemd.show_status=true",
+		}...)
+	} else {
+		hv.KernelParams = append(hv.KernelParams, []string{
+			"systemd.show_status=false",
+			"rd.udev.log-priority=3",
+			"quiet=vga",
+			"quiet systemd.log_level=emerg",
+		}...)
+	}
+}

--- a/stage1/init/kvm/hypervisor/lkvm_driver.go
+++ b/stage1/init/kvm/hypervisor/lkvm_driver.go
@@ -1,0 +1,73 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build hv_lkvm
+
+package hypervisor
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/coreos/rkt/stage1/init/kvm"
+)
+
+// StartCmd takes path to stage1, name of the machine, path to kernel, network describers, memory in megabytes
+// and quantity of cpus and prepares command line to run LKVM process
+func StartCmd(wdPath, name, kernelPath string, nds []kvm.NetDescriber, cpu, mem int64, debug bool) []string {
+	driverConfiguration := KvmHypervisor{
+		Bin: "./lkvm",
+		KernelParams: []string{
+			"systemd.default_standard_error=journal+console",
+			"systemd.default_standard_output=journal+console",
+		},
+	}
+
+	driverConfiguration.InitKernelParams(debug)
+
+	startCmd := []string{
+		filepath.Join(wdPath, driverConfiguration.Bin),
+		"run",
+		"--name", "rkt-" + name,
+		"--no-dhcp",
+		"--cpu", strconv.Itoa(int(cpu)),
+		"--mem", strconv.Itoa(int(mem)),
+		"--console=virtio",
+		"--kernel", kernelPath,
+		"--disk", "stage1/rootfs", // relative to run/pods/uuid dir this is a place where systemd resides
+		// MACHINEID will be available as environment variable
+		"--params", strings.Join(driverConfiguration.KernelParams, " "),
+	}
+	return append(startCmd, kvmNetArgs(nds)...)
+}
+
+// kvmNetArgs returns additional arguments that need to be passed
+// to lkvm tool to configure networks properly. Logic is based on
+// network configuration extracted from Networking struct
+// and essentially from activeNets that expose NetDescriber behavior
+func kvmNetArgs(nds []kvm.NetDescriber) []string {
+	var lkvmArgs []string
+
+	for _, nd := range nds {
+		lkvmArgs = append(lkvmArgs, "--network")
+		lkvmArgs = append(
+			lkvmArgs,
+			fmt.Sprintf("mode=tap,tapif=%s,host_ip=%s,guest_ip=%s", nd.IfName(), nd.Gateway(), nd.GuestIP()),
+		)
+	}
+
+	return lkvmArgs
+}

--- a/stage1/init/kvm/hypervisor/none_driver.go
+++ b/stage1/init/kvm/hypervisor/none_driver.go
@@ -1,0 +1,24 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build hv_none
+
+package hypervisor
+
+import "github.com/coreos/rkt/stage1/init/kvm"
+
+// StartCmd always returns nil in case of no hypervisor is set.
+func StartCmd(wdPath, name, kernelPath string, nds []kvm.NetDescriber, cpu, mem int64, debug bool) []string {
+	return nil
+}

--- a/stage1/init/kvm/network.go
+++ b/stage1/init/kvm/network.go
@@ -28,18 +28,17 @@ import (
 	"github.com/hashicorp/errwrap"
 )
 
-// GetNetworkDescriptions explicitly convert slice of activeNets to slice of netDescribers
-// which is slice required by GetKVMNetArgs
-func GetNetworkDescriptions(n *networking.Networking) []netDescriber {
-	var nds []netDescriber
+// GetNetworkDescriptions converts activeNets to netDescribers
+func GetNetworkDescriptions(n *networking.Networking) []NetDescriber {
+	var nds []NetDescriber
 	for _, an := range n.GetActiveNetworks() {
 		nds = append(nds, an)
 	}
 	return nds
 }
 
-// netDescriber is something that describes network configuration
-type netDescriber interface {
+// NetDescriber is the interface that describes a network configuration
+type NetDescriber interface {
 	GuestIP() net.IP
 	Mask() net.IP
 	IfName() string
@@ -53,7 +52,7 @@ type netDescriber interface {
 // to lkvm tool to configure networks properly.
 // Logic is based on Network configuration extracted from Networking struct
 // and essentially from activeNets that expose netDescriber behavior
-func GetKVMNetArgs(nds []netDescriber) ([]string, error) {
+func GetKVMNetArgs(nds []NetDescriber) ([]string, error) {
 
 	var lkvmArgs []string
 
@@ -103,8 +102,7 @@ func upInterfaceCommand(ifName string) string {
 	return fmt.Sprintf("/bin/ip link set dev %s up", ifName)
 }
 
-func GenerateNetworkInterfaceUnits(unitsPath string, netDescriptions []netDescriber) error {
-
+func GenerateNetworkInterfaceUnits(unitsPath string, netDescriptions []NetDescriber) error {
 	for i, netDescription := range netDescriptions {
 		ifName := fmt.Sprintf(networking.IfNamePattern, i)
 		netAddress := net.IPNet{

--- a/stage1/init/kvm/network_test.go
+++ b/stage1/init/kvm/network_test.go
@@ -41,11 +41,11 @@ func (t testNetDescriber) Routes() []types.Route { return []types.Route{} }
 
 func TestGetKVMNetArgs(t *testing.T) {
 	tests := []struct {
-		netDescriptions []netDescriber
+		netDescriptions []NetDescriber
 		expectedLkvm    []string
 	}{
 		{ // without Masquerading - not gw passed to kernel
-			netDescriptions: []netDescriber{
+			netDescriptions: []NetDescriber{
 				testNetDescriber{
 					net.ParseIP("1.1.1.1"),
 					net.ParseIP("2.2.2.2"),
@@ -58,7 +58,7 @@ func TestGetKVMNetArgs(t *testing.T) {
 			expectedLkvm: []string{"--network", "mode=tap,tapif=fooInt,host_ip=1.1.1.1,guest_ip=2.2.2.2"},
 		},
 		{ // extra gw passed to kernel on (third position)
-			netDescriptions: []netDescriber{
+			netDescriptions: []NetDescriber{
 				testNetDescriber{
 					net.ParseIP("1.1.1.1"),
 					net.ParseIP("2.2.2.2"),
@@ -71,7 +71,7 @@ func TestGetKVMNetArgs(t *testing.T) {
 			expectedLkvm: []string{"--network", "mode=tap,tapif=barInt,host_ip=1.1.1.1,guest_ip=2.2.2.2"},
 		},
 		{ // two networks
-			netDescriptions: []netDescriber{
+			netDescriptions: []NetDescriber{
 				testNetDescriber{
 					net.ParseIP("1.1.1.1"),
 					net.ParseIP("2.2.2.2"),


### PR DESCRIPTION
Here's the first PR in our plan to put some focus on qemu as a KVM hypervisor. Whole code is based on Michał Stachowski's (@mstachowski) work in https://github.com/coreos/rkt/pull/2592 ,and it's taken by me, due to the other activities inside our company that Michał must handle. We're also closing #2592.
This code provides a generic mechanism to use different kvm hypervisors (such as lkvm, qemu-kvm), to set it by passing proper option to ./configure (New configure option --with-stage1-kvm-hypervisor). This PR covers only implementation of KvmHypervisor type and a small refactor of kvm's part of init.go to match the new KvmHypervisor interface (lkvm is the only option that could be passed to --with-stage1-kvm-hypervisor and it's also default)
I fixed most of the review suggestions from #2592 