### PR TITLE
rkt/run: added --set-env-file switch and priorities for environments

### DIFF
--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -44,6 +44,7 @@ c9fad0e6-8236-4fc2-ad17-55d0a4c7d742
 | `--private-users` |  `false` | `true` or `false` | Run within user namespaces |
 | `--quiet` |  `false` | `true` or `false` | Suppress superfluous output on stdout, print only the UUID on success |
 | `--set-env` |  `` | An environment variable. Syntax `NAME=VALUE` | An environment variable to set for apps |
+| `--set-env-file` |  `` | Path of an environment variables file | Environment variables to set for apps |
 | `--signature` |  `` | A file path | Local signature file to use in validating the preceding image |
 | `--stage1-url` |  `` | A URL to a stage1 image. HTTP/HTTPS/File/Docker URLs are supported | Image to use as stage1 |
 | `--stage1-path` |  `` | A path to a stage1 image. Absolute and relative paths are supported | Image to use as stage1 |

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -80,11 +80,13 @@ To inherit all environment variables from the parent use the `--inherit-env` fla
 
 To explicitly set individual environment variables use the `--set-env` flag.
 
+To explicitly set environment variables from a file use the `--set-env-file` flag. Variables are expected to be in the format `VAR_NAME=VALUE` separated by the new line character `\n`. Lines starting with `#` or `;` and empty ones will be ignored.
 The precedence is as follows with the last item replacing previous environment entries:
 
 - Parent environment
 - App image environment
-- Explicitly set environment
+- Explicitly set environment variables from file (`--set-env-file`)
+- Explicitly set environment variables on command line (`--set-env`)
 
 ```
 # export EXAMPLE_ENV=hello
@@ -360,6 +362,7 @@ For more details see the [hacking documentation](../hacking.md).
 | `--port` | none | A port name and number pair | Container port name to expose through host port number. Requires [contained network](../networking/overview.md#contained-mode). Syntax: `--port=NAME:HOSTPORT` The NAME is that given in the ACI. By convention, Docker containers' EXPOSEd ports are given a name formed from the port number, a hyphen, and the protocol, e.g., `80-tcp`, giving something like `--port=80-tcp:8080` |
 | `--private-users` |  `false` | `true` or `false` | Run within user namespaces. |
 | `--set-env` | none | An environment variable (ex. `--set-env=NAME=VALUE`) | An environment variable to set for apps. |
+| `--set-env-file` |  `` | Path of an environment variables file (ex. `--set-env-file=/path/to/env/file`) | Environment variables to set for apps |
 | `--signature` | none | A file path | Local signature file to use in validating the preceding image |
 | `--stage1-from-dir` | none | Image name (ex. `--stage1-name=coreos.com/rkt/stage1-coreos`) | A stage1 image file name to search for inside the default stage1 images directory. |
 | `--stage1-hash` | none | Image hash (ex. `--stage1-hash=sha512-dedce9f5ea50`) | A hash of a stage1 image. The image must exist in the store. |

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -60,6 +60,7 @@ func init() {
 	cmdPrepare.Flags().BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
 	cmdPrepare.Flags().BoolVar(&flagPrivateUsers, "private-users", false, "run within user namespaces.")
 	cmdPrepare.Flags().Var(&flagExplicitEnv, "set-env", "environment variable to set for apps in the form name=value")
+	cmdPrepare.Flags().Var(&flagEnvFromFile, "set-env-file", "the path to an environment variables file")
 	cmdPrepare.Flags().BoolVar(&flagStoreOnly, "store-only", false, "use only available images in the store (do not discover or download from remote URLs)")
 	cmdPrepare.Flags().BoolVar(&flagNoStore, "no-store", false, "fetch images ignoring the local store")
 	cmdPrepare.Flags().StringVar(&flagPodManifest, "pod-manifest", "", "the path to the pod manifest. If it's non-empty, then only '--quiet' and '--no-overlay' will have effect")
@@ -107,7 +108,8 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	if len(flagPodManifest) > 0 && (len(flagPorts) > 0 || flagInheritEnv || !flagExplicitEnv.IsEmpty() || flagStoreOnly || flagNoStore ||
+	if len(flagPodManifest) > 0 && (len(flagPorts) > 0 || flagStoreOnly || flagNoStore ||
+		flagInheritEnv || !flagExplicitEnv.IsEmpty() || !flagEnvFromFile.IsEmpty() ||
 		(*appsVolume)(&rktApps).String() != "" || (*appMount)(&rktApps).String() != "" || (*appExec)(&rktApps).String() != "" ||
 		(*appUser)(&rktApps).String() != "" || (*appGroup)(&rktApps).String() != "") {
 		stderr.Print("conflicting flags set with --pod-manifest (see --help)")
@@ -181,6 +183,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		pcfg.Ports = []types.ExposedPort(flagPorts)
 		pcfg.InheritEnv = flagInheritEnv
 		pcfg.ExplicitEnv = flagExplicitEnv.Strings()
+		pcfg.EnvFromFile = flagEnvFromFile.Strings()
 		pcfg.Apps = &rktApps
 	}
 

--- a/tests/env_file_test.conf
+++ b/tests/env_file_test.conf
@@ -1,0 +1,1 @@
+VAR_OTHER=file

--- a/tests/rkt_env_test.go
+++ b/tests/rkt_env_test.go
@@ -78,6 +78,18 @@ var envTests = []struct {
 		`/bin/sh -c "export VAR_OTHER=host ; ^RKT_BIN^ --debug --insecure-options=image run --mds-register=false --interactive --inherit-env=true --set-env=VAR_OTHER=setenv ^SLEEP^"`,
 		`/bin/sh -c "export VAR_OTHER=host ; ^RKT_BIN^ --debug enter $(^RKT_BIN^ list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_OTHER"`,
 	},
+	{
+		`/bin/sh -c "^RKT_BIN^ --debug --insecure-options=image run --mds-register=false --set-env=VAR_OTHER=setenv --set-env-file=env_file_test.conf ^PRINT_VAR_OTHER^"`,
+		"VAR_OTHER=setenv",
+		`/bin/sh -c "^RKT_BIN^ --debug --insecure-options=image run --mds-register=false --interactive --set-env=VAR_OTHER=setenv --set-env-file=env_file_test.conf ^SLEEP^"`,
+		`/bin/sh -c "export VAR_OTHER=host ; ^RKT_BIN^ --debug enter $(^RKT_BIN^ list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_OTHER"`,
+	},
+	{
+		`/bin/sh -c "^RKT_BIN^ --debug --insecure-options=image run --mds-register=false --set-env-file=env_file_test.conf ^PRINT_VAR_OTHER^"`,
+		"VAR_OTHER=file",
+		`/bin/sh -c "^RKT_BIN^ --debug --insecure-options=image run --mds-register=false --interactive --set-env-file=env_file_test.conf ^SLEEP^"`,
+		`/bin/sh -c "^RKT_BIN^ --debug enter $(^RKT_BIN^ list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_OTHER"`,
+	},
 }
 
 func TestEnv(t *testing.T) {


### PR DESCRIPTION
--set-env-file gets an environment variables file path in the format "VAR=VALUE\n...".
This switch may be used multiple times on the command line to provide multiple
environment files. When it used multiple times, it merges each environment file
in a single environment and it returns an error if the same variable is set multiple
times (either in different files or in the same file).

This patch implements priorities among the various way to specify
environment variables, from highest to least priority:
1. Command line (--set-env)
2. From files (--set-env-file)
3. Image Manifest
4. Inherit (--inherit-env)
A variable in a group with an higher priority will override the value
of a variable with the same name in groups with lower priority without
producing any error. Variables with unique names will be always preserved.

Fixes https://github.com/coreos/rkt/issues/647