### PR TITLE
store: refactor GetRemote

### DIFF
--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -230,7 +230,7 @@ func TestDownloading(t *testing.T) {
 		denyAuthTS.URL: "deny auth",
 	}
 	tests := []struct {
-		ACIURL       string
+		aciURL       string
 		remoteExists bool
 		options      http.Header
 		authFail     bool
@@ -259,7 +259,7 @@ func TestDownloading(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		_, err := s.GetRemote(tt.ACIURL)
+		_, err := s.GetRemote(tt.aciURL)
 		if err != nil {
 			if err != imagestore.ErrRemoteNotFound {
 				t.Fatalf("unexpected err: %v", err)
@@ -272,9 +272,9 @@ func TestDownloading(t *testing.T) {
 			t.Fatalf("should've gotten a remote not found error")
 		}
 
-		parsed, err := url.Parse(tt.ACIURL)
+		parsed, err := url.Parse(tt.aciURL)
 		if err != nil {
-			panic(fmt.Sprintf("Invalid url from test server: %s", tt.ACIURL))
+			panic(fmt.Sprintf("Invalid url from test server: %s", tt.aciURL))
 		}
 		headers := map[string]config.Headerer{
 			parsed.Host: &testHeaderer{tt.options},
@@ -284,12 +284,12 @@ func TestDownloading(t *testing.T) {
 			Headers:       headers,
 			InsecureFlags: insecureFlags,
 		}
-		_, err = ft.FetchImage(tt.ACIURL, "", apps.AppImageURL)
+		_, err = ft.FetchImage(tt.aciURL, "", apps.AppImageURL)
 		if err != nil && !tt.authFail {
-			t.Fatalf("expected download to succeed, it failed: %v (server: %q, headers: `%v`)", err, urlToName[tt.ACIURL], tt.options)
+			t.Fatalf("expected download to succeed, it failed: %v (server: %q, headers: `%v`)", err, urlToName[tt.aciURL], tt.options)
 		}
 		if err == nil && tt.authFail {
-			t.Fatalf("expected download to fail, it succeeded (server: %q, headers: `%v`)", urlToName[tt.ACIURL], tt.options)
+			t.Fatalf("expected download to fail, it succeeded (server: %q, headers: `%v`)", urlToName[tt.aciURL], tt.options)
 		}
 	}
 

--- a/rkt/image/common.go
+++ b/rkt/image/common.go
@@ -223,10 +223,14 @@ func maybeUseCached(rem *imagestore.Remote, cd *cacheData) string {
 
 func remoteForURL(s *imagestore.Store, u *url.URL) (*imagestore.Remote, error) {
 	urlStr := u.String()
-	if rem, ok, err := s.GetRemote(urlStr); err != nil {
+	rem, err := s.GetRemote(urlStr)
+	if err != nil {
+		if err == imagestore.ErrRemoteNotFound {
+			return nil, nil
+		}
+
 		return nil, errwrap.Wrap(fmt.Errorf("failed to fetch remote for URL %q", urlStr), err)
-	} else if ok {
-		return rem, nil
 	}
-	return nil, nil
+
+	return rem, nil
 }

--- a/store/imagestore/remote_test.go
+++ b/store/imagestore/remote_test.go
@@ -42,25 +42,24 @@ func TestNewRemote(t *testing.T) {
 	s.WriteRemote(na)
 
 	// Get a new remote w the same parameters, reading from table should be fine
-	nb, ok, err := s.GetRemote(u1)
+	nb, err := s.GetRemote(u1)
 	if err != nil {
 		t.Fatalf("unexpected error reading index: %v", err)
 	}
-	if !ok {
-		t.Fatalf("unexpected index not found")
-	}
+
 	if nb.BlobKey != data {
 		t.Fatalf("bad data returned from store: got %v, want %v", nb.BlobKey, data)
 	}
 
 	// Get a remote with a different URI
-	nc, ok, err := s.GetRemote(u2)
+	nc, err := s.GetRemote(u2)
 	// Should get an error, since the URI shouldn't be present in the table
-	if ok {
-		t.Fatalf("unexpected index found")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
 	}
+
 	// Remote shouldn't be populated
-	if nc.BlobKey != "" {
-		t.Errorf("unexpected blob: got %v", nc.BlobKey)
+	if nc != nil {
+		t.Errorf("unexpected remote: got %v", nc)
 	}
 }

--- a/store/imagestore/store.go
+++ b/store/imagestore/store.go
@@ -549,17 +549,23 @@ func (s *Store) RemoveACI(key string) error {
 	return nil
 }
 
-// GetRemote tries to retrieve a remote with the given ACIURL. found will be
-// false if remote doesn't exist.
-func (s *Store) GetRemote(aciURL string) (*Remote, bool, error) {
+// GetRemote tries to retrieve a remote with the given ACIURL.
+// If remote doesn't exist, it returns ErrRemoteNotFound error.
+func (s *Store) GetRemote(aciURL string) (*Remote, error) {
 	var remote *Remote
-	found := false
+
 	err := s.db.Do(func(tx *sql.Tx) error {
 		var err error
-		remote, found, err = GetRemote(tx, aciURL)
+
+		remote, err = GetRemote(tx, aciURL)
+
 		return err
 	})
-	return remote, found, err
+	if err != nil {
+		return nil, err
+	}
+
+	return remote, nil
 }
 
 // WriteRemote adds or updates the provided Remote.

--- a/store/imagestore/store_test.go
+++ b/store/imagestore/store_test.go
@@ -386,12 +386,9 @@ func TestRemoveACI(t *testing.T) {
 	}
 
 	// Verify that no remote for the specified key exists
-	_, found, err := s.GetRemote(aciURL)
-	if err != nil {
+	_, err = s.GetRemote(aciURL)
+	if err != ErrRemoteNotFound {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if found {
-		t.Fatalf("expected to find no remote, but a remote was found")
 	}
 
 	// Try to remove a non-existent key
@@ -437,5 +434,4 @@ func TestRemoveACI(t *testing.T) {
 	if _, ok := err.(*StoreRemovalError); !ok {
 		t.Fatalf("expected StoreRemovalError got: %v", err)
 	}
-
 }


### PR DESCRIPTION
Removes the 2nd argument signalling whether the remote is found or not
and returns a distinct error instead.

cc @lucab @sgotti 