### PR TITLE
common: introduce RemoveEmptyLines()

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -346,3 +346,17 @@ func FSSupportsOverlay(path string) bool {
 
 	return true
 }
+
+// RemoveEmptyLines removes empty lines from the given string
+// and breaks it up into a list of strings at newline characters
+func RemoveEmptyLines(str string) []string {
+	lines := make([]string, 0)
+
+	for _, v := range strings.Split(str, "\n") {
+		if len(v) > 0 {
+			lines = append(lines, v)
+		}
+	}
+
+	return lines
+}

--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -823,13 +823,7 @@ type LogsStreamWriter struct {
 }
 
 func (sw LogsStreamWriter) Write(b []byte) (int, error) {
-	// Remove empty lines
-	lines := make([]string, 0)
-	for _, v := range strings.Split(string(b), "\n") {
-		if len(v) > 0 {
-			lines = append(lines, v)
-		}
-	}
+	lines := common.RemoveEmptyLines(string(b))
 
 	if err := sw.server.Send(&v1alpha.GetLogsResponse{Lines: lines}); err != nil {
 		return 0, err

--- a/rkt/api_service_sdjournal.go
+++ b/rkt/api_service_sdjournal.go
@@ -21,12 +21,12 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/appc/spec/schema/types"
 	"github.com/coreos/go-systemd/sdjournal"
 	"github.com/coreos/rkt/api/v1alpha"
+	"github.com/coreos/rkt/common"
 )
 
 func (s *v1AlphaAPIServer) constrainedGetLogs(request *v1alpha.GetLogsRequest, server v1alpha.PublicAPI_GetLogsServer) error {
@@ -87,12 +87,6 @@ func (s *v1AlphaAPIServer) constrainedGetLogs(request *v1alpha.GetLogsRequest, s
 	if err != nil {
 		return err
 	}
-	// Remove empty lines
-	lines := make([]string, 0)
-	for _, v := range strings.Split(string(data), "\n") {
-		if len(v) > 0 {
-			lines = append(lines, v)
-		}
-	}
-	return server.Send(&v1alpha.GetLogsResponse{Lines: lines})
+
+	return server.Send(&v1alpha.GetLogsResponse{Lines: common.RemoveEmptyLines(string(data))})
 }


### PR DESCRIPTION
Couple of places uses the same functionality which removes empty lines from
a multiline string. This patch introduces RemoveEmptyLines() function to
achive this functionality in one place and get rid from code duplication.

Not sure that `common/common.go` is the best place for this although.