### PR TITLE
pkg/selinux: various fixes

### DIFF
--- a/pkg/label/label_selinux.go
+++ b/pkg/label/label_selinux.go
@@ -34,7 +34,10 @@ func InitLabels(options []string) (string, string, error) {
 	if !selinux.SelinuxEnabled() {
 		return "", "", nil
 	}
-	processLabel, mountLabel := selinux.GetLxcContexts()
+	processLabel, mountLabel, err := selinux.GetLxcContexts()
+	if err != nil {
+		return "", "", err
+	}
 	if processLabel != "" {
 		pcon := selinux.NewContext(processLabel)
 		mcon := selinux.NewContext(mountLabel)

--- a/pkg/selinux/selinux_test.go
+++ b/pkg/selinux/selinux_test.go
@@ -1,3 +1,4 @@
+// Copyright 2016 The rkt Authors
 // Copyright 2014,2015 Red Hat, Inc
 // Copyright 2014,2015 Docker, Inc
 //
@@ -18,66 +19,76 @@
 package selinux_test
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/coreos/rkt/pkg/selinux"
 )
 
-func testSetfilecon(t *testing.T) {
-	if selinux.SelinuxEnabled() {
-		tmp := "selinux_test"
-		out, _ := os.OpenFile(tmp, os.O_WRONLY, 0)
-		out.Close()
-		err := selinux.Setfilecon(tmp, "system_u:object_r:bin_t:s0")
-		if err != nil {
-			t.Log("Setfilecon failed")
-			t.Fatal(err)
-		}
-		os.Remove(tmp)
+func TestSetfilecon(t *testing.T) {
+	if !selinux.SelinuxEnabled() {
+		t.Skip("SELinux not enabled")
+	}
+
+	f, err := ioutil.TempFile("", "rkt-selinux-test")
+	if err != nil {
+		panic(fmt.Sprintf("unable to create tempfile: %v", err))
+	}
+	f.Close()
+	defer os.Remove(f.Name())
+	err = selinux.Setfilecon(f.Name(), "system_u:object_r:bin_t:s0")
+	if err != nil {
+		t.Log("Setfilecon failed")
+		t.Fatal(err)
 	}
 }
 
 func TestSELinux(t *testing.T) {
-	var (
-		err            error
-		plabel, flabel string
-	)
-
-	if selinux.SelinuxEnabled() {
-		t.Log("Enabled")
-		plabel, flabel = selinux.GetLxcContexts()
-		if plabel == "" {
-			t.Log("No lxc contexts, skipping tests")
-			return
-		}
-		t.Log(plabel)
-		t.Log(flabel)
-		selinux.FreeLxcContexts(plabel)
-		plabel, flabel = selinux.GetLxcContexts()
-		t.Log(plabel)
-		t.Log(flabel)
-		selinux.FreeLxcContexts(plabel)
-		t.Log("getenforce ", selinux.SelinuxGetEnforce())
-		t.Log("getenforcemode ", selinux.SelinuxGetEnforceMode())
-		pid := os.Getpid()
-		t.Logf("PID:%d MCS:%s\n", pid, selinux.IntToMcs(pid, 1023))
-		err = selinux.Setfscreatecon("unconfined_u:unconfined_r:unconfined_t:s0")
-		if err == nil {
-			t.Log(selinux.Getfscreatecon())
-		} else {
-			t.Log("setfscreatecon failed", err)
-			t.Fatal(err)
-		}
-		err = selinux.Setfscreatecon("")
-		if err == nil {
-			t.Log(selinux.Getfscreatecon())
-		} else {
-			t.Log("setfscreatecon failed", err)
-			t.Fatal(err)
-		}
-		t.Log(selinux.Getpidcon(1))
-	} else {
-		t.Log("Disabled")
+	if !selinux.SelinuxEnabled() {
+		t.Skip("SELinux not enabled")
 	}
+
+	dir, err := ioutil.TempDir("", "rkt-selinux-test")
+	if err != nil {
+		panic(fmt.Sprintf("unable to create temp dir: %v", err))
+	}
+	defer os.RemoveAll(dir)
+	if err := selinux.SetMCSDir(dir); err != nil {
+		t.Errorf("error setting MCS directory: %v", err)
+	}
+
+	var plabel, flabel string
+
+	plabel, flabel = selinux.GetLxcContexts()
+	if plabel == "" {
+		t.Skip("No LXC contexts, skipping tests")
+	}
+	t.Log(plabel)
+	t.Log(flabel)
+	selinux.FreeLxcContexts(plabel)
+	plabel, flabel = selinux.GetLxcContexts()
+	t.Log(plabel)
+	t.Log(flabel)
+	selinux.FreeLxcContexts(plabel)
+	t.Log("getenforce ", selinux.SelinuxGetEnforce())
+	t.Log("getenforcemode ", selinux.SelinuxGetEnforceMode())
+	pid := os.Getpid()
+	t.Logf("PID:%d MCS:%s\n", pid, selinux.IntToMcs(pid, 1023))
+	err = selinux.Setfscreatecon("unconfined_u:unconfined_r:unconfined_t:s0")
+	if err == nil {
+		t.Log(selinux.Getfscreatecon())
+	} else {
+		t.Log("setfscreatecon failed", err)
+		t.Fatal(err)
+	}
+	err = selinux.Setfscreatecon("")
+	if err == nil {
+		t.Log(selinux.Getfscreatecon())
+	} else {
+		t.Log("setfscreatecon failed", err)
+		t.Fatal(err)
+	}
+	t.Log(selinux.Getpidcon(1))
 }

--- a/pkg/selinux/selinux_test.go
+++ b/pkg/selinux/selinux_test.go
@@ -61,14 +61,20 @@ func TestSELinux(t *testing.T) {
 
 	var plabel, flabel string
 
-	plabel, flabel = selinux.GetLxcContexts()
+	plabel, flabel, err = selinux.GetLxcContexts()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if plabel == "" {
 		t.Skip("No LXC contexts, skipping tests")
 	}
 	t.Log(plabel)
 	t.Log(flabel)
 	selinux.FreeLxcContexts(plabel)
-	plabel, flabel = selinux.GetLxcContexts()
+	plabel, flabel, err = selinux.GetLxcContexts()
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Log(plabel)
 	t.Log(flabel)
 	selinux.FreeLxcContexts(plabel)


### PR DESCRIPTION
TestSELinux was not setting the MCS dir which caused the paths of every
MCS to be in the root of the file system (the path is calculated as
`fmt.Sprintf("%s/%s", mcsdir, mcs)` and `mcsdir` was the empty string by
default). This was making the test to fail when it runs as non-root.

The test failure was non-obvious because of the way the algorithm to get
a unique MCS is implemented. We first try to create the MCS file with a
random category pair and, if it doesn't work, we continue with a
different random category pair. Since we can't write to the MCS
directory, we'll continue doing this until the test times out and we
don't print any errors when we can't create the MCS file.

Let's clean this package a bit.