### PR TITLE
tests: enable all cases in capabilities test for rkt-kvm

### DIFF
--- a/tests/rkt_caps_kvm_test.go
+++ b/tests/rkt_caps_kvm_test.go
@@ -19,9 +19,5 @@ package main
 import "testing"
 
 func TestCaps(t *testing.T) {
-	// KVM is running VMs as stage1 pods, so root has access to all VM options.
-	// The case with access to PID 1 is skipped...
-	// KVM flavor runs systemd stage1 with full capabilities in stage1 (pid=1)
-	// so expect every capability enabled
-	NewCapsTest(true, []int{2}).Execute(t)
+	NewCapsTest(true).Execute(t)
 }

--- a/tests/rkt_caps_nspawn_test.go
+++ b/tests/rkt_caps_nspawn_test.go
@@ -19,5 +19,5 @@ package main
 import "testing"
 
 func TestCaps(t *testing.T) {
-	NewCapsTest(false, []int{1, 2}).Execute(t)
+	NewCapsTest(false).Execute(t)
 }

--- a/tests/rkt_caps_test.go
+++ b/tests/rkt_caps_test.go
@@ -373,8 +373,7 @@ var capsTests = []struct {
 	},
 }
 
-// CommonTestCaps creates a new capabilities test fixture for the given stages.
-func NewCapsTest(hasStage1FullCaps bool, stages []int) testutils.Test {
+func NewCapsTest(hasStage1FullCaps bool) testutils.Test {
 	return testutils.TestFunc(func(t *testing.T) {
 		ctx := testutils.NewRktRunCtx()
 		defer ctx.Cleanup()
@@ -392,7 +391,7 @@ func NewCapsTest(hasStage1FullCaps bool, stages []int) testutils.Test {
 			defer os.Remove(stage2FileName)
 			stageFileNames := []string{stage1FileName, stage2FileName}
 
-			for _, stage := range stages {
+			for _, stage := range []int{1, 2} {
 				t.Logf("Running test #%v: %v [stage%v]", i, tt.testName, stage)
 
 				cmd := fmt.Sprintf("%s --debug --insecure-options=image run --mds-register=false --set-env=CAPABILITY=%d %s", ctx.Cmd(), int(tt.capa), stageFileNames[stage-1])


### PR DESCRIPTION
We can enable it now.