### PR TITLE
git-validation: check only the HEAD commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
 
 before_install:
  - go get -u github.com/coreos/git-validation
- - git-validation -run subsystem-in-subject,dangling-whitespace
+ - git-validation -run subsystem-in-subject,dangling-whitespace -range HEAD^..
 
 install:
  - sudo apt-get update -qq


### PR DESCRIPTION
Travis fails because git-validation also checks Godeps changes.

Let's check only HEAD until
https://github.com/coreos/git-validation/issues/4 is solved.