### PR TITLE
functional tests: set cpu isolator correctly

### DIFF
--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -729,7 +729,7 @@ func TestPodManifest(t *testing.T) {
 							Isolators: []types.Isolator{
 								mustNewIsolator(`{
 									"name":     "resource/cpu",
-									"value":    { "request": "100", "limit": "100"}
+									"value":    { "request": "100m", "limit": "100m"}
 								}`),
 								mustNewIsolator(`{
 									"name":     "os/linux/capabilities-retain-set",


### PR DESCRIPTION
The ACE spec defines limit as:

*limit*: cores that can be consumed before the kernel temporarily throttles
the process

and core as:

*core*: seconds/second that the app/pod will be able to run. e.g. 1 (or
1000m for 1000 milli-seconds) would represent full use of a single CPU
core every second.

So setting 100 would mean 100 seconds/second which doesn't make sense.

Somehow this wasn't failing until now but testing the flavor src with
the (yet to be released) systemd v231 makes it fail.