### PR TITLE
build: Build system fixes

### DIFF
--- a/makelib/misc.mk
+++ b/makelib/misc.mk
@@ -187,12 +187,20 @@ $(strip \
 	$(call undefine-namespaces,_MISC_GFD))
 endef
 
+# Escapes all single quotes in $1 (by replacing all ' with '"'"')
+define sq_escape
+$(subst ','"'"',$1)
+endef
+#'
+
 # Returns 1 if both parameters are equal, otherwise returns empty
 # string.
 # Example: is_a_equal_to_b := $(if $(call equal,a,b),yes,no)
 define equal
 $(strip \
-        $(eval _MISC_EQ_TMP_ := $(shell expr '$1' = '$2')) \
+        $(eval _MISC_EQ_OP1_ := $(call sq_escape,$1)) \
+        $(eval _MISC_EQ_OP2_ := $(call sq_escape,$2)) \
+        $(eval _MISC_EQ_TMP_ := $(shell expr '$(_MISC_EQ_OP1_)' = '$(_MISC_EQ_OP2_)')) \
         $(filter $(_MISC_EQ_TMP_),1) \
         $(call undefine-namespaces,_MISC_EQ))
 endef

--- a/stage1/net-plugins/net-plugins.mk
+++ b/stage1/net-plugins/net-plugins.mk
@@ -41,7 +41,7 @@ BGB_BINARY := $$(NPM_PLUGIN)
 BGB_PKG_IN_REPO := vendor/github.com/containernetworking/cni/plugins/$1
 include makelib/build_go_bin.mk
 
-$$(NPM_PLUGIN): $(TARGET_TOOLSDIR)
+$$(NPM_PLUGIN): | $(TARGET_TOOLSDIR)
 
 $$(call generate-stamp-rule,$$(NPM_STAMP))
 


### PR DESCRIPTION
This should fix the `expr: syntax error` and useless rebuilds of network plugins.