### PR TITLE
Documentation: Fix issues from downstream: fmt and link

### DIFF
--- a/Documentation/capabilities-guide.md
+++ b/Documentation/capabilities-guide.md
@@ -24,8 +24,9 @@ Once running, each process has a bounding set of capabilities which it can
 enable and use; such process cannot get further capabilities outside of this set.
 
 In the context of containers, capabilities are useful for:
- * restricting the effective privileges of applications running as root
- * allowing applications to perform specific privileged operations, without
+
+* Restricting the effective privileges of applications running as root
+* Allowing applications to perform specific privileged operations, without
    having to run them as root
 
 For the complete list of existing Linux capabilities and a detailed description
@@ -36,7 +37,7 @@ of this security mechanism, see [capabilities(7)](http://man7.org/linux/man-page
 By default, rkt enforces [a default set of
 capabilities](https://github.com/appc/spec/blob/master/spec/ace.md#oslinuxcapabilities-remove-set)
 onto applications.
-This default set is tailored to stop applications from performing a large 
+This default set is tailored to stop applications from performing a large
 variety of privileged actions, while not impacting their normal behavior.
 Operations which are typically not needed in containers and which may
 impact host state, eg. invoking `reboot(2)`, are denied in this way.
@@ -50,12 +51,13 @@ of the customizable isolators available in rkt.
 
 When running Linux containers, rkt provides two mutually exclusive isolators
 to define the bounding set under which an application will be run:
- * `os/linux/capabilities-retain-set`
- * `os/linux/capabilities-remove-set`
+
+* `os/linux/capabilities-retain-set`
+* `os/linux/capabilities-remove-set`
 
 Those isolators cover different use-cases and employ different techniques to
 achieve the same goal of limiting available capabilities. As such, they cannot
-be used together at the same time, and recommended usage varies on a 
+be used together at the same time, and recommended usage varies on a
 case-by-case basis.
 
 As the granularity of capabilities varies for specific permission cases, a word
@@ -69,12 +71,12 @@ Many other ways to maliciously transition across capabilities have already been
 
 ### Retain-set
 
-`os/linux/capabilities-retain-set` allows for an additive approach to 
+`os/linux/capabilities-retain-set` allows for an additive approach to
 capabilities: applications will be stripped of all capabilities, except the ones
 listed in this isolator.
 
 This whitelisting approach is useful for completely locking down environments
-and whenever application requirements (in terms of capabilities) are 
+and whenever application requirements (in terms of capabilities) are
 well-defined in advance. It allows one to ensure that exactly and only the
 specified capabilities could ever be used.
 
@@ -84,7 +86,7 @@ its "retain-set".
 
 ### Remove-set
 
-`os/linux/capabilities-remove-set` tackles capabilities in a subtractive way: 
+`os/linux/capabilities-remove-set` tackles capabilities in a subtractive way:
 starting from the default set of capabilities, single entries can be further
 forbidden in order to prevent specific actions.
 
@@ -92,7 +94,7 @@ This blacklisting approach is useful to somehow limit applications which have
 broad requirements in terms of privileged operations, in order to deny some
 potentially malicious operations.
 
-For example, an application that will need to perform multiple privileged 
+For example, an application that will need to perform multiple privileged
 operations but is known to never open a raw socket, will have
 `CAP_NET_RAW` specified in its "remove-set".
 
@@ -105,12 +107,12 @@ CoreOS which ships with `ping` and `nc` commands (from busybox). Those
 commands respectively requires `CAP_NET_RAW` and `CAP_NET_BIND_SERVICE`
 capabilities in order to perform privileged operations.
 To block their usage, capabilities bounding set
-can be manipulated via `os/linux/capabilities-remove-set` or 
+can be manipulated via `os/linux/capabilities-remove-set` or
 `os/linux/capabilities-retain-set`; both approaches are shown here.
 
 ### Removing specific capabilities
 
-This example shows how to block `ping` only, by removing `CAP_NET_RAW` from 
+This example shows how to block `ping` only, by removing `CAP_NET_RAW` from
 capabilities bounding set.
 
 First, a local image is built with an explicit "remove-set" isolator.
@@ -129,8 +131,9 @@ $ acbuild end
 
 Once properly built, this image can be run in order to check that `ping` usage has
 been effectively disabled:
+
 ```
-$ sudo rkt run --interactive --insecure-options=image caps-remove-set-example.aci 
+$ sudo rkt run --interactive --insecure-options=image caps-remove-set-example.aci
 image: using image from file stage1-coreos.aci
 image: using image from file caps-remove-set-example.aci
 image: using image from local store for image name quay.io/coreos/alpine-sh
@@ -146,8 +149,9 @@ ping: permission denied (are you root?)
 This means that `CAP_NET_RAW` had been effectively disabled inside the container.
 At the same time, `CAP_NET_BIND_SERVICE` is still available in the default bounding
 set, so the `nc` command will be able to bind to port 80:
+
 ```
-$ sudo rkt run --interactive --insecure-options=image caps-remove-set-example.aci 
+$ sudo rkt run --interactive --insecure-options=image caps-remove-set-example.aci
 image: using image from file stage1-coreos.aci
 image: using image from file caps-remove-set-example.aci
 image: using image from local store for image name quay.io/coreos/alpine-sh
@@ -184,7 +188,7 @@ Once run, it can be easily verified that `ping` from inside the container is now
 functional:
 
 ```
-$ sudo rkt run --interactive --insecure-options=image caps-retain-set-example.aci 
+$ sudo rkt run --interactive --insecure-options=image caps-retain-set-example.aci
 image: using image from file stage1-coreos.aci
 image: using image from file caps-retain-set-example.aci
 image: using image from local store for image name quay.io/coreos/alpine-sh
@@ -206,7 +210,7 @@ For example, using `nc` to bind to port 80 will now result in a failure due to
 the missing `CAP_NET_BIND_SERVICE` capability:
 
 ```
-$ sudo rkt run --interactive --insecure-options=image caps-remove-set-example.aci 
+$ sudo rkt run --interactive --insecure-options=image caps-remove-set-example.aci
 image: using image from file stage1-coreos.aci
 image: using image from file caps-remove-set-example.aci
 image: using image from local store for image name quay.io/coreos/alpine-sh

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -309,7 +309,7 @@ Strictly seen, this is only true when `rkt run` is invoked on the host directly,
 
 ### Other Networking Examples
 
-More details about rkt's networking options and examples can be found in the [networking documentation](https://github.com/coreos/rkt/blob/master/Documentation/networking.md)
+More details about rkt's networking options and examples can be found in the [networking documentation](../networking/overview.md)
 
 ## Run rkt as a Daemon
 


### PR DESCRIPTION
- Fix formatting of code blocks and lists in capabilities-guide doc
- Fix broken link to networking/overview in Docs/subcmd/run.