### PR TITLE
stage1: prepare-app: don't mount /sys if path already used

### DIFF
--- a/stage1/init/common/path.go
+++ b/stage1/init/common/path.go
@@ -65,7 +65,7 @@ func ServiceWantPath(root string, appName types.ACName) string {
 func InstantiatedPrepareAppUnitName(appName types.ACName) string {
 	// Naming respecting escaping rules, see systemd.unit(5) and systemd-escape(1)
 	escapedRoot := unit.UnitNamePathEscape(common.RelAppRootfsPath(appName))
-	return "prepare-app@" + escapedRoot + ".service"
+	return "prepare-app@-" + escapedRoot + ".service"
 }
 
 // SocketUnitName returns a systemd socket unit name for the given app name.

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -288,3 +288,60 @@ func TestDockerVolumeSemanticsPodManifest(t *testing.T) {
 		runRktAndCheckOutput(t, cmd, expected, false)
 	}
 }
+
+var volSysfsTests = []struct {
+	name          string
+	imgPatch      string
+	cmdParams     string
+	expected      string
+	expectedError bool
+}{
+	{
+		"Without any mount",
+		"--name=base",
+		"",
+		"/sys/class: mode: drwxr-xr-x",
+		false,
+	},
+	{
+		"With /sys as an empty volume",
+		"--mounts=sysdir,path=/sys,readOnly=false",
+		"",
+		"stat /sys/class: no such file or directory",
+		true,
+	},
+	{
+		"With /sys bind-mounted from the host",
+		"--mounts=sysdir,path=/sys,readOnly=false",
+		"--volume=sysdir,kind=host,source=/sys,readOnly=false",
+		"/sys/class: mode: drwxr-xr-x",
+		false,
+	},
+	{
+		"With /sys/class bind-mounted from the host",
+		"--mounts=sysdir,path=/sys/class,readOnly=false",
+		"--volume=sysdir,kind=host,source=/dev/null,readOnly=false",
+		"/sys/class: mode: Dcrw-rw-rw-",
+		false,
+	},
+}
+
+// TestVolumeSysfs checks that sysfs is available for the apps, but only if
+// the app does not have mount points in /sys or a subdirectory.
+// See: https://github.com/coreos/rkt/issues/2874
+func TestVolumeSysfs(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	for i, tt := range volSysfsTests {
+		t.Logf("Running test #%v: %s", i, tt.name)
+
+		img := patchTestACI("rkt-sysfs.aci", tt.imgPatch)
+		defer os.Remove(img)
+		cmd := fmt.Sprintf(`%s --debug --insecure-options=image --set-env=FILE=/sys/class run %s %s --exec /inspect -- --stat-file`,
+			ctx.Cmd(), tt.cmdParams, img)
+
+		runRktAndCheckOutput(t, cmd, tt.expected, tt.expectedError)
+	}
+
+}


### PR DESCRIPTION
When users mount /sys or a sub-directory of /sys as a volume,
prepare-app should not mount /sys: that would mask the volume provided
by users. This patch detects if there is a volume mounted in /sys or a
subdirectory and skips the mount.

Fixes https://github.com/coreos/rkt/issues/2874

-----

/cc @tjdett

TODO:
- [x] add tests