### PR TITLE
rkt-monitor: misc fixes

### DIFF
--- a/tests/rkt-monitor/README.md
+++ b/tests/rkt-monitor/README.md
@@ -15,6 +15,9 @@ rkt-monitor mem-stresser.aci -v -d 30s
 
 Flags:
   -f, --to-file[=false]: Save benchmark results to files in a temp dir
+  -w, --output-dir="/tmp": Specify directory to write results
+  -p, --rkt-dir="": Directory with rkt binary
+  -s, --stage1-path="": Path to Stage1 image to use, default: coreos
   -d, --duration="10s": How long to run the ACI
   -h, --help[=false]: help for rkt-monitor
   -r, --repetitions=1: Numbers of benchmark repetitions
@@ -28,7 +31,7 @@ attempt to eat up resources in different ways.
 An example usage:
 
 ```
-derek@rokot ~/go/src/github.com/coreos/rkt> ./tests/rkt-monitor/build-stresser.sh log
+$ ./tests/rkt-monitor/build-stresser.sh log
 Building worker...
 Beginning build with an empty ACI
 Setting name of ACI to appc.io/rkt-log-stresser
@@ -36,7 +39,7 @@ Copying host:worker-binary to aci:/worker
 Setting exec command [/worker]
 Writing ACI to log-stresser.aci
 Ending the build
-derek@rokot ~/go/src/github.com/coreos/rkt> sudo ./build-rkt-1.8.0+git/bin/rkt-monitor log-stresser.aci 
+$ sudo ./build-rkt-1.10.0+git/target/bin/rkt-monitor log-stresser.aci 
 [sudo] password for derek: 
 rkt(13261): seconds alive: 10  avg CPU: 33.113897%  avg Mem: 4 kB  peak Mem: 4 kB
 systemd(13302): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB

--- a/tests/rkt-monitor/build-stresser.sh
+++ b/tests/rkt-monitor/build-stresser.sh
@@ -28,7 +28,7 @@ trap acbuildEnd EXIT
 
 acbuild --debug set-name appc.io/rkt-"${1}"-stresser
 
-acbuild --debug copy build-rkt-1.8.0+git/bin/"${1}"-stresser /worker
+acbuild --debug copy build-rkt-1.10.0+git/target/bin/"${1}"-stresser /worker
 
 acbuild --debug set-exec -- /worker
 

--- a/tools/cpu-stresser.mk
+++ b/tools/cpu-stresser.mk
@@ -1,7 +1,7 @@
 $(call setup-stamp-file,CPU_STRESSER_STAMP)
 
 # variables for makelib/build_go_bin.mk
-CPU_STRESSER := $(BINDIR)/cpu-stresser
+CPU_STRESSER := $(TARGET_BINDIR)/cpu-stresser
 BGB_STAMP := $(CPU_STRESSER_STAMP)
 BGB_PKG_IN_REPO := tests/rkt-monitor/cpu-stresser
 BGB_BINARY := $(CPU_STRESSER)

--- a/tools/log-stresser.mk
+++ b/tools/log-stresser.mk
@@ -1,7 +1,7 @@
 $(call setup-stamp-file,LOG_STRESSER_STAMP)
 
 # variables for makelib/build_go_bin.mk
-LOG_STRESSER := $(BINDIR)/log-stresser
+LOG_STRESSER := $(TARGET_BINDIR)/log-stresser
 BGB_STAMP := $(LOG_STRESSER_STAMP)
 BGB_PKG_IN_REPO := tests/rkt-monitor/log-stresser
 BGB_BINARY := $(LOG_STRESSER)

--- a/tools/mem-stresser.mk
+++ b/tools/mem-stresser.mk
@@ -1,7 +1,7 @@
 $(call setup-stamp-file,MEM_STRESSER_STAMP)
 
 # variables for makelib/build_go_bin.mk
-MEM_STRESSER := $(BINDIR)/mem-stresser
+MEM_STRESSER := $(TARGET_BINDIR)/mem-stresser
 BGB_STAMP := $(MEM_STRESSER_STAMP)
 BGB_PKG_IN_REPO := tests/rkt-monitor/mem-stresser
 BGB_BINARY := $(MEM_STRESSER)

--- a/tools/rkt-monitor.mk
+++ b/tools/rkt-monitor.mk
@@ -1,7 +1,7 @@
 $(call setup-stamp-file,RKT_MONITOR_STAMP)
 
 # variables for makelib/build_go_bin.mk
-RKT_MONITOR := $(BINDIR)/rkt-monitor
+RKT_MONITOR := $(TARGET_BINDIR)/rkt-monitor
 BGB_STAMP := $(RKT_MONITOR_STAMP)
 BGB_PKG_IN_REPO := tests/rkt-monitor
 BGB_BINARY := $(RKT_MONITOR)

--- a/tools/sleeper.mk
+++ b/tools/sleeper.mk
@@ -1,7 +1,7 @@
 $(call setup-stamp-file,SLEEPER_STAMP)
 
 # variables for makelib/build_go_bin.mk
-SLEEPER := $(BINDIR)/sleeper
+SLEEPER := $(TARGET_BINDIR)/sleeper
 BGB_STAMP := $(SLEEPER_STAMP)
 BGB_PKG_IN_REPO := tests/rkt-monitor/sleeper
 BGB_BINARY := $(SLEEPER)


### PR DESCRIPTION
* Fix to build issue introduced with glide? (BINDIR -> TARGET_BINDIR)
* Fix to build issue with rkt v1.10
* New flag: output-dir, output CSV files will be placed there
* New flag: rkt-dir: directory with rkt binary
* New flag: stage1-path: which flavor use in tests
* CSV output filename now contains date, time and flavor
* Output file flag don't prevents printing result summary to stdout