### PR TITLE
functional tests: sleep on every app when testing exit code

### DIFF
--- a/tests/rkt_exit_test.go
+++ b/tests/rkt_exit_test.go
@@ -46,15 +46,15 @@ func TestExitCodeSimple(t *testing.T) {
 // exit codes.
 func TestExitCodeWithSeveralApps(t *testing.T) {
 	image0File := patchTestACI("rkt-inspect-exit-0.aci", "--name=hello0",
-		"--exec=/inspect --print-msg=HelloWorld --exit-code=0")
+		"--exec=/inspect --print-msg=HelloWorld --exit-code=0 --sleep=1")
 	defer os.Remove(image0File)
 
 	image1File := patchTestACI("rkt-inspect-exit-1.aci", "--name=hello1",
-		"--exec=/inspect --print-msg=HelloWorld --exit-code=5")
+		"--exec=/inspect --print-msg=HelloWorld --exit-code=5 --sleep=1")
 	defer os.Remove(image1File)
 
 	image2File := patchTestACI("rkt-inspect-exit-2.aci", "--name=hello2",
-		"--exec=/inspect --print-msg=HelloWorld --exit-code=6 --sleep=1")
+		"--exec=/inspect --print-msg=HelloWorld --exit-code=6 --sleep=2")
 	defer os.Remove(image2File)
 
 	ctx := testutils.NewRktRunCtx()


### PR DESCRIPTION
Sometimes, the first app (hello0) didn't have time to print its message
before the pod exits. Sleep on every app so all of them have time to
print it.

Fixes #2779 