### PR TITLE
run/prepare: improve error message with usage

### DIFF
--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -115,7 +115,12 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	if rktApps.Count() < 1 && len(flagPodManifest) == 0 {
-		stderr.Print("must provide at least one image or specify the pod manifest")
+		stderr.Printf(`must provide at least one image or specify the pod manifest
+
+Usage: 
+	%s
+
+Use --help for more information.`, cmd.Use)
 		return 1
 	}
 

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -161,7 +161,12 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	if rktApps.Count() < 1 && len(flagPodManifest) == 0 {
-		stderr.Print("must provide at least one image or specify the pod manifest")
+		stderr.Printf(`must provide at least one image or specify the pod manifest
+
+Usage: 
+	 %s
+
+Use --help for more information.`, cmd.Use)
 		return 1
 	}
 


### PR DESCRIPTION
At the moment the error message does not show how to use the cmd

Fixes #2564

@blixtra @jonboulle PTAL. This would end in:

```
./build-rkt-1.7.0+git/bin/rkt run
run: must provide at least one image or specify the pod manifest

Usage:
	 run [--volume=name,kind=host,...] [--mount volume=VOL,target=PATH] IMAGE [-- image-args...[---]]...

Use --help for more information.
```

This this what you expected?