### PR TITLE
issue template: Add '\n' to the end of environment output

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 Replace this with the output of:
 
-`printf "$(rkt version)\n--\n$(uname -srm)\n--\n$(cat /etc/os-release)\n--\n$(systemctl --version)"`
+`printf "$(rkt version)\n--\n$(uname -srm)\n--\n$(cat /etc/os-release)\n--\n$(systemctl --version)\n"`
 
 **What did you do?**
 


### PR DESCRIPTION
Hello All,

It will be much convenient to copy output of the script
without touching of bash prompt at the last line of the
output.

Here is little example of last part of the script from the ` .github/ISSUE_TEMPLATE.md`

Before:

```
~/dev/rkt (master) $ printf "$(systemctl --version)"
systemd 229
+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN~/dev/rkt (master) $ 
```

After:

```
~/dev/rkt (master) $ printf "$(systemctl --version)\n"
systemd 229
+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN
~/dev/rkt (master) $ 
```
