### PR TITLE
rkt/stop: implement --uuid-file

### DIFF
--- a/rkt/rm.go
+++ b/rkt/rm.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	cmdRm = &cobra.Command{
-		Use:   "rm [--uuid-file=FILE] UUID ...",
+		Use:   "rm --uuid-file=FILE | UUID ...",
 		Short: "Remove all files and resources associated with an exited pod",
 		Long:  `Unlike gc, rm allows users to remove specific pods.`,
 		Run:   ensureSuperuser(runWrapper(runRm)),

--- a/rkt/stop.go
+++ b/rkt/stop.go
@@ -77,11 +77,11 @@ func runStop(cmd *cobra.Command, args []string) (exit int) {
 		p, err := getPod(podUUID)
 		if err != nil {
 			errors++
-			stderr.PrintE("stop: cannot get pod", err)
+			stderr.PrintE("cannot get pod", err)
 		}
 
 		if !p.isRunning() {
-			stderr.Error(fmt.Errorf("stop: pod %q is not running", p.uuid))
+			stderr.Error(fmt.Errorf("pod %q is not running", p.uuid))
 			errors++
 			continue
 		}
@@ -89,13 +89,13 @@ func runStop(cmd *cobra.Command, args []string) (exit int) {
 		if err := stage0.StopPod(p.path(), flagForce, podUUID); err == nil {
 			stdout.Printf("%q", p.uuid)
 		} else {
-			stderr.PrintE(fmt.Sprintf("stop: error stopping %q", p.uuid), err)
+			stderr.PrintE(fmt.Sprintf("error stopping %q", p.uuid), err)
 			errors++
 		}
 	}
 
 	if errors > 0 {
-		stderr.Error(fmt.Errorf("stop: failed to stop %d pod(s)", errors))
+		stderr.Error(fmt.Errorf("failed to stop %d pod(s)", errors))
 		return 1
 	}
 


### PR DESCRIPTION
So the user can use the value saved on rkt run with --uuid-file-save.

Fixes #2892 