### PR TITLE
MAINTAINERS: add Piotr Skamruk (@jellonek)

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,12 +1,15 @@
-Alban Crequy <alban.crequy@coreos.com> (@alban)
-Brandon Philips <brandon.philips@coreos.com> (@philips)
-Derek Gonyeo <derek.gonyeo@coreos.com> (@dgonyeo)
-Iago López Galeiras <iago.lopez@coreos.com> (@iaguis)
-Jonathan Boulle <jonathan.boulle@coreos.com> (@jonboulle)
-Krzesimir Nowak <krzesimir.nowak@coreos.com> (@krnowak)
-Luca Bruno <luca.bruno@coreos.com> (@lucab)
-Sergiusz Urbaniak <sergiusz.urbaniak@coreos.com> (@s-urbaniak)
-Stefan Junker <stefan.junker@coreos.com> (@steveeJ)
-Tamer Tas <tamer.tas@coreos.com> (@tmrts)
-Vito Caputo <vito.caputo@coreos.com> (@vcaputo)
-Yifan Gu <yifan.gu@coreos.com> (@yifan-gu)
+Alban Crequy <alban.crequy@coreos.com> (@alban) pkg: *
+Brandon Philips <brandon.philips@coreos.com> (@philips) pkg: *
+Derek Gonyeo <derek.gonyeo@coreos.com> (@dgonyeo) pkg: *
+Euan Kemp <euan.kemp@coreos.com> (@euank) pkg: *
+Iago López Galeiras <iago.lopez@coreos.com> (@iaguis) pkg: *
+Jonathan Boulle <jonathan.boulle@coreos.com> (@jonboulle) pkg: *
+Krzesimir Nowak <krzesimir.nowak@coreos.com> (@krnowak) pkg: *
+Luca Bruno <luca.bruno@coreos.com> (@lucab) pkg: *
+Sergiusz Urbaniak <sergiusz.urbaniak@coreos.com> (@s-urbaniak) pkg: *
+Stefan Junker <stefan.junker@coreos.com> (@steveeJ) pkg: *
+Tamer Tas <tamer.tas@coreos.com> (@tmrts) pkg: *
+Vito Caputo <vito.caputo@coreos.com> (@vcaputo) pkg: *
+Yifan Gu <yifan.gu@coreos.com> (@yifan-gu) pkg: *
+
+Piotr Skamruk <piotr.skamruk@gmail.com> (@jellonek) pkg: *kvm*


### PR DESCRIPTION
Piotr has provided invaluable contributions to the project, mostly
around the KVM stage1 but also more generally. This proposes adding him
as a maintainer of all KVM-related areas.

This format is taken straight from
https://github.com/coreos/etcd/blob/master/MAINTAINERS but open to
better suggestions. I don't think it's necessary yet to go to a fully
structured approach (i.e. human parseable is fine for now).