### PR TITLE
store: tell the user to run as root on db update

### DIFF
--- a/store/imagestore/store.go
+++ b/store/imagestore/store.go
@@ -66,7 +66,8 @@ var diskvStores = [...]string{
 }
 
 var (
-	ErrKeyNotFound = errors.New("no image IDs found")
+	ErrKeyNotFound       = errors.New("no image IDs found")
+	ErrDBUpdateNeedsRoot = errors.New("database schema needs to be updated, re-run as root to perform the update")
 )
 
 // ACINotFoundError is returned when an ACI cannot be found by GetACI
@@ -278,6 +279,9 @@ func (s *Store) Close() error {
 
 // backupDB backs up current database.
 func (s *Store) backupDB() error {
+	if os.Geteuid() != 0 {
+		return ErrDBUpdateNeedsRoot
+	}
 	backupsDir := filepath.Join(s.dir, "db-backups")
 	return backup.CreateBackup(s.dbDir(), backupsDir, backupsNumber)
 }


### PR DESCRIPTION
If the CAS database is updated and the user runs a command that opens
the store as non-root, the DB backup will fail because it requires
privileges to copy the old DB.

Moreover, this leads to a state where manual intervention is required:

```
$ sudo rkt image list
list: cannot open store: mkdir /var/lib/rkt/cas/db-backups/tmp: file
exists
```

To avoid these issues, let's give a friendly error message asking the
user to run the command as root.