### PR TITLE
pkg/tar: remove errwrap

### DIFF
--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -28,7 +28,6 @@ import (
 	"github.com/appc/spec/pkg/device"
 	"github.com/coreos/rkt/pkg/fileutil"
 	"github.com/coreos/rkt/pkg/user"
-	"github.com/hashicorp/errwrap"
 )
 
 const DEFAULT_DIR_MODE os.FileMode = 0755
@@ -94,13 +93,13 @@ Tar:
 			}
 			err = extractFile(tr, target, hdr, overwrite, editor)
 			if err != nil {
-				return errwrap.Wrap(errors.New("error extracting tarball"), err)
+				return err
 			}
 			if hdr.Typeflag == tar.TypeDir {
 				dirhdrs = append(dirhdrs, hdr)
 			}
 		default:
-			return errwrap.Wrap(errors.New("error extracting tarball"), err)
+			return err
 		}
 	}
 
@@ -242,11 +241,11 @@ func extractFileFromTar(tr *tar.Reader, file string) ([]byte, error) {
 			}
 			buf, err := ioutil.ReadAll(tr)
 			if err != nil {
-				return nil, errwrap.Wrap(errors.New("error extracting tarball"), err)
+				return nil, err
 			}
 			return buf, nil
 		default:
-			return nil, errwrap.Wrap(errors.New("error extracting tarball"), err)
+			return nil, err
 		}
 	}
 }


### PR DESCRIPTION
Since this package can be used outside of rkt, there is no need to
obscure the return values by using errwrap. All of the internal
consumers of these functions already wrap the output anyway, so this is
actually redundant. For example, `extractTarCommand()` may return:

```
  error extracting tarball
    error extracting tarball
      no such file or directory
```

This change removes the outermost wrap:

```
  error extracting tarball
    no such file or directory
```