### PR TITLE
Doc/subcmd: add missing flags

### DIFF
--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -35,6 +35,7 @@ c9fad0e6-8236-4fc2-ad17-55d0a4c7d742
 | Flag | Default | Options | Description |
 | --- | --- | --- | --- |
 | `--exec` | none | Path to executable | Override the exec command for the preceding image. |
+| `--group` | root | gid, groupname or file path | Group override for the preceding image (example: '--group=group') |
 | `--inherit-env` | `false` | `true` or `false` | Inherit all environment variables not set by apps. |
 | `--mount` | none | Mount syntax (ex. `--mount volume=NAME,target=PATH`) | Mount point binding a volume to a path within an app. See [Mounting Volumes without Mount Points](#mounting-volumes-without-mount-points). |
 | `--no-overlay` | `false` | `true` or `false` | Disable the overlay filesystem. |
@@ -51,9 +52,8 @@ c9fad0e6-8236-4fc2-ad17-55d0a4c7d742
 | `--stage1-hash` |  `` | A hash of a stage1 image. The image must exist in the store | Image to use as stage1 |
 | `--stage1-from-dir` |  `` | A stage1 image file inside the default stage1 images directory | Image to use as stage1 |
 | `--store-only` |  `false` | `true` or `false` | Use only available images in the store (do not discover or download from remote URLs). See [image fetching behavior](../image-fetching-behavior.md) |
+| `--user` | none | uid, username or file path | user override for the preceding image (example: '--user=user') |
 | `--volume` |  `` | Volume syntax (`NAME,kind=KIND,source=PATH,readOnly=BOOL`). See [Mount Volumes into a Pod](run.md#mount-volumes-into-a-pod) | Volumes to make available in the pod |
-| `--user` | none | username or UID | user override for the preceding image (example: '--user=user') |
-| `--group` | none | group or GID | group override for the preceding image (example: '--group=group') |
 
 ## Global options
 

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -342,11 +342,14 @@ For more details see the [hacking documentation](../hacking.md).
 
 | Flag | Default | Options | Description |
 | --- | --- | --- | --- |
+| `--cap-remove` | none | capability to remove (example: '--cap-remove=CAP\_SYS\_CHROOT,CAP\_MKNOD') | Capabilities to remove from the process's capabilities bounding set, all others from the default set will be included |
+| `--cap-retain` | none | capability to retain (example: '--cap-remove=CAP\_SYS\_ADMIN,CAP\_NET\_ADMIN') | Capabilities to retain in the process's capabilities bounding set, all others will be removed |
 | `--cpu` | none | CPU units (ex. `--cpu=500m`) | CPU limit for the preceding image in [Kubernetes resource model](https://github.com/kubernetes/kubernetes/blob/release-1.2/docs/design/resources.md) format. |
 | `--dns` | none | IP Address | Name server to write in `/etc/resolv.conf`. It can be specified several times |
 | `--dns-opt` | none | DNS option  | DNS option from resolv.conf(5) to write in `/etc/resolv.conf`. It can be specified several times. |
 | `--dns-search` | none | Domain name | DNS search domain to write in `/etc/resolv.conf`. It can be specified several times. |
 | `--exec` | none | Path to executable | Override the exec command for the preceding image. |
+| `--group` | root | gid, groupname or file path | Group override for the preceding image (example: '--group=group') |
 | `--hostname` | "rkt-$PODUUID" | A host name | Set pod's host name. |
 | `--inherit-env` | `false` | `true` or `false` | Inherit all environment variables not set by apps. |
 | `--interactive` | `false` | `true` or `false` | Run pod interactively. If true, only one image may be supplied. |
@@ -367,6 +370,7 @@ For more details see the [hacking documentation](../hacking.md).
 | `--stage1-path` | none | Absolute or relative path | A path to a stage1 image. |
 | `--stage1-url` | none | URL with protocol | A URL to a stage1 image. HTTP/HTTPS/File/Docker URLs are supported. |
 | `--store-only` | `false` | `true` or `false` | Use only available images in the store (do not discover or download from remote URLs). See [image fetching behavior](../image-fetching-behavior.md). |
+| `--user` | none | uid, username or file path | user override for the preceding image (example: '--user=user') |
 | `--uuid-file-save` | none | A file path | Write out the pod UUID to a file. |
 | `--volume` |  none | Volume syntax (ex. `--volume NAME,kind=KIND,source=PATH,readOnly=BOOL`) | Volumes to make available in the pod. See [Mount Volumes into a Pod](#mount-volumes-into-a-pod). |
 


### PR DESCRIPTION
https://github.com/coreos/rkt/pull/2771 previously added --cap-retain and --cap-remove in the "rkt run" command but they were not added in the documentation. This patch adds them.

Also, the flags --user and --group were only partially documented. This patch also completes that.