### PR TITLE
rkt/image: when using heuristics to determine app type, stat first

### DIFF
--- a/rkt/image/common.go
+++ b/rkt/image/common.go
@@ -160,7 +160,14 @@ func guessImageType(image string) apps.AppImageType {
 	// Well, at this point is basically heuristics time. The image
 	// parameter can be either a relative path or an image name.
 
-	// First, let's check if there is a colon in the image
+	// First, let's try to stat whatever file the URL would specify. If it
+	// exists, that's probably what the user wanted.
+	f, err := os.Stat(image)
+	if err == nil && f.Mode().IsRegular() {
+		return apps.AppImagePath
+	}
+
+	// Second, let's check if there is a colon in the image
 	// parameter. Colon often serves as a paths separator (like in
 	// the PATH environment variable), so if it exists, then it is
 	// highly unlikely that the image parameter is a path. Colon
@@ -170,14 +177,14 @@ func guessImageType(image string) apps.AppImageType {
 		return apps.AppImageName
 	}
 
-	// Second, let's check if there is a dot followed by a slash
+	// Third, let's check if there is a dot followed by a slash
 	// (./) - if so, it is likely that the image parameter is path
 	// like ./aci-in-this-dir or ../aci-in-parent-dir
 	if strings.Contains(image, "./") {
 		return apps.AppImagePath
 	}
 
-	// Third, let's check if the image parameter has an .aci
+	// Fourth, let's check if the image parameter has an .aci
 	// extension. If so, likely a path like "stage1-coreos.aci".
 	if filepath.Ext(image) == schema.ACIExtension {
 		return apps.AppImagePath


### PR DESCRIPTION
At some point rkt will fall back to using heuristics to determine if the
provided image name is referring to an ACI on disk or if it's an image
name to perform discovery on / look in the store for. This commit
modifies the function that determines this to begin by stat'ing the
provided image name. If a file to that exact path exists on disk, that's
probably what the user wished to run.

This commit was prompted by me attempting to run a filename that docker2aci had decided to put a colon in (docker2aci docker://localhost:5000/thing)