### PR TITLE
[test] stage1: seccomp: experimenting...

### DIFF
--- a/stage1/init/common/pod.go
+++ b/stage1/init/common/pod.go
@@ -455,6 +455,7 @@ func appToSystemd(p *stage1commontypes.Pod, ra *schema.RuntimeApp, interactive b
 		// systemd unit name not getting written to the journal if the unit is
 		// short-lived and runs as non-root.
 		unit.NewUnitOption("Service", "SyslogIdentifier", appName.String()),
+		unit.NewUnitOption("Service", "SystemCallFilter", "~chroot"),
 	}
 
 	// Restrict access to some security-sensitive paths under /proc and /sys.


### PR DESCRIPTION
I am trying to use seccomp with this simple patch that blocks the chroot syscall:

```
$ docker2aci docker://ubuntu
$ actool \
    patch-manifest \
    --overwrite \
    --capability=CAP_AUDIT_WRITE,CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FSETID,CAP_FOWNER,CAP_KILL,CAP_MKNOD,CAP_NET_RAW,CAP_NET_BIND_SERVICE,CAP_SETUID,CAP_SETGID,CAP_SETPCAP,CAP_SETFCAP,CAP_SYS_CHROOT,CAP_SYS_MODULE \
    ubuntu-latest.aci \
    ubuntu-god.aci
$ sudo ./build-rkt-1.7.0+git/bin/rkt \
    run \
    --volume=mod,kind=host,source=/lib/modules/`uname -r`/,readOnly=true \
    --dns=8.8.8.8 \
    --insecure-options=image \
    ./ubuntu-god.aci \
    --mount=volume=mod,target=/mod \
    --interactive
...
# apt-get update
# apt-get install strace kmod xz-utils
# chroot / 
Bad system call
# strace -f chroot /
...
+++ killed by SIGSYS +++
# cp /mod/kernel/drivers/net/ifb.ko.xz /
# xz -d ifb.ko.xz
# insmod /ifb.ko
```

I was checking insmod because systemd-nspawn restricts it in [blacklist](https://github.com/systemd/systemd/blob/master/src/nspawn/nspawn-seccomp.c#L53). In this test, I can successfully insert a kernel module, but it's because nspawn only disables the `init_module()` syscall if `CAP_SYS_MODULE` is not given. But my image has `CAP_SYS_MODULE`.

https://github.com/coreos/rkt/issues/1614

/cc @jfrazelle