### PR TITLE
store: update goroutine leak check

### DIFF
--- a/store/main_test.go
+++ b/store/main_test.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 )
 
 func interestingGoroutines() (gs []string) {
@@ -52,17 +53,21 @@ func goroutineLeaked() bool {
 		// not counting goroutines for leakage in -short mode
 		return false
 	}
-	gs := interestingGoroutines()
 
-	n := 0
-	stackCount := make(map[string]int)
-	for _, g := range gs {
-		stackCount[g]++
-		n++
-	}
-
-	if n == 0 {
-		return false
+	var stackCount map[string]int
+	for i := 0; i < 5; i++ {
+		n := 0
+		stackCount = make(map[string]int)
+		gs := interestingGoroutines()
+		for _, g := range gs {
+			stackCount[g]++
+			n++
+		}
+		if n == 0 {
+			return false
+		}
+		// Wait for goroutines to schedule and die off:
+		time.Sleep(100 * time.Millisecond)
 	}
 	fmt.Fprintf(os.Stderr, "Too many goroutines running after integration test(s).\n")
 	for stack, count := range stackCount {


### PR DESCRIPTION
The code this check was based on changed lately and we've been getting
some occurrences of a goroutine leak when running unit tests.

Update the code to match golang upstream [1][1], which waits a bit for
goroutines to finish, in the hope of getting rid of those issues.

[1]: https://github.com/golang/go/blob/release-branch.go1.6/src/net/http/main_test.go#L21