### PR TITLE
stage1: update coreos image to 1097.0.0

### DIFF
--- a/stage1/usr_from_coreos/coreos-common.mk
+++ b/stage1/usr_from_coreos/coreos-common.mk
@@ -11,7 +11,7 @@ $(call setup-tmp-dir,CCN_TMPDIR)
 # systemd version in coreos image
 CCN_SYSTEMD_VERSION := v229
 # coreos image version
-CCN_IMG_RELEASE := 1068.0.0
+CCN_IMG_RELEASE := 1097.0.0
 # coreos image URL
 CCN_IMG_URL := https://alpha.release.core-os.net/$(RKT_STAGE1_COREOS_BOARD)/$(CCN_IMG_RELEASE)/coreos_production_pxe_image.cpio.gz
 # path to downloaded pxe image

--- a/stage1/usr_from_coreos/manifest-amd64-usr.d/systemd.manifest
+++ b/stage1/usr_from_coreos/manifest-amd64-usr.d/systemd.manifest
@@ -40,7 +40,7 @@ lib64/libgcc_s.so
 lib64/libgcc_s.so.1
 lib64/libgcrypt.so
 lib64/libgcrypt.so.20
-lib64/libgcrypt.so.20.0.3
+lib64/libgcrypt.so.20.0.5
 lib64/libgpg-error.so
 lib64/libgpg-error.so.0
 lib64/libgpg-error.so.0.10.0
@@ -75,7 +75,7 @@ lib64/librt.so
 lib64/librt.so.1
 lib64/libseccomp.so
 lib64/libseccomp.so.2
-lib64/libseccomp.so.2.1.1
+lib64/libseccomp.so.2.3.0
 lib64/libselinux.so
 lib64/libselinux.so.1
 lib64/libuuid.so

--- a/stage1/usr_from_coreos/manifest-arm64-usr.d/systemd.manifest
+++ b/stage1/usr_from_coreos/manifest-arm64-usr.d/systemd.manifest
@@ -33,8 +33,8 @@ lib64/libc.so.6
 lib64/libdl-2.21.so
 lib64/libdl.so
 lib64/libdl.so.2
-lib64/libgcrypt.so.11
-lib64/libgcrypt.so.11.8.3
+lib64/libgcrypt.so.20
+lib64/libgcrypt.so.20.0.5
 lib64/libgpg-error.so.0
 lib64/libgpg-error.so.0.10.0
 lib64/libip4tc.so.0


### PR DESCRIPTION
This is needed for a recent enough version of libseccomp (2.3.0), with support for
new syscalls (eg. getrandom).