### PR TITLE
api_service: Fix the GetLogs() when appname is given.

### DIFF
--- a/api/v1alpha/client_example.go
+++ b/api/v1alpha/client_example.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/coreos/rkt/api/v1alpha"
 	"golang.org/x/net/context"
@@ -29,9 +30,11 @@ import (
 
 func getLogsWithoutFollow(c v1alpha.PublicAPIClient, p *v1alpha.Pod) {
 	logsResp, err := c.GetLogs(context.Background(), &v1alpha.GetLogsRequest{
-		PodId:   p.Id,
-		Follow:  false,
-		AppName: p.Apps[0].Name,
+		PodId:     p.Id,
+		Follow:    false,
+		AppName:   p.Apps[0].Name,
+		SinceTime: time.Now().Add(-time.Second * 5).Unix(),
+		Lines:     10,
 	})
 	if err != nil {
 		fmt.Println(err)

--- a/api/v1alpha/client_example.go
+++ b/api/v1alpha/client_example.go
@@ -29,8 +29,9 @@ import (
 
 func getLogsWithoutFollow(c v1alpha.PublicAPIClient, p *v1alpha.Pod) {
 	logsResp, err := c.GetLogs(context.Background(), &v1alpha.GetLogsRequest{
-		PodId:  p.Id,
-		Follow: false,
+		PodId:   p.Id,
+		Follow:  false,
+		AppName: p.Apps[0].Name,
 	})
 	if err != nil {
 		fmt.Println(err)
@@ -50,8 +51,9 @@ func getLogsWithoutFollow(c v1alpha.PublicAPIClient, p *v1alpha.Pod) {
 
 func getLogsWithFollow(c v1alpha.PublicAPIClient, p *v1alpha.Pod) {
 	logsResp, err := c.GetLogs(context.Background(), &v1alpha.GetLogsRequest{
-		PodId:  p.Id,
-		Follow: true,
+		PodId:   p.Id,
+		Follow:  true,
+		AppName: p.Apps[0].Name,
 	})
 	if err != nil {
 		fmt.Println(err)

--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -34,7 +34,6 @@ import (
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/common/cgroup"
 	"github.com/coreos/rkt/pkg/set"
-	stage1common "github.com/coreos/rkt/stage1/init/common"
 	"github.com/coreos/rkt/store"
 	"github.com/coreos/rkt/version"
 	"github.com/spf13/cobra"
@@ -740,14 +739,10 @@ func (s *v1AlphaAPIServer) GetLogs(request *v1alpha.GetLogsRequest, server v1alp
 		Path: path,
 	}
 	if request.AppName != "" {
-		acname, err := types.NewACName(request.AppName)
-		if err != nil {
-			return err
-		}
 		jconf.Matches = []sdjournal.Match{
 			{
 				Field: sdjournal.SD_JOURNAL_FIELD_SYSLOG_IDENTIFIER,
-				Value: stage1common.ServiceUnitName(*acname),
+				Value: request.AppName,
 			},
 		}
 	}

--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -748,7 +748,7 @@ func (s *v1AlphaAPIServer) GetLogs(request *v1alpha.GetLogsRequest, server v1alp
 	}
 	if request.SinceTime != 0 {
 		t := time.Unix(request.SinceTime, 0)
-		jconf.Since = time.Since(t)
+		jconf.Since = -time.Since(t)
 	}
 	if request.Lines != 0 {
 		jconf.NumFromTail = uint64(request.Lines)


### PR DESCRIPTION
When appname is given, we should set SYSLOG_IDENTIFIER=appname instead of the service name.

cc @alban @iaguis