### PR TITLE
fetch: drop privileges when run by root

### DIFF
--- a/tests/build-and-run-tests.sh
+++ b/tests/build-and-run-tests.sh
@@ -230,6 +230,8 @@ function prepareBuildEnv {
         sudo rm -rf "builds/${BUILD_DIR}"
     fi
     mkdir -p builds
+    sudo groupadd --force --system rkt
+    sudo groupadd --force --system rkt-admin
 }
 
 # Run docs scan

--- a/tests/rkt_api_service_test.go
+++ b/tests/rkt_api_service_test.go
@@ -44,8 +44,8 @@ func startAPIService(t *testing.T, ctx *testutils.RktRunCtx) *gexpect.ExpectSubp
 		t.Logf("no %q group, will run api service with root, ONLY DO THIS FOR TESTING!", common.RktGroup)
 		noGid = true
 	} else {
-		if err := ctx.SetupDataDir(); err != nil {
-			t.Fatalf("failed to setup data directory: %v", err)
+		if err := ctx.SetupRktDirs(); err != nil {
+			t.Fatalf("failed to setup ancillary dirs: %v", err)
 		}
 	}
 

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -68,6 +68,9 @@ func testFetchFromFile(t *testing.T, arg string, image string) {
 
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
+	if err := ctx.SetupRktDirs(); err != nil {
+		t.Fatalf("failed to setup ancillary dirs: %v", err)
+	}
 
 	cmd := fmt.Sprintf("%s %s %s", ctx.Cmd(), arg, image)
 
@@ -125,6 +128,9 @@ func TestFetchFullHash(t *testing.T) {
 
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
+	if err := ctx.SetupRktDirs(); err != nil {
+		t.Fatalf("failed to setup ancillary dirs: %v", err)
+	}
 
 	tests := []struct {
 		fetchArgs          string
@@ -153,6 +159,9 @@ func testFetchDefault(t *testing.T, arg string, image string, imageArgs string, 
 
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
+	if err := ctx.SetupRktDirs(); err != nil {
+		t.Fatalf("failed to setup ancillary dirs: %v", err)
+	}
 
 	cmd := fmt.Sprintf("%s %s %s %s", ctx.Cmd(), arg, image, imageArgs)
 
@@ -180,6 +189,9 @@ func testFetchStoreOnly(t *testing.T, args string, image string, imageArgs strin
 
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
+	if err := ctx.SetupRktDirs(); err != nil {
+		t.Fatalf("failed to setup ancillary dirs: %v", err)
+	}
 
 	cmd := fmt.Sprintf("%s --store-only %s %s %s", ctx.Cmd(), args, image, imageArgs)
 
@@ -198,6 +210,9 @@ func testFetchNoStore(t *testing.T, args string, image string, imageArgs string,
 
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
+	if err := ctx.SetupRktDirs(); err != nil {
+		t.Fatalf("failed to setup ancillary dirs: %v", err)
+	}
 
 	importImageAndFetchHash(t, ctx, "", image)
 
@@ -252,6 +267,9 @@ func TestResumedFetch(t *testing.T) {
 
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
+	if err := ctx.SetupRktDirs(); err != nil {
+		t.Fatalf("failed to setup ancillary dirs: %v", err)
+	}
 
 	cmd := fmt.Sprintf("%s --no-store --insecure-options=image fetch %s", ctx.Cmd(), server.URL)
 	child := spawnOrFail(t, cmd)
@@ -287,6 +305,9 @@ func TestResumedFetchInvalidCache(t *testing.T) {
 
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
+	if err := ctx.SetupRktDirs(); err != nil {
+		t.Fatalf("failed to setup ancillary dirs: %v", err)
+	}
 
 	shouldInterrupt := &synchronizedBool{}
 	shouldInterrupt.Write(true)
@@ -454,6 +475,9 @@ func TestDeferredSignatureDownload(t *testing.T) {
 
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
+	if err := ctx.SetupRktDirs(); err != nil {
+		t.Fatalf("failed to setup ancillary dirs: %v", err)
+	}
 
 	runRktTrust(t, ctx, "", 1)
 
@@ -525,6 +549,9 @@ func TestDifferentDiscoveryLabels(t *testing.T) {
 func testDifferentDiscoveryNameLabels(t *testing.T, imageName string, expectedMessage string) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
+	if err := ctx.SetupRktDirs(); err != nil {
+		t.Fatalf("failed to setup ancillary dirs: %v", err)
+	}
 
 	runRktTrust(t, ctx, "", 1)
 

--- a/tests/rkt_non_root_test.go
+++ b/tests/rkt_non_root_test.go
@@ -43,8 +43,8 @@ func TestNonRootReadInfo(t *testing.T) {
 		t.Skipf("Skipping the test because there's no %q group", common.RktGroup)
 	}
 
-	if err := ctx.SetupDataDir(); err != nil {
-		t.Fatalf("failed to setup data dir: %v", err)
+	if err := ctx.SetupRktDirs(); err != nil {
+		t.Fatalf("failed to setup ancillary dirs: %v", err)
 	}
 
 	// Launch some pods, this creates the environment for later testing.
@@ -96,8 +96,8 @@ func TestNonRootFetchRmGCImage(t *testing.T) {
 		t.Skipf("Skipping the test because there's no %q group", common.RktGroup)
 	}
 
-	if err := ctx.SetupDataDir(); err != nil {
-		t.Fatalf("failed to setup data dir: %v", err)
+	if err := ctx.SetupRktDirs(); err != nil {
+		t.Fatalf("failed to setup ancillary dirs: %v", err)
 	}
 
 	rootImg := patchTestACI("rkt-inspect-root-rm.aci", "--exec=/inspect --print-msg=foobar")

--- a/tests/testutils/ctx.go
+++ b/tests/testutils/ctx.go
@@ -101,8 +101,20 @@ func NewRktRunCtx() *RktRunCtx {
 	}
 }
 
-func (ctx *RktRunCtx) SetupDataDir() error {
-	return setupDataDir(ctx.DataDir())
+// SetupRktDirs adjust permissions on ancillary directories for rkt execution
+func (ctx *RktRunCtx) SetupRktDirs() error {
+	err := setupDataDir(ctx.DataDir())
+	if err != nil {
+		return err
+	}
+
+	for i := 1; i <= 3; i++ {
+		err = setDirPermissions(ctx.dir(i), nil, "rkt-admin", os.FileMode(0750|os.ModeSetgid))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (ctx *RktRunCtx) LaunchMDS() error {


### PR DESCRIPTION
This PR patches rkt-fetch to detect when being run as root
and drop privileges before hitting the network. In that case,
it will drop to user nobody while retaining supplementary groups
for operating on system-wide stores and configs.
