### PR TITLE
run: added support for selecting an image to run via docker image ID

### DIFF
--- a/store/migrate.go
+++ b/store/migrate.go
@@ -33,6 +33,7 @@ var (
 		3: migrateToV3,
 		4: migrateToV4,
 		5: migrateToV5,
+		6: migrateToV6,
 	}
 )
 
@@ -139,6 +140,25 @@ func migrateToV5(tx *sql.Tx) error {
 		"INSERT INTO aciinfo_tmp (blobkey, name, importtime, lastused, latest) SELECT blobkey, name, importtime, lastusedtime, latest from aciinfo",
 		"DROP TABLE aciinfo",
 		"CREATE TABLE aciinfo (blobkey string, name string, importtime time, lastused time, latest bool, size int64 DEFAULT 0, treestoresize int64 DEFAULT 0);",
+		"CREATE UNIQUE INDEX IF NOT EXISTS blobkeyidx ON aciinfo (blobkey)",
+		"CREATE INDEX IF NOT EXISTS nameidx ON aciinfo (name)",
+		"INSERT INTO aciinfo SELECT * from aciinfo_tmp",
+		"DROP TABLE aciinfo_tmp",
+	} {
+		_, err := tx.Exec(t)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func migrateToV6(tx *sql.Tx) error {
+	for _, t := range []string{
+		"CREATE TABLE aciinfo_tmp (blobkey string, name string, dockerid string, importtime time, lastused time, latest bool, size int64, treestoresize int64);",
+		"INSERT INTO aciinfo_tmp (blobkey, name, importtime, lastused, latest, size, treestoresize) SELECT blobkey, name, importtime, lastusedtime, latest, size, treestoresize from aciinfo",
+		"DROP TABLE aciinfo",
+		"CREATE TABLE aciinfo (blobkey string, name string, dockerid string DEFAULT \"\", importtime time, lastused time, latest bool, size int64, treestoresize int64);",
 		"CREATE UNIQUE INDEX IF NOT EXISTS blobkeyidx ON aciinfo (blobkey)",
 		"CREATE INDEX IF NOT EXISTS nameidx ON aciinfo (name)",
 		"INSERT INTO aciinfo SELECT * from aciinfo_tmp",

--- a/store/schema.go
+++ b/store/schema.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// Incremental db version at the current code revision.
-	dbVersion = 5
+	dbVersion = 6
 )
 
 // Statement to run when creating a db. These are the statements to create the
@@ -37,7 +37,7 @@ var dbCreateStmts = [...]string{
 	"CREATE UNIQUE INDEX IF NOT EXISTS aciurlidx ON remote (aciurl)",
 
 	// aciinfo table. The primary key is "blobkey" and it matches the key used to save that aci in the blob store
-	"CREATE TABLE IF NOT EXISTS aciinfo (blobkey string, name string, importtime time, lastused time, latest bool, size int64 DEFAULT 0, treestoresize int64 DEFAULT 0);",
+	"CREATE TABLE IF NOT EXISTS aciinfo (blobkey string, name string, dockerid string, importtime time, lastused time, latest bool, size int64 DEFAULT 0, treestoresize int64 DEFAULT 0);",
 	"CREATE UNIQUE INDEX IF NOT EXISTS blobkeyidx ON aciinfo (blobkey)",
 	"CREATE INDEX IF NOT EXISTS nameidx ON aciinfo (name)",
 }


### PR DESCRIPTION
This commit modifies the store's schema to store the docker id for any
image imported into the store. This value comes from the
"appc.io/docker/imageid" annotation on the image being imported. If this
annotation is missing, the stored dockerid is blank.

When an image is being run, if the schema is "docker-hash", rkt will
search for an image with this docker image ID in the store (using the
field that was added for quick lookup).

Fixes part of https://github.com/coreos/rkt/issues/2188.

