### PR TITLE
rkt/gc: mount stage1 on GC

### DIFF
--- a/stage0/gc.go
+++ b/stage0/gc.go
@@ -29,19 +29,22 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/coreos/rkt/common"
+
 	"github.com/appc/spec/schema/types"
 	"github.com/hashicorp/errwrap"
 )
 
 // GC enters the pod by fork/exec()ing the stage1's /gc similar to /init.
 // /gc can expect to have its CWD set to the pod root.
-// stage1Path is the path of the stage1 rootfs
-func GC(pdir string, uuid *types.UUID, stage1Path string) error {
+func GC(pdir string, uuid *types.UUID) error {
 	err := unregisterPod(pdir, uuid)
 	if err != nil {
 		// Probably not worth abandoning the rest
 		log.PrintE("warning: could not unregister pod with metadata service", err)
 	}
+
+	stage1Path := common.Stage1RootfsPath(pdir)
 
 	ep, err := getStage1Entrypoint(pdir, gcEntrypoint)
 	if err != nil {

--- a/tests/rkt_gc_nspawn_test.go
+++ b/tests/rkt_gc_nspawn_test.go
@@ -47,8 +47,7 @@ func TestGCCgroup(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	imagePath := patchImportAndFetchHash("inspect-gc-test-run.aci", []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=0"}, t, ctx)
-	defer os.Remove(imagePath)
+	imagePath := getInspectImagePath()
 	cmd := fmt.Sprintf("%s --insecure-options=image prepare %s", ctx.Cmd(), imagePath)
 	uuid := runRktAndGetUUID(t, cmd)
 	shortUUID := strings.Split(uuid, "-")[0]

--- a/tests/rkt_gc_test.go
+++ b/tests/rkt_gc_test.go
@@ -32,15 +32,14 @@ func TestGC(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
+	imagePath := getInspectImagePath()
 	// Finished pods.
-	patchImportAndRun("inspect-gc-test-run.aci", []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=0"}, t, ctx)
+	importImageAndRun(imagePath, t, ctx)
 
 	// Prepared pods.
-	patchImportAndPrepare("inspect-gc-test-prepare.aci", []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=0"}, t, ctx)
+	importImageAndPrepare(imagePath, t, ctx)
 
 	// Abort prepare.
-	imagePath := patchTestACI("inspect-gc-test-abort.aci", []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=0"}...)
-	defer os.Remove(imagePath)
 	cmd := fmt.Sprintf("%s --insecure-options=image prepare %s %s", ctx.Cmd(), imagePath, imagePath)
 	spawnAndWaitOrFail(t, cmd, 1)
 
@@ -89,10 +88,11 @@ func TestGCAfterUnmount(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
+	imagePath := getInspectImagePath()
+
 	for _, rmNetns := range []bool{false, true} {
 
-		imagePath := patchImportAndFetchHash("inspect-gc-test-run.aci", []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=0"}, t, ctx)
-		defer os.Remove(imagePath)
+		importImageAndFetchHash(t, ctx, "", imagePath)
 		cmd := fmt.Sprintf("%s --insecure-options=image prepare %s", ctx.Cmd(), imagePath)
 		uuid := runRktAndGetUUID(t, cmd)
 

--- a/tests/rkt_rm_nspawn_test.go
+++ b/tests/rkt_rm_nspawn_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -29,8 +28,7 @@ func TestRmCgroup(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	imagePath := patchImportAndFetchHash("inspect-rm-test-run.aci", []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=0"}, t, ctx)
-	defer os.Remove(imagePath)
+	imagePath := getInspectImagePath()
 	cmd := fmt.Sprintf("%s --insecure-options=image prepare %s", ctx.Cmd(), imagePath)
 	uuid := runRktAndGetUUID(t, cmd)
 	shortUUID := strings.Split(uuid, "-")[0]

--- a/tests/rkt_rm_test.go
+++ b/tests/rkt_rm_test.go
@@ -32,8 +32,7 @@ func TestRm(t *testing.T) {
 
 	var uuids []string
 
-	img := patchTestACI("inspect-rm-test-run.aci", []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=0"}...)
-	defer os.Remove(img)
+	img := getInspectImagePath()
 	prepareCmd := fmt.Sprintf("%s --insecure-options=image prepare %s", ctx.Cmd(), img)
 
 	// Finished pod.

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -225,6 +225,16 @@ func importImageAndFetchHash(t *testing.T, ctx *testutils.RktRunCtx, fetchArgs s
 	return importImageAndFetchHashAsGid(t, ctx, fetchArgs, img, 0)
 }
 
+func importImageAndRun(imagePath string, t *testing.T, ctx *testutils.RktRunCtx) {
+	cmd := fmt.Sprintf("%s --insecure-options=image run %s", ctx.Cmd(), imagePath)
+	spawnAndWaitOrFail(t, cmd, 0)
+}
+
+func importImageAndPrepare(imagePath string, t *testing.T, ctx *testutils.RktRunCtx) {
+	cmd := fmt.Sprintf("%s --insecure-options=image prepare %s", ctx.Cmd(), imagePath)
+	spawnAndWaitOrFail(t, cmd, 0)
+}
+
 func patchImportAndFetchHash(image string, patches []string, t *testing.T, ctx *testutils.RktRunCtx) string {
 	imagePath := patchTestACI(image, patches...)
 	defer os.Remove(imagePath)


### PR DESCRIPTION
It might happen that stage1 is unmounted between the time where the pod
was stopped and it is GCd. This causes the stage1 GC or the CNI
plugins not to be accessible.

To fix it, we mount stage1 from the treestore at GC time.