### PR TITLE
rkt: add command to export a pod to an aci

### DIFF
--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -39,6 +39,7 @@ rkt provides subcommands to list, get status, and clean its pods.
 
 * [list](subcommands/list.md)
 * [status](subcommands/status.md)
+* [export](subcommands/export.md)
 * [gc](subcommands/gc.md)
 * [rm](subcommands/rm.md)
 * [cat-manifest](subcommands/cat-manifest.md)

--- a/Documentation/subcommands/export.md
+++ b/Documentation/subcommands/export.md
@@ -10,7 +10,7 @@ $ rkt export UUID .aci
 
 | Flag | Default | Options | Description |
 | --- | --- | --- | --- |
-| `--overwrite` |  `false` | `true` or `false` | Overwrite the output aci if it exists  |
+| `--overwrite` |  `false` | `true` or `false` | Overwrite the output ACI if it exists  |
 
 ## Global options
 

--- a/Documentation/subcommands/export.md
+++ b/Documentation/subcommands/export.md
@@ -1,0 +1,17 @@
+# rkt export
+
+Exports an exited, single-app pod to an App Container Image (.aci)
+
+```
+$ rkt export UUID .aci
+```
+
+## Options
+
+| Flag | Default | Options | Description |
+| --- | --- | --- | --- |
+| `--overwrite` |  `false` | `true` or `false` | Overwrite the output aci if it exists  |
+
+## Global options
+
+See the table with [global options in general commands documentation](../commands.md#global-options).

--- a/common/common.go
+++ b/common/common.go
@@ -55,6 +55,15 @@ const (
 
 	DefaultLocalConfigDir  = "/etc/rkt"
 	DefaultSystemConfigDir = "/usr/lib/rkt"
+
+	// Default perm bits for the regular files
+	// within the stage1 directory. (e.g. image manifest,
+	// pod manifest, stage1ID, etc).
+	DefaultRegularFilePerm = os.FileMode(0640)
+
+	// Default perm bits for the regular directories
+	// within the stage1 directory.
+	DefaultRegularDirPerm = os.FileMode(0750)
 )
 
 const (

--- a/common/overlay/overlay.go
+++ b/common/overlay/overlay.go
@@ -22,9 +22,10 @@ import (
 	"github.com/hashicorp/errwrap"
 )
 
-// MountCfg containes the needed data to construct the overlay mount syscall. The Lower and Upper fields
-// are paths to the filesystems to be merged. The Work field should be an empty directory. Dest is where
-// the mount will be located. Lbl is an SELinux label.
+// MountCfg contains the needed data to construct the overlay mount syscall.
+// The Lower and Upper fields are paths to the filesystems to be merged. The
+// Work field should be an empty directory. Dest is where the mount will be
+// located. Lbl is an SELinux label.
 type MountCfg struct {
 	Lower,
 	Upper,
@@ -33,15 +34,15 @@ type MountCfg struct {
 	Lbl string
 }
 
-// Mount mounts the upper and lower directories to the destination directory. The MountCfg struct supplies
-// information required to build the mount system call. The path to the mounted files system is returned
-// upon success.
-func Mount(cfg *MountCfg) (string, error) {
+// Mount mounts the upper and lower directories to the destination directory.
+// The MountCfg struct supplies information required to build the mount system
+// call.
+func Mount(cfg *MountCfg) error {
 	opts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", cfg.Lower, cfg.Upper, cfg.Work)
 	opts = label.FormatMountLabel(opts, cfg.Lbl)
 	if err := syscall.Mount("overlay", cfg.Dest, "overlay", 0, opts); err != nil {
-		return "", errwrap.Wrap(fmt.Errorf("error mounting overlay with options '%s' and dest '%s'", opts, cfg.Dest), err)
+		return errwrap.Wrap(fmt.Errorf("error mounting overlay with options '%s' and dest '%s'", opts, cfg.Dest), err)
 	}
 
-	return cfg.Dest, nil
+	return nil
 }

--- a/common/overlay/overlay.go
+++ b/common/overlay/overlay.go
@@ -1,0 +1,47 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package overlay
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/coreos/rkt/pkg/label"
+	"github.com/hashicorp/errwrap"
+)
+
+// MountCfg containes the needed data to construct the overlay mount syscall. The Lower and Upper fields
+// are paths to the filesystems to be merged. The Work field should be an empty directory. Dest is where
+// the mount will be located. Lbl is an SELinux label.
+type MountCfg struct {
+	Lower,
+	Upper,
+	Work,
+	Dest,
+	Lbl string
+}
+
+// Mount mounts the upper and lower directories to the destination directory. The MountCfg struct supplies
+// information required to build the mount system call. The path to the mounted files system is returned
+// upon success.
+func Mount(cfg *MountCfg) (string, error) {
+	opts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", cfg.Lower, cfg.Upper, cfg.Work)
+	opts = label.FormatMountLabel(opts, cfg.Lbl)
+	if err := syscall.Mount("overlay", cfg.Dest, "overlay", 0, opts); err != nil {
+		return "", errwrap.Wrap(fmt.Errorf("error mounting overlay with options '%s' and dest '%s'", opts, cfg.Dest), err)
+	}
+
+	return cfg.Dest, nil
+}

--- a/rkt/export.go
+++ b/rkt/export.go
@@ -1,0 +1,149 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/appc/spec/aci"
+	"github.com/appc/spec/schema"
+	"github.com/coreos/rkt/common"
+	"github.com/hashicorp/errwrap"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdExport = &cobra.Command{
+		Use:   "export UUID OUTPUT_ACI_FILE",
+		Short: "Export an exited pod to an ACI file",
+		Long: `UUID should be the uuid of an exited pod.
+
+Note that currently only pods with a single app and started with the --no-overlay option are supported.`,
+		Run: runWrapper(runExport),
+	}
+)
+
+func init() {
+	cmdRkt.AddCommand(cmdExport)
+	cmdExport.Flags().BoolVar(&flagOverwriteACI, "overwrite", false, "overwrite output ACI")
+}
+
+func runExport(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) != 2 {
+		cmd.Usage()
+		return 1
+	}
+
+	aci := args[1]
+	ext := filepath.Ext(aci)
+	if ext != schema.ACIExtension {
+		stderr.Printf("extension must be %s (given %s)", schema.ACIExtension, aci)
+		return 1
+	}
+
+	p, err := getPodFromUUIDString(args[0])
+	if err != nil {
+		stderr.PrintE("problem retrieving pod", err)
+		return 1
+	}
+	defer p.Close()
+
+	if !p.isExited {
+		stderr.Print("pod is not exited. Only exited pods are supported.")
+		return 1
+	}
+
+	if p.usesOverlay() {
+		stderr.Print("pod uses overlayfs. Only pods using the --no-overlay flag are supported.")
+		return 1
+	}
+
+	var apps schema.AppList
+	if apps, err = p.getApps(); err != nil {
+		stderr.PrintE("problem getting pod's app list", err)
+		return 1
+	}
+
+	if len(apps) != 1 {
+		stderr.Print("pod has more than one app. Only pods with one app are supported.")
+		return 1
+	}
+
+	root := common.AppPath(p.path(), apps[0].Name)
+	if err = buildAci(root, aci); err != nil {
+		stderr.PrintE("error building aci", err)
+		return 1
+	}
+
+	return 0
+}
+
+func buildAci(root, target string) (e error) {
+	mode := os.O_CREATE | os.O_WRONLY
+	if flagOverwriteACI {
+		mode |= os.O_TRUNC
+	} else {
+		mode |= os.O_EXCL
+	}
+	aciFile, err := os.OpenFile(target, mode, 0644)
+	if err != nil {
+		if os.IsExist(err) {
+			return errors.New("target file exists (try --overwrite)")
+		} else {
+			return errwrap.Wrap(fmt.Errorf("unable to open target %s", target), err)
+		}
+	}
+
+	gw := gzip.NewWriter(aciFile)
+	tr := tar.NewWriter(gw)
+
+	defer func() {
+		tr.Close()
+		gw.Close()
+		aciFile.Close()
+		// e is implicitly assigned by the return statement. As defer runs
+		// after return, but before actually returning, this works.
+		if e != nil {
+			os.Remove(target)
+		}
+	}()
+
+	mpath := filepath.Join(root, aci.ManifestFile)
+	b, err := ioutil.ReadFile(mpath)
+	if err != nil {
+		return errwrap.Wrap(errors.New("unable to read Image Manifest"), err)
+	}
+	var im schema.ImageManifest
+	if err := im.UnmarshalJSON(b); err != nil {
+		return errwrap.Wrap(errors.New("unable to load Image Manifest"), err)
+	}
+	iw := aci.NewImageWriter(im, tr)
+
+	if err := filepath.Walk(root, aci.BuildWalker(root, iw, nil)); err != nil {
+		return errwrap.Wrap(errors.New("error walking rootfs"), err)
+	}
+
+	if err = iw.Close(); err != nil {
+		return errwrap.Wrap(fmt.Errorf("unable to close image %s", target), err)
+	}
+
+	return
+}

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -771,7 +771,7 @@ func overlayRender(cfg RunConfig, treeStoreID string, cdir string, dest string, 
 	if err != nil {
 		return errwrap.Wrap(errors.New("problem preparing overlay directories"), err)
 	}
-	if _, err = overlay.Mount(mc); err != nil {
+	if err = overlay.Mount(mc); err != nil {
 		return errwrap.Wrap(errors.New("problem mounting overlay filesystem"), err)
 	}
 

--- a/tests/rkt_export_container_test.go
+++ b/tests/rkt_export_container_test.go
@@ -1,0 +1,39 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !fly
+
+package main
+
+import (
+	"testing"
+
+	"github.com/coreos/rkt/common"
+)
+
+func TestExport(t *testing.T) {
+	testCases := []ExportTestCase{noOverlaySimpleTest}
+
+	// Need to do both checks
+	if common.SupportsUserNS() && checkUserNS() == nil {
+		testCases = append(testCases, userNS)
+	}
+
+	if common.SupportsOverlay() {
+		testCases = append(testCases, overlaySimpleTest)
+		testCases = append(testCases, overlaySimulateReboot)
+	}
+
+	NewTestExport(testCases...).Execute(t)
+}

--- a/tests/rkt_export_fly_test.go
+++ b/tests/rkt_export_fly_test.go
@@ -1,0 +1,33 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build fly
+
+package main
+
+import (
+	"testing"
+
+	"github.com/coreos/rkt/common"
+)
+
+func TestExport(t *testing.T) {
+	if !common.SupportsOverlay() {
+		t.Skip("Overlay fs not supported.")
+	}
+
+	// TODO(iaguis): we need a new function to unmount the fly pod so we can also test
+	// overlaySimulateReboot
+	NewTestExport(overlaySimpleTest).Execute(t)
+}

--- a/tests/rkt_export_test.go
+++ b/tests/rkt_export_test.go
@@ -38,6 +38,7 @@ func TestExport(t *testing.T) {
 		writeArgs      string
 		readArgs       string
 		expectedResult string
+		unmountOverlay bool
 	}
 
 	tests := []testCfg{
@@ -46,6 +47,7 @@ func TestExport(t *testing.T) {
 			"--write-file --file-name=" + testFile + " --content=" + testContent,
 			"--read-file --file-name=" + testFile,
 			testContent,
+			false,
 		},
 	}
 
@@ -57,6 +59,7 @@ func TestExport(t *testing.T) {
 				"--write-file --file-name=" + testFile + " --content=" + testContent,
 				"--read-file --file-name=" + testFile,
 				testContent,
+				false,
 			},
 		}...)
 	}
@@ -68,6 +71,15 @@ func TestExport(t *testing.T) {
 				"--write-file --file-name=" + testFile + " --content=" + testContent,
 				"--read-file --file-name=" + testFile,
 				testContent,
+				false,
+			},
+			// Test unmounting overlay to simulate a reboot
+			{
+				"--insecure-options=image",
+				"--write-file --file-name=" + testFile + " --content=" + testContent,
+				"--read-file --file-name=" + testFile,
+				testContent,
+				true,
 			},
 		}...)
 	}
@@ -88,6 +100,10 @@ func TestExport(t *testing.T) {
 		t.Logf("Running 'inspect --write-file'")
 		child := spawnOrFail(t, runCmd)
 		waitOrFail(t, child, 0)
+
+		if tt.unmountOverlay {
+			unmountPod(t, ctx, uuid, true)
+		}
 
 		// Export the image
 		exportCmd := fmt.Sprintf("%s export %s %s", ctx.Cmd(), uuid, tmpTestAci)

--- a/tests/rkt_export_test.go
+++ b/tests/rkt_export_test.go
@@ -1,0 +1,91 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+func TestExport(t *testing.T) {
+	const (
+		testAci     = "test.aci"
+		testFile    = "test.txt"
+		testContent = "ThisIsATest"
+		runInspect  = "%s %s %s %s --exec=/inspect -- %s"
+	)
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	tests := []struct {
+		runArgs        string
+		writeArgs      string
+		readArgs       string
+		expectedStatus int
+		expectedResult string
+	}{
+		{
+			"--no-overlay --insecure-options=image",
+			"--write-file --file-name=" + testFile + " --content=" + testContent,
+			"--read-file --file-name=" + testFile,
+			0,
+			testContent,
+		},
+	}
+	for _, tt := range tests {
+		tmpDir := createTempDirOrPanic("rkt-TestExport-tmp-")
+		defer os.RemoveAll(tmpDir)
+
+		tmpTestAci := filepath.Join(tmpDir, testAci)
+
+		// Prepare the image with modifications
+		prepareCmd := fmt.Sprintf(runInspect, ctx.Cmd(), "prepare", tt.runArgs, getInspectImagePath(), tt.writeArgs)
+		t.Logf("Preparing 'inspect --write-file'")
+		uuid := runRktAndGetUUID(t, prepareCmd)
+
+		runCmd := fmt.Sprintf("%s run-prepared %s", ctx.Cmd(), uuid)
+		t.Logf("Running 'inspect --write-file'")
+		child := spawnOrFail(t, runCmd)
+		waitOrFail(t, child, 0)
+
+		// Export the image
+		exportCmd := fmt.Sprintf("%s export %s %s", ctx.Cmd(), uuid, tmpTestAci)
+		t.Logf("Running 'export'")
+		child = spawnOrFail(t, exportCmd)
+		waitOrFail(t, child, tt.expectedStatus)
+
+		if tt.expectedStatus == 0 {
+			// Run the newly created ACI and check the output
+			readCmd := fmt.Sprintf(runInspect, ctx.Cmd(), "run", tt.runArgs, tmpTestAci, tt.readArgs)
+			t.Logf("Running 'inspect --read-file'")
+			child := spawnOrFail(t, readCmd)
+			if tt.expectedResult != "" {
+				if _, out, err := expectRegexWithOutput(child, tt.expectedResult); err != nil {
+					t.Fatalf("expected %q but not found: %v\n%s", tt.expectedResult, err, out)
+				}
+			}
+			waitOrFail(t, child, tt.expectedStatus)
+		}
+
+		// run garbage collector on pods and images
+		runGC(t, ctx)
+		runImageGC(t, ctx)
+	}
+}


### PR DESCRIPTION
Adds a new `export` command to rkt which generates an aci from a
pod; saving any changes made to the pod.

Usage is `rkt export POD_UUID my.aci`

This is currently restricted to only working with exited pods with a
single app.

Fixes #1197