### PR TITLE
rkt: implements --insecure-options={capabilities,paths,seccomp}

### DIFF
--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -68,6 +68,12 @@ Stage1 implementors have two options for doing so; only one must be implemented:
 
 * `--hostname=$HOSTNAME` configures the host name of the pod. If empty, it will be "rkt-$PODUUID".
 
+#### Arguments added in interface version 3
+
+* `--disable-capabilities-restriction` gives all capabilities to apps (overrides `retain-set` and `remove-set`)
+* `--disable-paths` disables inaccessible and read-only paths (such as `/proc/sysrq-trigger`)
+* `--disable-seccomp` disables seccomp (overrides `retain-set` and `remove-set`)
+
 ### rkt enter
 
 `coreos.com/rkt/stage1/enter`
@@ -120,7 +126,7 @@ In the bundled rkt stage 1, the entrypoint is sending SIGTERM signal to systemd-
 The stage1 command line interface is versioned using an annotation with the name `coreos.com/rkt/stage1/interface-version`.
 If the annotation is not present, rkt assumes the version is 1.
 
-The current version of the stage1 interface is 2.
+The current version of the stage1 interface is 3.
 
 ## Examples
 

--- a/rkt/flag/secflags.go
+++ b/rkt/flag/secflags.go
@@ -25,9 +25,10 @@ const (
 	insecurePubKey
 	insecureCapabilities
 	insecurePaths
+	insecureSeccomp
 
 	insecureAllFetch = (insecureImage | insecureTLS | insecureHTTP | insecurePubKey)
-	insecureAllRun   = (insecureOnDisk | insecureCapabilities | insecurePaths)
+	insecureAllRun   = (insecureOnDisk | insecureCapabilities | insecurePaths | insecureSeccomp)
 	insecureAll      = (insecureAllFetch | insecureAllRun)
 )
 
@@ -41,6 +42,7 @@ var (
 		"pubkey",
 		"capabilities",
 		"paths",
+		"seccomp",
 		"all-fetch",
 		"all-run",
 		"all",
@@ -55,9 +57,10 @@ var (
 		insecureOptions[5]:  insecurePubKey,
 		insecureOptions[6]:  insecureCapabilities,
 		insecureOptions[7]:  insecurePaths,
-		insecureOptions[8]:  insecureAllFetch,
-		insecureOptions[9]:  insecureAllRun,
-		insecureOptions[10]: insecureAll,
+		insecureOptions[8]:  insecureSeccomp,
+		insecureOptions[9]:  insecureAllFetch,
+		insecureOptions[10]: insecureAllRun,
+		insecureOptions[11]: insecureAll,
 	}
 )
 
@@ -111,6 +114,10 @@ func (sf *SecFlags) SkipCapabilities() bool {
 
 func (sf *SecFlags) SkipPaths() bool {
 	return sf.hasFlag(insecurePaths)
+}
+
+func (sf *SecFlags) SkipSeccomp() bool {
+	return sf.hasFlag(insecureSeccomp)
 }
 
 func (sf *SecFlags) SkipAllSecurityChecks() bool {

--- a/rkt/flag/secflags.go
+++ b/rkt/flag/secflags.go
@@ -23,21 +23,41 @@ const (
 	insecureOnDisk
 	insecureHTTP
 	insecurePubKey
+	insecureCapabilities
+	insecurePaths
 
-	insecureAll = (insecureImage | insecureTLS | insecureOnDisk | insecureHTTP | insecurePubKey)
+	insecureAllFetch = (insecureImage | insecureTLS | insecureHTTP | insecurePubKey)
+	insecureAllRun   = (insecureOnDisk | insecureCapabilities | insecurePaths)
+	insecureAll      = (insecureAllFetch | insecureAllRun)
 )
 
 var (
-	insecureOptions = []string{"none", "image", "tls", "ondisk", "http", "pubkey", "all"}
+	insecureOptions = []string{
+		"none",
+		"image",
+		"tls",
+		"ondisk",
+		"http",
+		"pubkey",
+		"capabilities",
+		"paths",
+		"all-fetch",
+		"all-run",
+		"all",
+	}
 
 	insecureOptionsMap = map[string]int{
-		insecureOptions[0]: insecureNone,
-		insecureOptions[1]: insecureImage,
-		insecureOptions[2]: insecureTLS,
-		insecureOptions[3]: insecureOnDisk,
-		insecureOptions[4]: insecureHTTP,
-		insecureOptions[5]: insecurePubKey,
-		insecureOptions[6]: insecureAll,
+		insecureOptions[0]:  insecureNone,
+		insecureOptions[1]:  insecureImage,
+		insecureOptions[2]:  insecureTLS,
+		insecureOptions[3]:  insecureOnDisk,
+		insecureOptions[4]:  insecureHTTP,
+		insecureOptions[5]:  insecurePubKey,
+		insecureOptions[6]:  insecureCapabilities,
+		insecureOptions[7]:  insecurePaths,
+		insecureOptions[8]:  insecureAllFetch,
+		insecureOptions[9]:  insecureAllRun,
+		insecureOptions[10]: insecureAll,
 	}
 )
 
@@ -83,6 +103,14 @@ func (sf *SecFlags) AllowHTTP() bool {
 
 func (sf *SecFlags) ConsiderInsecurePubKeys() bool {
 	return sf.hasFlag(insecurePubKey)
+}
+
+func (sf *SecFlags) SkipCapabilities() bool {
+	return sf.hasFlag(insecureCapabilities)
+}
+
+func (sf *SecFlags) SkipPaths() bool {
+	return sf.hasFlag(insecurePaths)
 }
 
 func (sf *SecFlags) SkipAllSecurityChecks() bool {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -311,17 +311,19 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	rcfg := stage0.RunConfig{
-		CommonConfig: &cfg,
-		Net:          flagNet,
-		LockFd:       lfd,
-		Interactive:  flagInteractive,
-		DNS:          flagDNS,
-		DNSSearch:    flagDNSSearch,
-		DNSOpt:       flagDNSOpt,
-		MDSRegister:  flagMDSRegister,
-		LocalConfig:  globalFlags.LocalConfigDir,
-		RktGid:       rktgid,
-		Hostname:     flagHostname,
+		CommonConfig:         &cfg,
+		Net:                  flagNet,
+		LockFd:               lfd,
+		Interactive:          flagInteractive,
+		DNS:                  flagDNS,
+		DNSSearch:            flagDNSSearch,
+		DNSOpt:               flagDNSOpt,
+		MDSRegister:          flagMDSRegister,
+		LocalConfig:          globalFlags.LocalConfigDir,
+		RktGid:               rktgid,
+		Hostname:             flagHostname,
+		InsecureCapabilities: globalFlags.InsecureFlags.SkipCapabilities(),
+		InsecurePaths:        globalFlags.InsecureFlags.SkipPaths(),
 	}
 
 	apps, err := p.getApps()

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -324,6 +324,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		Hostname:             flagHostname,
 		InsecureCapabilities: globalFlags.InsecureFlags.SkipCapabilities(),
 		InsecurePaths:        globalFlags.InsecureFlags.SkipPaths(),
+		InsecureSeccomp:      globalFlags.InsecureFlags.SkipSeccomp(),
 	}
 
 	apps, err := p.getApps()

--- a/stage0/interface.go
+++ b/stage0/interface.go
@@ -59,3 +59,7 @@ func getStage1InterfaceVersion(cdir string) (int, error) {
 func interfaceVersionSupportsHostname(version int) bool {
 	return version > 1
 }
+
+func interfaceVersionSupportsInsecureOptions(version int) bool {
+	return version > 2
+}

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -74,17 +74,19 @@ type PrepareConfig struct {
 // configuration parameters needed by Run
 type RunConfig struct {
 	*CommonConfig
-	Net         common.NetList // pod should have its own network stack
-	LockFd      int            // lock file descriptor
-	Interactive bool           // whether the pod is interactive or not
-	MDSRegister bool           // whether to register with metadata service or not
-	Apps        schema.AppList // applications (prepare gets them via Apps)
-	LocalConfig string         // Path to local configuration
-	Hostname    string         // hostname of the pod
-	RktGid      int            // group id of the 'rkt' group, -1 if there's no rkt group.
-	DNS         []string       // DNS name servers to write in /etc/resolv.conf
-	DNSSearch   []string       // DNS search domains to write in /etc/resolv.conf
-	DNSOpt      []string       // DNS options to write in /etc/resolv.conf
+	Net                  common.NetList // pod should have its own network stack
+	LockFd               int            // lock file descriptor
+	Interactive          bool           // whether the pod is interactive or not
+	MDSRegister          bool           // whether to register with metadata service or not
+	Apps                 schema.AppList // applications (prepare gets them via Apps)
+	LocalConfig          string         // Path to local configuration
+	Hostname             string         // hostname of the pod
+	RktGid               int            // group id of the 'rkt' group, -1 if there's no rkt group.
+	DNS                  []string       // DNS name servers to write in /etc/resolv.conf
+	DNSSearch            []string       // DNS search domains to write in /etc/resolv.conf
+	DNSOpt               []string       // DNS options to write in /etc/resolv.conf
+	InsecureCapabilities bool           // Do not restrict capabilities
+	InsecurePaths        bool           // Do not restrict access to files in sysfs or procfs
 }
 
 // configuration shared by both Run and Prepare
@@ -569,6 +571,15 @@ func Run(cfg RunConfig, dir string, dataDir string) {
 			args = append(args, "--hostname="+cfg.Hostname)
 		} else {
 			log.Printf("warning: --hostname option is not supported by stage1")
+		}
+	}
+
+	if interfaceVersionSupportsInsecureOptions(s1v) {
+		if cfg.InsecureCapabilities {
+			args = append(args, "--disable-capabilities-restriction")
+		}
+		if cfg.InsecurePaths {
+			args = append(args, "--disable-paths")
 		}
 	}
 

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -87,6 +87,7 @@ type RunConfig struct {
 	DNSOpt               []string       // DNS options to write in /etc/resolv.conf
 	InsecureCapabilities bool           // Do not restrict capabilities
 	InsecurePaths        bool           // Do not restrict access to files in sysfs or procfs
+	InsecureSeccomp      bool           // Do not add seccomp restrictions
 }
 
 // configuration shared by both Run and Prepare
@@ -580,6 +581,9 @@ func Run(cfg RunConfig, dir string, dataDir string) {
 		}
 		if cfg.InsecurePaths {
 			args = append(args, "--disable-paths")
+		}
+		if cfg.InsecureSeccomp {
+			args = append(args, "--disable-seccomp")
 		}
 	}
 

--- a/stage1/aci/aci-manifest.in
+++ b/stage1/aci/aci-manifest.in
@@ -35,7 +35,7 @@
         },
         {
             "name": "coreos.com/rkt/stage1/interface-version",
-            "value": "2"
+            "value": "3"
         }
     ]
 }

--- a/stage1/init/common/pod_test.go
+++ b/stage1/init/common/pod_test.go
@@ -153,7 +153,8 @@ func TestAppToNspawnArgsOverridesImageManifestReadOnly(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 
 		p := &stage1commontypes.Pod{Manifest: podManifest, Root: tmpDir}
-		output, err := appToNspawnArgs(p, appManifest)
+		insecureOptions := Stage1InsecureOptions{}
+		output, err := appToNspawnArgs(p, appManifest, insecureOptions)
 		if err != nil {
 			t.Errorf("#%d: unexpected error: `%v`", i, err)
 		}

--- a/tests/rkt_paths_test.go
+++ b/tests/rkt_paths_test.go
@@ -1,0 +1,65 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build host coreos src
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+// TestPaths checks whether access to paths like /proc/sysrq-trigger are
+// restricted
+func TestPaths(t *testing.T) {
+	imageFile := patchTestACI("rkt-inspect-paths.aci",
+		"--exec=/inspect --write-file --print-msg=testing-insecure-option")
+	defer os.Remove(imageFile)
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	tests := []struct {
+		Path    string
+		Content string
+	}{
+		{
+			Path:    "/proc/sysrq-trigger",
+			Content: "h", // Print help message in dmesg: not dangerous
+		},
+	}
+
+	for _, tt := range tests {
+		// Without --insecure-options=paths
+		for _, insecureOption := range []string{"image", "image,ondisk,capabilities", "all-fetch"} {
+			cmd := fmt.Sprintf(`%s --debug --insecure-options=%s run --set-env=FILE=%s --set-env=CONTENT=%s %s`,
+				ctx.Cmd(), insecureOption, tt.Path, tt.Content, imageFile)
+			t.Logf("Attempting to write on %q with --insecure-options=%s (expecting error)\n", tt.Path, insecureOption)
+			expect := fmt.Sprintf("open %s: read-only file system", tt.Path)
+			runRktAndCheckOutput(t, cmd, expect, true)
+		}
+
+		// With --insecure-options=paths
+		for _, insecureOption := range []string{"image,paths", "image,paths,ondisk,capabilities", "image,all-run", "all"} {
+			cmd := fmt.Sprintf(`%s --debug --insecure-options=%s run --set-env=FILE=%s --set-env=CONTENT=%s %s`,
+				ctx.Cmd(), insecureOption, tt.Path, tt.Content, imageFile)
+			t.Logf("Attempting to write on %q with --insecure-options=%s (expecting success)\n", tt.Path, insecureOption)
+			runRktAndCheckOutput(t, cmd, "testing-insecure-option", false)
+		}
+	}
+}

--- a/tests/rkt_seccomp_test.go
+++ b/tests/rkt_seccomp_test.go
@@ -120,6 +120,27 @@ var seccompTestCases = []struct {
 		"exchange full",
 		true,
 	},
+	{
+		`insecure-options fake override: remove-set blacklist stat with custom error`,
+		[]string{baseApp, "--seccomp-mode=remove,errno=EMULTIHOP", "--seccomp-set=stat"},
+		[]string{"--insecure-options=image,ondisk,capabilities,paths"},
+		"multihop attempted",
+		true,
+	},
+	{
+		`insecure-options simple override: remove-set blacklist stat with custom error`,
+		[]string{baseApp, "--seccomp-mode=remove,errno=EMULTIHOP", "--seccomp-set=stat"},
+		[]string{"--insecure-options=image,seccomp"},
+		`/: mode: d`,
+		false,
+	},
+	{
+		`insecure-options complete override: remove-set blacklist stat with custom error`,
+		[]string{baseApp, "--seccomp-mode=remove,errno=EMULTIHOP", "--seccomp-set=stat"},
+		[]string{"--insecure-options=image,all-run"},
+		`/: mode: d`,
+		false,
+	},
 }
 
 func TestAppIsolatorSeccomp(t *testing.T) {


### PR DESCRIPTION
Add the following options: `--insecure-options={capabilities,paths,seccomp}`

* capabilities:
 * remove the `CapabilityBoundingSet` option from the .service file
 * call nspawn `--capability=all` so the pod will have all caps
* paths: skip options like `ReadOnlyDirectories` and InaccessibleDirectories
* seccomp: does not do anything. It will be up to @lucab's https://github.com/coreos/rkt/pull/2753 to do something with that

This also includes:
- all-fetch: for the fetch related insecure options
- all-run: for the run related insecure options
- all: for all insecure options

This is implemented using a new option `--disable-{paths,seccomp,capabilities}` in the stage1's run entrypoint.

This feature will be useful for:
- rkt in rkt https://github.com/coreos/rkt/issues/2158 (for getting access to /sys/fs/)
- allow changes on sysctl (e.g. with `--net=host`) https://github.com/coreos/rkt/issues/2694

Fixes https://github.com/coreos/rkt/issues/2962

-----

TODO:
- [x] tests
- [ ] check other flavors

/cc @lucab @iaguis @s-urbaniak @Quentin-M 