### PR TITLE
kvm: use diagnostic messages for diagnostics

### DIFF
--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -566,6 +566,7 @@ func stage1() int {
 	}
 
 	if flavor == "kvm" {
+		kvm.InitDebug(debug)
 		if err := KvmNetworkingToSystemd(p, n); err != nil {
 			log.PrintE("failed to configure systemd for kvm", err)
 			return 1

--- a/stage1/init/kvm/log.go
+++ b/stage1/init/kvm/log.go
@@ -15,13 +15,21 @@
 package kvm
 
 import (
+	"io/ioutil"
 	"os"
 
 	rktlog "github.com/coreos/rkt/pkg/log"
 )
 
-var rlog *rktlog.Logger
+var diag *rktlog.Logger
 
 func init() {
-	rlog = rktlog.New(os.Stderr, "kvm", false)
+	diag = rktlog.New(os.Stderr, "kvm", false)
+}
+
+func InitDebug(debug bool) {
+	diag.SetDebug(debug)
+	if !debug {
+		diag.SetOutput(ioutil.Discard)
+	}
 }

--- a/stage1/init/kvm/network.go
+++ b/stage1/init/kvm/network.go
@@ -158,7 +158,7 @@ func GenerateNetworkInterfaceUnits(unitsPath string, netDescriptions []netDescri
 			return errwrap.Wrap(fmt.Errorf("failed to create network unit file %q", unitName), err)
 		}
 
-		rlog.Printf("network unit created: %q in %q (iface=%q, addr=%q)", unitName, unitsPath, ifName, address)
+		diag.Printf("network unit created: %q in %q (iface=%q, addr=%q)", unitName, unitsPath, ifName, address)
 	}
 	return nil
 }


### PR DESCRIPTION
This switches the kvm package to using a diagnostic logger whose
messages are only sent to stderr when debugging is switched on.
Otherwise messages are discarded.