### PR TITLE
trust: provide InsecureSkipTLSCheck to pubkey manager

### DIFF
--- a/rkt/trust.go
+++ b/rkt/trust.go
@@ -91,10 +91,11 @@ Otherwise, trust at the root domain (not recommended) must be explicitly request
 
 	pkls := args
 	m := &pubkey.Manager{
-		InsecureAllowHTTP:  flagAllowHTTP,
-		TrustKeysFromHTTPS: globalFlags.TrustKeysFromHTTPS,
-		Ks:                 ks,
-		Debug:              globalFlags.Debug,
+		InsecureAllowHTTP:    flagAllowHTTP,
+		InsecureSkipTLSCheck: globalFlags.InsecureFlags.SkipTLSCheck(),
+		TrustKeysFromHTTPS:   globalFlags.TrustKeysFromHTTPS,
+		Ks:                   ks,
+		Debug:                globalFlags.Debug,
 	}
 	if len(pkls) == 0 {
 		pkls, err = m.GetPubKeyLocations(flagPrefix)


### PR DESCRIPTION
We should be able to pass --insecure-options=tls option to the `rkt trust`
command. But now we can't because we test insecure tls value not from
global options but from already initialized public key manager in the
metaDiscoverPubKeyLocations():

if m.InsecureSkipTLSCheck {
        insecure = insecure | discovery.InsecureTLS
}

This patch adds InsecureSkipTLSCheck to the initialization of a public
key manager structure during `rkt trust` command execution. So, the
value of the `--insecure-option=tls` will be matched and used as we
suppose.