### PR TITLE
glide: bump docker2aci to v0.12.3

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 6dd4eb2d90cb8ac317ad1aeb1a1cd0ed0d29375f4fecddaf5ae168eb62f6bc4b
-updated: 2016-08-01T11:52:19.106454487-07:00
+hash: d9834cb91d3632bb241bce57f16fba13fbdce46aee98c555774efcf73f94bb10
+updated: 2016-08-04T11:49:40.691485819+02:00
 imports:
 - name: github.com/appc/docker2aci
-  version: 90dfcf166a2967b926e77e4864fb616dc291c026
+  version: 15d68b33bfee95a448c4da37dbe876baa8fcb5b6
   subpackages:
   - lib
   - lib/common

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/StackExchange/wmi
   version: f3e2bae1e0cb5aef83e319133eabfee30013a4a5
 - package: github.com/appc/docker2aci
-  version: v0.12.2
+  version: v0.12.3
   subpackages:
   - lib
   - lib/common

--- a/vendor/github.com/appc/docker2aci/lib/internal/backend/repository/repository.go
+++ b/vendor/github.com/appc/docker2aci/lib/internal/backend/repository/repository.go
@@ -50,7 +50,7 @@ type RepositoryBackend struct {
 	imageManifests    map[types.ParsedDockerURL]v2Manifest
 	imageV2Manifests  map[types.ParsedDockerURL]*typesV2.ImageManifest
 	imageConfigs      map[types.ParsedDockerURL]*typesV2.ImageConfig
-	reverseLayers     map[string]int
+	layersIndex       map[string]int
 }
 
 func NewRepositoryBackend(username string, password string, insecure common.InsecureConfig) *RepositoryBackend {
@@ -63,7 +63,7 @@ func NewRepositoryBackend(username string, password string, insecure common.Inse
 		imageManifests:    make(map[types.ParsedDockerURL]v2Manifest),
 		imageV2Manifests:  make(map[types.ParsedDockerURL]*typesV2.ImageManifest),
 		imageConfigs:      make(map[types.ParsedDockerURL]*typesV2.ImageConfig),
-		reverseLayers:     make(map[string]int),
+		layersIndex:       make(map[string]int),
 	}
 }
 

--- a/vendor/github.com/appc/docker2aci/lib/version.go
+++ b/vendor/github.com/appc/docker2aci/lib/version.go
@@ -16,5 +16,5 @@ package docker2aci
 
 import "github.com/appc/spec/schema"
 
-var Version = "0.12.2"
+var Version = "0.12.3"
 var AppcVersion = schema.AppContainerVersion


### PR DESCRIPTION
Fixes bugs in layer ordering for Docker API v2.1 and v2.2.

Fixes #3025 
Fixes #3003 
Fixes #3018