### PR TITLE
rkt/uuid: fix match when uuid is an empty string

### DIFF
--- a/rkt/uuid.go
+++ b/rkt/uuid.go
@@ -30,6 +30,10 @@ import (
 // matchUUID attempts to match the uuid specified as uuid against all pods present.
 // An array of matches is returned, which may be empty when nothing matches.
 func matchUUID(uuid string) ([]string, error) {
+	if uuid == "" {
+		return nil, types.ErrNoEmptyUUID
+	}
+
 	ls, err := listPods(includePrepareDir | includePreparedDir | includeRunDir | includeExitedGarbageDir)
 	if err != nil {
 		return nil, err

--- a/tests/rkt_rm_test.go
+++ b/tests/rkt_rm_test.go
@@ -99,3 +99,14 @@ func TestRmInvalid(t *testing.T) {
 	cmd = fmt.Sprintf("%s rm --uuid-file=%s", ctx.Cmd(), uuidFile)
 	runRktAndCheckOutput(t, cmd, expected, true)
 }
+
+func TestRmEmptyUUID(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	emptyUUID := "\"\""
+	expected := fmt.Sprintf("UUID cannot be empty")
+
+	cmd := fmt.Sprintf("%s rm %s", ctx.Cmd(), emptyUUID)
+	runRktAndCheckOutput(t, cmd, expected, true)
+}


### PR DESCRIPTION
After the patch, if the uuid is an empty string then matchUUID(uuid string)
returns no matches instead of all the pods.
This is done to avoid `rkt rm` or `rkt enter` to delete or enter pods
without intending to.

Fixes https://github.com/coreos/rkt/issues/2806