### PR TITLE
kvm: print message about network only when --debug is given

### DIFF
--- a/stage1/init/kvm.go
+++ b/stage1/init/kvm.go
@@ -39,7 +39,7 @@ func KvmNetworkingToSystemd(p *stage1commontypes.Pod, n *networking.Networking) 
 
 	// networking
 	netDescriptions := kvm.GetNetworkDescriptions(n)
-	if err := kvm.GenerateNetworkInterfaceUnits(filepath.Join(podRoot, stage1initcommon.UnitsDir), netDescriptions); err != nil {
+	if err := kvm.GenerateNetworkInterfaceUnits(filepath.Join(podRoot, stage1initcommon.UnitsDir), netDescriptions, debug); err != nil {
 		return errwrap.Wrap(errors.New("failed to transform networking to units"), err)
 	}
 

--- a/stage1/init/kvm/network.go
+++ b/stage1/init/kvm/network.go
@@ -103,7 +103,7 @@ func upInterfaceCommand(ifName string) string {
 	return fmt.Sprintf("/bin/ip link set dev %s up", ifName)
 }
 
-func GenerateNetworkInterfaceUnits(unitsPath string, netDescriptions []netDescriber) error {
+func GenerateNetworkInterfaceUnits(unitsPath string, netDescriptions []netDescriber, debug bool) error {
 
 	for i, netDescription := range netDescriptions {
 		ifName := fmt.Sprintf(networking.IfNamePattern, i)
@@ -158,7 +158,9 @@ func GenerateNetworkInterfaceUnits(unitsPath string, netDescriptions []netDescri
 			return errwrap.Wrap(fmt.Errorf("failed to create network unit file %q", unitName), err)
 		}
 
-		rlog.Printf("network unit created: %q in %q (iface=%q, addr=%q)", unitName, unitsPath, ifName, address)
+		if debug {
+			rlog.Printf("network unit created: %q in %q (iface=%q, addr=%q)", unitName, unitsPath, ifName, address)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
in the context of #2622

Simple change to perform quiet mode on kvm side.

Actually rlog doesn't have method for printing messages only when debug is given. So I handed 'debug' argument into GenerateNetworkInterfaceUnits method.