### PR TITLE
api: GetLogs: improve client example with 'Follow'

### DIFF
--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -704,7 +704,14 @@ type LogsStreamWriter struct {
 }
 
 func (sw LogsStreamWriter) Write(b []byte) (int, error) {
-	lines := strings.Split(string(b), "\n")
+	// Remove empty lines
+	lines := make([]string, 0)
+	for _, v := range strings.Split(string(b), "\n") {
+		if len(v) > 0 {
+			lines = append(lines, v)
+		}
+	}
+
 	if err := sw.server.Send(&v1alpha.GetLogsResponse{Lines: lines}); err != nil {
 		return 0, err
 	}
@@ -766,7 +773,13 @@ func (s *v1AlphaAPIServer) GetLogs(request *v1alpha.GetLogsRequest, server v1alp
 	if err != nil {
 		return err
 	}
-	lines := strings.Split(string(data), "\n")
+	// Remove empty lines
+	lines := make([]string, 0)
+	for _, v := range strings.Split(string(data), "\n") {
+		if len(v) > 0 {
+			lines = append(lines, v)
+		}
+	}
 	return server.Send(&v1alpha.GetLogsResponse{Lines: lines})
 }
 


### PR DESCRIPTION
With this PR, the api client_example gets a new flag `-follow` to use the 'Follow' feature of GetLogs.

To test this, start with running a container:
```
sudo rkt run docker://busybox --exec sh -- -c 'while sleep 1 ; do date ; done'
```

In another terminal, start rkt's API service:
```
rkt api-service
```

In another terminal, start client_example with different options:

```
cd api/v1alpha
go build  client_example.go
./client_example
./client_example -follow
```

See also https://github.com/coreos/rkt/issues/2740

/cc @yifan-gu @euank @pskrzyns 
