### PR TITLE
stage1: Implemented notifications from the app in the container to the host

### DIFF
--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -322,7 +322,8 @@ func getArgsEnv(p *stage1commontypes.Pod, flavor string, canMachinedRegister boo
 	case "coreos":
 		args = append(args, filepath.Join(common.Stage1RootfsPath(p.Root), interpBin))
 		args = append(args, filepath.Join(common.Stage1RootfsPath(p.Root), nspawnBin))
-		args = append(args, "--boot") // Launch systemd in the pod
+		args = append(args, "--boot")             // Launch systemd in the pod
+		args = append(args, "--notify-ready=yes") // From systemd v231
 
 		if context := os.Getenv(common.EnvSELinuxContext); context != "" {
 			args = append(args, fmt.Sprintf("-Z%s", context))
@@ -348,7 +349,8 @@ func getArgsEnv(p *stage1commontypes.Pod, flavor string, canMachinedRegister boo
 	case "src":
 		args = append(args, filepath.Join(common.Stage1RootfsPath(p.Root), interpBin))
 		args = append(args, filepath.Join(common.Stage1RootfsPath(p.Root), nspawnBin))
-		args = append(args, "--boot") // Launch systemd in the pod
+		args = append(args, "--boot")             // Launch systemd in the pod
+		args = append(args, "--notify-ready=yes") // From systemd v231
 
 		if context := os.Getenv(common.EnvSELinuxContext); context != "" {
 			args = append(args, fmt.Sprintf("-Z%s", context))
@@ -389,6 +391,9 @@ func getArgsEnv(p *stage1commontypes.Pod, flavor string, canMachinedRegister boo
 		}
 		if n != 1 || version < 220 {
 			return nil, nil, fmt.Errorf("rkt needs systemd-nspawn >= 220. %s version not supported: %v", hostNspawnBin, versionStr)
+		}
+		if version >= 231 {
+			args = append(args, "--notify-ready=yes") // From systemd v231
 		}
 
 		// Copy systemd, bash, etc. in stage1 at run-time

--- a/stage1/prepare-app/prepare-app.c
+++ b/stage1/prepare-app/prepare-app.c
@@ -263,6 +263,8 @@ int main(int argc, char *argv[])
 		{ "/etc/rkt-hosts", "/etc/hosts", "bind", NULL, MS_BIND, false },
 		{ "/etc/hosts-fallback", "/etc/hosts", "bind", NULL, MS_BIND, true }, // only create as fallback
 		{ "/proc/sys/kernel/hostname", "/etc/hostname", "bind", NULL, MS_BIND, false },
+		// TODO @alepuccetti this could be removed when https://github.com/systemd/systemd/issues/3544 is solved
+		{ "/run/systemd/notify", "/run/systemd/notify", "bind", NULL, MS_BIND, false },
 	};
 	const char *root;
 	int rootfd;

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -70,6 +70,10 @@
         {
             "name": "coreos.com/rkt/stage1/gc",
             "value": "/ex/gc"
+        },
+        {
+            "name": "appc.io/executor/supports-systemd-notify",
+            "value": "true"
         }
     ]
 }


### PR DESCRIPTION


After this patch, systemd on the host marks the container as "active"
when the init systemd in the container sends the ready message
instead of doing it after the container is created.
After this patch rkt sets --notify-ready=yes on systemd-nspawn.

Also appc/spec in godeps is patched to expose `SupportsNotify`.

Fixes: https://github.com/coreos/rkt/issues/1464

Warning:
If the application launched by rkt does not notify (with sd_notify())
that it is ready, then the application may be killed after a timeout.

Note: Requires systemd v231 in stage1, so this commit must not be merged before.