### PR TITLE
Release 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+## 1.12.0
+
+This release introduces support for seccomp filtering via two new seccomp isolators. It also gives a boost to api-service performance by introducing manifest caching. Finally it fixes several regressions related to Docker images handling.
+
+#### New features and UX changes
+
+- cli: rename `--cap-retain` and `--cap-remove` to `--caps-*` ([#2994](https://github.com/coreos/rkt/pull/2994)).
+- stage1: apply seccomp isolators ([#2753](https://github.com/coreos/rkt/pull/2753)). This introduces support for appc seccomp isolators.
+- scripts: add /etc/rkt owned by group rkt-admin in setup-data-dir.sh ([#2944](https://github.com/coreos/rkt/pull/2944)).
+- rkt: add `--caps-retain` and `--caps-remove` to prepare ([#3007](https://github.com/coreos/rkt/pull/3007)).
+- store: allow users in the rkt group to delete images ([#2961](https://github.com/coreos/rkt/pull/2961)).
+- api_service: cache pod manifest ([#2891](https://github.com/coreos/rkt/pull/2891)). Manifest caching considerably improves api-service performances.
+- store: tell the user to run as root on db update ([#2966](https://github.com/coreos/rkt/pull/2966)).
+- stage1: disabling cgroup namespace in systemd-nspawn ([#2989](https://github.com/coreos/rkt/pull/2989)). For more information see [systemd#3589](https://github.com/systemd/systemd/pull/3589).
+- fly: copy rkt-resolv.conf in the app ([#2982](https://github.com/coreos/rkt/pull/2982)).
+- store: decouple aci store and treestore implementations ([#2919](https://github.com/coreos/rkt/pull/2919)).
+- store: record ACI fetching information ([#2960](https://github.com/coreos/rkt/pull/2960)).
+
+#### Bug fixes
+- stage1/init: fix writing of /etc/machine-id ([#2977](https://github.com/coreos/rkt/pull/2977)).
+- rkt-monitor: multiple fixes ([#2927](https://github.com/coreos/rkt/pull/2927), [#2988](https://github.com/coreos/rkt/pull/2988)).
+- rkt: don't errwrap cli_apps errors ([#2958](https://github.com/coreos/rkt/pull/2958)).
+- pkg/tar/chroot: avoid errwrap in function called by multicall ([#2997](https://github.com/coreos/rkt/pull/2997)).
+- networking: apply CNI args to the default networks as well ([#2985](https://github.com/coreos/rkt/pull/2985)).
+- trust: provide InsecureSkipTLSCheck to pubkey manager ([#3016](https://github.com/coreos/rkt/pull/3016)).
+- api_service: update grpc version ([#3015](https://github.com/coreos/rkt/pull/3015)).
+- fetcher: httpcaching fixes ([#2965](https://github.com/coreos/rkt/pull/2965)).
+
+#### Other changes
+- build,stage1/init: set interpBin at build time for src flavor ([#2978](https://github.com/coreos/rkt/pull/2978)).
+- common: introduce RemoveEmptyLines() ([#3004](https://github.com/coreos/rkt/pull/3004)).
+- glide: update docker2aci to v0.12.3 ([#3026](https://github.com/coreos/rkt/pull/3026)). This fixes multiple bugs in layers ordering for Docker images.
+- glide: update go-systemd to v11 ([#2970](https://github.com/coreos/rkt/pull/2970)). This fixes a buggy corner-case in journal seeking (implicit seek to head).
+- docs: document capabilities overriding ([#2917](https://github.com/coreos/rkt/pull/2917), [#2991](https://github.com/coreos/rkt/pull/2991)).
+- issue template: add '\n' to the end of environment output ([#3008](https://github.com/coreos/rkt/pull/3008)).
+- functional tests: multiple fixes ([#2999](https://github.com/coreos/rkt/pull/2999), [#2979](https://github.com/coreos/rkt/pull/2979), [#3014](https://github.com/coreos/rkt/pull/3014)).
+
 ## 1.11.0
 
 This release sets the ground for the new upcoming KVM qemu flavor. It adds support for exporting a pod to an ACI including all modifications. The rkt API service now also supports systemd socket activation. Finally we have diagnostics back, helping users to find out why their app failed to execute.

--- a/Documentation/running-fly-stage1.md
+++ b/Documentation/running-fly-stage1.md
@@ -60,14 +60,14 @@ $ ./autogen.sh && ./configure --with-stage1-flavors=fly && make
 ```
 
 For more details about configure parameters, see the [configure script parameters documentation](build-configure.md).
-This will build the rkt binary and the stage1-fly.aci in `build-rkt-1.11.0+git/bin/`.
+This will build the rkt binary and the stage1-fly.aci in `build-rkt-1.12.0+git/bin/`.
 
 ### Selecting stage1 at runtime
 
 Here is a quick example of how to use a container with the official fly stage1:
 
 ```
-# rkt run --stage1-name=coreos.com/rkt/stage1-fly:1.11.0 coreos.com/etcd:v2.2.5
+# rkt run --stage1-name=coreos.com/rkt/stage1-fly:1.12.0 coreos.com/etcd:v2.2.5
 ```
 
 If the image is not in the store, `--stage1-name` will perform discovery and fetch the image.

--- a/Documentation/running-lkvm-stage1.md
+++ b/Documentation/running-lkvm-stage1.md
@@ -13,7 +13,7 @@ $ ./autogen.sh && ./configure --with-stage1-flavors=kvm && make
 ```
 
 For more details about configure parameters, see [configure script parameters documentation](build-configure.md).
-This will build the rkt binary and the LKVM stage1-kvm.aci in `build-rkt-1.11.0+git/bin/`.
+This will build the rkt binary and the LKVM stage1-kvm.aci in `build-rkt-1.12.0+git/bin/`.
 
 Provided you have hardware virtualization support and the [kernel KVM module](http://www.linux-kvm.org/page/Getting_the_kvm_kernel_modules) loaded (refer to your distribution for instructions), you can then run an image like you would normally do with rkt:
 
@@ -84,7 +84,7 @@ If you want to run software that requires hypervisor isolation along with truste
 For example, to use the official lkvm stage1:
 
 ```
-# rkt run --stage1-name=coreos.com/rkt/stage1-kvm:1.11.0 coreos.com/etcd:v2.0.9
+# rkt run --stage1-name=coreos.com/rkt/stage1-kvm:1.12.0 coreos.com/etcd:v2.0.9
 ...
 ```
 

--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -14,7 +14,7 @@ Therefore, the supported arguments are mostly the same as in `run` except runtim
 ```
 # rkt prepare coreos.com/etcd:v2.0.10
 rkt prepare coreos.com/etcd:v2.0.10
-rkt: using image from local store for image name coreos.com/rkt/stage1-coreos:1.11.0
+rkt: using image from local store for image name coreos.com/rkt/stage1-coreos:1.12.0
 rkt: searching for app image coreos.com/etcd:v2.0.10
 rkt: remote fetching from url https://github.com/coreos/etcd/releases/download/v2.0.10/etcd-v2.0.10-linux-amd64.aci
 prefix: "coreos.com/etcd"

--- a/Documentation/subcommands/version.md
+++ b/Documentation/subcommands/version.md
@@ -6,7 +6,7 @@ This command prints the rkt version, the appc version rkt is built against, and 
 
 ```
 $ rkt version
-rkt Version: 1.11.0
+rkt Version: 1.12.0
 appc Version: 0.7.4
 Go Version: go1.5.3
 Go OS/Arch: linux/amd64

--- a/Documentation/trying-out-rkt.md
+++ b/Documentation/trying-out-rkt.md
@@ -20,9 +20,9 @@ rkt is written in Go and can be compiled for several CPU architectures. The rkt 
 To start running the latest version of rkt on amd64, grab the release directly from the rkt GitHub project:
 
 ```
-wget https://github.com/coreos/rkt/releases/download/v1.11.0/rkt-v1.11.0.tar.gz
-tar xzvf rkt-v1.11.0.tar.gz
-cd rkt-v1.11.0
+wget https://github.com/coreos/rkt/releases/download/v1.12.0/rkt-v1.12.0.tar.gz
+tar xzvf rkt-v1.12.0.tar.gz
+cd rkt-v1.12.0
 ./rkt help
 ```
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([rkt], [1.12.0], [https://github.com/coreos/rkt/issues])
+AC_INIT([rkt], [1.12.0+git], [https://github.com/coreos/rkt/issues])
 
 AC_PROG_CC
 AC_PROG_CXX

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([rkt], [1.11.0+git], [https://github.com/coreos/rkt/issues])
+AC_INIT([rkt], [1.12.0], [https://github.com/coreos/rkt/issues])
 
 AC_PROG_CC
 AC_PROG_CXX

--- a/scripts/install-rkt.sh
+++ b/scripts/install-rkt.sh
@@ -4,7 +4,7 @@ set -x
 
 cd $(mktemp -d)
 
-version="1.11.0"
+version="1.12.0"
 
 export DEBIAN_FRONTEND=noninteractive
 

--- a/tests/empty-image/manifest
+++ b/tests/empty-image/manifest
@@ -5,7 +5,7 @@
     "labels": [
         {
             "name": "version",
-            "value": "1.11.0"
+            "value": "1.12.0"
         },
         {
             "name": "arch",

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -5,7 +5,7 @@
     "labels": [
         {
             "name": "version",
-            "value": "1.11.0"
+            "value": "1.12.0"
         },
         {
             "name": "arch",

--- a/tests/rkt-monitor/build-stresser.sh
+++ b/tests/rkt-monitor/build-stresser.sh
@@ -28,7 +28,7 @@ trap acbuildEnd EXIT
 
 acbuild --debug set-name appc.io/rkt-"${1}"-stresser
 
-acbuild --debug copy build-rkt-1.11.0+git/target/bin/"${1}"-stresser /worker
+acbuild --debug copy build-rkt-1.12.0/target/bin/"${1}"-stresser /worker
 
 acbuild --debug set-exec -- /worker
 

--- a/tests/rkt-monitor/build-stresser.sh
+++ b/tests/rkt-monitor/build-stresser.sh
@@ -28,7 +28,7 @@ trap acbuildEnd EXIT
 
 acbuild --debug set-name appc.io/rkt-"${1}"-stresser
 
-acbuild --debug copy build-rkt-1.12.0/target/bin/"${1}"-stresser /worker
+acbuild --debug copy build-rkt-1.12.0+git/target/bin/"${1}"-stresser /worker
 
 acbuild --debug set-exec -- /worker
 

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.11.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
+	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.12.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
 )
 
 func TestRunOverrideExec(t *testing.T) {

--- a/tests/rkt_image_cat_manifest_test.go
+++ b/tests/rkt_image_cat_manifest_test.go
@@ -29,7 +29,7 @@ import (
 const (
 
 	// The expected image manifest of the 'rkt-inspect-image-cat-manifest.aci'.
-	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"IMG_NAME","labels":[{"name":"version","value":"1.11.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"IMG_NAME","labels":[{"name":"version","value":"1.12.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageCatManifest tests 'rkt image cat-manifest', it will:

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"IMG_NAME","labels":[{"name":"version","value":"1.11.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"IMG_NAME","labels":[{"name":"version","value":"1.12.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageExport tests 'rkt image export', it will import some existing

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"IMG_NAME","labels":[{"name":"version","value":"1.11.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"IMG_NAME","labels":[{"name":"version","value":"1.12.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageRender tests 'rkt image render', it will import some existing empty

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	manifestOSArchTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"IMG_NAME","labels":[{"name":"version","value":"1.11.0"}ARCH_OS],"app":{"exec":["/inspect", "--print-msg=HelloWorld"],"user":"0","group":"0","workingDirectory":"/"}}`
+	manifestOSArchTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"IMG_NAME","labels":[{"name":"version","value":"1.12.0"}ARCH_OS],"app":{"exec":["/inspect", "--print-msg=HelloWorld"],"user":"0","group":"0","workingDirectory":"/"}}`
 )
 
 type osArchTest struct {


### PR DESCRIPTION
## 1.12.0

This release introduces support for seccomp filtering via two new seccomp isolators. It also gives a boost to api-service performance by introducing manifest caching. Finally it fixes several regressions related to Docker images handling.

Closes #2981