### PR TITLE
rkt/api_service: fix fly pods

### DIFF
--- a/api/v1alpha/client_example.go
+++ b/api/v1alpha/client_example.go
@@ -41,15 +41,21 @@ func getLogsWithoutFollow(c v1alpha.PublicAPIClient, p *v1alpha.Pod) {
 		SinceTime: time.Now().Add(-time.Second * 5).Unix(),
 		Lines:     10,
 	})
+
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
 	logsRecvResp, err := logsResp.Recv()
+
+	if err == io.EOF {
+		return
+	}
+
 	if err != nil {
 		fmt.Println(err)
-		os.Exit(1)
+		return
 	}
 
 	for _, l := range logsRecvResp.Lines {
@@ -81,7 +87,7 @@ func getLogsWithFollow(c v1alpha.PublicAPIClient, p *v1alpha.Pod) {
 
 		if err != nil {
 			fmt.Println(err)
-			os.Exit(1)
+			return
 		}
 
 		for _, l := range logsRecvResp.Lines {

--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -735,6 +735,11 @@ func (s *v1AlphaAPIServer) GetLogs(request *v1alpha.GetLogsRequest, server v1alp
 		stage1Path = fmt.Sprintf("/overlay/%s/upper/", stage1TreeStoreID)
 	}
 	path := filepath.Join(getDataDir(), "/pods/run/", request.PodId, stage1Path, "/var/log/journal/")
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return fmt.Errorf("%s: logging unsupported", uuid.String())
+	}
+
 	jconf := sdjournal.JournalReaderConfig{
 		Path: path,
 	}

--- a/stage1_fly/run/main.go
+++ b/stage1_fly/run/main.go
@@ -334,7 +334,7 @@ func stage1() int {
 		}
 	}
 
-	if err = stage1common.WritePid(os.Getpid(), "ppid"); err != nil {
+	if err = stage1common.WritePid(os.Getpid(), "pid"); err != nil {
 		log.Error(err)
 		return 1
 	}


### PR DESCRIPTION
rkt fly currently is stuck in an endless loop when `GetLogs()` is invoked in the api service. This PR fixes it by returning an empty log for fly pods.

Fixes #2792