### PR TITLE
stage1/enterexec: remove trailing `\n` in environment variables.

### DIFF
--- a/stage1/enterexec/enterexec.c
+++ b/stage1/enterexec/enterexec.c
@@ -181,7 +181,7 @@ static void set_env(const char *env_file)
 	char 		*line = NULL;
 	size_t 		len = 0;
 	ssize_t 	read;
-	char 		*v;
+	char 		*v, *nl;
 
 	pexit_if((f = fopen(env_file, "r")) == NULL,
              "Unable to fopen \"%s\"", env_file);
@@ -190,6 +190,9 @@ static void set_env(const char *env_file)
 				"Malformed environment entry: \"%s\"", line);
 		*v = '\0';
 		v++;
+		/* remove new line character */
+		if ((nl = strchr(v, '\n')) != NULL)
+			*nl = '\0';
 		pexit_if(setenv(line, v, 1) == -1,
 				 "Unable to set env variable: \"%s\"=\"%s\"", line, v);
 	}

--- a/tests/env_file_test.conf
+++ b/tests/env_file_test.conf
@@ -1,1 +1,3 @@
 VAR_OTHER=file
+
+VAR_2=2


### PR DESCRIPTION
Loading environment retained the new line character (`\n`),
this produced an incorrect evaluation of the environment variables.

Fixes: https://github.com/coreos/rkt/issues/2893
Related to: https://github.com/coreos/rkt/pull/2839