### PR TITLE
pkg/tar: overwrite tests was failing due to not using overwrite flag

### DIFF
--- a/pkg/tar/tar_test.go
+++ b/pkg/tar/tar_test.go
@@ -427,7 +427,7 @@ func TestExtractTarOverwrite(t *testing.T) {
 	if !sys.HasChrootCapability() {
 		t.Skipf("chroot capability not available. Disabling test.")
 	}
-	testExtractTarOverwrite(t, extractTarHelper)
+	testExtractTarOverwrite(t, extractTarOverwriteHelper)
 }
 func TestExtractTarOverwriteInsecure(t *testing.T) {
 	testExtractTarOverwrite(t, extractTarInsecureHelper)
@@ -785,6 +785,10 @@ func testExtractTarHardLink(t *testing.T, extractTar func(io.Reader, string) err
 	if origFile.Ino != linkedFile.Ino {
 		t.Errorf("original file and linked file have different inodes")
 	}
+}
+
+func extractTarOverwriteHelper(rdr io.Reader, target string) error {
+	return ExtractTar(rdr, target, true, user.NewBlankUidRange(), nil)
 }
 
 func extractTarHelper(rdr io.Reader, target string) error {


### PR DESCRIPTION
TestExtractTarOverwrite was failing due to attempting to test the tar
package's ability to overwrite files during extraction, but called
ExtractTar with the overwrite argument set to false. This went unnoticed
since the test is skipped when not run as root, which is the case in our
CI.

Fixes https://github.com/coreos/rkt/issues/1923.