### PR TITLE
glide: bump docker2aci to v0.12.2

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: e3d37aa49d23e987f708f967f805d4cd176295dbe852b278f325fd9e03b476d7
-updated: 2016-07-25T11:28:59.622207002-07:00
+hash: 921b4843584237d360fb529fb07e2ba9e869968232e61db80e120c1fa4a15e8b
+updated: 2016-07-28T12:11:29.703586483+02:00
 imports:
 - name: github.com/appc/docker2aci
-  version: d77d6e4b99a0d8b6be6f70c623c86ba777110cbd
+  version: 90dfcf166a2967b926e77e4864fb616dc291c026
   subpackages:
   - lib
   - lib/common

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/StackExchange/wmi
   version: f3e2bae1e0cb5aef83e319133eabfee30013a4a5
 - package: github.com/appc/docker2aci
-  version: v0.12.1
+  version: v0.12.2
   subpackages:
   - lib
   - lib/common

--- a/vendor/github.com/appc/docker2aci/lib/internal/backend/repository/repository2.go
+++ b/vendor/github.com/appc/docker2aci/lib/internal/backend/repository/repository2.go
@@ -345,7 +345,7 @@ func (rb *RepositoryBackend) getManifestV21(dockerURL *types.ParsedDockerURL, re
 	layers := make([]string, len(manifest.FSLayers))
 
 	for i, layer := range manifest.FSLayers {
-		rb.reverseLayers[layer.BlobSum] = i
+		rb.reverseLayers[layer.BlobSum] = len(manifest.FSLayers) - 1 - i
 		layers[i] = layer.BlobSum
 	}
 

--- a/vendor/github.com/appc/docker2aci/lib/version.go
+++ b/vendor/github.com/appc/docker2aci/lib/version.go
@@ -16,5 +16,5 @@ package docker2aci
 
 import "github.com/appc/spec/schema"
 
-var Version = "0.12.1"
+var Version = "0.12.2"
 var AppcVersion = schema.AppContainerVersion


### PR DESCRIPTION
Fixes a bug where the converted Image Manifest had the wrong fields.