### PR TITLE
store/*: remove insecureoptions, and aci and sig urls

### DIFF
--- a/rkt/image/dockerfetcher.go
+++ b/rkt/image/dockerfetcher.go
@@ -76,8 +76,7 @@ func (f *dockerFetcher) fetchImageFrom(u *url.URL, latest bool) (string, error) 
 	defer aciFile.Close()
 
 	key, err := f.S.WriteACI(aciFile, imagestore.ACIFetchInfo{
-		Latest:          latest,
-		InsecureOptions: int64(f.InsecureFlags.Value()),
+		Latest: latest,
 	})
 	if err != nil {
 		return "", err

--- a/rkt/image/filefetcher.go
+++ b/rkt/image/filefetcher.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/coreos/rkt/pkg/keystore"
 	rktflag "github.com/coreos/rkt/rkt/flag"
@@ -52,22 +51,8 @@ func (f *fileFetcher) Hash(aciPath string, a *asc) (string, error) {
 	defer aciFile.Close()
 
 	key, err := f.S.WriteACI(aciFile, imagestore.ACIFetchInfo{
-		Latest:          false,
-		InsecureOptions: int64(f.InsecureFlags.Value()),
+		Latest: false,
 	})
-	if err != nil {
-		return "", err
-	}
-
-	ascLocation := ""
-	if a != nil {
-		ascLocation = "file://" + a.Location
-	}
-
-	newRem := imagestore.NewRemote("file://"+aciPath, ascLocation)
-	newRem.BlobKey = key
-	newRem.DownloadTime = time.Now()
-	err = f.S.WriteRemote(newRem)
 	if err != nil {
 		return "", err
 	}

--- a/rkt/image/httpfetcher.go
+++ b/rkt/image/httpfetcher.go
@@ -17,7 +17,6 @@ package image
 import (
 	"errors"
 	"io"
-
 	"net/url"
 	"time"
 
@@ -72,8 +71,7 @@ func (f *httpFetcher) Hash(u *url.URL, a *asc) (string, error) {
 		return key, nil
 	}
 	key, err := f.S.WriteACI(aciFile, imagestore.ACIFetchInfo{
-		Latest:          false,
-		InsecureOptions: int64(f.InsecureFlags.Value()),
+		Latest: false,
 	})
 	if err != nil {
 		return "", err

--- a/rkt/image/namefetcher.go
+++ b/rkt/image/namefetcher.go
@@ -130,8 +130,7 @@ func (f *nameFetcher) fetchImageFromSingleEndpoint(app *discovery.App, aciURL st
 		return key, nil
 	}
 	key, err := f.S.WriteACI(aciFile, imagestore.ACIFetchInfo{
-		Latest:          latest,
-		InsecureOptions: int64(f.InsecureFlags.Value()),
+		Latest: latest,
 	})
 	if err != nil {
 		return "", err

--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -32,15 +32,12 @@ import (
 const (
 	defaultTimeLayout = "2006-01-02 15:04:05.999 -0700 MST"
 
-	id              = "id"
-	name            = "name"
-	importTime      = "import time"
-	lastUsed        = "last used"
-	size            = "size"
-	latest          = "latest"
-	insecureOptions = "insecure options"
-	aciURL          = "ACI URL"
-	signatureURL    = "signature URL"
+	id         = "id"
+	name       = "name"
+	importTime = "import time"
+	lastUsed   = "last used"
+	size       = "size"
+	latest     = "latest"
 )
 
 // Convenience methods for formatting fields
@@ -54,29 +51,23 @@ func u(s string) string {
 var (
 	// map of valid fields and related header name
 	ImagesFieldHeaderMap = map[string]string{
-		l(id):              u(id),
-		l(name):            u(name),
-		l(importTime):      u(importTime),
-		l(lastUsed):        u(lastUsed),
-		l(latest):          u(latest),
-		l(size):            u(size),
-		l(insecureOptions): u(insecureOptions),
-		l(aciURL):          u(aciURL),
-		l(signatureURL):    u(signatureURL),
+		l(id):         u(id),
+		l(name):       u(name),
+		l(importTime): u(importTime),
+		l(lastUsed):   u(lastUsed),
+		l(latest):     u(latest),
+		l(size):       u(size),
 	}
 
 	// map of valid sort fields containing the mapping between the provided field name
 	// and the related aciinfo's field name.
 	ImagesFieldAciInfoMap = map[string]string{
-		l(id):              "blobkey",
-		l(name):            l(name),
-		l(importTime):      l(importTime),
-		l(lastUsed):        l(lastUsed),
-		l(latest):          l(latest),
-		l(size):            l(size),
-		l(insecureOptions): u(insecureOptions),
-		l(aciURL):          u(aciURL),
-		l(signatureURL):    u(signatureURL),
+		l(id):         "blobkey",
+		l(name):       l(name),
+		l(importTime): l(importTime),
+		l(lastUsed):   l(lastUsed),
+		l(latest):     l(latest),
+		l(size):       l(size),
 	}
 
 	ImagesSortableFields = map[string]struct{}{
@@ -127,7 +118,7 @@ var (
 func init() {
 	sortFields := []string{l(name), l(importTime), l(lastUsed), l(size)}
 
-	fields := []string{l(id), l(name), l(aciURL), l(signatureURL), l(insecureOptions), l(size), l(importTime), l(lastUsed)}
+	fields := []string{l(id), l(name), l(size), l(importTime), l(lastUsed)}
 
 	// Set defaults
 	var err error
@@ -245,37 +236,8 @@ func runImages(cmd *cobra.Command, args []string) int {
 				}
 			case l(latest):
 				fieldValue = fmt.Sprintf("%t", aciInfo.Latest)
-			case l(insecureOptions):
-				f, err := rktflag.NewSecFlagsFromValue(int(aciInfo.InsecureOptions))
-				if err != nil {
-					stderr.Error(err)
-					return 1
-				}
-
-				// remove ondisk, it's a runtime insecure option
-				sp := strings.Split(f.String(), ",")
-				for i, o := range sp {
-					if o == "ondisk" {
-						sp = append(sp[:i], sp[i+1:]...)
-					}
-				}
-
-				fieldValue = fmt.Sprintf("%s", strings.Join(sp, ","))
-			case l(aciURL):
-				if imageRemote := remoteMap[aciInfo.BlobKey]; imageRemote == nil {
-					fieldValue = ""
-				} else {
-					fieldValue = fmt.Sprintf("%s", imageRemote.ACIURL)
-				}
-			case l(signatureURL):
-				if imageRemote := remoteMap[aciInfo.BlobKey]; imageRemote == nil {
-					fieldValue = ""
-				} else {
-					fieldValue = fmt.Sprintf("%s", imageRemote.SigURL)
-				}
 			}
 			fieldValues = append(fieldValues, fieldValue)
-
 		}
 		fmt.Fprintf(tabOut, "%s\n", strings.Join(fieldValues, "\t"))
 	}

--- a/store/imagestore/aciinfo.go
+++ b/store/imagestore/aciinfo.go
@@ -26,9 +26,6 @@ type ACIFetchInfo struct {
 	// Latest defines if the ACI was imported using the latest pattern
 	// (no version label was provided on ACI discovery).
 	Latest bool
-
-	// InsecureOptions are the insecure options that was used when retrieving the ACI.
-	InsecureOptions int64
 }
 
 // ACIInfo is used to store information about an ACI.
@@ -49,8 +46,6 @@ type ACIInfo struct {
 	// Latest defines if the ACI was imported using the latest pattern (no
 	// version label was provided on ACI discovery)
 	Latest bool
-	// InsecureOptions are the insecure options that were used when retrieving the ACI.
-	InsecureOptions int64
 }
 
 func NewACIInfo(blobKey string, latest bool, t time.Time, size int64, treeStoreSize int64) *ACIInfo {
@@ -66,7 +61,7 @@ func NewACIInfo(blobKey string, latest bool, t time.Time, size int64, treeStoreS
 
 func aciinfoRowScan(rows *sql.Rows, aciinfo *ACIInfo) error {
 	// This ordering MUST match that in schema.go
-	return rows.Scan(&aciinfo.BlobKey, &aciinfo.Name, &aciinfo.ImportTime, &aciinfo.LastUsed, &aciinfo.Latest, &aciinfo.Size, &aciinfo.TreeStoreSize, &aciinfo.InsecureOptions)
+	return rows.Scan(&aciinfo.BlobKey, &aciinfo.Name, &aciinfo.ImportTime, &aciinfo.LastUsed, &aciinfo.Latest, &aciinfo.Size, &aciinfo.TreeStoreSize)
 }
 
 // GetAciInfosWithKeyPrefix returns all the ACIInfos with a blobkey starting with the given prefix.
@@ -173,7 +168,7 @@ func WriteACIInfo(tx *sql.Tx, aciinfo *ACIInfo) error {
 	if err != nil {
 		return err
 	}
-	_, err = tx.Exec("INSERT into aciinfo (blobkey, name, importtime, lastused, latest, size, treestoresize, insecureoptions) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)", aciinfo.BlobKey, aciinfo.Name, aciinfo.ImportTime, aciinfo.LastUsed, aciinfo.Latest, aciinfo.Size, aciinfo.TreeStoreSize, aciinfo.InsecureOptions)
+	_, err = tx.Exec("INSERT into aciinfo (blobkey, name, importtime, lastused, latest, size, treestoresize) VALUES ($1, $2, $3, $4, $5, $6, $7)", aciinfo.BlobKey, aciinfo.Name, aciinfo.ImportTime, aciinfo.LastUsed, aciinfo.Latest, aciinfo.Size, aciinfo.TreeStoreSize)
 	if err != nil {
 		return err
 	}

--- a/store/imagestore/schema.go
+++ b/store/imagestore/schema.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// Incremental db version at the current code revision.
-	dbVersion = 6
+	dbVersion = 7
 )
 
 // Statement to run when creating a db. These are the statements to create the
@@ -37,7 +37,7 @@ var dbCreateStmts = [...]string{
 	"CREATE UNIQUE INDEX IF NOT EXISTS aciurlidx ON remote (aciurl)",
 
 	// aciinfo table. The primary key is "blobkey" and it matches the key used to save that aci in the blob store
-	"CREATE TABLE IF NOT EXISTS aciinfo (blobkey string, name string, importtime time, lastused time, latest bool, size int64 DEFAULT 0, treestoresize int64 DEFAULT 0, insecureoptions int64 DEFAULT 0);",
+	"CREATE TABLE IF NOT EXISTS aciinfo (blobkey string, name string, importtime time, lastused time, latest bool, size int64 DEFAULT 0, treestoresize int64 DEFAULT 0);",
 	"CREATE UNIQUE INDEX IF NOT EXISTS blobkeyidx ON aciinfo (blobkey)",
 	"CREATE INDEX IF NOT EXISTS nameidx ON aciinfo (name)",
 }

--- a/store/imagestore/store.go
+++ b/store/imagestore/store.go
@@ -482,13 +482,12 @@ func (s *Store) WriteACI(r io.ReadSeeker, fetchInfo ACIFetchInfo) (string, error
 	// Save aciinfo
 	if err = s.db.Do(func(tx *sql.Tx) error {
 		aciinfo := &ACIInfo{
-			BlobKey:         key,
-			Name:            im.Name.String(),
-			ImportTime:      time.Now(),
-			LastUsed:        time.Now(),
-			Latest:          fetchInfo.Latest,
-			Size:            sz,
-			InsecureOptions: fetchInfo.InsecureOptions,
+			BlobKey:    key,
+			Name:       im.Name.String(),
+			ImportTime: time.Now(),
+			LastUsed:   time.Now(),
+			Latest:     fetchInfo.Latest,
+			Size:       sz,
 		}
 		return WriteACIInfo(tx, aciinfo)
 	}); err != nil {

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -627,13 +627,13 @@ func parseImageInfoOutput(t *testing.T, result string) *imageInfo {
 	if len(nameVersion) != 2 {
 		t.Fatalf("Failed to parse name version string: %q", fields[1])
 	}
-	importTime, err := time.Parse(defaultTimeLayout, fields[6])
+	importTime, err := time.Parse(defaultTimeLayout, fields[3])
 	if err != nil {
-		t.Fatalf("Failed to parse time string: %q", fields[6])
+		t.Fatalf("Failed to parse time string: %q", fields[3])
 	}
-	size, err := strconv.Atoi(fields[5])
+	size, err := strconv.Atoi(fields[2])
 	if err != nil {
-		t.Fatalf("Failed to parse image size string: %q", fields[5])
+		t.Fatalf("Failed to parse image size string: %q", fields[2])
 	}
 
 	return &imageInfo{


### PR DESCRIPTION
There're some design issues around these fields (see
https://github.com/coreos/rkt/issues/3012 for details) so let's remove
them for now.

Supersedes #3017 