### PR TITLE
docs: clarify the URL for the discovery example

### DIFF
--- a/Documentation/signing-and-verification-guide.md
+++ b/Documentation/signing-and-verification-guide.md
@@ -143,7 +143,7 @@ pubkeys.gpg
 
 ## Distributing Images via Meta Discovery
 
-Host an HTML page with the following meta tags:
+Host `example.com/hello` with the following HTML contents and meta tags:
 
 ```html
 <!DOCTYPE html>
@@ -152,8 +152,8 @@ Host an HTML page with the following meta tags:
     <meta charset="utf-8">
     <meta name="ac-discovery" content="example.com/hello https://example.com/images/{name}-{version}-{os}-{arch}.{ext}">
     <meta name="ac-discovery-pubkeys" content="example.com/hello https://example.com/pubkeys.gpg">
-  <head>
-<html>
+  </head>
+</html>
 ```
 
 Serve the following files at the locations described in the meta tags:


### PR DESCRIPTION
This is a small clarification, but I think the guidelines can be extended further with the following information:

For demo purposes using a CoreOS instance the assets created in the tutorial can be put in the following directory structure:

```
./hello
./images
./images/example.com
./images/example.com/hello-0.0.1-linux-amd64.aci.asc
./images/example.com/hello-0.0.1-linux-amd64.aci
./pubkeys.gpg
```

`/etc/hosts` can be modified as follows:
```
core@core-01 ~ $ cat /etc/hosts
127.0.0.1 core-01
127.0.0.1 example.com
```

If Docker is available, we can easily host the discovery page:
```
docker run -d --name nginx -v $(pwd):/usr/share/nginx/html:ro -p 80:80 nginx:mainline-alpine
```

Effectively seeing rkt discovering & verifying the image:
```
sudo rkt run --insecure-options=http,pubkey --debug example.com/hello:0.0.1
```

Explanation of the `--insecure-options=http,pubkey`:

* http: Allow HTTP connections. Be warned that this will send any credentials as clear text.
* pubkey: Allow fetching pubkeys via insecure connections

Although I realize Docker may not be available on the environment of the user going through these steps (I was using CoreOS itself to step through these guides, doing all golang compilation in a Docker golang:1.6 container.)