### PR TITLE
KVM: Update LKVM patch to mount with mmap mode.

### DIFF
--- a/stage1/usr_from_kvm/lkvm/patches/do_synchronous_writes.patch
+++ b/stage1/usr_from_kvm/lkvm/patches/do_synchronous_writes.patch
@@ -7,7 +7,7 @@ index edcaf3e..f2f2d73 100644
  
  	if (kvm->cfg.using_rootfs) {
 -		strcat(real_cmdline, " rw rootflags=trans=virtio,version=9p2000.L,cache=loose rootfstype=9p");
-+		strcat(real_cmdline, " rw rootflags=trans=virtio,version=9p2000.L,cache=none rootfstype=9p");
++		strcat(real_cmdline, " rw rootflags=trans=virtio,version=9p2000.L,cache=mmap rootfstype=9p");
  		if (kvm->cfg.custom_rootfs) {
  			kvm_run_set_sandbox(kvm);
  


### PR DESCRIPTION
It is minimal cache that is only used for read-write mmap.
Nothing else is cached, like cache=none, but it allows to read logs from rkt+kvm.
9p doc: https://www.kernel.org/doc/Documentation/filesystems/9p.txt

/cc @pskrzyns @iaguis @jellonek 