### PR TITLE
functional tests: skip test if remote fetch fails

### DIFF
--- a/tests/rkt_api_service_bench_test.go
+++ b/tests/rkt_api_service_bench_test.go
@@ -96,7 +96,10 @@ func fetchImages(ctx *testutils.RktRunCtx, numOfImages int) {
 	wg.Add(numOfImages)
 	for i := 0; i < numOfImages; i++ {
 		go func(i int) {
-			patchImportAndFetchHash(fmt.Sprintf("rkt-inspect-sleep-%d.aci", i), []string{"--exec=/inspect"}, t, ctx)
+			_, err := patchImportAndFetchHash(fmt.Sprintf("rkt-inspect-sleep-%d.aci", i), []string{"--exec=/inspect"}, t, ctx)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
 			wg.Done()
 		}(i)
 	}

--- a/tests/rkt_api_service_test.go
+++ b/tests/rkt_api_service_test.go
@@ -346,7 +346,10 @@ func NewAPIServiceListInspectPodsTest() testutils.Test {
 		}
 
 		patches := []string{"--exec=/inspect --print-msg=HELLO_API --exit-code=0"}
-		imageHash := patchImportAndFetchHash("rkt-inspect-print.aci", patches, t, ctx)
+		imageHash, err := patchImportAndFetchHash("rkt-inspect-print.aci", patches, t, ctx)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 		imgID, err := types.NewHash(imageHash)
 		if err != nil {
 			t.Fatalf("Cannot generate types.Hash from %v: %v", imageHash, err)
@@ -503,7 +506,10 @@ func TestAPIServiceListInspectImages(t *testing.T) {
 		t.Errorf("Unexpected result: %v, should see zero images", resp.Images)
 	}
 
-	patchImportAndFetchHash("rkt-inspect-sleep.aci", []string{"--exec=/inspect"}, t, ctx)
+	_, err = patchImportAndFetchHash("rkt-inspect-sleep.aci", []string{"--exec=/inspect"}, t, ctx)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 
 	// ListImages(detail=false).
 	resp, err = c.ListImages(context.Background(), &v1alpha.ListImagesRequest{})

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -136,7 +136,10 @@ func TestFetchFullHash(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		hash := importImageAndFetchHash(t, ctx, tt.fetchArgs, imagePath)
+		hash, err := importImageAndFetchHash(t, ctx, tt.fetchArgs, imagePath)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 		if len(hash) != tt.expectedHashLength {
 			t.Fatalf("expected hash length of %d, got %d", tt.expectedHashLength, len(hash))
 		}
@@ -187,7 +190,9 @@ func testFetchStoreOnly(t *testing.T, args string, image string, imageArgs strin
 	// 1. Run cmd with the image not available in the store should get $cannotFetchMsg.
 	runRktAndCheckRegexOutput(t, cmd, cannotFetchMsg)
 
-	importImageAndFetchHash(t, ctx, "", image)
+	if _, err := importImageAndFetchHash(t, ctx, "", image); err != nil {
+		t.Skip(fmt.Sprintf("%v, probably a network failure. Skipping...", err))
+	}
 
 	// 2. Run cmd with the image available in the store, should get $storeMsg.
 	runRktAndCheckRegexOutput(t, cmd, storeMsg)
@@ -200,7 +205,9 @@ func testFetchNoStore(t *testing.T, args string, image string, imageArgs string,
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	importImageAndFetchHash(t, ctx, "", image)
+	if _, err := importImageAndFetchHash(t, ctx, "", image); err != nil {
+		t.Skip(fmt.Sprintf("%v, probably a network failure. Skipping...", err))
+	}
 
 	cmd := fmt.Sprintf("%s --no-store %s %s %s", ctx.Cmd(), args, image, imageArgs)
 

--- a/tests/rkt_fly_test.go
+++ b/tests/rkt_fly_test.go
@@ -177,7 +177,10 @@ func TestFlyMountPodManifest(t *testing.T) {
 	for i, tt := range tests {
 		var hashesToRemove []string
 		for j, v := range tt.images {
-			hash := patchImportAndFetchHash(v.name, v.patches, t, ctx)
+			hash, err := patchImportAndFetchHash(v.name, v.patches, t, ctx)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
 			hashesToRemove = append(hashesToRemove, hash)
 			imgName := types.MustACIdentifier(v.name)
 			imgID, err := types.NewHash(hash)

--- a/tests/rkt_gc_test.go
+++ b/tests/rkt_gc_test.go
@@ -90,8 +90,10 @@ func TestGCAfterUnmount(t *testing.T) {
 	imagePath := getInspectImagePath()
 
 	for _, rmNetns := range []bool{false, true} {
-
-		importImageAndFetchHash(t, ctx, "", imagePath)
+		_, err := importImageAndFetchHash(t, ctx, "", imagePath)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 		cmd := fmt.Sprintf("%s --insecure-options=image prepare %s", ctx.Cmd(), imagePath)
 		uuid := runRktAndGetUUID(t, cmd)
 

--- a/tests/rkt_image_cat_manifest_test.go
+++ b/tests/rkt_image_cat_manifest_test.go
@@ -55,7 +55,10 @@ func TestImageCatManifest(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	testImageHash := importImageAndFetchHash(t, ctx, "", testImage)
+	testImageHash, err := importImageAndFetchHash(t, ctx, "", testImage)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 
 	tests := []struct {
 		image      string

--- a/tests/rkt_image_dependencies_test.go
+++ b/tests/rkt_image_dependencies_test.go
@@ -84,7 +84,9 @@ func generateComplexDependencyTree(t *testing.T, ctx *testutils.RktRunCtx) (map[
 	defer os.RemoveAll(tmpDir)
 
 	baseImage := getInspectImagePath()
-	_ = importImageAndFetchHash(t, ctx, "", baseImage)
+	if _, err := importImageAndFetchHash(t, ctx, "", baseImage); err != nil {
+		t.Fatalf("%v", err)
+	}
 	emptyImage := getEmptyImagePath()
 	fileSet := make(map[string]string)
 
@@ -188,7 +190,10 @@ func TestImageDependencies(t *testing.T) {
 		img := imageList[i]
 		if img.prefetch {
 			t.Logf("Importing image %q: %q", img.imageName, img.fileName)
-			testImageShortHash := importImageAndFetchHash(t, ctx, "", img.fileName)
+			testImageShortHash, err := importImageAndFetchHash(t, ctx, "", img.fileName)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
 			t.Logf("Imported image %q: %s", img.imageName, testImageShortHash)
 		}
 	}
@@ -238,7 +243,10 @@ func TestRenderOnFetch(t *testing.T) {
 		img := imageList[i]
 		if img.prefetch {
 			t.Logf("Importing image %q: %q", img.imageName, img.fileName)
-			testImageShortHash := importImageAndFetchHash(t, ctx, "", img.fileName)
+			testImageShortHash, err := importImageAndFetchHash(t, ctx, "", img.fileName)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
 			t.Logf("Imported image %q: %s", img.imageName, testImageShortHash)
 		}
 	}

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -57,7 +57,10 @@ func TestImageExport(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	testImageID := importImageAndFetchHash(t, ctx, "", testImage)
+	testImageID, err := importImageAndFetchHash(t, ctx, "", testImage)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 
 	testImageHash, err := getHash(testImage)
 	if err != nil {

--- a/tests/rkt_image_extract_test.go
+++ b/tests/rkt_image_extract_test.go
@@ -41,7 +41,10 @@ func TestImageExtract(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	testImageShortHash := importImageAndFetchHash(t, ctx, "", testImage)
+	testImageShortHash, err := importImageAndFetchHash(t, ctx, "", testImage)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 
 	tests := []struct {
 		image        string

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -63,8 +63,14 @@ func TestImageRender(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	_ = importImageAndFetchHash(t, ctx, "", baseImage)
-	testImageShortHash := importImageAndFetchHash(t, ctx, "", testImage)
+	_, err = importImageAndFetchHash(t, ctx, "", baseImage)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	testImageShortHash, err := importImageAndFetchHash(t, ctx, "", testImage)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 
 	tests := []struct {
 		image        string

--- a/tests/rkt_non_root_test.go
+++ b/tests/rkt_non_root_test.go
@@ -102,7 +102,10 @@ func TestNonRootFetchRmGCImage(t *testing.T) {
 
 	rootImg := patchTestACI("rkt-inspect-root-rm.aci", "--exec=/inspect --print-msg=foobar")
 	defer os.Remove(rootImg)
-	rootImgHash := importImageAndFetchHash(t, ctx, "", rootImg)
+	rootImgHash, err := importImageAndFetchHash(t, ctx, "", rootImg)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 
 	// Launch/gc a pod so we can test non-root image gc.
 	runCmd := fmt.Sprintf("%s --insecure-options=image run --mds-register=false %s", ctx.Cmd(), rootImg)
@@ -124,7 +127,10 @@ func TestNonRootFetchRmGCImage(t *testing.T) {
 	// Should be able to remove the image fetched by ourselves.
 	nonrootImg := patchTestACI("rkt-inspect-non-root-rm.aci", "--exec=/inspect")
 	defer os.Remove(nonrootImg)
-	nonrootImgHash := importImageAndFetchHashAsGid(t, ctx, nonrootImg, "", gid)
+	nonrootImgHash, err := importImageAndFetchHashAsGid(t, ctx, nonrootImg, "", gid)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 
 	imgRmCmd = fmt.Sprintf("%s image rm %s", ctx.Cmd(), nonrootImgHash)
 	t.Logf("Running %s", imgRmCmd)

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -154,7 +154,10 @@ func TestMissingOrInvalidOSArchFetchRun(t *testing.T) {
 	defer osArchTestRemoveImages(tests)
 
 	for i, tt := range tests {
-		imgHash := importImageAndFetchHash(t, ctx, "", tt.image)
+		imgHash, err := importImageAndFetchHash(t, ctx, "", tt.image)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 		rktCmd := fmt.Sprintf("%s run --mds-register=false %s", ctx.Cmd(), imgHash)
 		t.Logf("Running test #%v: %v", i, rktCmd)
 		runRktAndCheckOutput(t, rktCmd, tt.expectedLine, tt.expectError)

--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -1056,7 +1056,10 @@ func TestPodManifest(t *testing.T) {
 
 		var hashesToRemove []string
 		for j, v := range tt.images {
-			hash := patchImportAndFetchHash(v.name, v.patches, t, ctx)
+			hash, err := patchImportAndFetchHash(v.name, v.patches, t, ctx)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
 			hashesToRemove = append(hashesToRemove, hash)
 			imgName := types.MustACIdentifier(v.name)
 			imgID, err := types.NewHash(hash)

--- a/tests/rkt_stage1_loading_test.go
+++ b/tests/rkt_stage1_loading_test.go
@@ -400,7 +400,10 @@ func TestStage1LoadingFromFlagsHash(t *testing.T) {
 	setup := newStubStage1Setup(t, nil)
 	defer setup.cleanup()
 
-	stubHash := importImageAndFetchHash(setup.t, setup.ctx, "", setup.getLocation(stubStage1PathAbs))
+	stubHash, err := importImageAndFetchHash(setup.t, setup.ctx, "", setup.getLocation(stubStage1PathAbs))
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 	cmd := fmt.Sprintf("%s --insecure-options=image,tls --debug run --stage1-hash=%s %s", setup.ctx.Cmd(), stubHash, getInspectImagePath())
 	child := spawnOrFail(setup.t, cmd)
 	defer waitOrFail(setup.t, child, 0)

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -247,7 +247,10 @@ func TestDockerVolumeSemanticsPodManifest(t *testing.T) {
 	for i, tt := range volDockerTests {
 		t.Logf("Running test #%v on directory %s", i, tt.dir)
 
-		hash := patchImportAndFetchHash(fmt.Sprintf("rkt-volume-image-pm-%d.aci", i), []string{fmt.Sprintf("--mounts=mydir,path=%s,readOnly=false", tt.dir)}, t, ctx)
+		hash, err := patchImportAndFetchHash(fmt.Sprintf("rkt-volume-image-pm-%d.aci", i), []string{fmt.Sprintf("--mounts=mydir,path=%s,readOnly=false", tt.dir)}, t, ctx)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 
 		imgID, err := types.NewHash(hash)
 		if err != nil {


### PR DESCRIPTION
On eed65378a we started skipping tests that fail on remote fetch when
calling rkt run or prepare. However, we didn't do the same with the
fetching functions we run before those.

Modify those functions to return an error if the exit status is not 0
and skip the test when this happens.

On the other tests, we always fetch from local files so treat errors as
Failures.