### PR TITLE
Doc/devel/stage1-implementors-guide: Fix heading fmt

### DIFF
--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -1,8 +1,6 @@
-Stage1 ACI implementor's guide
-=============================
+# Stage1 ACI implementor's guide
 
-Background
-----------
+## Background
 
 rkt's execution of pods is divided roughly into three separate stages:
 
@@ -25,10 +23,11 @@ Stage1 is the vehicle for getting there from stage0.
 For any given pod instance, stage1 may be replaced by a completely different implementation.
 This allows users to employ different containment strategies on the same host running the same interchangeable ACIs.
 
-Entrypoints
------------
+## Entrypoints
 
-### `rkt run` => `coreos.com/rkt/stage1/run`
+### rkt run
+
+`coreos.com/rkt/stage1/run`
 
 1. rkt prepares the pod's stage1 and stage2 images and pod manifest under `/var/lib/rkt/pods/prepare/$uuid`, acquiring an exclusive advisory lock on the directory.
    Upon a successful preparation, the directory will be renamed to `/var/lib/rkt/pods/run/$uuid`.
@@ -59,17 +58,19 @@ Stage1 implementors have two options for doing so; only one must be implemented:
 
 * `--debug` to activate debugging
 * `--net[=$NET1,$NET2,...]` to configure the creation of a contained network.
-  See the [rkt networking documentation](../networking.md) for details.
+  See the [rkt networking documentation](../networking.html) for details.
 * `--mds-token=$TOKEN` passes the auth token to the apps via `AC_METADATA_URL` env var
 * `--interactive` to run a pod interactively, that is, pass standard input to the application (only for pods with one application)
 * `--local-config=$PATH` to override the local configuration directory
 * `--private-users=$SHIFT` to define a UID/GID shift when using user namespaces. SHIFT is a two-value colon-separated parameter, the first value is the first host UID to assign to the container and the second one is the number of host UIDs to assign.
 
-##### Arguments added in interface version 2
+#### Arguments added in interface version 2
 
 * `--hostname=$HOSTNAME` configures the host name of the pod. If empty, it will be "rkt-$PODUUID".
 
-### `rkt enter` => `coreos.com/rkt/stage1/enter`
+### rkt enter
+
+`coreos.com/rkt/stage1/enter`
 
 1. rkt verifies the pod and image to enter are valid and running
 2. chdirs to `/var/lib/rkt/pods/run/$uuid`
@@ -91,7 +92,9 @@ An alternative stage1 would need to do whatever is appropriate for entering the 
 4. cmd to execute.
 5. optionally, any cmd arguments.
 
-### `rkt gc` => `coreos.com/rkt/stage1/gc`
+### rkt gc
+
+`coreos.com/rkt/stage1/gc`
 
 The gc entrypoint deals with garbage collecting resources allocated by stage1.
 For example, it removes the network namespace of a pod.
@@ -101,16 +104,14 @@ For example, it removes the network namespace of a pod.
 * `--debug` to activate debugging
 * UUID of the pod
 
-Versioning
-----------
+## Versioning
 
 The stage1 command line interface is versioned using an annotation with the name `coreos.com/rkt/stage1/interface-version`.
 If the annotation is not present, rkt assumes the version is 1.
 
 The current version of the stage1 interface is 2.
 
-Examples
---------
+## Examples
 
 ### Stage1 ACI manifest
 
@@ -159,20 +160,26 @@ Examples
 The following paths are reserved for the stage1 image, and they will be created during stage0.
 When creating a stage1 image, developers SHOULD NOT create or use these paths in the image's filesystem.
 
-### opt/stage2
+### stage2
+
+`opt/stage2`
 
 This directory path is used for extracting the ACI of every app in the pod.
 Each app's rootfs will appear under this directory,
 e.g. `/var/lib/rkt/pods/run/$uuid/stage1/rootfs/opt/stage2/$appname/rootfs`.
 
-### rkt/status
+### status
+
+`rkt/status`
 
 This directory path is used for storing the apps' exit statuses.
 For example, if an app named `foo` exits with status = `42`, stage1 should write `42`
 in `/var/lib/rkt/pods/run/$uuid/stage1/rootfs/rkt/status/foo`.
 Later the exit status can be retrieved and shown by `rkt status $uuid`.
 
-### rkt/env
+### env
+
+`rkt/env`
 
 This directory path is used for passing environment variables to each app.
 For example, environment variables for an app named `foo` will be stored in `rkt/env/foo`.


### PR DESCRIPTION
Switch to all atx-style markdown for headings and sort the hierarchy.
Remove special chars from all headings to please the jquery.
Ref https://github.com/coreos/rkt/issues/2707
Ref https://github.com/coreos-inc/coreos-pages/pull/711

Supersedes (belatedly) #2730 