### PR TITLE
scripts: add /etc/rkt owned by group rkt-admin in setup-data-dir.sh

### DIFF
--- a/dist/scripts/setup-data-dir.sh
+++ b/dist/scripts/setup-data-dir.sh
@@ -20,19 +20,21 @@ if [[ -z "${datadir}" ]]; then
     datadir="/var/lib/rkt"
 fi
 
-# Creates the directory with the given mode and rkt group
+# Creates the directory with the given mode and given group
 # 1 - directory to create if it does not exist
 # 2 - mode to set the directory to
-make_rkt_directory() {
+# 3 - group to set the directory ownership to
+make_directory() {
     local dir="${1}"
     local mode="${2}"
+    local group="${3}"
 
     if [[ -e "${dir}" ]]; then
         chmod "${mode}" "${dir}"
     else
         mkdir --mode="${mode}" "${dir}"
     fi
-    chgrp rkt "${dir}"
+    chgrp "${group}" "${dir}"
 }
 
 # Creates the file with the given mode and rkt group
@@ -49,27 +51,37 @@ create_rkt_file() {
     chgrp rkt "${file}"
 }
 
-make_rkt_directory "${datadir}" 2750
-make_rkt_directory "${datadir}/tmp" 2750
+getent group rkt-admin || groupadd --force --system rkt-admin
+getent group rkt || groupadd --force --system rkt
 
-make_rkt_directory "${datadir}/cas" 2770
-make_rkt_directory "${datadir}/cas/db" 2770
+if which systemd-tmpfiles; then
+    systemd-tmpfiles --create /usr/lib/tmpfiles.d/rkt.conf
+    exit
+fi
+
+make_directory "${datadir}" 2750 "rkt"
+make_directory "${datadir}/tmp" 2750 "rkt"
+
+make_directory "${datadir}/cas" 2770 "rkt"
+make_directory "${datadir}/cas/db" 2770 "rkt"
 create_rkt_file "${datadir}/cas/db/ql.db" 0660
 # the ql database uses a WAL file whose name is generated from the sha1 hash of
 # the database name
 create_rkt_file "${datadir}/cas/db/.34a8b4c1ad933745146fdbfef3073706ee571625" 0660
-make_rkt_directory "${datadir}/cas/imagelocks" 2770
-make_rkt_directory "${datadir}/cas/imageManifest" 2770
-make_rkt_directory "${datadir}/cas/blob" 2770
-make_rkt_directory "${datadir}/cas/tmp" 2770
-make_rkt_directory "${datadir}/cas/tree" 2700
-make_rkt_directory "${datadir}/cas/treestorelocks" 2700
-make_rkt_directory "${datadir}/locks" 2750
+make_directory "${datadir}/cas/imagelocks" 2770 "rkt"
+make_directory "${datadir}/cas/imageManifest" 2770 "rkt"
+make_directory "${datadir}/cas/blob" 2770 "rkt"
+make_directory "${datadir}/cas/tmp" 2770 "rkt"
+make_directory "${datadir}/cas/tree" 2700 "rkt"
+make_directory "${datadir}/cas/treestorelocks" 2700 "rkt"
+make_directory "${datadir}/locks" 2750 "rkt"
 
-make_rkt_directory "${datadir}/pods" 2750
-make_rkt_directory "${datadir}/pods/embryo" 2750
-make_rkt_directory "${datadir}/pods/prepare" 2750
-make_rkt_directory "${datadir}/pods/prepared" 2750
-make_rkt_directory "${datadir}/pods/run" 2750
-make_rkt_directory "${datadir}/pods/exited-garbage" 2750
-make_rkt_directory "${datadir}/pods/garbage" 2750
+make_directory "${datadir}/pods" 2750 "rkt"
+make_directory "${datadir}/pods/embryo" 2750 "rkt"
+make_directory "${datadir}/pods/prepare" 2750 "rkt"
+make_directory "${datadir}/pods/prepared" 2750 "rkt"
+make_directory "${datadir}/pods/run" 2750 "rkt"
+make_directory "${datadir}/pods/exited-garbage" 2750 "rkt"
+make_directory "${datadir}/pods/garbage" 2750 "rkt"
+
+make_directory "/etc/rkt" 2775 "rkt-admin"


### PR DESCRIPTION
Fixes the immediate problem with `scripts/setup-data-dir.sh` being out of sync with `init/systemd/tmpfiles.d/rkt.conf`(#2862).

This doesn't include the tips mentioned by @lucab in the issue. I'm working on it. Just wanted to take a first stab to fix the problem for now while I work on the rest of the points mentioned in #2862 to make the script better and avoid duplicating the directories.