### PR TITLE
api: GetLogs: use the correct type in LogsStreamWriter

### DIFF
--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -702,7 +702,8 @@ type LogsStreamWriter struct {
 }
 
 func (sw LogsStreamWriter) Write(b []byte) (int, error) {
-	if err := sw.server.SendMsg(b); err != nil {
+	lines := strings.Split(string(b), "\n")
+	if err := sw.server.Send(&v1alpha.GetLogsResponse{Lines: lines}); err != nil {
 		return 0, err
 	}
 	return len(b), nil


### PR DESCRIPTION
Symptoms:

> panic: interface conversion: []uint8 is not proto.Message: missing
> method ProtoMessage

This patch fixes the panic, but there are other crashes that are not
related to LogsStreamWriter. I'll file a separate PR.

Helps with https://github.com/coreos/rkt/issues/2740