### PR TITLE
pkg/tar/chroot: avoid errwrap in function called by multicall

### DIFF
--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -93,7 +93,7 @@ Tar:
 			}
 			err = extractFile(tr, target, hdr, overwrite, editor)
 			if err != nil {
-				return err
+				return fmt.Errorf("could not extract file %q in %q: %v", hdr.Name, target, err)
 			}
 			if hdr.Typeflag == tar.TypeDir {
 				dirhdrs = append(dirhdrs, hdr)
@@ -108,7 +108,7 @@ Tar:
 	for _, hdr := range dirhdrs {
 		p := filepath.Join(target, hdr.Name)
 		if err := syscall.UtimesNano(p, HdrToTimespec(hdr)); err != nil {
-			return err
+			return fmt.Errorf("UtimesNano failed on %q: %v", p, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
When a function is called by multicall, it is not possible to use errwrap
because the log pkg is not initialized yet. Also initialize the log pkg will
not show the correct indentation in the log because the new process will
start printing from the most left.

Fixes https://github.com/coreos/rkt/issues/2984