### PR TITLE
functional test: check PATH variable for trailer `\n` character

### DIFF
--- a/tests/rkt_env_test.go
+++ b/tests/rkt_env_test.go
@@ -90,6 +90,12 @@ var envTests = []struct {
 		`/bin/sh -c "^RKT_BIN^ --debug --insecure-options=image run --mds-register=false --interactive --set-env-file=env_file_test.conf ^SLEEP^"`,
 		`/bin/sh -c "^RKT_BIN^ --debug enter $(^RKT_BIN^ list --full|grep running|awk '{print $1}') /inspect --print-env=VAR_OTHER"`,
 	},
+	{
+		`/bin/sh -c "^RKT_BIN^ --debug --insecure-options=image run --mds-register=false --set-env-file=env_file_test.conf ^CHECK_PATH^"`,
+		"PATH is good",
+		`/bin/sh -c "^RKT_BIN^ --debug --insecure-options=image run --mds-register=false --interactive --set-env-file=env_file_test.conf ^SLEEP^"`,
+		`/bin/sh -c "^RKT_BIN^ --debug enter $(^RKT_BIN^ list --full|grep running|awk '{print $1}') /inspect --check-path"`,
+	},
 }
 
 func TestEnv(t *testing.T) {
@@ -99,6 +105,8 @@ func TestEnv(t *testing.T) {
 	defer os.Remove(printVarOtherImage)
 	printTermHostImage := patchTestACI("rkt-inspect-print-term-host.aci", "--exec=/inspect --print-env=TERM")
 	defer os.Remove(printTermHostImage)
+	checkPathImage := patchTestACI("rkt-inspect-check-path.aci", "--exec=/inspect --check-path")
+	defer os.Remove(checkPathImage)
 	sleepImage := patchTestACI("rkt-inspect-sleep.aci", "--exec=/inspect --read-stdin")
 	defer os.Remove(sleepImage)
 	ctx := testutils.NewRktRunCtx()
@@ -111,6 +119,7 @@ func TestEnv(t *testing.T) {
 		fixed = strings.Replace(fixed, "^PRINT_VAR_FROM_MANIFEST^", printVarFromManifestImage, -1)
 		fixed = strings.Replace(fixed, "^PRINT_VAR_OTHER^", printVarOtherImage, -1)
 		fixed = strings.Replace(fixed, "^PRINT_TERM_HOST^", printTermHostImage, -1)
+		fixed = strings.Replace(fixed, "^CHECK_PATH^", checkPathImage, -1)
 		fixed = strings.Replace(fixed, "^SLEEP^", sleepImage, -1)
 		fixed = strings.Replace(fixed, "^HOST_TERM^", term, -1)
 		return fixed


### PR DESCRIPTION
This patch implements the test for https://github.com/coreos/rkt/pull/2901,
it tests that `$PATH` does not end with `\n\0` but with `\0`.

This fixes https://github.com/coreos/rkt/issues/2905
Related to https://github.com/coreos/rkt/issues/2893

This patch also introduces the `--check-path` flag in `inspect.go` to carry out the test.