### PR TITLE
stage1/init: fix writing of /etc/machine-id

### DIFF
--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -361,7 +361,8 @@ func getArgsEnv(p *stage1commontypes.Pod, flavor string, debug bool, n *networki
 		return nil, nil, fmt.Errorf("unrecognized stage1 flavor: %q", flavor)
 	}
 
-	if err := ioutil.WriteFile(mPath, []byte(machineID), 0644); err != nil {
+	machineIDBytes := append([]byte(machineID), '\n')
+	if err := ioutil.WriteFile(mPath, machineIDBytes, 0644); err != nil {
 		log.FatalE("error writing /etc/machine-id", err)
 	}
 


### PR DESCRIPTION
According to machine-id(5):

  machine ID is a single newline-terminated, hexadecimal, 32-character,
  lowercase machine ID string.

Let's finish the file with a new line. Otherwise, systemd ~v231 will
fail.