### PR TITLE
Move 'fetch' option to 'image fetch'

### DIFF
--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -44,7 +44,6 @@ again.`,
 )
 
 func init() {
-	cmdRkt.AddCommand(cmdFetch)
 	// Disable interspersed flags to stop parsing after the first non flag
 	// argument. All the subsequent parsing will be done by parseApps.
 	// This is needed to correctly handle multiple IMAGE --signature=sigfile options
@@ -54,6 +53,13 @@ func init() {
 	cmdFetch.Flags().BoolVar(&flagStoreOnly, "store-only", false, "use only available images in the store (do not discover or download from remote URLs)")
 	cmdFetch.Flags().BoolVar(&flagNoStore, "no-store", false, "fetch images ignoring the local store")
 	cmdFetch.Flags().BoolVar(&flagFullHash, "full", false, "print the full image hash after fetching")
+
+	cmdRkt.AddCommand(cmdFetch)
+
+	// Hide image fetch option in command list
+	cmdImageFetch := *cmdFetch
+	cmdImageFetch.Hidden = true
+	cmdImage.AddCommand(&cmdImageFetch)
 }
 
 func runFetch(cmd *cobra.Command, args []string) (exit int) {

--- a/rkt/help.go
+++ b/rkt/help.go
@@ -129,8 +129,10 @@ func rktFlagUsages(flagSet *pflag.FlagSet) string {
 func getSubCommands(cmd *cobra.Command) []*cobra.Command {
 	var subCommands []*cobra.Command
 	for _, subCmd := range cmd.Commands() {
-		subCommands = append(subCommands, subCmd)
-		subCommands = append(subCommands, getSubCommands(subCmd)...)
+		if !subCmd.Hidden {
+			subCommands = append(subCommands, subCmd)
+			subCommands = append(subCommands, getSubCommands(subCmd)...)
+		}
 	}
 	return subCommands
 }


### PR DESCRIPTION
The 'fetch' option belongs under 'image'. I left a hidden option 'rkt fetch' to make this a non-breaking change. Note: I had trouble getting all tests to run.

Fixes #2701 