### PR TITLE
rkt/image_list: cosmetic changes

### DIFF
--- a/rkt/flag/optionlist.go
+++ b/rkt/flag/optionlist.go
@@ -75,6 +75,34 @@ func (ol *OptionList) Set(s string) error {
 	return nil
 }
 
+func (ol *OptionList) Contains(s string) bool {
+	for _, o := range ol.Options {
+		if o == s {
+			return true
+		}
+	}
+	return false
+}
+
+func (ol *OptionList) Add(s string) {
+	if ol.Contains(s) {
+		return
+	}
+	ol.Options = append(ol.Options, s)
+}
+
+func (ol *OptionList) Remove(s string) error {
+	if !ol.Contains(s) {
+		return fmt.Errorf("option %q not found", s)
+	}
+	for i, o := range ol.Options {
+		if o == s {
+			ol.Options = append(ol.Options[:i], ol.Options[i+1:]...)
+		}
+	}
+	return nil
+}
+
 func (ol *OptionList) String() string {
 	return strings.Join(ol.Options, ",")
 }

--- a/rkt/image/filefetcher.go
+++ b/rkt/image/filefetcher.go
@@ -60,7 +60,7 @@ func (f *fileFetcher) Hash(aciPath string, a *asc) (string, error) {
 	}
 
 	ascLocation := ""
-	if a != nil {
+	if a != nil && a.Location != "" {
 		ascLocation = "file://" + a.Location
 	}
 

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -623,13 +623,13 @@ func parseImageInfoOutput(t *testing.T, result string) *imageInfo {
 	if len(nameVersion) != 2 {
 		t.Fatalf("Failed to parse name version string: %q", fields[1])
 	}
-	importTime, err := time.Parse(defaultTimeLayout, fields[6])
+	importTime, err := time.Parse(defaultTimeLayout, fields[4])
 	if err != nil {
-		t.Fatalf("Failed to parse time string: %q", fields[6])
+		t.Fatalf("Failed to parse time string: %q", fields[4])
 	}
-	size, err := strconv.Atoi(fields[5])
+	size, err := strconv.Atoi(fields[3])
 	if err != nil {
-		t.Fatalf("Failed to parse image size string: %q", fields[5])
+		t.Fatalf("Failed to parse image size string: %q", fields[3])
 	}
 
 	return &imageInfo{


### PR DESCRIPTION
They will be shown if the user passes the option `--full` or if they're
explicitly selected with `--fields`.

Also, fix a bug where images fetched from a file without signature had `file://` on their signature URL.