### PR TITLE
functional tests: re-purpose aws.sh for generating AMIs

### DIFF
--- a/tests/aws.sh
+++ b/tests/aws.sh
@@ -8,95 +8,65 @@ SCRIPTPATH=$PWD
 
 KEY_PAIR_NAME=rkt-testing-${USER}
 SECURITY_GROUP=rkt-testing-${USER}-security-group
+REGION=us-west-1
 
 ## First time only
 if [ "$1" = "setup" ] ; then
   MYIP=$(curl --silent http://checkip.amazonaws.com/)
 
-  aws ec2 create-key-pair --key-name $KEY_PAIR_NAME --query 'KeyMaterial' --output text > ${KEY_PAIR_NAME}.pem
+  aws --region $REGION ec2 create-key-pair --key-name $KEY_PAIR_NAME --query 'KeyMaterial' --output text > ${KEY_PAIR_NAME}.pem
   chmod 0600 ${KEY_PAIR_NAME}.pem
-  aws ec2 create-security-group --group-name $SECURITY_GROUP --description "Security group for rkt testing"
-  aws ec2 authorize-security-group-ingress --group-name $SECURITY_GROUP --protocol tcp --port 22 --cidr $MYIP/32
+  aws --region $REGION ec2 create-security-group --group-name $SECURITY_GROUP --description "Security group for rkt testing"
+  aws --region $REGION ec2 authorize-security-group-ingress --group-name $SECURITY_GROUP --protocol tcp --port 22 --cidr $MYIP/32
   exit 0
 fi
 
 DISTRO=$1
-GIT_URL=${2-https://github.com/coreos/rkt.git}
-GIT_BRANCH=${3-master}
-FLAVOR=${4-coreos}
-
-if [ "$DISTRO" = "all" ] ; then
-  gnome-terminal \
-	--tab --command="$SCRIPTPATH/aws.sh fedora-22      $GIT_URL $GIT_BRANCH $FLAVOR" \
-	--tab --command="$SCRIPTPATH/aws.sh fedora-23      $GIT_URL $GIT_BRANCH $FLAVOR" \
-	--tab --command="$SCRIPTPATH/aws.sh fedora-24      $GIT_URL $GIT_BRANCH $FLAVOR" \
-	--tab --command="$SCRIPTPATH/aws.sh fedora-rawhide $GIT_URL $GIT_BRANCH $FLAVOR" \
-	--tab --command="$SCRIPTPATH/aws.sh ubuntu-1604    $GIT_URL $GIT_BRANCH $FLAVOR" \
-	--tab --command="$SCRIPTPATH/aws.sh ubuntu-1510    $GIT_URL $GIT_BRANCH $FLAVOR" \
-	--tab --command="$SCRIPTPATH/aws.sh debian         $GIT_URL $GIT_BRANCH $FLAVOR" \
-	--tab --command="$SCRIPTPATH/aws.sh centos         $GIT_URL $GIT_BRANCH $FLAVOR"
-
-  exit 0
-fi
 
 test -f cloudinit/${DISTRO}.cloudinit
-CLOUDINIT_IN=$PWD/cloudinit/${DISTRO}.cloudinit
+CLOUDINIT=$PWD/cloudinit/${DISTRO}.cloudinit
 
 if [ "$DISTRO" = "fedora-22" ] ; then
   # https://getfedora.org/en/cloud/download/
-  # Search on AWS or look at
+  # Search on aws --region $REGION or look at
   # https://apps.fedoraproject.org/datagrepper/raw?category=fedimg
   # Sources: https://github.com/fedora-infra/fedimg/blob/develop/bin/list-the-amis.py
 
-  # Fedora-Cloud-Base-22-20160218.x86_64-eu-central-1-HVM-standard-0
-  AMI=ami-7a1b0116
+  # Fedora-Cloud-Base-22-20160218.x86_64-us-west-1-HVM-standard-0
+  AMI=ami-e291e082
   AWS_USER=fedora
-
-  # Workarounds
-  DISABLE_SELINUX=true
 elif [ "$DISTRO" = "fedora-23" ] ; then
-  # Fedora-Cloud-Base-23-20160323.x86_64-eu-central-1-HVM-standard-0
-  AMI=ami-d59670ba
+  # Fedora-Cloud-Base-23-20151030.x86_64-us-west-1-HVM-standard-0
+  AMI=ami-a6fc90c6
   AWS_USER=fedora
-
-  # Workarounds
-  DISABLE_SELINUX=true
 elif [ "$DISTRO" = "fedora-24" ] ; then
-  # Fedora-Cloud-Base-24_Alpha-7.x86_64-eu-central-1-HVM-standard-0
-  AMI=ami-748b6d1b
+  # Fedora-Cloud-Base-24-20160507.n.0.x86_64-us-west-1-HVM-standard-0
+  AMI=ami-8b4c35eb
   AWS_USER=fedora
-
-  # Workarounds
-  DISABLE_OVERLAY=true
 elif [ "$DISTRO" = "fedora-rawhide" ] ; then
-  # Fedora-Cloud-Base-Rawhide-20160321.0.x86_64-eu-central-1-HVM-standard-0
-  AMI=ami-69967006
+  # Fedora-Cloud-Base-rawhide-20160129.x86_64-us-west-1-HVM-standard-0
+  AMI=ami-a18dfac1
   AWS_USER=fedora
-
-  # Workarounds
-  # systemd in stage1 does not have the fixes for SELinux yet
-  FLAVOR=host
-  DISABLE_OVERLAY=true
 elif [ "$DISTRO" = "ubuntu-1604" ] ; then
   # https://cloud-images.ubuntu.com/locator/ec2/
-  # ubuntu/images-milestone/hvm/ubuntu-xenial-alpha2-amd64-server-20160125
-  AMI=ami-b4a5b9d8
+  # ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20160627
+  AMI=ami-b20542d2
   AWS_USER=ubuntu
 elif [ "$DISTRO" = "ubuntu-1510" ] ; then
   # https://cloud-images.ubuntu.com/locator/ec2/
-  # ubuntu/images/hvm/ubuntu-wily-15.10-amd64-server-20160123
-  AMI=ami-e9869f85
+  # ubuntu/images/hvm-instance/ubuntu-wily-15.10-amd64-server-20160715
+  AMI=ami-cee8aeae
   AWS_USER=ubuntu
 elif [ "$DISTRO" = "debian" ] ; then
   # https://wiki.debian.org/Cloud/AmazonEC2Image/Jessie
-  # Debian 8.1
-  AMI=ami-02b78e1f
+  # Debian 8.4
+  AMI=ami-45374b25
   AWS_USER=admin
 elif [ "$DISTRO" = "centos" ] ; then
   # Needs to subscribe first, see:
   # https://wiki.centos.org/Cloud/AWS
   # CentOS-7 x86_64 HVM
-  AMI=ami-e68f82fb
+  AMI=ami-af4333cf
   AWS_USER=centos
 fi
 
@@ -104,15 +74,7 @@ test -n "$AMI"
 test -n "$AWS_USER"
 test -f "${KEY_PAIR_NAME}.pem"
 
-CLOUDINIT=$(mktemp --tmpdir rkt-cloudinit.XXXXXXXXXX)
-sed -e "s#@GIT_URL@#${GIT_URL}#g" \
-    -e "s#@GIT_BRANCH@#${GIT_BRANCH}#g" \
-    -e "s#@FLAVOR@#${FLAVOR}#g" \
-    -e "s#@DISABLE_SELINUX@#${DISABLE_SELINUX}#g" \
-    -e "s#@DISABLE_OVERLAY@#${DISABLE_OVERLAY}#g" \
-    < $CLOUDINIT_IN >> $CLOUDINIT
-
-INSTANCE_ID=$(aws ec2 run-instances \
+INSTANCE_ID=$(aws --region $REGION ec2 run-instances \
 	--image-id $AMI \
 	--count 1 \
 	--key-name $KEY_PAIR_NAME \
@@ -125,16 +87,15 @@ INSTANCE_ID=$(aws ec2 run-instances \
 	)
 echo INSTANCE_ID=$INSTANCE_ID
 
-aws ec2 create-tags --resources $INSTANCE_ID \
+aws --region $REGION ec2 create-tags \
+	--resources ${INSTANCE_ID} \
 	--tags \
-	Key=Name,Value=rkt-tst-${DISTRO}-${GIT_BRANCH}-${FLAVOR} \
-	Key=Distro,Value=${DISTRO} \
-	Key=Repo,Value=${GIT_URL} \
-	Key=Branch,Value=${GIT_BRANCH} \
-	Key=Flavor,Value=${FLAVOR} \
-	Key=User,Value=${USER}
+	Key=Name,Value=rkt-tst-${DISTRO} \
+	Key=BaseAmi,Value=${AMI} \
+	Key=User,Value=${AWS_USER}
 
-while state=$(aws ec2 describe-instances \
+
+while state=$(aws --region $REGION ec2 describe-instances \
 	--instance-ids $INSTANCE_ID \
 	--output text \
 	--query 'Reservations[*].Instances[*].State.Name' \
@@ -142,33 +103,39 @@ while state=$(aws ec2 describe-instances \
   sleep 1; echo -n '.'
 done; echo " $state"
 
-AWS_IP=$(aws ec2 describe-instances \
+AWS_IP=$(aws --region $REGION ec2 describe-instances \
 	--instance-ids $INSTANCE_ID \
 	--output text \
 	--query 'Reservations[*].Instances[*].PublicIpAddress' \
 	)
 echo AWS_IP=$AWS_IP
 
-rm -f $CLOUDINIT
-
-sleep 5
-aws ec2 get-console-output --instance-id $INSTANCE_ID --output text |
-  perl -ne 'print if /BEGIN SSH .* FINGERPRINTS/../END SSH .* FINGERPRINTS/'
-
-echo
-echo "Check the logs with:"
-echo tail -n 5000 -f /var/tmp/rkt-test.log
-
-repeat="Y"
-while [ "$repeat" = "Y" ] ; do
-  ssh -o ServerAliveInterval=20 -o ConnectTimeout=10 -o ConnectionAttempts=60 -i ${SCRIPTPATH}/${KEY_PAIR_NAME}.pem ${AWS_USER}@${AWS_IP}
-
-  echo -n "Reconnect? (Y/N)"
-  read -n1 Input
-  echo
-  case $Input in
-    [Nn]):
-    repeat="N"
-    ;;
-  esac
+echo "Waiting for the instance to boot..."
+sleep 60
+echo "Waiting for the instance to be initialized..."
+echo "To check the logs:"
+echo ssh -i ${SCRIPTPATH}/${KEY_PAIR_NAME}.pem ${AWS_USER}@${AWS_IP} tail -f /var/log/cloud-init-output.log
+while ! ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=20 -o ConnectTimeout=10 -o ConnectionAttempts=60 -i ${SCRIPTPATH}/${KEY_PAIR_NAME}.pem ${AWS_USER}@${AWS_IP} stat /var/lib/cloud/instances/$INSTANCE_ID/boot-finished >/dev/null 2>&1
+do
+  echo -n '.'
+  sleep 30
 done
+
+
+NAME=$DISTRO-rkt-test-$(date +"%d-%m-%Y")
+AMI_ID=$(aws --region $REGION ec2 create-image --instance-id $INSTANCE_ID --name $NAME --output text)
+
+echo -e "\nWaiting for the AMI to be avaliable..."
+while ! aws --region $REGION ec2 describe-images --image-id $AMI_ID | grep -q available
+do
+  echo -n '.'
+  sleep 30
+done
+
+aws --region $REGION ec2 modify-image-attribute --image-id $AMI_ID --launch-permission "{\"Add\":[{\"Group\":\"all\"}]}"
+
+echo -e "\nRemoving instance..."
+
+aws --region $REGION ec2 terminate-instances --instance-ids $INSTANCE_ID --output text
+
+echo "${DISTRO} AMI available: $AMI_ID (Region $REGION)"

--- a/tests/cloudinit/centos.cloudinit
+++ b/tests/cloudinit/centos.cloudinit
@@ -1,43 +1,25 @@
 #!/bin/bash
-cat > /var/tmp/rkt-test.sh <<TESTEOF
-#!/bin/bash
-
 set -e
 set -x
 
-# Sometimes journald does not work on CentOS :-(
-exec > >(tee -a "/var/tmp/rkt-test.log") 2>&1
-
-groupadd rkt
-gpasswd -a centos rkt
+groupadd rkt || true
+gpasswd -a centos rkt || true
 
 #yum update -y
 yum -y -v groupinstall "Development Tools"
-yum -y -v install wget squashfs-tools patch glibc-static gnupg libacl-devel systemd-devel
+yum -y -v install wget squashfs-tools patch glibc-static gnupg libacl-devel openssl-devel bc
+yum -y -v install java # for Jenkins
+dnf -y -v install iptables intltool
 
 pushd /tmp
-wget https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz
+wget -c https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz
 popd
 tar -C /usr/local -xzf /tmp/go1.5.3.linux-amd64.tar.gz
-ln -s /usr/local/go/bin/go /usr/local/bin/go
-ln -s /usr/local/go/bin/godoc /usr/local/bin/godoc
-ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
-export GOROOT=/usr/local/go
-
-/usr/sbin/setenforce 0
-
-# unsquashfs is in /usr/sbin
-export PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/centos/.local/bin:/home/centos/bin
+ln -sf /usr/local/go/bin/go /usr/local/bin/go
+ln -sf /usr/local/go/bin/godoc /usr/local/bin/godoc
+ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
 # sudo/su without tty is disabled on old CentOS.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1020147
 # Cannot workaround with /usr/bin/expect because this would need expect > 2.27
 sed -i 's/ requiretty$/ !requiretty/g' /etc/sudoers
-
-su - centos --command="cd /var/tmp ; git clone --branch @GIT_BRANCH@ @GIT_URL@ rkt"
-su - centos --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/build-and-run-tests.sh -f @FLAVOR@"
-TESTEOF
-
-chmod +x /var/tmp/rkt-test.sh
-
-systemd-run --unit=rkt-test /var/tmp/rkt-test.sh

--- a/tests/cloudinit/debian.cloudinit
+++ b/tests/cloudinit/debian.cloudinit
@@ -1,28 +1,15 @@
 #!/bin/bash
-cat > /var/tmp/rkt-test.sh <<TESTEOF
-#!/bin/bash
 
-set -e
-set -x
+groupadd rkt || true
+gpasswd -a admin rkt || true
 
-# Sometimes journald does not work well on old versions
-exec > >(tee -a "/var/tmp/rkt-test.log") 2>&1
+sed -i 's/jessie/testing/g' /etc/apt/sources.list
 
-sudo groupadd rkt
-sudo gpasswd -a admin rkt
+DEBIAN_FRONTEND=noninteractive apt-get update -y --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew"
+DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew"
 
-export DEBIAN_FRONTEND=noninteractive
-echo 'deb http://cloudfront.debian.net/debian testing main' | tee -a /etc/apt/sources.list
-echo 'deb-src http://cloudfront.debian.net/debian testing main' | tee -a /etc/apt/sources.list
-apt-get update -y
-#apt-get dist-upgrade -y --force-yes
-apt-get install -y --force-yes build-essential autoconf
-apt-get install -y --force-yes wget squashfs-tools patch gnupg golang git dbus libacl1-dev systemd-container
-
-su - admin --command="cd /var/tmp ; git clone --branch @GIT_BRANCH@ @GIT_URL@ rkt"
-su - admin --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/build-and-run-tests.sh -f @FLAVOR@"
-TESTEOF
-
-chmod +x /var/tmp/rkt-test.sh
-
-systemd-run --unit=rkt-test /var/tmp/rkt-test.sh
+DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes build-essential autoconf
+DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" squashfs-tools patch gnupg golang dbus libacl1-dev systemd-container libssl-dev libsystemd-dev libpam-systemd
+DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" default-jre
+DEBIAN_FRONTEND=noninteractive apt-get build-dep -y --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" systemd
+DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" git

--- a/tests/cloudinit/fedora-24.cloudinit
+++ b/tests/cloudinit/fedora-24.cloudinit
@@ -1,0 +1,1 @@
+fedora.cloudinit

--- a/tests/cloudinit/fedora.cloudinit
+++ b/tests/cloudinit/fedora.cloudinit
@@ -1,42 +1,24 @@
 #!/bin/bash
 
-if [ "@DISABLE_OVERLAY@" = true ] ; then
-  # Workaround for SELinux: do not use overlay fs
-  /sbin/rmmod overlay || true
-  mv /lib/modules/`uname -r`/kernel/fs/overlayfs/overlay.ko.xz /root/overlay.ko.xz-disabled
-fi
-
-if [ "@DISABLE_SELINUX@" = true ] ; then
-  /usr/sbin/setenforce 0
-fi
-
-cat > /var/tmp/rkt-test.sh <<TESTEOF
-#!/bin/bash
-
 set -e
 set -x
 
-# Sometimes journald does not work well on old versions
-exec > >(tee -a "/var/tmp/rkt-test.log") 2>&1
+# ---pretend-input-tty (with 3 dashes) is an undocumented feature of parted
+parted /dev/xvda ---pretend-input-tty resizepart 1 yes 100%
+resize2fs /dev/xvda1
 
-groupadd rkt
-gpasswd -a fedora rkt
+chmod 755 /home/fedora
 
 dnf -y -v update
-dnf -y -v groupinstall "Development Tools"
-dnf -y -v groupinstall "C Development Tools and Libraries"
-dnf -y -v install wget squashfs-tools patch glibc-static gnupg golang libacl-devel file systemd-devel
+dnf -y -v groupinstall "Development Tools" "C Development Tools and Libraries"
+dnf -y -v install wget squashfs-tools patch glibc-static gnupg golang libacl-devel file openssl-devel bc
 # systemd-container only available in newer versions of Fedora
 dnf -y -v install systemd-container || true
+dnf -y -v install java || true
+dnf -y -v install iptables || true
+dnf builddep -y -v systemd
+dnf -y -v install systemd-devel || true
+dnf -y -v install iptables intltool
 
-# unsquashfs is in /usr/sbin
-export PATH=/usr/lib64/ccache:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/fedora/.local/bin:/home/fedora/bin
-
-su - fedora --command="cd /var/tmp ; git clone --branch @GIT_BRANCH@ @GIT_URL@ rkt"
-su - fedora --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/build-and-run-tests.sh -f @FLAVOR@"
-TESTEOF
-
-chmod +x /var/tmp/rkt-test.sh
-
-# "sh -c" is necessary, otherwise SELinux would reject the service
-systemd-run --unit=rkt-test sh -c /var/tmp/rkt-test.sh
+groupadd rkt || true
+gpasswd -a fedora rkt || true

--- a/tests/cloudinit/ubuntu.cloudinit
+++ b/tests/cloudinit/ubuntu.cloudinit
@@ -1,27 +1,14 @@
 #!/bin/bash
-cat > /var/tmp/rkt-test.sh <<TESTEOF
-#!/bin/bash
 
 set -e
 set -x
 
-# Sometimes journald does not work well on old versions
-exec > >(tee -a "/var/tmp/rkt-test.log") 2>&1
-
 export DEBIAN_FRONTEND=noninteractive
 
-groupadd rkt
-gpasswd -a ubuntu rkt
+groupadd rkt || true
+gpasswd -a ubuntu rkt || true
 
-apt-get update -y
-apt-get dist-upgrade -y --force-yes
-apt-get install -y build-essential autoconf
-apt-get install -y wget squashfs-tools patch gnupg golang libacl1-dev systemd-container libsystemd-dev
-
-su - ubuntu --command="cd /var/tmp ; git clone --branch @GIT_BRANCH@ @GIT_URL@ rkt"
-su - ubuntu --command="PATH=\$PATH ; cd /var/tmp/rkt ; ./tests/build-and-run-tests.sh -f @FLAVOR@"
-TESTEOF
-
-chmod +x /var/tmp/rkt-test.sh
-
-systemd-run --unit=rkt-test /var/tmp/rkt-test.sh
+DEBIAN_FRONTEND=noninteractive apt-get update -y
+DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y --force-yes
+DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" -y --force-yes build-essential autoconf
+DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" -y --force-yes wget squashfs-tools patch gnupg golang dbus libacl1-dev systemd-container libssl-dev libsystemd-dev libpam-systemd

--- a/tests/test-on-several-distro.md
+++ b/tests/test-on-several-distro.md
@@ -2,15 +2,18 @@
 
 rkt aims to be supported on several Linux distributions.
 In order to notice distro-specific issues, Continuous Integration should ideally run the tests on several Linux distributions.
-This is not done yet but there is a script to help with manual testing on several Linux distributions.
 
 rkt tests can be intrusive and require full root privileges.
 Each test should be run on a fresh VM.
 VMs should not be reused for next tests.
 
-## AWS
+## Jenkins
 
-The script `tests/aws.sh` can automatically spawn a fresh VM of the specified Linux distribution and start the rkt tests.
+Tests run on Jenkins [Jenkins](https://jenkins-ci.org/) [for each PR](https://jenkins-rkt-public.prod.coreos.systems/job/rkt-github-ci/) and [periodically on the master branch](https://jenkins-rkt-public.prod.coreos.systems/job/rkt-master-periodic/).
+
+### AMIs
+
+The script `tests/aws.sh` can generate a AMI of the specified Linux distribution with all the dependencies rkt needs.
 
 First, install [aws-cli](https://github.com/aws/aws-cli) and configure it with your AWS credentials.
 Then, create a key pair and a security group for rkt tests:
@@ -19,11 +22,12 @@ Then, create a key pair and a security group for rkt tests:
 $ tests/aws.sh setup
 ```
 
-Then run the tests with the specified Linux distribution:
+Then generate an AMI of the specified Linux distribution:
 
 ```
 $ tests/aws.sh fedora-22
 $ tests/aws.sh fedora-23
+$ tests/aws.sh fedora-24
 $ tests/aws.sh fedora-rawhide
 $ tests/aws.sh ubuntu-1604
 $ tests/aws.sh ubuntu-1510
@@ -31,26 +35,6 @@ $ tests/aws.sh debian
 $ tests/aws.sh centos
 ```
 
-By default, this tests the upstream master branch.
-A specific branch can be tested with:
+The generated AMIs can then be used to configure Jenkins.
 
-```
-$ tests/aws.sh fedora-23 https://github.com/coreos/rkt.git branch-name
-```
-
-Additionally, a stage1 flavor can be selected:
-```
-$ tests/aws.sh fedora-23 https://github.com/coreos/rkt.git branch-name coreos
-```
-
-The VM instances are configured to terminate automatically on shutdown to reduce costs.
-However they are not shut down automatically after the tests.
-It is recommended to check in the AWS console that instances are terminated.
-
-## Jenkins
-
-This could be automatised with [Jenkins](https://jenkins-ci.org/).
-In order to spawn a new VM for each test, the [Amazon EC2 Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Amazon+EC2+Plugin) could be used.
-However, it would require additional fixes: [JENKINS-8618](https://issues.jenkins-ci.org/browse/JENKINS-8618).
-
-
+If new packages are needed they can be added to the corresponding cloudinit files in `test/cloudinit`.


### PR DESCRIPTION
This changes the aws.sh script to generate AMIs with the rkt
dependencies installed so they can be used in Jenkins.

cc @albanc