### PR TITLE
stage0:  remove superfluous error verbs

### DIFF
--- a/networking/networking.go
+++ b/networking/networking.go
@@ -274,7 +274,7 @@ func (n *Networking) Teardown(flavor string, debug bool) {
 
 	podNS, err := n.podNSLoad()
 	if err != nil {
-		stderr.PrintE("error loading podNS: %v", err)
+		stderr.PrintE("error loading podNS", err)
 	}
 	if podNS != nil {
 		defer func() {

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -576,7 +576,7 @@ func prepareAppImage(cfg PrepareConfig, appName types.ACName, img types.Hash, cd
 		if !cfg.SkipTreeStoreCheck {
 			hash, err := cfg.Store.CheckTreeStore(treeStoreID)
 			if err != nil {
-				log.PrintE("warning: tree cache is in a bad state: %v. Rebuilding...", err)
+				log.PrintE("warning: tree cache is in a bad state.  Rebuilding...", err)
 				var err error
 				treeStoreID, hash, err = cfg.Store.RenderTreeStore(img.String(), true)
 				if err != nil {


### PR DESCRIPTION
stage0:  remove superfluous %v Printf verb from logged message when tree cache is bad

Fixes #2749