### PR TITLE
dist: Add rkt-api systemd unit

### DIFF
--- a/Documentation/packaging.md
+++ b/Documentation/packaging.md
@@ -48,12 +48,13 @@ When the ownership and permissions of `/var/lib/rkt` are set up correctly, membe
 
 ### systemd units
 
-A few [example systemd unit files for rkt helper services][rkt-units] are included in the rkt sources. These units demonstrate a systemd-managed, socket-activated rkt [metadata-service][rkt-metadata-svc], along with a convenient periodic [garbage collection][rkt-gc] service invoked at 12-hour intervals to purge dead pods.
+A few [example systemd unit files for rkt helper services][rkt-units] are included in the rkt sources. These units demonstrate systemd-managed units to run the rkt [metadata-service][rkt-metadata-svc] with socket-activation, the rkt [api-service][api-service], and a periodic [garbage collection][rkt-gc] service invoked at 12-hour intervals to purge dead pods.
 
 
 [build-config]: build-configure.md
 [rkt-gc]: subcommands/gc.md
 [rkt-metadata-svc]: subcommands/metadata-service.md
+[api-service]: subcommands/api-service.md
 [rkt-units]: https://github.com/coreos/rkt/tree/master/dist/init/systemd
 [build-deps]: dependencies.md#build-time-dependencies
 [run-deps]: dependencies.md#run-time-dependencies

--- a/Documentation/subcommands/api-service.md
+++ b/Documentation/subcommands/api-service.md
@@ -13,6 +13,8 @@ The API service listens for gRPC requests on the address and port specified by t
 The default is to listen on the loopback interface on port number `15441`, equivalent to invoking `rkt api-service --listen=localhost:15441`.
 Specify the address `0.0.0.0` to listen on all interfaces.
 
+Typically, the API service will be run via a unit file similar to the one included in the [dist directory](../dist/init/systemd/rkt-api.service).
+
 ## Using the API service
 
 The interfaces are defined in the [protobuf here](../../api/v1alpha/api.proto).

--- a/dist/init/systemd/rkt-api.service
+++ b/dist/init/systemd/rkt-api.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=rkt api service
+Documentation=http://github.com/coreos/rkt
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/rkt api-service --listen="127.0.0.1:15441"
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This commit adds a sample service file for a rkt api-service listening
on localhost.

The existing documentation around the`init` scripts is sparse and it links to the entire directory already, but I'm happy to also make improvements there.