### PR TITLE
common: remove unused GetImageIDs()

### DIFF
--- a/common/apps/apps.go
+++ b/common/apps/apps.go
@@ -145,13 +145,3 @@ func (al *Apps) GetArgs() [][]string {
 	}
 	return aal
 }
-
-// GetImageIDs returns a list of the imageIDs in al, one per app.
-// The order reflects the app order in al.
-func (al *Apps) GetImageIDs() []types.Hash {
-	var hl []types.Hash
-	for _, a := range al.apps {
-		hl = append(hl, a.ImageID)
-	}
-	return hl
-}


### PR DESCRIPTION
This patch removes apps.GetImageIds() method as it has no callers anymore.
This helper was added to pass list of image ids to the state0, but now we
pass list of apps in a pod instead.

Last user of the GetImageIDs() was removed in the 227fe3cc2 commit
(  Move pod registration from stage1 to stage0. by @eyakubovich ) and it is
not used anywhere anymore.

So we can remove it.