### PR TITLE
export: name flag for exporting multi-app pods

### DIFF
--- a/tests/rkt_export_container_test.go
+++ b/tests/rkt_export_container_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestExport(t *testing.T) {
-	testCases := []ExportTestCase{noOverlaySimpleTest}
+	testCases := []ExportTestCase{noOverlaySimpleTest, specifiedAppTest}
 
 	// Need to do both checks
 	if common.SupportsUserNS() && checkUserNS() == nil {

--- a/tests/rkt_export_test.go
+++ b/tests/rkt_export_test.go
@@ -32,6 +32,7 @@ type ExportTestCase struct {
 	runArgs        string
 	writeArgs      string
 	readArgs       string
+	exportArgs     string
 	expectedResult string
 	unmountOverlay bool
 }
@@ -43,6 +44,16 @@ var (
 		"--no-overlay --insecure-options=image",
 		"--write-file --file-name=" + testFile + " --content=" + testContent,
 		"--read-file --file-name=" + testFile,
+		"",
+		testContent,
+		false,
+	}
+
+	specifiedAppTest = ExportTestCase{
+		"--no-overlay --insecure-options=image",
+		"--write-file --file-name=" + testFile + " --content=" + testContent,
+		"--read-file --file-name=" + testFile,
+		"--app=rkt-inspect",
 		testContent,
 		false,
 	}
@@ -51,6 +62,7 @@ var (
 		"--private-users --no-overlay --insecure-options=image",
 		"--write-file --file-name=" + testFile + " --content=" + testContent,
 		"--read-file --file-name=" + testFile,
+		"",
 		testContent,
 		false,
 	}
@@ -59,6 +71,7 @@ var (
 		"--insecure-options=image",
 		"--write-file --file-name=" + testFile + " --content=" + testContent,
 		"--read-file --file-name=" + testFile,
+		"",
 		testContent,
 		false,
 	}
@@ -67,6 +80,7 @@ var (
 		"--insecure-options=image",
 		"--write-file --file-name=" + testFile + " --content=" + testContent,
 		"--read-file --file-name=" + testFile,
+		"",
 		testContent,
 		true,
 	}
@@ -103,7 +117,7 @@ func (ct ExportTestCase) Execute(t *testing.T, ctx *testutils.RktRunCtx) {
 	}
 
 	// Export the image
-	exportCmd := fmt.Sprintf("%s export %s %s", ctx.Cmd(), uuid, tmpTestAci)
+	exportCmd := fmt.Sprintf("%s export %s %s %s", ctx.Cmd(), ct.exportArgs, uuid, tmpTestAci)
 	t.Logf("Running 'export'")
 	child = spawnOrFail(t, exportCmd)
 	waitOrFail(t, child, 0)


### PR DESCRIPTION
Names are specified in a similar manner to `rkt enter`:
```
$ rkt export --help
NAME:
        export - Export an app from an exited pod to an ACI file

USAGE:
        rkt export [--app=APPNAME] UUID OUTPUT_ACI_FILE

DESCRIPTION:
        UUID should be the uuid of an exited pod.

OPTIONS:
      --app=""                  name of the app to export within the specified pod
      --overwrite[=false]       overwrite output ACI
```

As with `rkt enter`, previous behaviour for single app pods is preserved. A name only needs to be specified for multi-app pods.