### PR TITLE
glide: update docker2aci to v0.12.1

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: c98a3d0cb1340703d2bbf77ac3bf2f6e357c0de64fb02f5d502ffac399b5d5e5
-updated: 2016-07-06T16:44:19.414775414+02:00
+hash: 79f133fbb4e0f79f65f0b5303420513c3e3f8859b9d11ef7b6ff65120dcd29e4
+updated: 2016-07-14T12:45:07.658245282+02:00
 imports:
 - name: github.com/appc/docker2aci
-  version: 355af275fa8d48b4ecdd361a5feaf173abff81e7
+  version: d77d6e4b99a0d8b6be6f70c623c86ba777110cbd
   subpackages:
   - lib
   - lib/common
@@ -14,6 +14,7 @@ imports:
   - lib/internal/types
   - lib/internal/util
   - pkg/log
+  - lib/internal/typesV2
 - name: github.com/appc/goaci
   version: ba7b591f930783c0ab75f5bbfd6ff65c7bd011bf
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/StackExchange/wmi
   version: f3e2bae1e0cb5aef83e319133eabfee30013a4a5
 - package: github.com/appc/docker2aci
-  version: v0.11.1
+  version: v0.12.1
   subpackages:
   - lib
   - lib/common

--- a/vendor/github.com/appc/docker2aci/lib/internal/backend/repository/repository.go
+++ b/vendor/github.com/appc/docker2aci/lib/internal/backend/repository/repository.go
@@ -27,6 +27,7 @@ import (
 	"github.com/appc/docker2aci/lib/common"
 	"github.com/appc/docker2aci/lib/internal/docker"
 	"github.com/appc/docker2aci/lib/internal/types"
+	"github.com/appc/docker2aci/lib/internal/typesV2"
 	"github.com/appc/docker2aci/lib/internal/util"
 	"github.com/appc/spec/schema"
 )
@@ -47,6 +48,9 @@ type RepositoryBackend struct {
 	hostsV2AuthTokens map[string]map[string]string
 	schema            string
 	imageManifests    map[types.ParsedDockerURL]v2Manifest
+	imageV2Manifests  map[types.ParsedDockerURL]*typesV2.ImageManifest
+	imageConfigs      map[types.ParsedDockerURL]*typesV2.ImageConfig
+	reverseLayers     map[string]int
 }
 
 func NewRepositoryBackend(username string, password string, insecure common.InsecureConfig) *RepositoryBackend {
@@ -57,6 +61,9 @@ func NewRepositoryBackend(username string, password string, insecure common.Inse
 		hostsV2Support:    make(map[string]bool),
 		hostsV2AuthTokens: make(map[string]map[string]string),
 		imageManifests:    make(map[types.ParsedDockerURL]v2Manifest),
+		imageV2Manifests:  make(map[types.ParsedDockerURL]*typesV2.ImageManifest),
+		imageConfigs:      make(map[types.ParsedDockerURL]*typesV2.ImageConfig),
+		reverseLayers:     make(map[string]int),
 	}
 }
 

--- a/vendor/github.com/appc/docker2aci/lib/internal/typesV2/docker_types.go
+++ b/vendor/github.com/appc/docker2aci/lib/internal/typesV2/docker_types.go
@@ -1,0 +1,138 @@
+// Copyright 2016 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typesV2
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+const (
+	MediaTypeDockerV21Manifest       = "application/vnd.docker.distribution.manifest.v1+json"
+	MediaTypeDockerV21SignedManifest = "application/vnd.docker.distribution.manifest.v1+prettyjws"
+	MediaTypeDockerV21ManifestLayer  = "application/vnd.docker.container.image.rootfs.diff+x-gtar"
+
+	MediaTypeDockerV22Manifest     = "application/vnd.docker.distribution.manifest.v2+json"
+	MediaTypeDockerV22ManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
+	MediaTypeDockerV22Config       = "application/vnd.docker.container.image.v1+json"
+	MediaTypeDockerV22RootFS       = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+
+	MediaTypeOCIManifest     = "application/vnd.oci.image.manifest.v1+json"
+	MediaTypeOCIManifestList = "application/vnd.oci.image.manifest.list.v1+json"
+	MediaTypeOCIConfig       = "application/vnd.oci.image.serialization.config.v1+json"
+	MediaTypeOCIRootFS       = "application/vnd.oci.image.serialization.rootfs.tar.gzip"
+	MediaTypeOCICombined     = "application/vnd.oci.image.serialization.combined.v1+json"
+)
+
+var (
+	ErrIncorrectMediaType = errors.New("incorrect mediaType")
+	ErrMissingConfig      = errors.New("the config field is empty")
+	ErrMissingLayers      = errors.New("the layers field is empty")
+)
+
+type ImageManifest struct {
+	SchemaVersion int                    `json:"schemaVersion"`
+	MediaType     string                 `json:"mediaType"`
+	Config        *ImageManifestDigest   `json:"config"`
+	Layers        []*ImageManifestDigest `json:"layers"`
+	Annotations   map[string]string      `json:"annotations"`
+}
+
+type ImageManifestDigest struct {
+	MediaType string `json:"mediaType"`
+	Size      int    `json:"size"`
+	Digest    string `json:"digest"`
+}
+
+func (im *ImageManifest) String() string {
+	manblob, err := json.Marshal(im)
+	if err != nil {
+		return err.Error()
+	}
+	return string(manblob)
+}
+
+func (im *ImageManifest) PrettyString() string {
+	manblob, err := json.MarshalIndent(im, "", "    ")
+	if err != nil {
+		return err.Error()
+	}
+	return string(manblob)
+}
+
+func (im *ImageManifest) Validate() error {
+	if im.MediaType != MediaTypeDockerV22Manifest && im.MediaType != MediaTypeOCIManifest {
+		return ErrIncorrectMediaType
+	}
+	if im.Config == nil {
+		return ErrMissingConfig
+	}
+	if len(im.Layers) == 0 {
+		return ErrMissingLayers
+	}
+	return nil
+}
+
+type ImageConfig struct {
+	Created      string                `json:"created"`
+	Author       string                `json:"author"`
+	Architecture string                `json:"architecture"`
+	OS           string                `json:"os"`
+	Config       *ImageConfigConfig    `json:"config"`
+	RootFS       *ImageConfigRootFS    `json:"rootfs"`
+	History      []*ImageConfigHistory `json:"history"`
+}
+
+type ImageConfigConfig struct {
+	User         string              `json:"User"`
+	Memory       int                 `json:"Memory"`
+	MemorySwap   int                 `json:"MemorySwap"`
+	CpuShares    int                 `json:"CpuShares"`
+	ExposedPorts map[string]struct{} `json:"ExposedPorts"`
+	Env          []string            `json:"Env"`
+	Entrypoint   []string            `json:"Entrypoint"`
+	Cmd          []string            `json:"Cmd"`
+	Volumes      map[string]struct{} `json:"Volumes"`
+	WorkingDir   string              `json:"WorkingDir"`
+}
+
+type ImageConfigRootFS struct {
+	DiffIDs []string `json:"diff_ids"`
+	Type    string   `json:"type"`
+}
+
+type ImageConfigHistory struct {
+	Created    string `json:"created,omitempty"`
+	Author     string `json:"author,omitempty"`
+	CreatedBy  string `json:"created_by,omitempty"`
+	Comment    string `json:"comment,omitempty"`
+	EmptyLayer bool   `json:"empty_layer,omitempty"`
+}
+
+func (ic *ImageConfig) String() string {
+	manblob, err := json.Marshal(ic)
+	if err != nil {
+		return err.Error()
+	}
+	return string(manblob)
+}
+
+func (ic *ImageConfig) PrettyString() string {
+	manblob, err := json.MarshalIndent(ic, "", "    ")
+	if err != nil {
+		return err.Error()
+	}
+	return string(manblob)
+}

--- a/vendor/github.com/appc/docker2aci/lib/version.go
+++ b/vendor/github.com/appc/docker2aci/lib/version.go
@@ -16,5 +16,5 @@ package docker2aci
 
 import "github.com/appc/spec/schema"
 
-var Version = "0.11.1"
+var Version = "0.12.1"
 var AppcVersion = schema.AppContainerVersion


### PR DESCRIPTION
It includes support for the docker image format v2.2 and OCI image
format and allows fetching via digest.

Ref: https://github.com/coreos/rkt/issues/2188

To fully fix #2188 it we need to verify signatures (https://github.com/appc/docker2aci/issues/156)