### PR TITLE
functional tests: add --silent-sigterm on rkt stop test

### DIFF
--- a/tests/rkt_stop_test.go
+++ b/tests/rkt_stop_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestRktStop(t *testing.T) {
-	image := patchTestACI("rkt-stop-test.aci", "--name=rkt-stop-test", "--exec=/inspect --read-stdin")
+	image := patchTestACI("rkt-stop-test.aci", "--name=rkt-stop-test", "--exec=/inspect --read-stdin --silent-sigterm")
 	defer os.Remove(image)
 
 	ctx := testutils.NewRktRunCtx()


### PR DESCRIPTION
On the fly flavor, rkt stop just sends SIGTERM to the process, since we
don't do anything special, inspect returns a non-zero exit status which
makes the test fail because we expect 0.

Add `--silent-sigterm` so the test works on fly too.