### PR TITLE
git-validation: disable short-subject validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
 
 before_install:
  - go get -u github.com/coreos/git-validation
- - git-validation -run subsystem-in-subject,short-subject,dangling-whitespace
+ - git-validation -run subsystem-in-subject,dangling-whitespace
 
 install:
  - sudo apt-get update -qq


### PR DESCRIPTION
Complains when the commit is a merge commit, it shouldn't!

Discovered in  #2684