### PR TITLE
Don't remove the cleanSrc if it equals '.'

### DIFF
--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -62,13 +62,15 @@ func CopySymlink(src, dest string) error {
 
 func CopyTree(src, dest string, uidRange *user.UidRange) error {
 	cleanSrc := filepath.Clean(src)
-
 	dirs := make(map[string][]syscall.Timespec)
 	copyWalker := func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 		rootLess := path[len(cleanSrc):]
+		if cleanSrc == "." {
+			rootLess = path
+		}
 		target := filepath.Join(dest, rootLess)
 		mode := info.Mode()
 		switch {


### PR DESCRIPTION
This fixes the issue where when cleanSrc equals '.', copied files are missing the first character from their names.
Note: I had issues getting the functional and unit tests working on my machine.

Fixes appc/acbuild#211