### PR TITLE
api_service: Cache pod manifest

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3664e0406cca66d626364cc1303ab1d94ff457d8274c3003f982019fafc9a1b8
-updated: 2016-07-22T17:45:52.776583272Z
+hash: e3d37aa49d23e987f708f967f805d4cd176295dbe852b278f325fd9e03b476d7
+updated: 2016-07-25T11:28:59.622207002-07:00
 imports:
 - name: github.com/appc/docker2aci
   version: d77d6e4b99a0d8b6be6f70c623c86ba777110cbd
@@ -181,6 +181,10 @@ imports:
   version: e444e69cbd2e2e3e0749a2f3c717cec491552bbf
 - name: github.com/hashicorp/errwrap
   version: 7554cd9344cec97297fa6649b055a8c98c2a1e55
+- name: github.com/hashicorp/golang-lru
+  version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
+  subpackages:
+  - simplelru
 - name: github.com/hydrogen18/stoppableListener
   version: 2eebd04b47ff393f4bc50b7fcacf8f048994c6fd
 - name: github.com/inconshreveable/mousetrap

--- a/glide.yaml
+++ b/glide.yaml
@@ -287,3 +287,5 @@ import:
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
+- package: github.com/hashicorp/golang-lru
+  version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4

--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -38,10 +38,14 @@ import (
 	"github.com/coreos/rkt/version"
 	"github.com/godbus/dbus"
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/golang-lru"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
+
+// Default size for the pod manifest LRU cache.
+const defaultCacheSize = 512
 
 var (
 	supportedAPIVersion = "1.0.0-alpha"
@@ -68,9 +72,33 @@ func init() {
 	cmdAPIService.Flags().StringVar(&flagAPIServiceListenAddr, "listen", "", "address to listen for client API requests")
 }
 
+type podCacheItem struct {
+	pod   *v1alpha.Pod
+	mtime time.Time
+}
+
+// copyPod copies the immutable information of the pod into the new pod.
+func copyPod(pod *v1alpha.Pod) *v1alpha.Pod {
+	p := &v1alpha.Pod{
+		Id:          pod.Id,
+		Manifest:    pod.Manifest,
+		Annotations: pod.Annotations,
+	}
+
+	for _, app := range pod.Apps {
+		p.Apps = append(p.Apps, &v1alpha.App{
+			Name:        app.Name,
+			Image:       app.Image,
+			Annotations: app.Annotations,
+		})
+	}
+	return p
+}
+
 // v1AlphaAPIServer implements v1Alpha.APIServer interface.
 type v1AlphaAPIServer struct {
-	store *imagestore.Store
+	store    *imagestore.Store
+	podCache *lru.Cache
 }
 
 var _ v1alpha.PublicAPIServer = &v1AlphaAPIServer{}
@@ -81,8 +109,14 @@ func newV1AlphaAPIServer() (*v1AlphaAPIServer, error) {
 		return nil, err
 	}
 
+	cache, err := lru.New(defaultCacheSize)
+	if err != nil {
+		return nil, err
+	}
+
 	return &v1AlphaAPIServer{
-		store: s,
+		store:    s,
+		podCache: cache,
 	}, nil
 }
 
@@ -251,8 +285,10 @@ func satisfiesAnyPodFilters(pod *v1alpha.Pod, filters []*v1alpha.PodFilter) bool
 }
 
 // getPodManifest returns the pod manifest of the pod.
+// It will try to find the manifest in the LRU cache first, if not found or the manifest is stale,
+// then it will read the manifest from the disk.
 // Both marshaled and unmarshaled manifest are returned.
-func getPodManifest(p *pod) (*schema.PodManifest, []byte, error) {
+func (s *v1AlphaAPIServer) getPodManifest(p *pod) (*schema.PodManifest, []byte, error) {
 	data, err := p.readFile("pod")
 	if err != nil {
 		stderr.PrintE(fmt.Sprintf("failed to read pod manifest for pod %q", p.uuid), err)
@@ -264,6 +300,7 @@ func getPodManifest(p *pod) (*schema.PodManifest, []byte, error) {
 		stderr.PrintE(fmt.Sprintf("failed to unmarshal pod manifest for pod %q", p.uuid), err)
 		return nil, nil, err
 	}
+
 	return &manifest, data, nil
 }
 
@@ -286,7 +323,8 @@ func getApplist(manifest *schema.PodManifest) []*v1alpha.App {
 			Name:        app.Name.String(),
 			Image:       img,
 			Annotations: convertAnnotationsToKeyValue(app.Annotations),
-			// State and exit code are not returned in 'ListPods()'.
+			State:       v1alpha.AppState_APP_STATE_UNDEFINED,
+			ExitCode:    -1,
 		})
 	}
 	return apps
@@ -305,100 +343,109 @@ func getNetworks(p *pod) []*v1alpha.Network {
 	return networks
 }
 
-// getBasicPod returns *v1alpha.Pod with basic pod information.
-func getBasicPod(p *pod) *v1alpha.Pod {
-	pod := &v1alpha.Pod{Id: p.uuid.String(), Pid: -1}
+type errs struct {
+	errs []error
+}
 
-	manifest, data, err := getPodManifest(p)
+// Error is part of the error interface.
+func (e errs) Error() string {
+	return fmt.Sprintf("%v", e.errs)
+}
+
+// fillStaticAppInfo will modify the 'v1pod' in place with the infomation retrived with 'pod'.
+// Today, these information are static and will not change during the pod's lifecycle.
+func fillStaticAppInfo(store *imagestore.Store, pod *pod, v1pod *v1alpha.Pod) error {
+	var errlist []error
+
+	// Fill static app image info.
+	for _, app := range v1pod.Apps {
+		// Fill app's image info (id, name, version).
+		fullImageID, err := store.ResolveKey(app.Image.Id)
+		if err != nil {
+			stderr.PrintE(fmt.Sprintf("failed to resolve the image ID %q", app.Image.Id), err)
+			errlist = append(errlist, err)
+		}
+
+		// The following information is always known
+		app.Image = &v1alpha.Image{
+			BaseFormat: &v1alpha.ImageFormat{
+				// Only support appc image now. If it's a docker image, then it
+				// will be transformed to appc before storing in the disk store.
+				Type:    v1alpha.ImageType_IMAGE_TYPE_APPC,
+				Version: schema.AppContainerVersion.String(),
+			},
+			Id: fullImageID,
+			// Other information are not available because they require the image
+			// info from store. Some of it is filled in below if possible.
+		}
+
+		im, err := pod.getAppImageManifest(*types.MustACName(app.Name))
+		if err != nil {
+			stderr.PrintE(fmt.Sprintf("failed to get image manifests for app %q", app.Name), err)
+			errlist = append(errlist, err)
+		} else {
+			app.Image.Name = im.Name.String()
+
+			version, ok := im.Labels.Get("version")
+			if !ok {
+				version = "latest"
+			}
+			app.Image.Version = version
+		}
+	}
+
+	if len(errlist) != 0 {
+		return errs{errlist}
+	}
+	return nil
+}
+
+func (s *v1AlphaAPIServer) getBasicPodFromDisk(p *pod) (*v1alpha.Pod, error) {
+	pod := &v1alpha.Pod{Id: p.uuid.String()}
+
+	manifest, data, err := s.getPodManifest(p)
 	if err != nil {
 		stderr.PrintE(fmt.Sprintf("failed to get the pod manifest for pod %q", p.uuid), err)
 	} else {
-		pod.Manifest = data
 		pod.Annotations = convertAnnotationsToKeyValue(manifest.Annotations)
 		pod.Apps = getApplist(manifest)
+		pod.Manifest = data
+		err = fillStaticAppInfo(s.store, p, pod)
 	}
 
-	switch p.getState() {
-	case Embryo:
-		pod.State = v1alpha.PodState_POD_STATE_EMBRYO
-		// When a pod is in embryo state, there is not much
-		// information to return.
-		return pod
-	case Preparing:
-		pod.State = v1alpha.PodState_POD_STATE_PREPARING
-	case AbortedPrepare:
-		pod.State = v1alpha.PodState_POD_STATE_ABORTED_PREPARE
-	case Prepared:
-		pod.State = v1alpha.PodState_POD_STATE_PREPARED
-	case Running:
-		pod.State = v1alpha.PodState_POD_STATE_RUNNING
-		pod.Networks = getNetworks(p)
-	case Deleting:
-		pod.State = v1alpha.PodState_POD_STATE_DELETING
-	case Exited:
-		pod.State = v1alpha.PodState_POD_STATE_EXITED
-	case Garbage:
-		pod.State = v1alpha.PodState_POD_STATE_GARBAGE
-	default:
-		pod.State = v1alpha.PodState_POD_STATE_UNDEFINED
-		return pod
+	return pod, err
+}
+
+// getBasicPod returns v1alpha.Pod with basic pod information.
+func (s *v1AlphaAPIServer) getBasicPod(p *pod) *v1alpha.Pod {
+	mtime, mtimeErr := p.getModTime("pod")
+	if mtimeErr != nil {
+		stderr.PrintE(fmt.Sprintf("failed to read the pod manifest's mtime for pod %q", p.uuid), mtimeErr)
 	}
 
-	createdAt, err := p.getCreationTime()
-	if err != nil {
-		stderr.PrintE(fmt.Sprintf("failed to get the creation time for pod %q", p.uuid), err)
-	} else if !createdAt.IsZero() {
-		pod.CreatedAt = createdAt.UnixNano()
-	}
+	// Couldn't use pod.uuid directly as it's a pointer.
+	itemValue, found := s.podCache.Get(p.uuid.String())
+	if found && mtimeErr == nil {
+		cacheItem := itemValue.(*podCacheItem)
 
-	startedAt, err := p.getStartTime()
-	if err != nil {
-		stderr.PrintE(fmt.Sprintf("failed to get the start time for pod %q", p.uuid), err)
-	} else if !startedAt.IsZero() {
-		pod.StartedAt = startedAt.UnixNano()
-
-	}
-
-	gcMarkedAt, err := p.getGCMarkedTime()
-	if err != nil {
-		stderr.PrintE(fmt.Sprintf("failed to get the gc marked time for pod %q", p.uuid), err)
-	} else if !gcMarkedAt.IsZero() {
-		pod.GcMarkedAt = gcMarkedAt.UnixNano()
-	}
-
-	pid, err := p.getPID()
-	if err != nil {
-		stderr.PrintE(fmt.Sprintf("failed to get the PID for pod %q", p.uuid), err)
-	} else {
-		pod.Pid = int32(pid)
-	}
-
-	if pod.State == v1alpha.PodState_POD_STATE_RUNNING {
-		if err := waitForMachinedRegistration(pod.Id); err != nil {
-			// If there's an error, it means we're not registered to machined
-			// in a reasonable time. Just output the cgroup we're in.
-			stderr.PrintE("checking for machined registration failed", err)
-		}
-		// Get cgroup for the "name=systemd" controller.
-		pid, err := p.getContainerPID1()
-		if err != nil {
-			stderr.PrintE(fmt.Sprintf("failed to get the container PID1 for pod %q", p.uuid), err)
-		} else {
-			cgroup, err := cgroup.GetCgroupPathByPid(pid, "name=systemd")
-			if err != nil {
-				stderr.PrintE(fmt.Sprintf("failed to get the cgroup path for pod %q", p.uuid), err)
-			} else {
-				// If the stage1 systemd > v226, it will put the PID1 into "init.scope"
-				// implicit scope unit in the root slice.
-				// See https://github.com/coreos/rkt/pull/2331#issuecomment-203540543
-				//
-				// TODO(yifan): Revisit this when using unified cgroup hierarchy.
-				pod.Cgroup = strings.TrimSuffix(cgroup, "/init.scope")
-			}
+		// Check the mtime to make sure we are not returning stale manifests.
+		if !mtime.After(cacheItem.mtime) {
+			return copyPod(cacheItem.pod)
 		}
 	}
 
-	return pod
+	pod, err := s.getBasicPodFromDisk(p)
+	if mtimeErr != nil || err != nil {
+		// If any error happens or the mtime is unknown,
+		// returns the raw pod directly without adding it to the cache.
+		return pod
+	}
+
+	cacheItem := &podCacheItem{pod, mtime}
+	s.podCache.Add(p.uuid.String(), cacheItem)
+
+	// Return a copy of the pod, so the cached pod is not mutated later.
+	return copyPod(cacheItem.pod)
 }
 
 func waitForMachinedRegistration(uuid string) error {
@@ -420,36 +467,90 @@ func waitForMachinedRegistration(uuid string) error {
 	return errors.New("pod not found")
 }
 
-func (s *v1AlphaAPIServer) ListPods(ctx context.Context, request *v1alpha.ListPodsRequest) (*v1alpha.ListPodsResponse, error) {
-	var pods []*v1alpha.Pod
-	if err := walkPods(includeMostDirs, func(p *pod) {
-		pod := getBasicPod(p)
+// fillPodDetails fills the v1pod's dynamic info in place, e.g. the pod's state,
+// the pod's network info, the apps' state, etc. Such information can change
+// during the lifecycle of the pod, so we need to read it in every request.
+func fillPodDetails(store *imagestore.Store, p *pod, v1pod *v1alpha.Pod) {
+	v1pod.Pid = -1
 
-		// Filters are combined with 'OR'.
-		if !satisfiesAnyPodFilters(pod, request.Filters) {
-			return
-		}
-
-		if request.Detail {
-			fillAppInfo(s.store, p, pod)
-		} else {
-			pod.Manifest = nil
-		}
-		pods = append(pods, pod)
-	}); err != nil {
-		stderr.PrintE("failed to list pod", err)
-		return nil, err
+	switch p.getState() {
+	case Embryo:
+		v1pod.State = v1alpha.PodState_POD_STATE_EMBRYO
+		// When a pod is in embryo state, there is not much
+		// information to return.
+		return
+	case Preparing:
+		v1pod.State = v1alpha.PodState_POD_STATE_PREPARING
+	case AbortedPrepare:
+		v1pod.State = v1alpha.PodState_POD_STATE_ABORTED_PREPARE
+	case Prepared:
+		v1pod.State = v1alpha.PodState_POD_STATE_PREPARED
+	case Running:
+		v1pod.State = v1alpha.PodState_POD_STATE_RUNNING
+		v1pod.Networks = getNetworks(p)
+	case Deleting:
+		v1pod.State = v1alpha.PodState_POD_STATE_DELETING
+	case Exited:
+		v1pod.State = v1alpha.PodState_POD_STATE_EXITED
+	case Garbage:
+		v1pod.State = v1alpha.PodState_POD_STATE_GARBAGE
+	default:
+		v1pod.State = v1alpha.PodState_POD_STATE_UNDEFINED
+		return
 	}
-	return &v1alpha.ListPodsResponse{Pods: pods}, nil
-}
 
-// fillAppInfo fills the apps' state and image info of the pod.
-func fillAppInfo(store *imagestore.Store, p *pod, v1pod *v1alpha.Pod) {
-	switch v1pod.State {
-	case v1alpha.PodState_POD_STATE_UNDEFINED:
-		return
-	case v1alpha.PodState_POD_STATE_EMBRYO:
-		return
+	createdAt, err := p.getCreationTime()
+	if err != nil {
+		stderr.PrintE(fmt.Sprintf("failed to get the creation time for pod %q", p.uuid), err)
+	} else if !createdAt.IsZero() {
+		v1pod.CreatedAt = createdAt.UnixNano()
+	}
+
+	startedAt, err := p.getStartTime()
+	if err != nil {
+		stderr.PrintE(fmt.Sprintf("failed to get the start time for pod %q", p.uuid), err)
+	} else if !startedAt.IsZero() {
+		v1pod.StartedAt = startedAt.UnixNano()
+
+	}
+
+	gcMarkedAt, err := p.getGCMarkedTime()
+	if err != nil {
+		stderr.PrintE(fmt.Sprintf("failed to get the gc marked time for pod %q", p.uuid), err)
+	} else if !gcMarkedAt.IsZero() {
+		v1pod.GcMarkedAt = gcMarkedAt.UnixNano()
+	}
+
+	pid, err := p.getPID()
+	if err != nil {
+		stderr.PrintE(fmt.Sprintf("failed to get the PID for pod %q", p.uuid), err)
+	} else {
+		v1pod.Pid = int32(pid)
+	}
+
+	if v1pod.State == v1alpha.PodState_POD_STATE_RUNNING {
+		if err := waitForMachinedRegistration(v1pod.Id); err != nil {
+			// If there's an error, it means we're not registered to machined
+			// in a reasonable time. Just output the cgroup we're in.
+			stderr.PrintE("checking for machined registration failed", err)
+		}
+		// Get cgroup for the "name=systemd" controller.
+		pid, err := p.getContainerPID1()
+		if err != nil {
+			stderr.PrintE(fmt.Sprintf("failed to get the container PID1 for pod %q", p.uuid), err)
+		} else {
+			cgroup, err := cgroup.GetCgroupPathByPid(pid, "name=systemd")
+			if err != nil {
+				stderr.PrintE(fmt.Sprintf("failed to get the cgroup path for pod %q", p.uuid), err)
+			} else {
+				// If the stage1 systemd > v226, it will put the PID1 into "init.scope"
+				// implicit scope unit in the root slice.
+				// See https://github.com/coreos/rkt/pull/2331#issuecomment-203540543
+				//
+				// TODO(yifan): Revisit this when using unified cgroup hierarchy.
+				v1pod.Cgroup = strings.TrimSuffix(cgroup, "/init.scope")
+			}
+		}
 	}
 
 	for _, app := range v1pod.Apps {
@@ -465,40 +566,7 @@ func fillAppInfo(store *imagestore.Store, p *pod, v1pod *v1alpha.Pod) {
 			app.State = v1alpha.AppState_APP_STATE_UNDEFINED
 		}
 
-		// Fill app's image info (id, name, version).
-		fullImageID, err := store.ResolveKey(app.Image.Id)
-		if err != nil {
-			stderr.PrintE(fmt.Sprintf("failed to resolve the image ID %q", app.Image.Id), err)
-		}
-
-		// The following information is always known
-		app.Image = &v1alpha.Image{
-			BaseFormat: &v1alpha.ImageFormat{
-				// Only support appc image now. If it's a docker image, then it
-				// will be transformed to appc before storing in the disk store.
-				Type:    v1alpha.ImageType_IMAGE_TYPE_APPC,
-				Version: schema.AppContainerVersion.String(),
-			},
-			Id: fullImageID,
-			// Other information are not available because they require the image
-			// info from store. Some of it is filled in below if possible.
-		}
-
-		im, err := p.getAppImageManifest(*types.MustACName(app.Name))
-		if err != nil {
-			stderr.PrintE(fmt.Sprintf("failed to get image manifests for app %q", app.Name), err)
-		} else {
-			app.Image.Name = im.Name.String()
-
-			version, ok := im.Labels.Get("version")
-			if !ok {
-				version = "latest"
-			}
-			app.Image.Version = version
-		}
-
 		if readStatus {
-			// Fill app's state and exit code.
 			statusDir, err := p.getStatusDir()
 			if err != nil {
 				stderr.PrintE("failed to get pod exit status directory", err)
@@ -512,6 +580,30 @@ func fillAppInfo(store *imagestore.Store, p *pod, v1pod *v1alpha.Pod) {
 			}
 		}
 	}
+}
+
+func (s *v1AlphaAPIServer) ListPods(ctx context.Context, request *v1alpha.ListPodsRequest) (*v1alpha.ListPodsResponse, error) {
+	var pods []*v1alpha.Pod
+	if err := walkPods(includeMostDirs, func(p *pod) {
+		pod := s.getBasicPod(p)
+
+		fillPodDetails(s.store, p, pod)
+
+		// Filters are combined with 'OR'.
+		if !satisfiesAnyPodFilters(pod, request.Filters) {
+			return
+		}
+
+		if !request.Detail {
+			pod.Manifest = nil
+		}
+
+		pods = append(pods, pod)
+	}); err != nil {
+		stderr.PrintE("failed to list pod", err)
+		return nil, err
+	}
+	return &v1alpha.ListPodsResponse{Pods: pods}, nil
 }
 
 func (s *v1AlphaAPIServer) InspectPod(ctx context.Context, request *v1alpha.InspectPodRequest) (*v1alpha.InspectPodResponse, error) {
@@ -528,10 +620,9 @@ func (s *v1AlphaAPIServer) InspectPod(ctx context.Context, request *v1alpha.Insp
 	}
 	defer p.Close()
 
-	pod := getBasicPod(p)
+	pod := s.getBasicPod(p)
 
-	// Fill the extra pod info that is not available in ListPods(detail=false).
-	fillAppInfo(s.store, p, pod)
+	fillPodDetails(s.store, p, pod)
 
 	return &v1alpha.InspectPodResponse{Pod: pod}, nil
 }

--- a/vendor/github.com/hashicorp/golang-lru/2q.go
+++ b/vendor/github.com/hashicorp/golang-lru/2q.go
@@ -1,0 +1,212 @@
+package lru
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+const (
+	// Default2QRecentRatio is the ratio of the 2Q cache dedicated
+	// to recently added entries that have only been accessed once.
+	Default2QRecentRatio = 0.25
+
+	// Default2QGhostEntries is the default ratio of ghost
+	// entries kept to track entries recently evicted
+	Default2QGhostEntries = 0.50
+)
+
+// TwoQueueCache is a thread-safe fixed size 2Q cache.
+// 2Q is an enhancement over the standard LRU cache
+// in that it tracks both frequently and recently used
+// entries separately. This avoids a burst in access to new
+// entries from evicting frequently used entries. It adds some
+// additional tracking overhead to the standard LRU cache, and is
+// computationally about 2x the cost, and adds some metadata over
+// head. The ARCCache is similar, but does not require setting any
+// parameters.
+type TwoQueueCache struct {
+	size       int
+	recentSize int
+
+	recent      *simplelru.LRU
+	frequent    *simplelru.LRU
+	recentEvict *simplelru.LRU
+	lock        sync.RWMutex
+}
+
+// New2Q creates a new TwoQueueCache using the default
+// values for the parameters.
+func New2Q(size int) (*TwoQueueCache, error) {
+	return New2QParams(size, Default2QRecentRatio, Default2QGhostEntries)
+}
+
+// New2QParams creates a new TwoQueueCache using the provided
+// parameter values.
+func New2QParams(size int, recentRatio float64, ghostRatio float64) (*TwoQueueCache, error) {
+	if size <= 0 {
+		return nil, fmt.Errorf("invalid size")
+	}
+	if recentRatio < 0.0 || recentRatio > 1.0 {
+		return nil, fmt.Errorf("invalid recent ratio")
+	}
+	if ghostRatio < 0.0 || ghostRatio > 1.0 {
+		return nil, fmt.Errorf("invalid ghost ratio")
+	}
+
+	// Determine the sub-sizes
+	recentSize := int(float64(size) * recentRatio)
+	evictSize := int(float64(size) * ghostRatio)
+
+	// Allocate the LRUs
+	recent, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	frequent, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	recentEvict, err := simplelru.NewLRU(evictSize, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize the cache
+	c := &TwoQueueCache{
+		size:        size,
+		recentSize:  recentSize,
+		recent:      recent,
+		frequent:    frequent,
+		recentEvict: recentEvict,
+	}
+	return c, nil
+}
+
+func (c *TwoQueueCache) Get(key interface{}) (interface{}, bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check if this is a frequent value
+	if val, ok := c.frequent.Get(key); ok {
+		return val, ok
+	}
+
+	// If the value is contained in recent, then we
+	// promote it to frequent
+	if val, ok := c.recent.Peek(key); ok {
+		c.recent.Remove(key)
+		c.frequent.Add(key, val)
+		return val, ok
+	}
+
+	// No hit
+	return nil, false
+}
+
+func (c *TwoQueueCache) Add(key, value interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check if the value is frequently used already,
+	// and just update the value
+	if c.frequent.Contains(key) {
+		c.frequent.Add(key, value)
+		return
+	}
+
+	// Check if the value is recently used, and promote
+	// the value into the frequent list
+	if c.recent.Contains(key) {
+		c.recent.Remove(key)
+		c.frequent.Add(key, value)
+		return
+	}
+
+	// If the value was recently evicted, add it to the
+	// frequently used list
+	if c.recentEvict.Contains(key) {
+		c.ensureSpace(true)
+		c.recentEvict.Remove(key)
+		c.frequent.Add(key, value)
+		return
+	}
+
+	// Add to the recently seen list
+	c.ensureSpace(false)
+	c.recent.Add(key, value)
+	return
+}
+
+// ensureSpace is used to ensure we have space in the cache
+func (c *TwoQueueCache) ensureSpace(recentEvict bool) {
+	// If we have space, nothing to do
+	recentLen := c.recent.Len()
+	freqLen := c.frequent.Len()
+	if recentLen+freqLen < c.size {
+		return
+	}
+
+	// If the recent buffer is larger than
+	// the target, evict from there
+	if recentLen > 0 && (recentLen > c.recentSize || (recentLen == c.recentSize && !recentEvict)) {
+		k, _, _ := c.recent.RemoveOldest()
+		c.recentEvict.Add(k, nil)
+		return
+	}
+
+	// Remove from the frequent list otherwise
+	c.frequent.RemoveOldest()
+}
+
+func (c *TwoQueueCache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.recent.Len() + c.frequent.Len()
+}
+
+func (c *TwoQueueCache) Keys() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	k1 := c.frequent.Keys()
+	k2 := c.recent.Keys()
+	return append(k1, k2...)
+}
+
+func (c *TwoQueueCache) Remove(key interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.frequent.Remove(key) {
+		return
+	}
+	if c.recent.Remove(key) {
+		return
+	}
+	if c.recentEvict.Remove(key) {
+		return
+	}
+}
+
+func (c *TwoQueueCache) Purge() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.recent.Purge()
+	c.frequent.Purge()
+	c.recentEvict.Purge()
+}
+
+func (c *TwoQueueCache) Contains(key interface{}) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.frequent.Contains(key) || c.recent.Contains(key)
+}
+
+func (c *TwoQueueCache) Peek(key interface{}) (interface{}, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	if val, ok := c.frequent.Peek(key); ok {
+		return val, ok
+	}
+	return c.recent.Peek(key)
+}

--- a/vendor/github.com/hashicorp/golang-lru/LICENSE
+++ b/vendor/github.com/hashicorp/golang-lru/LICENSE
@@ -1,0 +1,362 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of  any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.

--- a/vendor/github.com/hashicorp/golang-lru/arc.go
+++ b/vendor/github.com/hashicorp/golang-lru/arc.go
@@ -1,0 +1,257 @@
+package lru
+
+import (
+	"sync"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+// ARCCache is a thread-safe fixed size Adaptive Replacement Cache (ARC).
+// ARC is an enhancement over the standard LRU cache in that tracks both
+// frequency and recency of use. This avoids a burst in access to new
+// entries from evicting the frequently used older entries. It adds some
+// additional tracking overhead to a standard LRU cache, computationally
+// it is roughly 2x the cost, and the extra memory overhead is linear
+// with the size of the cache. ARC has been patented by IBM, but is
+// similar to the TwoQueueCache (2Q) which requires setting parameters.
+type ARCCache struct {
+	size int // Size is the total capacity of the cache
+	p    int // P is the dynamic preference towards T1 or T2
+
+	t1 *simplelru.LRU // T1 is the LRU for recently accessed items
+	b1 *simplelru.LRU // B1 is the LRU for evictions from t1
+
+	t2 *simplelru.LRU // T2 is the LRU for frequently accessed items
+	b2 *simplelru.LRU // B2 is the LRU for evictions from t2
+
+	lock sync.RWMutex
+}
+
+// NewARC creates an ARC of the given size
+func NewARC(size int) (*ARCCache, error) {
+	// Create the sub LRUs
+	b1, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	b2, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	t1, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	t2, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize the ARC
+	c := &ARCCache{
+		size: size,
+		p:    0,
+		t1:   t1,
+		b1:   b1,
+		t2:   t2,
+		b2:   b2,
+	}
+	return c, nil
+}
+
+// Get looks up a key's value from the cache.
+func (c *ARCCache) Get(key interface{}) (interface{}, bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Ff the value is contained in T1 (recent), then
+	// promote it to T2 (frequent)
+	if val, ok := c.t1.Peek(key); ok {
+		c.t1.Remove(key)
+		c.t2.Add(key, val)
+		return val, ok
+	}
+
+	// Check if the value is contained in T2 (frequent)
+	if val, ok := c.t2.Get(key); ok {
+		return val, ok
+	}
+
+	// No hit
+	return nil, false
+}
+
+// Add adds a value to the cache.
+func (c *ARCCache) Add(key, value interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check if the value is contained in T1 (recent), and potentially
+	// promote it to frequent T2
+	if c.t1.Contains(key) {
+		c.t1.Remove(key)
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if the value is already in T2 (frequent) and update it
+	if c.t2.Contains(key) {
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if this value was recently evicted as part of the
+	// recently used list
+	if c.b1.Contains(key) {
+		// T1 set is too small, increase P appropriately
+		delta := 1
+		b1Len := c.b1.Len()
+		b2Len := c.b2.Len()
+		if b2Len > b1Len {
+			delta = b2Len / b1Len
+		}
+		if c.p+delta >= c.size {
+			c.p = c.size
+		} else {
+			c.p += delta
+		}
+
+		// Potentially need to make room in the cache
+		if c.t1.Len()+c.t2.Len() >= c.size {
+			c.replace(false)
+		}
+
+		// Remove from B1
+		c.b1.Remove(key)
+
+		// Add the key to the frequently used list
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if this value was recently evicted as part of the
+	// frequently used list
+	if c.b2.Contains(key) {
+		// T2 set is too small, decrease P appropriately
+		delta := 1
+		b1Len := c.b1.Len()
+		b2Len := c.b2.Len()
+		if b1Len > b2Len {
+			delta = b1Len / b2Len
+		}
+		if delta >= c.p {
+			c.p = 0
+		} else {
+			c.p -= delta
+		}
+
+		// Potentially need to make room in the cache
+		if c.t1.Len()+c.t2.Len() >= c.size {
+			c.replace(true)
+		}
+
+		// Remove from B2
+		c.b2.Remove(key)
+
+		// Add the key to the frequntly used list
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Potentially need to make room in the cache
+	if c.t1.Len()+c.t2.Len() >= c.size {
+		c.replace(false)
+	}
+
+	// Keep the size of the ghost buffers trim
+	if c.b1.Len() > c.size-c.p {
+		c.b1.RemoveOldest()
+	}
+	if c.b2.Len() > c.p {
+		c.b2.RemoveOldest()
+	}
+
+	// Add to the recently seen list
+	c.t1.Add(key, value)
+	return
+}
+
+// replace is used to adaptively evict from either T1 or T2
+// based on the current learned value of P
+func (c *ARCCache) replace(b2ContainsKey bool) {
+	t1Len := c.t1.Len()
+	if t1Len > 0 && (t1Len > c.p || (t1Len == c.p && b2ContainsKey)) {
+		k, _, ok := c.t1.RemoveOldest()
+		if ok {
+			c.b1.Add(k, nil)
+		}
+	} else {
+		k, _, ok := c.t2.RemoveOldest()
+		if ok {
+			c.b2.Add(k, nil)
+		}
+	}
+}
+
+// Len returns the number of cached entries
+func (c *ARCCache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.t1.Len() + c.t2.Len()
+}
+
+// Keys returns all the cached keys
+func (c *ARCCache) Keys() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	k1 := c.t1.Keys()
+	k2 := c.t2.Keys()
+	return append(k1, k2...)
+}
+
+// Remove is used to purge a key from the cache
+func (c *ARCCache) Remove(key interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.t1.Remove(key) {
+		return
+	}
+	if c.t2.Remove(key) {
+		return
+	}
+	if c.b1.Remove(key) {
+		return
+	}
+	if c.b2.Remove(key) {
+		return
+	}
+}
+
+// Purge is used to clear the cache
+func (c *ARCCache) Purge() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.t1.Purge()
+	c.t2.Purge()
+	c.b1.Purge()
+	c.b2.Purge()
+}
+
+// Contains is used to check if the cache contains a key
+// without updating recency or frequency.
+func (c *ARCCache) Contains(key interface{}) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.t1.Contains(key) || c.t2.Contains(key)
+}
+
+// Peek is used to inspect the cache value of a key
+// without updating recency or frequency.
+func (c *ARCCache) Peek(key interface{}) (interface{}, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	if val, ok := c.t1.Peek(key); ok {
+		return val, ok
+	}
+	return c.t2.Peek(key)
+}

--- a/vendor/github.com/hashicorp/golang-lru/lru.go
+++ b/vendor/github.com/hashicorp/golang-lru/lru.go
@@ -1,0 +1,114 @@
+// This package provides a simple LRU cache. It is based on the
+// LRU implementation in groupcache:
+// https://github.com/golang/groupcache/tree/master/lru
+package lru
+
+import (
+	"sync"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+// Cache is a thread-safe fixed size LRU cache.
+type Cache struct {
+	lru  *simplelru.LRU
+	lock sync.RWMutex
+}
+
+// New creates an LRU of the given size
+func New(size int) (*Cache, error) {
+	return NewWithEvict(size, nil)
+}
+
+// NewWithEvict constructs a fixed size cache with the given eviction
+// callback.
+func NewWithEvict(size int, onEvicted func(key interface{}, value interface{})) (*Cache, error) {
+	lru, err := simplelru.NewLRU(size, simplelru.EvictCallback(onEvicted))
+	if err != nil {
+		return nil, err
+	}
+	c := &Cache{
+		lru: lru,
+	}
+	return c, nil
+}
+
+// Purge is used to completely clear the cache
+func (c *Cache) Purge() {
+	c.lock.Lock()
+	c.lru.Purge()
+	c.lock.Unlock()
+}
+
+// Add adds a value to the cache.  Returns true if an eviction occurred.
+func (c *Cache) Add(key, value interface{}) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.lru.Add(key, value)
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key interface{}) (interface{}, bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.lru.Get(key)
+}
+
+// Check if a key is in the cache, without updating the recent-ness
+// or deleting it for being stale.
+func (c *Cache) Contains(key interface{}) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.lru.Contains(key)
+}
+
+// Returns the key value (or undefined if not found) without updating
+// the "recently used"-ness of the key.
+func (c *Cache) Peek(key interface{}) (interface{}, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.lru.Peek(key)
+}
+
+// ContainsOrAdd checks if a key is in the cache  without updating the
+// recent-ness or deleting it for being stale,  and if not, adds the value.
+// Returns whether found and whether an eviction occurred.
+func (c *Cache) ContainsOrAdd(key, value interface{}) (ok, evict bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.lru.Contains(key) {
+		return true, false
+	} else {
+		evict := c.lru.Add(key, value)
+		return false, evict
+	}
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key interface{}) {
+	c.lock.Lock()
+	c.lru.Remove(key)
+	c.lock.Unlock()
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *Cache) RemoveOldest() {
+	c.lock.Lock()
+	c.lru.RemoveOldest()
+	c.lock.Unlock()
+}
+
+// Keys returns a slice of the keys in the cache, from oldest to newest.
+func (c *Cache) Keys() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.lru.Keys()
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.lru.Len()
+}

--- a/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
+++ b/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
@@ -1,0 +1,160 @@
+package simplelru
+
+import (
+	"container/list"
+	"errors"
+)
+
+// EvictCallback is used to get a callback when a cache entry is evicted
+type EvictCallback func(key interface{}, value interface{})
+
+// LRU implements a non-thread safe fixed size LRU cache
+type LRU struct {
+	size      int
+	evictList *list.List
+	items     map[interface{}]*list.Element
+	onEvict   EvictCallback
+}
+
+// entry is used to hold a value in the evictList
+type entry struct {
+	key   interface{}
+	value interface{}
+}
+
+// NewLRU constructs an LRU of the given size
+func NewLRU(size int, onEvict EvictCallback) (*LRU, error) {
+	if size <= 0 {
+		return nil, errors.New("Must provide a positive size")
+	}
+	c := &LRU{
+		size:      size,
+		evictList: list.New(),
+		items:     make(map[interface{}]*list.Element),
+		onEvict:   onEvict,
+	}
+	return c, nil
+}
+
+// Purge is used to completely clear the cache
+func (c *LRU) Purge() {
+	for k, v := range c.items {
+		if c.onEvict != nil {
+			c.onEvict(k, v.Value.(*entry).value)
+		}
+		delete(c.items, k)
+	}
+	c.evictList.Init()
+}
+
+// Add adds a value to the cache.  Returns true if an eviction occured.
+func (c *LRU) Add(key, value interface{}) bool {
+	// Check for existing item
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		ent.Value.(*entry).value = value
+		return false
+	}
+
+	// Add new item
+	ent := &entry{key, value}
+	entry := c.evictList.PushFront(ent)
+	c.items[key] = entry
+
+	evict := c.evictList.Len() > c.size
+	// Verify size not exceeded
+	if evict {
+		c.removeOldest()
+	}
+	return evict
+}
+
+// Get looks up a key's value from the cache.
+func (c *LRU) Get(key interface{}) (value interface{}, ok bool) {
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		return ent.Value.(*entry).value, true
+	}
+	return
+}
+
+// Check if a key is in the cache, without updating the recent-ness
+// or deleting it for being stale.
+func (c *LRU) Contains(key interface{}) (ok bool) {
+	_, ok = c.items[key]
+	return ok
+}
+
+// Returns the key value (or undefined if not found) without updating
+// the "recently used"-ness of the key.
+func (c *LRU) Peek(key interface{}) (value interface{}, ok bool) {
+	if ent, ok := c.items[key]; ok {
+		return ent.Value.(*entry).value, true
+	}
+	return nil, ok
+}
+
+// Remove removes the provided key from the cache, returning if the
+// key was contained.
+func (c *LRU) Remove(key interface{}) bool {
+	if ent, ok := c.items[key]; ok {
+		c.removeElement(ent)
+		return true
+	}
+	return false
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *LRU) RemoveOldest() (interface{}, interface{}, bool) {
+	ent := c.evictList.Back()
+	if ent != nil {
+		c.removeElement(ent)
+		kv := ent.Value.(*entry)
+		return kv.key, kv.value, true
+	}
+	return nil, nil, false
+}
+
+// GetOldest returns the oldest entry
+func (c *LRU) GetOldest() (interface{}, interface{}, bool) {
+	ent := c.evictList.Back()
+	if ent != nil {
+		kv := ent.Value.(*entry)
+		return kv.key, kv.value, true
+	}
+	return nil, nil, false
+}
+
+// Keys returns a slice of the keys in the cache, from oldest to newest.
+func (c *LRU) Keys() []interface{} {
+	keys := make([]interface{}, len(c.items))
+	i := 0
+	for ent := c.evictList.Back(); ent != nil; ent = ent.Prev() {
+		keys[i] = ent.Value.(*entry).key
+		i++
+	}
+	return keys
+}
+
+// Len returns the number of items in the cache.
+func (c *LRU) Len() int {
+	return c.evictList.Len()
+}
+
+// removeOldest removes the oldest item from the cache.
+func (c *LRU) removeOldest() {
+	ent := c.evictList.Back()
+	if ent != nil {
+		c.removeElement(ent)
+	}
+}
+
+// removeElement is used to remove a given list element from the cache
+func (c *LRU) removeElement(e *list.Element) {
+	c.evictList.Remove(e)
+	kv := e.Value.(*entry)
+	delete(c.items, kv.key)
+	if c.onEvict != nil {
+		c.onEvict(kv.key, kv.value)
+	}
+}


### PR DESCRIPTION
This PR enables rkt api service to cache pod manifest so that it will not read the disk unless:
- There is a cache miss.
- The pod manifest is modified on disk.

Ref #2877 