### PR TITLE
fetcher: httpcaching fixes

### DIFF
--- a/rkt/image/fetcher.go
+++ b/rkt/image/fetcher.go
@@ -164,7 +164,7 @@ func (f *Fetcher) fetchSingleImageByURL(urlStr string, a *asc) (string, error) {
 }
 
 func (f *Fetcher) fetchSingleImageByHTTPURL(u *url.URL, a *asc) (string, error) {
-	rem, err := f.getRemoteForURL(u)
+	rem, err := remoteForURL(f.S, u)
 	if err != nil {
 		return "", err
 	}
@@ -178,7 +178,7 @@ func (f *Fetcher) fetchSingleImageByHTTPURL(u *url.URL, a *asc) (string, error) 
 }
 
 func (f *Fetcher) fetchSingleImageByDockerURL(u *url.URL) (string, error) {
-	rem, err := f.getRemoteForURL(u)
+	rem, err := remoteForURL(f.S, u)
 	if err != nil {
 		return "", err
 	}
@@ -189,19 +189,6 @@ func (f *Fetcher) fetchSingleImageByDockerURL(u *url.URL) (string, error) {
 		return h, err
 	}
 	return "", fmt.Errorf("unable to fetch docker image from URL %q: either image was not found in the store or store was disabled and fetching from remote yielded nothing or it was disabled", u.String())
-}
-
-func (f *Fetcher) getRemoteForURL(u *url.URL) (*imagestore.Remote, error) {
-	if f.NoCache {
-		return nil, nil
-	}
-	urlStr := u.String()
-	if rem, ok, err := f.S.GetRemote(urlStr); err != nil {
-		return nil, errwrap.Wrap(fmt.Errorf("failed to fetch URL %q", urlStr), err)
-	} else if ok {
-		return rem, nil
-	}
-	return nil, nil
 }
 
 func (f *Fetcher) maybeCheckRemoteFromStore(rem *imagestore.Remote) string {
@@ -333,6 +320,7 @@ func (f *Fetcher) maybeFetchImageFromRemote(app *appBundle, a *asc) (string, err
 			InsecureFlags:      f.InsecureFlags,
 			S:                  f.S,
 			Ks:                 f.Ks,
+			NoCache:            f.NoCache,
 			Debug:              f.Debug,
 			Headers:            f.Headers,
 			TrustKeysFromHTTPS: f.TrustKeysFromHTTPS,

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -217,6 +217,59 @@ func testFetchNoStore(t *testing.T, args string, image string, imageArgs string,
 	}
 }
 
+func TestFetchNoStoreCacheControl(t *testing.T) {
+	imageName := "rkt-inspect-fetch-nostore-cachecontrol"
+	imageFileName := fmt.Sprintf("%s.aci", imageName)
+	// no spaces between words, because of an actool limitation
+	successMsg := "deferredSignatureDownloadWasSuccessful"
+
+	args := []string{
+		fmt.Sprintf("--exec=/inspect --print-msg='%s'", successMsg),
+		fmt.Sprintf("--name=%s", imageName),
+	}
+	image := patchTestACI(imageFileName, args...)
+	defer os.Remove(image)
+
+	asc := runSignImage(t, image, 1)
+	defer os.Remove(asc)
+	ascBase := filepath.Base(asc)
+
+	setup := taas.GetDefaultServerSetup()
+	setup.Server = taas.ServerQuay
+	server := runServer(t, setup)
+	defer server.Close()
+	fileSet := make(map[string]string, 2)
+	fileSet[imageFileName] = image
+	fileSet[ascBase] = asc
+	if err := server.UpdateFileSet(fileSet); err != nil {
+		t.Fatalf("Failed to populate a file list in test aci server: %v", err)
+	}
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	runRktTrust(t, ctx, "", 1)
+
+	tests := []struct {
+		imageArg string
+		imageURL string
+	}{
+		{"https://127.0.0.1/" + imageFileName, "https://127.0.0.1/" + imageFileName},
+	}
+
+	for _, tt := range tests {
+		cmd := fmt.Sprintf("%s --no-store --debug --insecure-options=tls,image fetch %s", ctx.Cmd(), tt.imageArg)
+		expectedMessage := fmt.Sprintf("fetching image from %s", tt.imageURL)
+		runRktAndCheckRegexOutput(t, cmd, expectedMessage)
+
+		cmd = fmt.Sprintf("%s --no-store --debug --insecure-options=tls,image fetch %s", ctx.Cmd(), tt.imageArg)
+		expectedMessage = fmt.Sprintf("image for %s isn't expired, not fetching.", tt.imageURL)
+		runRktAndCheckRegexOutput(t, cmd, expectedMessage)
+
+		ctx.Reset()
+	}
+}
+
 type synchronizedBool struct {
 	value bool
 	lock  sync.Mutex

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -255,6 +255,7 @@ func TestFetchNoStoreCacheControl(t *testing.T) {
 		imageURL string
 	}{
 		{"https://127.0.0.1/" + imageFileName, "https://127.0.0.1/" + imageFileName},
+		{"localhost/" + imageName, "https://127.0.0.1:443/localhost/" + imageFileName},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The fetchers refactor in #1763 changed some logic in handling http Cache-Control max-age. The two commits fixes some issues for httpfetcher and namefetcher and adds related functional tests.

As you can see there's a lot of duplicated code between namefetcher and httpfetcher since namefetcher once discovered the ACI URL needs to fetch them via http (at the moment the unique supported transport). The proposals in #2953 and #2964 will avoid this code duplication. 

The namefetcher commit will probably fix the problem reported in https://github.com/coreos/rkt/issues/2276#issuecomment-232428086

/cc @dgonyeo It might interest you