### PR TITLE
functional tests: fix check-cgroup on inspect

### DIFF
--- a/tests/inspect/inspect.go
+++ b/tests/inspect/inspect.go
@@ -371,10 +371,10 @@ func main() {
 		testPaths := []string{rootCgroupPath}
 
 		// test a couple of controllers if they're available
-		if cgroup.IsIsolatorSupported("memory") {
+		if _, err := os.Stat(filepath.Join(rootCgroupPath, "memory")); err == nil {
 			testPaths = append(testPaths, filepath.Join(rootCgroupPath, "memory"))
 		}
-		if cgroup.IsIsolatorSupported("cpu") {
+		if _, err := os.Stat(filepath.Join(rootCgroupPath, "cpu")); err == nil {
 			testPaths = append(testPaths, filepath.Join(rootCgroupPath, "cpu"))
 		}
 

--- a/tests/inspect/inspect.go
+++ b/tests/inspect/inspect.go
@@ -380,7 +380,7 @@ func main() {
 
 		for _, p := range testPaths {
 			if err := syscall.Mkdir(filepath.Join(p, "test"), 0600); err == nil || err != syscall.EROFS {
-				fmt.Println("check-cgroups: FAIL")
+				fmt.Fprintf(os.Stderr, "check-cgroups: FAIL (%v)", err)
 				os.Exit(1)
 			}
 		}


### PR DESCRIPTION
We're not mounting `/sys/fs/cgroup` on stage2 anymore so this check
doesn't make sense. Let's just check on
`/proc/1/root/sys/fs/cgroup/...`.