### PR TITLE
functional tests: sleep before killing rkt on TestResumedFetch

### DIFF
--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/tests/testutils"
@@ -395,6 +396,9 @@ func testInterruptingServerHandler(t *testing.T, imagePath string, kill, waitfor
 			panic(err)
 		}
 
+		// sleep a bit before signaling that rkt should be killed since it
+		// might not have had time to write everything to disk
+		time.Sleep(time.Second)
 		kill <- struct{}{}
 		<-waitforkill
 	}

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -165,7 +165,7 @@ func testFetchDefault(t *testing.T, arg string, image string, imageArgs string, 
 	err := child.Wait()
 	status := getExitStatus(err)
 	if status != 0 {
-		t.Errorf("rkt terminated with unexpected status %d, expected %d\nOutput:\n%s", status, 0, child.Collect())
+		t.Logf("rkt terminated with unexpected status %d, expected %d\nOutput:\n%s", status, 0, child.Collect())
 		t.Skip("remote fetching failed, probably a network failure. Skipping...")
 	}
 
@@ -212,7 +212,7 @@ func testFetchNoStore(t *testing.T, args string, image string, imageArgs string,
 	err := child.Wait()
 	status := getExitStatus(err)
 	if status != 0 {
-		t.Errorf("rkt terminated with unexpected status %d, expected %d\nOutput:\n%s", status, 0, child.Collect())
+		t.Logf("rkt terminated with unexpected status %d, expected %d\nOutput:\n%s", status, 0, child.Collect())
 		t.Skip("remote fetching failed, probably a network failure. Skipping...")
 	}
 }


### PR DESCRIPTION
Our test server sends half of the file and then tells TestResumedFetch
via a channel that it should kill rkt and start another rkt process
to check if it resumes the download.

However, it may happen that rkt doesn't have time to write everything to
disk before it gets killed, in some cases it doesn't even have time to
write anything and the test fails.

To fix it, we sleep a bit before telling TestResumedFetch that it should
kill rkt.

Also, in https://github.com/coreos/rkt/pull/2762 we skip TestFetch if remote fetching fails, but that was actually not working because we called `t.Errorf` before skipping. Fix that too.

Fixes #2668 