### PR TITLE
fly: copy rkt-resolv.conf in the app

### DIFF
--- a/tests/rkt_dns_test.go
+++ b/tests/rkt_dns_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build host coreos src
+// +build host coreos src fly
 
 package main
 


### PR DESCRIPTION
If the user specified the --dns option, a file named rkt-resolv.conf
will be created in /etc in the stage1 rootfs.

If this file is present, copy it in the app so the --dns option works
in rkt fly.

Fixes #2928 