### PR TITLE
KVM/networking: Add flannel default gateway parsing

### DIFF
--- a/networking/networking.go
+++ b/networking/networking.go
@@ -53,8 +53,9 @@ type Networking struct {
 // similar to CNI plugins
 type NetConf struct {
 	cnitypes.NetConf
-	IPMasq bool `json:"ipMasq"`
-	MTU    int  `json:"mtu"`
+	IPMasq           bool `json:"ipMasq"`
+	MTU              int  `json:"mtu"`
+	IsDefaultGateway bool `json:"isDefaultGateway"`
 }
 
 var stderr *log.Logger

--- a/tests/rkt_net_kvm_test.go
+++ b/tests/rkt_net_kvm_test.go
@@ -40,3 +40,11 @@ func TestNetLongName(t *testing.T) {
 func TestNetDefaultRestrictedConnectivity(t *testing.T) {
 	NewTestNetDefaultRestrictedConnectivity().Execute(t)
 }
+
+func TestNetPreserveNetName(t *testing.T) {
+	NewNetPreserveNetNameTest().Execute(t)
+}
+
+func TestNetDefaultGW(t *testing.T) {
+	NewNetDefaultGWTest().Execute(t)
+}

--- a/tests/rkt_net_nspawn_test.go
+++ b/tests/rkt_net_nspawn_test.go
@@ -75,3 +75,7 @@ func TestNetLongName(t *testing.T) {
 func TestNetDefaultRestrictedConnectivity(t *testing.T) {
 	NewTestNetDefaultRestrictedConnectivity().Execute(t)
 }
+
+func TestNetDefaultGW(t *testing.T) {
+	NewNetDefaultGWTest().Execute(t)
+}

--- a/tests/rkt_socket_proxyd_test.go
+++ b/tests/rkt_socket_proxyd_test.go
@@ -59,7 +59,7 @@ func TestSocketProxyd(t *testing.T) {
 		Type:   "ptp",
 		IpMasq: true,
 		Master: iface.Name,
-		Ipam: ipamTemplateT{
+		Ipam: &ipamTemplateT{
 			Type:   "host-local",
 			Subnet: "192.168.0.0/24",
 			Routes: []map[string]string{

--- a/tests/testutils/iputils.go
+++ b/tests/testutils/iputils.go
@@ -27,17 +27,18 @@ import (
 )
 
 func getDefaultGW(family int) (string, error) {
-	l, err := netlink.LinkByName("lo")
+	routes, err := netlink.RouteList(nil, family)
 	if err != nil {
 		return "", err
 	}
 
-	routes, err := netlink.RouteList(l, family)
-	if err != nil {
-		return "", err
+	for _, route := range routes {
+		if route.Src == nil && route.Dst == nil {
+			return route.Gw.String(), nil
+		}
 	}
 
-	return routes[0].Gw.String(), nil
+	return "", fmt.Errorf("Default route is not set")
 }
 func GetDefaultGWv4() (string, error) {
 	return getDefaultGW(netlink.FAMILY_V4)


### PR DESCRIPTION
It's simply parsing another json field and setting default gateway using code in:
https://github.com/containernetworking/cni/blob/master/plugins/main/bridge/bridge.go#L226-L245

Also checking if another default gateway is set (i.e. starting with `--net=...,default`) and returning error in this case.

cc @pskrzyns @jellonek @lukasredynk