### PR TITLE
store,rkt: fix fd leaks

### DIFF
--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -1061,7 +1061,8 @@ func (p *pod) getDirNames(path string) ([]string, error) {
 }
 
 func (p *pod) usesOverlay() bool {
-	_, err := p.openFile(common.OverlayPreparedFilename, syscall.O_RDONLY)
+	f, err := p.openFile(common.OverlayPreparedFilename, syscall.O_RDONLY)
+	defer f.Close()
 	return err == nil
 }
 

--- a/store/db.go
+++ b/store/db.go
@@ -85,6 +85,10 @@ func (dl *dbLock) unlock() {
 	dl.Unlock()
 }
 
+func (dl *dbLock) close() error {
+	return dl.fl.Close()
+}
+
 type DB struct {
 	dbdir string
 	dl    *dbLock

--- a/store/store.go
+++ b/store/store.go
@@ -307,7 +307,13 @@ func NewStore(baseDir string) (*Store, error) {
 
 // Close closes a Store opened with NewStore().
 func (s *Store) Close() error {
-	return s.storeLock.Close()
+	if err := s.storeLock.Close(); err != nil {
+		return err
+	}
+	if err := s.db.dl.close(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // backupDB backs up current database.


### PR DESCRIPTION
Close db lock on store close. If we don't do it, there's a fd leak everytime we open a new Store, even
if it was closed.

Also, close `overlay-prepared` when checking if a pod uses overlay.

cc @sgotti 

Fixes https://github.com/coreos/rkt/issues/2899