### PR TITLE
api_service: Add lru cache to cache image info

### DIFF
--- a/store/imagestore/store.go
+++ b/store/imagestore/store.go
@@ -743,6 +743,12 @@ func (s *Store) HashToKey(h hash.Hash) string {
 	return hashToKey(h)
 }
 
+// HasFullKey returns whether the image with the given key exists on the disk by
+// checking if the image manifest kv store contains the key.
+func (s *Store) HasFullKey(key string) bool {
+	return s.stores[imageManifestType].Has(key)
+}
+
 func hashToKey(h hash.Hash) string {
 	s := h.Sum(nil)
 	return keyToString(s)


### PR DESCRIPTION
Ref #2877 

Depends on #2909 and #2891 

The last 3 commits are new. Basically it adds an in-memory cache to cache image object, and reads the disk when there is a cache miss.

If the image is removed (by stating the image manifest path), return nil.
