### PR TITLE
run: add --cap-retain and --cap-remove

### DIFF
--- a/common/apps/apps.go
+++ b/common/apps/apps.go
@@ -38,15 +38,17 @@ const (
 )
 
 type App struct {
-	Image       string                // the image reference as supplied by the user on the cli
-	ImType      AppImageType          // the type of the image reference (to be guessed, url, path or hash)
-	Args        []string              // any arguments the user supplied for this app
-	Asc         string                // signature file override for image verification (if fetching occurs)
-	Exec        string                // exec override for image
-	Mounts      []schema.Mount        // mounts for this app (superseding any mounts in rktApps.mounts of same MountPoint)
-	MemoryLimit *types.ResourceMemory // memory isolator override
-	CPULimit    *types.ResourceCPU    // cpu isolator override
-	User, Group string                // user, group overrides
+	Image       string                            // the image reference as supplied by the user on the cli
+	ImType      AppImageType                      // the type of the image reference (to be guessed, url, path or hash)
+	Args        []string                          // any arguments the user supplied for this app
+	Asc         string                            // signature file override for image verification (if fetching occurs)
+	Exec        string                            // exec override for image
+	Mounts      []schema.Mount                    // mounts for this app (superseding any mounts in rktApps.mounts of same MountPoint)
+	MemoryLimit *types.ResourceMemory             // memory isolator override
+	CPULimit    *types.ResourceCPU                // cpu isolator override
+	User, Group string                            // user, group overrides
+	CapsRetain  *types.LinuxCapabilitiesRetainSet // os/linux/capabilities-retain-set overrides
+	CapsRemove  *types.LinuxCapabilitiesRevokeSet // os/linux/capabilities-remove-set overrides
 
 	// TODO(jonboulle): These images are partially-populated hashes, this should be clarified.
 	ImageID types.Hash // resolved image identifier

--- a/rkt/cli_apps.go
+++ b/rkt/cli_apps.go
@@ -353,3 +353,67 @@ func (ag *appGroup) String() string {
 func (ag *appGroup) Type() string {
 	return "appGroup"
 }
+
+// appCapsRetain is for --caps-retain flags in the form of: --caps-retain=CAP_KILL,CAP_NET_ADMIN
+type appCapsRetain apps.Apps
+
+func (au *appCapsRetain) Set(s string) error {
+	app := (*apps.Apps)(au).Last()
+	if app == nil {
+		return fmt.Errorf("--caps-retain must follow an image")
+	}
+	capsRetain, err := types.NewLinuxCapabilitiesRetainSet(strings.Split(s, ",")...)
+	if err != nil {
+		return err
+	}
+	app.CapsRetain = capsRetain
+	return nil
+}
+
+func (au *appCapsRetain) String() string {
+	app := (*apps.Apps)(au).Last()
+	if app == nil {
+		return ""
+	}
+	var vs []string
+	for _, v := range app.CapsRetain.Set() {
+		vs = append(vs, string(v))
+	}
+	return strings.Join(vs, ",")
+}
+
+func (au *appCapsRetain) Type() string {
+	return "appCapsRetain"
+}
+
+// appCapsRemove is for --caps-remove flags in the form of: --caps-remove=CAP_MKNOD,CAP_SYS_CHROOT
+type appCapsRemove apps.Apps
+
+func (au *appCapsRemove) Set(s string) error {
+	app := (*apps.Apps)(au).Last()
+	if app == nil {
+		return fmt.Errorf("--caps-retain must follow an image")
+	}
+	capsRemove, err := types.NewLinuxCapabilitiesRevokeSet(strings.Split(s, ",")...)
+	if err != nil {
+		return err
+	}
+	app.CapsRemove = capsRemove
+	return nil
+}
+
+func (au *appCapsRemove) String() string {
+	app := (*apps.Apps)(au).Last()
+	if app == nil {
+		return ""
+	}
+	var vs []string
+	for _, v := range app.CapsRemove.Set() {
+		vs = append(vs, string(v))
+	}
+	return strings.Join(vs, ",")
+}
+
+func (au *appCapsRemove) Type() string {
+	return "appCapsRemove"
+}

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -101,6 +101,8 @@ func init() {
 	cmdRun.Flags().Var((*appCPULimit)(&rktApps), "cpu", "cpu limit for the preceding image (example: '--cpu=500m')")
 	cmdRun.Flags().Var((*appUser)(&rktApps), "user", "user override for the preceding image (example: '--user=user')")
 	cmdRun.Flags().Var((*appGroup)(&rktApps), "group", "group override for the preceding image (example: '--group=group')")
+	cmdRun.Flags().Var((*appCapsRetain)(&rktApps), "cap-retain", "capability to retain (example: '--cap-retain=CAP_SYS_ADMIN')")
+	cmdRun.Flags().Var((*appCapsRemove)(&rktApps), "cap-remove", "capability to remove (example: '--cap-remove=CAP_MKNOD')")
 
 	flagPorts = portList{}
 	flagDNS = flagStringList{}
@@ -150,7 +152,8 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 
 	if len(flagPodManifest) > 0 && (len(flagPorts) > 0 || flagInheritEnv || !flagExplicitEnv.IsEmpty() || rktApps.Count() > 0 || flagStoreOnly || flagNoStore ||
 		(*appsVolume)(&rktApps).String() != "" || (*appMount)(&rktApps).String() != "" || (*appExec)(&rktApps).String() != "" ||
-		(*appUser)(&rktApps).String() != "" || (*appGroup)(&rktApps).String() != "") {
+		(*appUser)(&rktApps).String() != "" || (*appGroup)(&rktApps).String() != "" ||
+		(*appCapsRetain)(&rktApps).String() != "" || (*appCapsRemove)(&rktApps).String() != "") {
 		stderr.Print("conflicting flags set with --pod-manifest (see --help)")
 		return 1
 	}


### PR DESCRIPTION
This adds the isolators os/linux/capabilities-retain-set or
os/linux/capabilities-remove-set respectively.

Examples of usage:
```
sudo rkt run docker://ubuntu --cap-retain=CAP_KILL,CAP_NET_ADMIN --exec sh  -- -c 'capsh --print'
sudo rkt run docker://ubuntu --cap-remove=CAP_MKNOD,CAP_SYS_CHROOT --exec sh  -- -c 'capsh --print'
```

It is not allowed to specify both --cap-retain and --cap-remove on the
same image.

Both flags will override any existing capability isolator from the ACI.
The override also happens on a capability isolator of a different type.
For example, if the image had os/linux/capabilities-retain-set, using
cap-remove will remove it even if --cap-remove refers to
os/linux/capabilities-remove-set.

-----

@lucab  PTAL

TODO:
- [ ] add the flags in the documentation
- [ ] update [Capabilities Isolators Guide](https://github.com/coreos/rkt/blob/master/Documentation/capabilities-guide.md)
- [x] tests