### PR TITLE
build: compile generators for build platform

### DIFF
--- a/rkt/rkt.mk
+++ b/rkt/rkt.mk
@@ -29,10 +29,12 @@ $(BGB_BINARY): $(MK_PATH) | $(BINDIR)
 
 include makelib/build_go_bin.mk
 
+manpages: GO_ENV += GOARCH=$(GOARCH_FOR_BUILD) CC=$(CC_FOR_BUILD)
 manpages: | $(GOPATH_TO_CREATE)/src/$(REPO_PATH)
 	mkdir -p dist/manpages/
 	ls rkt/*.go | grep -vE '_test.go|main.go|_gen.go' | $(GO_ENV) xargs "$(GO)" run rkt/manpages_gen.go
 
+bash-completion: GO_ENV += GOARCH=$(GOARCH_FOR_BUILD) CC=$(CC_FOR_BUILD)
 bash-completion: | $(GOPATH_TO_CREATE)/src/$(REPO_PATH)
 	mkdir -p dist/bash_completion/
 	ls rkt/*.go | grep -vE '_test.go|main.go|_gen.go' | $(GO_ENV) xargs "$(GO)" run rkt/bash_completion_gen.go


### PR DESCRIPTION
manpages_gen and bash_completion_gen are compiled and run at build time,
so need to be built for the build platform, not the target platform.

This change overrides GOARCH/CC appropriately for these two targets.
Note building these tools requires that the systemd and acl C headers
are also available for the build architecture.