### PR TITLE
cli: Rename `cap-retain` and `cap-remove` to `caps-*`

### DIFF
--- a/Documentation/capabilities-guide.md
+++ b/Documentation/capabilities-guide.md
@@ -297,8 +297,8 @@ listening on [::]:80 ...
 
 Capabilities can be directly overridden at run time from the command-line,
 without changing the executed images.
-The `--cap-retain` option to `rkt run` manipulates the `retain` capabilities set.
-The `--cap-remove` option manipulates the `remove` set.
+The `--caps-retain` option to `rkt run` manipulates the `retain` capabilities set.
+The `--caps-remove` option manipulates the `remove` set.
 
 Capabilities specified from the command-line will replace all capability settings in the image manifest.
 Also as stated above the options `--cap-retain`, and `--cap-remove` are mutually exclusive.
@@ -308,7 +308,7 @@ Capabilities isolators can be added on the command line at run time by
 specifying the desired overriding set, as shown in this example:
 
 ```
-$ sudo rkt run --interactive quay.io/coreos/alpine-sh --cap-retain CAP_NET_BIND_SERVICE
+$ sudo rkt run --interactive quay.io/coreos/alpine-sh --caps-retain CAP_NET_BIND_SERVICE
 image: using image from file /usr/local/bin/stage1-coreos.aci
 image: using image from local store for image name quay.io/coreos/alpine-sh
 

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -344,8 +344,8 @@ For more details see the [hacking documentation](../hacking.md).
 
 | Flag | Default | Options | Description |
 | --- | --- | --- | --- |
-| `--cap-remove` | none | capability to remove (example: '--cap-remove=CAP\_SYS\_CHROOT,CAP\_MKNOD') | Capabilities to remove from the process's capabilities bounding set, all others from the default set will be included |
-| `--cap-retain` | none | capability to retain (example: '--cap-remove=CAP\_SYS\_ADMIN,CAP\_NET\_ADMIN') | Capabilities to retain in the process's capabilities bounding set, all others will be removed |
+| `--caps-remove` | none | capability to remove (example: '--caps-remove=CAP\_SYS\_CHROOT,CAP\_MKNOD') | Capabilities to remove from the process's capabilities bounding set, all others from the default set will be included |
+| `--caps-retain` | none | capability to retain (example: '--caps-remove=CAP\_SYS\_ADMIN,CAP\_NET\_ADMIN') | Capabilities to retain in the process's capabilities bounding set, all others will be removed |
 | `--cpu` | none | CPU units (ex. `--cpu=500m`) | CPU limit for the preceding image in [Kubernetes resource model](https://github.com/kubernetes/kubernetes/blob/release-1.2/docs/design/resources.md) format. |
 | `--dns` | none | IP Address | Name server to write in `/etc/resolv.conf`. It can be specified several times |
 | `--dns-opt` | none | DNS option  | DNS option from resolv.conf(5) to write in `/etc/resolv.conf`. It can be specified several times. |

--- a/rkt/cli_apps.go
+++ b/rkt/cli_apps.go
@@ -353,13 +353,13 @@ func (ag *appGroup) Type() string {
 	return "appGroup"
 }
 
-// appCapsRetain is for --caps-retain flags in the form of: --caps-retain=CAP_KILL,CAP_NET_ADMIN
+// appCapsRetain is for --cap-retain flags in the form of: --cap-retain=CAP_KILL,CAP_NET_ADMIN
 type appCapsRetain apps.Apps
 
 func (au *appCapsRetain) Set(s string) error {
 	app := (*apps.Apps)(au).Last()
 	if app == nil {
-		return fmt.Errorf("--caps-retain must follow an image")
+		return fmt.Errorf("--cap-retain must follow an image")
 	}
 	capsRetain, err := types.NewLinuxCapabilitiesRetainSet(strings.Split(s, ",")...)
 	if err != nil {
@@ -385,13 +385,13 @@ func (au *appCapsRetain) Type() string {
 	return "appCapsRetain"
 }
 
-// appCapsRemove is for --caps-remove flags in the form of: --caps-remove=CAP_MKNOD,CAP_SYS_CHROOT
+// appCapsRemove is for --cap-remove flags in the form of: --cap-remove=CAP_MKNOD,CAP_SYS_CHROOT
 type appCapsRemove apps.Apps
 
 func (au *appCapsRemove) Set(s string) error {
 	app := (*apps.Apps)(au).Last()
 	if app == nil {
-		return fmt.Errorf("--caps-retain must follow an image")
+		return fmt.Errorf("--cap-retain must follow an image")
 	}
 	capsRemove, err := types.NewLinuxCapabilitiesRevokeSet(strings.Split(s, ",")...)
 	if err != nil {

--- a/rkt/cli_apps.go
+++ b/rkt/cli_apps.go
@@ -353,13 +353,13 @@ func (ag *appGroup) Type() string {
 	return "appGroup"
 }
 
-// appCapsRetain is for --cap-retain flags in the form of: --cap-retain=CAP_KILL,CAP_NET_ADMIN
+// appCapsRetain is for --caps-retain flags in the form of: --caps-retain=CAP_KILL,CAP_NET_ADMIN
 type appCapsRetain apps.Apps
 
 func (au *appCapsRetain) Set(s string) error {
 	app := (*apps.Apps)(au).Last()
 	if app == nil {
-		return fmt.Errorf("--cap-retain must follow an image")
+		return fmt.Errorf("--caps-retain must follow an image")
 	}
 	capsRetain, err := types.NewLinuxCapabilitiesRetainSet(strings.Split(s, ",")...)
 	if err != nil {
@@ -385,13 +385,13 @@ func (au *appCapsRetain) Type() string {
 	return "appCapsRetain"
 }
 
-// appCapsRemove is for --cap-remove flags in the form of: --cap-remove=CAP_MKNOD,CAP_SYS_CHROOT
+// appCapsRemove is for --caps-remove flags in the form of: --caps-remove=CAP_MKNOD,CAP_SYS_CHROOT
 type appCapsRemove apps.Apps
 
 func (au *appCapsRemove) Set(s string) error {
 	app := (*apps.Apps)(au).Last()
 	if app == nil {
-		return fmt.Errorf("--cap-retain must follow an image")
+		return fmt.Errorf("--caps-retain must follow an image")
 	}
 	capsRemove, err := types.NewLinuxCapabilitiesRevokeSet(strings.Split(s, ",")...)
 	if err != nil {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -106,9 +106,15 @@ func init() {
 	cmdRun.Flags().Var((*appCPULimit)(&rktApps), "cpu", "cpu limit for the preceding image (example: '--cpu=500m')")
 	cmdRun.Flags().Var((*appUser)(&rktApps), "user", "user override for the preceding image (example: '--user=user')")
 	cmdRun.Flags().Var((*appGroup)(&rktApps), "group", "group override for the preceding image (example: '--group=group')")
-	cmdRun.Flags().Var((*appCapsRetain)(&rktApps), "cap-retain", "capability to retain (example: '--cap-retain=CAP_SYS_ADMIN')")
-	cmdRun.Flags().Var((*appCapsRemove)(&rktApps), "cap-remove", "capability to remove (example: '--cap-remove=CAP_MKNOD')")
+	cmdRun.Flags().Var((*appCapsRetain)(&rktApps), "caps-retain", "capability to retain (example: '--caps-retain=CAP_SYS_ADMIN')")
+	cmdRun.Flags().Var((*appCapsRemove)(&rktApps), "caps-remove", "capability to remove (example: '--caps-remove=CAP_MKNOD')")
 	cmdRun.Flags().Var((*appSeccompFilter)(&rktApps), "seccomp", "seccomp filter override (example: '--seccomp mode=retain,errno=EPERM,chmod,chown')")
+
+	// For backwards compatibility
+	cmdRun.Flags().Var((*appCapsRetain)(&rktApps), "cap-retain", "capability to retain (example: '--caps-retain=CAP_SYS_ADMIN')")
+	cmdRun.Flags().Var((*appCapsRemove)(&rktApps), "cap-remove", "capability to remove (example: '--caps-remove=CAP_MKNOD')")
+	cmdRun.Flags().MarkDeprecated("cap-retain", "use --caps-retain instead")
+	cmdRun.Flags().MarkDeprecated("cap-remove", "use --caps-remove instead")
 
 	flagPorts = portList{}
 	flagDNS = flagStringList{}

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -237,11 +237,11 @@ func generatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
 		}
 
 		if app.CapsRetain != nil && app.CapsRemove != nil {
-			return fmt.Errorf("error: cannot use both --cap-retain and --cap-remove on the same image")
+			return fmt.Errorf("error: cannot use both --caps-retain and --caps-remove on the same image")
 		}
 
 		// Delete existing caps isolators if the user wants to override
-		// them with either --cap-retain or --cap-remove
+		// them with either --caps-retain or --caps-remove
 		if app.CapsRetain != nil || app.CapsRemove != nil {
 			for i := len(ra.App.Isolators) - 1; i >= 0; i-- {
 				isolator := ra.App.Isolators[i]


### PR DESCRIPTION
The error messages are user visible and a bit confusing