### PR TITLE
stage1/prepare-app: always adjust /etc/hostname

### DIFF
--- a/stage1/prepare-app/prepare-app.c
+++ b/stage1/prepare-app/prepare-app.c
@@ -230,6 +230,7 @@ int main(int argc, char *argv[])
 	};
 	static const mount_point files_mount_table[] = {
 		{ "/etc/rkt-resolv.conf", "/etc/resolv.conf", "bind", NULL, MS_BIND },
+		{ "/proc/sys/kernel/hostname", "/etc/hostname", "bind", NULL, MS_BIND },
 	};
 	const char *root;
 	int rootfd;


### PR DESCRIPTION
This commit lets prepare-app bind mount /proc/sys/kernel/hostname
over /etc/hostname, so that applications have a consistent hostname
view.

Fixes #2657