### PR TITLE
build: Find also blackbox tests for unit-check

### DIFF
--- a/makelib/misc.mk
+++ b/makelib/misc.mk
@@ -165,11 +165,11 @@ $(eval $(call setup-custom-dep-file,$1,$(MK_PATH)$2))
 endef
 
 # Returns all not-excluded directories inside $REPO_PATH that have
-# nonzero files matching given "go list -f {{.ITEM}}".
+# nonzero files matching given "go list -f {{.ITEM1}} {{.ITEM2}}...".
 # 1 - where to look for files (./... to look for all files inside the project)
-# 2 - a "go list -f {{.ITEM}}" item (GoFiles, TestGoFiles, etc)
+# 2 - a list of "go list -f {{.ITEM}}" items (GoFiles, TestGoFiles, etc)
 # 3 - space-separated list of excluded directories
-# Example: $(call go-find-directories,./...,TestGoFiles,tests)
+# Example: $(call go-find-directories,./...,TestGoFiles XTestGoFiles,tests)
 define go-find-directories
 $(strip \
 	$(eval _MISC_GFD_ESCAPED_SRCDIR := $(MK_TOPLEVEL_ABS_SRCDIR)) \
@@ -177,8 +177,9 @@ $(strip \
 	$(eval _MISC_GFD_ESCAPED_SRCDIR := $(subst /,\/,$(_MISC_GFD_ESCAPED_SRCDIR))) \
 	$(eval _MISC_GFD_SPACE_ :=) \
 	$(eval _MISC_GFD_SPACE_ +=) \
-	$(eval _MISC_GFD_FILES_ := $(shell $(GO_ENV) "$(GO)" list -f '{{.ImportPath}} {{.$2}}' $1 | \
-		grep --invert-match '\[\]' | \
+	$(eval _MISC_GFD_GO_LIST_ITEMS_ := $(foreach i,$2,{{.$i}})) \
+	$(eval _MISC_GFD_FILES_ := $(shell $(GO_ENV) "$(GO)" list -f '{{.ImportPath}} $(_MISC_GFD_GO_LIST_ITEMS_)' $1 | \
+		grep '\[[^]]' | \
 		sed -e 's/.*$(_MISC_GFD_ESCAPED_SRCDIR)\///' -e 's/[[:space:]]*\[.*\]$$//' \
 		$(if $3,| grep --invert-match '^\($(subst $(_MISC_GFD_SPACE_),\|,$3)\)'))) \
 	$(_MISC_GFD_FILES_) \

--- a/tests/tests.mk
+++ b/tests/tests.mk
@@ -1,18 +1,15 @@
 $(call setup-stamp-file,TST_SHORT_TESTS_STAMP,/short-tests)
 
-TST_DIRS_WITH_GOFILES := $(call go-find-directories,$(GO_TEST_PACKAGES),GoFiles)
-TST_DIRS_WITH_TESTGOFILES := $(call go-find-directories,$(GO_TEST_PACKAGES),TestGoFiles,tests)
-
 # gofmt takes list of directories
-TST_GOFMT_DIRS := $(foreach d,$(TST_DIRS_WITH_GOFILES),./$d)
 # go vet and go test take a list of packages
-TST_GO_VET_PACKAGES := $(foreach d,$(TST_DIRS_WITH_GOFILES),$(REPO_PATH)/$d)
-TST_GO_TEST_PACKAGES := $(foreach d,$(TST_DIRS_WITH_TESTGOFILES),$(REPO_PATH)/$d)
-
 $(call forward-vars,$(TST_SHORT_TESTS_STAMP), \
-	GOFMT TST_GOFMT_DIRS GO_ENV GO TST_GO_VET_PACKAGES RKT_TAGS \
-	TST_GO_TEST_PACKAGES)
+	GOFMT GO_ENV GO RKT_TAGS)
 $(TST_SHORT_TESTS_STAMP):
+	$(eval TST_DIRS_WITH_GOFILES := $(call go-find-directories,$(GO_TEST_PACKAGES),GoFiles))
+	$(eval TST_DIRS_WITH_TESTGOFILES := $(call go-find-directories,$(GO_TEST_PACKAGES),TestGoFiles XTestGoFiles,tests))
+	$(eval TST_GOFMT_DIRS := $(foreach d,$(TST_DIRS_WITH_GOFILES),./$d))
+	$(eval TST_GO_VET_PACKAGES := $(foreach d,$(TST_DIRS_WITH_GOFILES),$(REPO_PATH)/$d))
+	$(eval TST_GO_TEST_PACKAGES := $(foreach d,$(TST_DIRS_WITH_TESTGOFILES),$(REPO_PATH)/$d))
 	$(VQ) \
 	set -e; \
 	$(call vb,vt,GOFMT,$(TST_GOFMT_DIRS)) \


### PR DESCRIPTION
We were only checking the packages that had non-empty TestGoFiles
field returned by "go list". But the TestGoFiles contains only files
that have the same package as the non-test files in the same
directory. The test files with the different package name are in the
XTestGoFiles field, which we did not handle before.

This makes go test to run the test for pkg/selinux and pkg/user
packages too.

Should help with #2496.