### PR TITLE
rkt: support for unified cgroups (cgroup2)

### DIFF
--- a/common/cgroup/cgroup.go
+++ b/common/cgroup/cgroup.go
@@ -47,7 +47,7 @@ var (
 		"cpu":    addCpuLimit,
 		"memory": addMemoryLimit,
 	}
-	legacyCgroupControllerRWFiles = map[string][]string{
+	v1CgroupControllerRWFiles = map[string][]string{
 		"memory":  {"memory.limit_in_bytes"},
 		"cpu":     {"cpu.cfs_quota_us"},
 		"devices": {"devices.allow", "devices.deny"},
@@ -66,6 +66,20 @@ func addCpuLimit(opts []*unit.UnitOption, limit *resource.Quantity) ([]*unit.Uni
 func addMemoryLimit(opts []*unit.UnitOption, limit *resource.Quantity) ([]*unit.UnitOption, error) {
 	opts = append(opts, unit.NewUnitOption("Service", "MemoryLimit", strconv.Itoa(int(limit.Value()))))
 	return opts, nil
+}
+
+func mountFsRO(mountPoint string) error {
+	var flags uintptr = syscall.MS_BIND |
+		syscall.MS_REMOUNT |
+		syscall.MS_NOSUID |
+		syscall.MS_NOEXEC |
+		syscall.MS_NODEV |
+		syscall.MS_RDONLY
+	if err := syscall.Mount(mountPoint, mountPoint, "", flags, ""); err != nil {
+		return errwrap.Wrap(fmt.Errorf("error remounting RO %q", mountPoint), err)
+	}
+
+	return nil
 }
 
 // MaybeAddIsolator considers the given isolator; if the type is known
@@ -102,7 +116,7 @@ func IsIsolatorSupported(isolator string) (bool, error) {
 	}
 
 	if isUnified {
-		controllers, err := GetEnabledControllers()
+		controllers, err := GetEnabledV2Controllers()
 		if err != nil {
 			return false, errwrap.Wrap(errors.New("error determining enabled controllers"), err)
 		}
@@ -114,7 +128,7 @@ func IsIsolatorSupported(isolator string) (bool, error) {
 		return false, nil
 	}
 
-	if files, ok := legacyCgroupControllerRWFiles[isolator]; ok {
+	if files, ok := v1CgroupControllerRWFiles[isolator]; ok {
 		for _, f := range files {
 			isolatorPath := filepath.Join("/sys/fs/cgroup/", isolator, f)
 			if _, err := os.Stat(isolatorPath); os.IsNotExist(err) {
@@ -138,7 +152,60 @@ func IsCgroupUnified(root string) (bool, error) {
 	return statfs.Type == Cgroup2fsMagicNumber, nil
 }
 
-func parseLegacyCgroups(f io.Reader) (map[int][]string, error) {
+/*
+ * cgroup v2 functions
+ */
+
+// GetEnabledV2Controllers returns a list of enabled cgroup controllers
+func GetEnabledV2Controllers() ([]string, error) {
+	controllersFile, err := os.Open("/sys/fs/cgroup/cgroup.controllers")
+	if err != nil {
+		return nil, err
+	}
+	defer controllersFile.Close()
+
+	sc := bufio.NewScanner(controllersFile)
+
+	sc.Scan()
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+
+	return strings.Split(sc.Text(), " "), nil
+}
+
+func parseV2ProcCgroupInfo(procCgroupInfoPath string) (string, error) {
+	cg, err := os.Open(procCgroupInfoPath)
+	if err != nil {
+		return "", errwrap.Wrap(errors.New("error opening /proc/self/cgroup"), err)
+	}
+	defer cg.Close()
+
+	s := bufio.NewScanner(cg)
+	s.Scan()
+	parts := strings.SplitN(s.Text(), ":", 3)
+	if len(parts) < 3 {
+		return "", fmt.Errorf("error parsing /proc/self/cgroup")
+	}
+
+	return parts[2], nil
+}
+
+// GetOwnCgroupPath returns the cgroup path of this process
+func GetOwnV2CgroupPath() (string, error) {
+	return parseV2ProcCgroupInfo("/proc/self/cgroup")
+}
+
+// GetCgroupPathByPid returns the cgroup path of the process
+func GetV2CgroupPathByPid(pid int) (string, error) {
+	return parseV2ProcCgroupInfo(fmt.Sprintf("/proc/%d/cgroup", pid))
+}
+
+/*
+ * cgroup v1 functions
+ */
+
+func parseV1Cgroups(f io.Reader) (map[int][]string, error) {
 	sc := bufio.NewScanner(f)
 
 	// skip first line since it is a comment
@@ -168,16 +235,16 @@ func parseLegacyCgroups(f io.Reader) (map[int][]string, error) {
 	return cgroups, nil
 }
 
-// GetEnabledLegacyCgroups returns a map with the enabled cgroup controllers grouped by
+// GetEnabledV1Cgroups returns a map with the enabled cgroup controllers grouped by
 // hierarchy
-func GetEnabledLegacyCgroups() (map[int][]string, error) {
+func GetEnabledV1Cgroups() (map[int][]string, error) {
 	cgroupsFile, err := os.Open("/proc/cgroups")
 	if err != nil {
 		return nil, err
 	}
 	defer cgroupsFile.Close()
 
-	cgroups, err := parseLegacyCgroups(cgroupsFile)
+	cgroups, err := parseV1Cgroups(cgroupsFile)
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("error parsing /proc/cgroups"), err)
 	}
@@ -185,28 +252,10 @@ func GetEnabledLegacyCgroups() (map[int][]string, error) {
 	return cgroups, nil
 }
 
-// GetEnabledControllers returns a list of enabled cgroup controllers
-func GetEnabledControllers() ([]string, error) {
-	controllersFile, err := os.Open("/sys/fs/cgroup/cgroup.controllers")
-	if err != nil {
-		return nil, err
-	}
-	defer controllersFile.Close()
-
-	sc := bufio.NewScanner(controllersFile)
-
-	sc.Scan()
-	if err := sc.Err(); err != nil {
-		return nil, err
-	}
-
-	return strings.Split(sc.Text(), " "), nil
-}
-
-// GetLegacyControllerDirs takes a map with the enabled cgroup controllers grouped by
+// GetV1ControllerDirs takes a map with the enabled cgroup controllers grouped by
 // hierarchy and returns the directory names as they should be in
 // /sys/fs/cgroup
-func GetLegacyControllerDirs(cgroups map[int][]string) []string {
+func GetV1ControllerDirs(cgroups map[int][]string) []string {
 	var controllers []string
 	for _, cs := range cgroups {
 		controllers = append(controllers, strings.Join(cs, ","))
@@ -215,7 +264,7 @@ func GetLegacyControllerDirs(cgroups map[int][]string) []string {
 	return controllers
 }
 
-func getLegacyControllerSymlinks(cgroups map[int][]string) map[string]string {
+func getV1ControllerSymlinks(cgroups map[int][]string) map[string]string {
 	symlinks := make(map[string]string)
 
 	for _, cs := range cgroups {
@@ -230,10 +279,10 @@ func getLegacyControllerSymlinks(cgroups map[int][]string) map[string]string {
 	return symlinks
 }
 
-func getLegacyControllerRWFiles(controller string) []string {
+func getV1ControllerRWFiles(controller string) []string {
 	parts := strings.Split(controller, ",")
 	for _, p := range parts {
-		if files, ok := legacyCgroupControllerRWFiles[p]; ok {
+		if files, ok := v1CgroupControllerRWFiles[p]; ok {
 			// cgroup.procs always needs to be RW for allowing systemd to add
 			// processes to the controller
 			files = append(files, "cgroup.procs")
@@ -244,7 +293,7 @@ func getLegacyControllerRWFiles(controller string) []string {
 	return nil
 }
 
-func parseLegacyCgroupController(cgroupPath, controller string) ([]string, error) {
+func parseV1CgroupController(cgroupPath, controller string) ([]string, error) {
 	cg, err := os.Open(cgroupPath)
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("error opening /proc/self/cgroup"), err)
@@ -268,56 +317,29 @@ func parseLegacyCgroupController(cgroupPath, controller string) ([]string, error
 	return nil, fmt.Errorf("controller %q not found", controller)
 }
 
-func parseProcCgroupInfo(procCgroupInfoPath string) (string, error) {
-	cg, err := os.Open(procCgroupInfoPath)
-	if err != nil {
-		return "", errwrap.Wrap(errors.New("error opening /proc/self/cgroup"), err)
-	}
-	defer cg.Close()
-
-	s := bufio.NewScanner(cg)
-	s.Scan()
-	parts := strings.SplitN(s.Text(), ":", 3)
-	if len(parts) < 3 {
-		return "", fmt.Errorf("error parsing /proc/self/cgroup")
-	}
-
-	return parts[2], nil
-}
-
-// GetOwnLegacyCgroupPath returns the cgroup path of this process in controller
+// GetOwnV1CgroupPath returns the cgroup path of this process in controller
 // hierarchy
-func GetOwnLegacyCgroupPath(controller string) (string, error) {
-	parts, err := parseLegacyCgroupController("/proc/self/cgroup", controller)
+func GetOwnV1CgroupPath(controller string) (string, error) {
+	parts, err := parseV1CgroupController("/proc/self/cgroup", controller)
 	if err != nil {
 		return "", err
 	}
 	return parts[2], nil
 }
 
-// GetOwnCgroupPath returns the cgroup path of this process
-func GetOwnCgroupPath() (string, error) {
-	return parseProcCgroupInfo("/proc/self/cgroup")
-}
-
-// GetLegacyCgroupPathByPid returns the cgroup path of the process with the given pid
+// GetV1CgroupPathByPid returns the cgroup path of the process with the given pid
 // and given controller.
-func GetLegacyCgroupPathByPid(pid int, controller string) (string, error) {
-	parts, err := parseLegacyCgroupController(fmt.Sprintf("/proc/%d/cgroup", pid), controller)
+func GetV1CgroupPathByPid(pid int, controller string) (string, error) {
+	parts, err := parseV1CgroupController(fmt.Sprintf("/proc/%d/cgroup", pid), controller)
 	if err != nil {
 		return "", err
 	}
 	return parts[2], nil
 }
 
-// GetCgroupPathByPid returns the cgroup path of the process
-func GetCgroupPathByPid(pid int) (string, error) {
-	return parseProcCgroupInfo(fmt.Sprintf("/proc/%d/cgroup", pid))
-}
-
-// JoinCgroup makes the calling process join the subcgroup hierarchy on a
+// JoinV1Subcgroup makes the calling process join the subcgroup hierarchy on a
 // particular controller
-func JoinLegacySubcgroup(controller string, subcgroup string) error {
+func JoinV1Subcgroup(controller string, subcgroup string) error {
 	subcgroupPath := filepath.Join("/sys/fs/cgroup", controller, subcgroup)
 	if err := os.MkdirAll(subcgroupPath, 0600); err != nil {
 		return errwrap.Wrap(fmt.Errorf("error creating %q subcgroup", subcgroup), err)
@@ -360,9 +382,9 @@ func fixCpusetKnobs(cpusetPath string) {
 	}
 }
 
-// IsLegacyControllerMounted returns whether a controller is mounted by checking that
+// IsV1ControllerMounted returns whether a controller is mounted by checking that
 // cgroup.procs is accessible
-func IsLegacyControllerMounted(c string) bool {
+func IsV1ControllerMounted(c string) bool {
 	cgroupProcsPath := filepath.Join("/sys/fs/cgroup", c, "cgroup.procs")
 	if _, err := os.Stat(cgroupProcsPath); err != nil {
 		return false
@@ -371,10 +393,10 @@ func IsLegacyControllerMounted(c string) bool {
 	return true
 }
 
-// CreateLegacyCgroups mounts the cgroup controllers hierarchy in /sys/fs/cgroup
+// CreateV1Cgroups mounts the v1 cgroup controllers hierarchy in /sys/fs/cgroup
 // under root
-func CreateLegacyCgroups(root string, enabledCgroups map[int][]string, mountContext string) error {
-	controllers := GetLegacyControllerDirs(enabledCgroups)
+func CreateV1Cgroups(root string, enabledCgroups map[int][]string, mountContext string) error {
+	controllers := GetV1ControllerDirs(enabledCgroups)
 	var flags uintptr
 
 	sys := filepath.Join(root, "/sys")
@@ -424,7 +446,7 @@ func CreateLegacyCgroups(root string, enabledCgroups map[int][]string, mountCont
 	}
 
 	// Create symlinks for combined controllers
-	symlinks := getLegacyControllerSymlinks(enabledCgroups)
+	symlinks := getV1ControllerSymlinks(enabledCgroups)
 	for ln, tgt := range symlinks {
 		lnPath := filepath.Join(cgroupTmpfs, ln)
 		if err := os.Symlink(tgt, lnPath); err != nil {
@@ -441,11 +463,11 @@ func CreateLegacyCgroups(root string, enabledCgroups map[int][]string, mountCont
 	return mountFsRO(cgroupTmpfs)
 }
 
-// RemountLegacyCgroupsRO remounts the cgroup hierarchy under root read-only,
+// RemountV1CgroupsRO remounts the v1 cgroup hierarchy under root read-only,
 // leaving the needed knobs in the subcgroup for each app read-write so the
 // systemd inside stage1 can apply isolators to them
-func RemountLegacyCgroupsRO(root string, enabledCgroups map[int][]string, subcgroup string, serviceNames []string) error {
-	controllers := GetLegacyControllerDirs(enabledCgroups)
+func RemountV1CgroupsRO(root string, enabledCgroups map[int][]string, subcgroup string, serviceNames []string) error {
+	controllers := GetV1ControllerDirs(enabledCgroups)
 	cgroupTmpfs := filepath.Join(root, "/sys/fs/cgroup")
 	sysPath := filepath.Join(root, "/sys")
 
@@ -466,7 +488,7 @@ func RemountLegacyCgroupsRO(root string, enabledCgroups map[int][]string, subcgr
 			if err := os.MkdirAll(appCgroup, 0755); err != nil {
 				return err
 			}
-			for _, f := range getLegacyControllerRWFiles(c) {
+			for _, f := range getV1ControllerRWFiles(c) {
 				cgroupFilePath := filepath.Join(appCgroup, f)
 				// the file may not be there if kernel doesn't support the
 				// feature, skip it in that case
@@ -487,18 +509,4 @@ func RemountLegacyCgroupsRO(root string, enabledCgroups map[int][]string, subcgr
 
 	// Bind-mount sys filesystem read-only
 	return mountFsRO(sysPath)
-}
-
-func mountFsRO(mountPoint string) error {
-	var flags uintptr = syscall.MS_BIND |
-		syscall.MS_REMOUNT |
-		syscall.MS_NOSUID |
-		syscall.MS_NOEXEC |
-		syscall.MS_NODEV |
-		syscall.MS_RDONLY
-	if err := syscall.Mount(mountPoint, mountPoint, "", flags, ""); err != nil {
-		return errwrap.Wrap(fmt.Errorf("error remounting RO %q", mountPoint), err)
-	}
-
-	return nil
 }

--- a/common/cgroup/cgroup.go
+++ b/common/cgroup/cgroup.go
@@ -35,15 +35,25 @@ import (
 
 type addIsolatorFunc func(opts []*unit.UnitOption, limit *resource.Quantity) ([]*unit.UnitOption, error)
 
+const (
+	// The following const comes from
+	// #define CGROUP2_SUPER_MAGIC  0x63677270
+	// https://github.com/torvalds/linux/blob/v4.6/include/uapi/linux/magic.h#L58
+	Cgroup2fsMagicNumber = 0x63677270
+)
+
 var (
 	isolatorFuncs = map[string]addIsolatorFunc{
 		"cpu":    addCpuLimit,
 		"memory": addMemoryLimit,
 	}
-	cgroupControllerRWFiles = map[string][]string{
+	legacyCgroupControllerRWFiles = map[string][]string{
 		"memory":  {"memory.limit_in_bytes"},
 		"cpu":     {"cpu.cfs_quota_us"},
 		"devices": {"devices.allow", "devices.deny"},
+	}
+	cgroupControllerRWFiles = map[string][]string{
+		"memory": {"memory.low", "memory.high", "memory.max", "memory.swap.max"},
 	}
 )
 
@@ -70,32 +80,61 @@ func MaybeAddIsolator(opts []*unit.UnitOption, isolator string, limit *resource.
 	if limit == nil {
 		return opts, nil
 	}
-	if IsIsolatorSupported(isolator) {
+	isSupported, err := IsIsolatorSupported(isolator)
+	if err != nil {
+		return nil, err
+	}
+
+	if isSupported {
 		opts, err = isolatorFuncs[isolator](opts, limit)
-		if err != nil {
-			return nil, err
-		}
 	} else {
 		fmt.Fprintf(os.Stderr, "warning: resource/%s isolator set but support disabled in the kernel, skipping\n", isolator)
+	}
+
+	if err != nil {
+		return nil, err
 	}
 	return opts, nil
 }
 
 // IsIsolatorSupported returns whether an isolator is supported in the kernel
-func IsIsolatorSupported(isolator string) bool {
-	if files, ok := cgroupControllerRWFiles[isolator]; ok {
-		for _, f := range files {
-			isolatorPath := filepath.Join("/sys/fs/cgroup/", isolator, f)
-			if _, err := os.Stat(isolatorPath); os.IsNotExist(err) {
-				return false
-			}
-		}
-		return true
+func IsIsolatorSupported(isolator string) (bool, error) {
+	procCgroupFile, err := os.Open("/proc/cgroups")
+	if err != nil {
+		return false, err
 	}
-	return false
+	defer procCgroupFile.Close()
+
+	sc := bufio.NewScanner(procCgroupFile)
+
+	sc.Scan()
+
+	for sc.Scan() {
+		if strings.HasPrefix(sc.Text(), isolator) {
+			return true, nil
+		}
+	}
+
+	if err := sc.Err(); err != nil {
+		return false, err
+	}
+
+	return false, nil
 }
 
-func parseCgroups(f io.Reader) (map[int][]string, error) {
+// IsCgroupUnified checks if cgroup mounted at /sys/fs/cgroup is
+// the new unified version (cgroup v2)
+func IsCgroupUnified(root string) (bool, error) {
+	cgroupFsPath := filepath.Join(root, "/sys/fs/cgroup")
+	var statfs syscall.Statfs_t
+	if err := syscall.Statfs(cgroupFsPath, &statfs); err != nil {
+		return false, err
+	}
+
+	return statfs.Type == Cgroup2fsMagicNumber, nil
+}
+
+func parseLegacyCgroups(f io.Reader) (map[int][]string, error) {
 	sc := bufio.NewScanner(f)
 
 	// skip first line since it is a comment
@@ -125,16 +164,16 @@ func parseCgroups(f io.Reader) (map[int][]string, error) {
 	return cgroups, nil
 }
 
-// GetEnabledCgroups returns a map with the enabled cgroup controllers grouped by
+// GetEnabledLegacyCgroups returns a map with the enabled cgroup controllers grouped by
 // hierarchy
-func GetEnabledCgroups() (map[int][]string, error) {
+func GetEnabledLegacyCgroups() (map[int][]string, error) {
 	cgroupsFile, err := os.Open("/proc/cgroups")
 	if err != nil {
 		return nil, err
 	}
 	defer cgroupsFile.Close()
 
-	cgroups, err := parseCgroups(cgroupsFile)
+	cgroups, err := parseLegacyCgroups(cgroupsFile)
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("error parsing /proc/cgroups"), err)
 	}
@@ -142,10 +181,28 @@ func GetEnabledCgroups() (map[int][]string, error) {
 	return cgroups, nil
 }
 
-// GetControllerDirs takes a map with the enabled cgroup controllers grouped by
+// GetEnabledControllers raturns a list of enabled cgroup controllers
+func GetEnabledControllers() ([]string, error) {
+	controllersFile, err := os.Open("/sys/fs/cgroup/cgroup.controllers")
+	if err != nil {
+		return nil, err
+	}
+	defer controllersFile.Close()
+
+	sc := bufio.NewScanner(controllersFile)
+
+	sc.Scan()
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+
+	return strings.Split(sc.Text(), " "), nil
+}
+
+// GetLegacyControllerDirs takes a map with the enabled cgroup controllers grouped by
 // hierarchy and returns the directory names as they should be in
 // /sys/fs/cgroup
-func GetControllerDirs(cgroups map[int][]string) []string {
+func GetLegacyControllerDirs(cgroups map[int][]string) []string {
 	var controllers []string
 	for _, cs := range cgroups {
 		controllers = append(controllers, strings.Join(cs, ","))
@@ -154,7 +211,7 @@ func GetControllerDirs(cgroups map[int][]string) []string {
 	return controllers
 }
 
-func getControllerSymlinks(cgroups map[int][]string) map[string]string {
+func getLegacyControllerSymlinks(cgroups map[int][]string) map[string]string {
 	symlinks := make(map[string]string)
 
 	for _, cs := range cgroups {
@@ -169,10 +226,10 @@ func getControllerSymlinks(cgroups map[int][]string) map[string]string {
 	return symlinks
 }
 
-func getControllerRWFiles(controller string) []string {
+func getLegacyControllerRWFiles(controller string) []string {
 	parts := strings.Split(controller, ",")
 	for _, p := range parts {
-		if files, ok := cgroupControllerRWFiles[p]; ok {
+		if files, ok := legacyCgroupControllerRWFiles[p]; ok {
 			// cgroup.procs always needs to be RW for allowing systemd to add
 			// processes to the controller
 			files = append(files, "cgroup.procs")
@@ -183,7 +240,16 @@ func getControllerRWFiles(controller string) []string {
 	return nil
 }
 
-func parseCgroupController(cgroupPath, controller string) ([]string, error) {
+func getControllersRWFiles() []string {
+	files := []string{"cgroup.procs", "cgroup.controllers", "cgroup.subtree_control", "cgroup.events"}
+	for _, controllerRWFiles := range cgroupControllerRWFiles {
+		files = append(files, controllerRWFiles...)
+	}
+
+	return files
+}
+
+func parseLegacyCgroupController(cgroupPath, controller string) ([]string, error) {
 	cg, err := os.Open(cgroupPath)
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("error opening /proc/self/cgroup"), err)
@@ -207,30 +273,71 @@ func parseCgroupController(cgroupPath, controller string) ([]string, error) {
 	return nil, fmt.Errorf("controller %q not found", controller)
 }
 
-// GetOwnCgroupPath returns the cgroup path of this process in controller
+func parseProcCgroupInfo(procCgroupInfoPath string) (string, error) {
+	cg, err := os.Open(procCgroupInfoPath)
+	if err != nil {
+		return "", errwrap.Wrap(errors.New("error opening /proc/self/cgroup"), err)
+	}
+	defer cg.Close()
+
+	s := bufio.NewScanner(cg)
+	s.Scan()
+	parts := strings.SplitN(s.Text(), ":", 3)
+	if len(parts) < 3 {
+		return "", fmt.Errorf("error parsing /proc/self/cgroup")
+	}
+
+	return parts[2], nil
+}
+
+// GetOwnLegacyCgroupPath returns the cgroup path of this process in controller
 // hierarchy
-func GetOwnCgroupPath(controller string) (string, error) {
-	parts, err := parseCgroupController("/proc/self/cgroup", controller)
+func GetOwnLegacyCgroupPath(controller string) (string, error) {
+	parts, err := parseLegacyCgroupController("/proc/self/cgroup", controller)
 	if err != nil {
 		return "", err
 	}
 	return parts[2], nil
 }
 
-// GetCgroupPathByPid returns the cgroup path of the process with the given pid
+// GetOwnCgroupPath returns the cgroup path of this process
+func GetOwnCgroupPath() (string, error) {
+	return parseProcCgroupInfo("/proc/self/cgroup")
+}
+
+// GetLegacyCgroupPathByPid returns the cgroup path of the process with the given pid
 // and given controller.
-func GetCgroupPathByPid(pid int, controller string) (string, error) {
-	parts, err := parseCgroupController(fmt.Sprintf("/proc/%d/cgroup", pid), controller)
+func GetLegacyCgroupPathByPid(pid int, controller string) (string, error) {
+	parts, err := parseLegacyCgroupController(fmt.Sprintf("/proc/%d/cgroup", pid), controller)
 	if err != nil {
 		return "", err
 	}
 	return parts[2], nil
+}
+
+// GetCgroupPathByPid returns the cgroup path of the process
+func GetCgroupPathByPid(pid int) (string, error) {
+	return parseProcCgroupInfo(fmt.Sprintf("/proc/%d/cgroup", pid))
 }
 
 // JoinCgroup makes the calling process join the subcgroup hierarchy on a
 // particular controller
-func JoinSubcgroup(controller string, subcgroup string) error {
+func JoinLegacySubcgroup(controller string, subcgroup string) error {
 	subcgroupPath := filepath.Join("/sys/fs/cgroup", controller, subcgroup)
+	if err := os.MkdirAll(subcgroupPath, 0600); err != nil {
+		return errwrap.Wrap(fmt.Errorf("error creating %q subcgroup", subcgroup), err)
+	}
+	pidBytes := []byte(strconv.Itoa(os.Getpid()))
+	if err := ioutil.WriteFile(filepath.Join(subcgroupPath, "cgroup.procs"), pidBytes, 0600); err != nil {
+		return errwrap.Wrap(fmt.Errorf("error adding ourselves to the %q subcgroup", subcgroup), err)
+	}
+
+	return nil
+}
+
+// JoinCgroup makes the calling process join the subcgroup hierarchy
+func JoinSubcgroup(subcgroup string) error {
+	subcgroupPath := filepath.Join("/sys/fs/cgroup", subcgroup)
 	if err := os.MkdirAll(subcgroupPath, 0600); err != nil {
 		return errwrap.Wrap(fmt.Errorf("error creating %q subcgroup", subcgroup), err)
 	}
@@ -272,9 +379,9 @@ func fixCpusetKnobs(cpusetPath string) {
 	}
 }
 
-// IsControllerMounted returns whether a controller is mounted by checking that
+// IsLegacyControllerMounted returns whether a controller is mounted by checking that
 // cgroup.procs is accessible
-func IsControllerMounted(c string) bool {
+func IsLegacyControllerMounted(c string) bool {
 	cgroupProcsPath := filepath.Join("/sys/fs/cgroup", c, "cgroup.procs")
 	if _, err := os.Stat(cgroupProcsPath); err != nil {
 		return false
@@ -283,10 +390,10 @@ func IsControllerMounted(c string) bool {
 	return true
 }
 
-// CreateCgroups mounts the cgroup controllers hierarchy in /sys/fs/cgroup
+// CreateLegacyCgroups mounts the cgroup controllers hierarchy in /sys/fs/cgroup
 // under root
-func CreateCgroups(root string, enabledCgroups map[int][]string, mountContext string) error {
-	controllers := GetControllerDirs(enabledCgroups)
+func CreateLegacyCgroups(root string, enabledCgroups map[int][]string, mountContext string) error {
+	controllers := GetLegacyControllerDirs(enabledCgroups)
 	var flags uintptr
 
 	sys := filepath.Join(root, "/sys")
@@ -336,7 +443,7 @@ func CreateCgroups(root string, enabledCgroups map[int][]string, mountContext st
 	}
 
 	// Create symlinks for combined controllers
-	symlinks := getControllerSymlinks(enabledCgroups)
+	symlinks := getLegacyControllerSymlinks(enabledCgroups)
 	for ln, tgt := range symlinks {
 		lnPath := filepath.Join(cgroupTmpfs, ln)
 		if err := os.Symlink(tgt, lnPath); err != nil {
@@ -353,11 +460,50 @@ func CreateCgroups(root string, enabledCgroups map[int][]string, mountContext st
 	return mountFsRO(cgroupTmpfs)
 }
 
+// CreateCgroups mounts the unigfied cgroup hierarchy in /sys/fs/cgroup
+// under root
+func CreateCgroups(root string) error {
+	var flags uintptr
+
+	sys := filepath.Join(root, "/sys")
+	if err := os.MkdirAll(sys, 0700); err != nil {
+		return err
+	}
+	flags = syscall.MS_NOSUID |
+		syscall.MS_NOEXEC |
+		syscall.MS_NODEV
+
+	if err := syscall.Mount("sysfs", sys, "sysfs", flags, ""); err != nil {
+		return errwrap.Wrap(fmt.Errorf("error mounting %q", sys), err)
+	}
+
+	cgroupFs := filepath.Join(root, "/sys/fs/cgroup")
+	if err := os.MkdirAll(cgroupFs, 0700); err != nil {
+		return err
+	}
+
+	flags = syscall.MS_NOSUID |
+		syscall.MS_NOEXEC |
+		syscall.MS_NODEV |
+		syscall.MS_STRICTATIME
+
+	if err := syscall.Mount("cgroup2", cgroupFs, "cgroup2", flags, ""); err != nil {
+		return errwrap.Wrap(fmt.Errorf("error mounting %q", cgroupFs), err)
+	}
+
+	machinePath := filepath.Join(root, "/sys/fs/cgroup/machine.slice")
+	if err := os.MkdirAll(machinePath, 0700); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // RemountCgroupsRO remounts the cgroup hierarchy under root read-only, leaving
 // the needed knobs in the subcgroup for each app read-write so the systemd
 // inside stage1 can apply isolators to them
-func RemountCgroupsRO(root string, enabledCgroups map[int][]string, subcgroup string, serviceNames []string) error {
-	controllers := GetControllerDirs(enabledCgroups)
+func RemountLegacyCgroupsRO(root string, enabledCgroups map[int][]string, subcgroup string, serviceNames []string) error {
+	controllers := GetLegacyControllerDirs(enabledCgroups)
 	cgroupTmpfs := filepath.Join(root, "/sys/fs/cgroup")
 	sysPath := filepath.Join(root, "/sys")
 
@@ -378,7 +524,7 @@ func RemountCgroupsRO(root string, enabledCgroups map[int][]string, subcgroup st
 			if err := os.MkdirAll(appCgroup, 0755); err != nil {
 				return err
 			}
-			for _, f := range getControllerRWFiles(c) {
+			for _, f := range getLegacyControllerRWFiles(c) {
 				cgroupFilePath := filepath.Join(appCgroup, f)
 				// the file may not be there if kernel doesn't support the
 				// feature, skip it in that case
@@ -410,6 +556,50 @@ func mountFsRO(mountPoint string) error {
 		syscall.MS_RDONLY
 	if err := syscall.Mount(mountPoint, mountPoint, "", flags, ""); err != nil {
 		return errwrap.Wrap(fmt.Errorf("error remounting RO %q", mountPoint), err)
+	}
+
+	return nil
+}
+
+// RemountCgroupsRO remounts the cgroup hierarchy under root read-only, leaving
+// the needed knobs in the subcgroup for each app read-write so the systemd
+// inside stage1 can apply isolators to them
+func RemountCgroupsRO(root string, subcgroup string, serviceNames []string) error {
+	cgroupFsPath := filepath.Join(root, "sys/fs/cgroup")
+	subcgroupPath := filepath.Join(root, "sys/fs/cgroup", subcgroup)
+	sysPath := filepath.Join(root, "/sys")
+
+	var flags uintptr
+
+	if err := os.MkdirAll(subcgroupPath, 0700); err != nil {
+		return err
+	}
+
+	machineDir := strings.TrimSuffix(subcgroupPath, "/system.slice")
+	if err := syscall.Mount(machineDir, machineDir, "", syscall.MS_BIND, ""); err != nil {
+		return errwrap.Wrap(fmt.Errorf("error bind mounting %q", subcgroupPath), err)
+	}
+
+	// Bind-mount cgroup filesystem read-only
+	flags = syscall.MS_BIND |
+		syscall.MS_REMOUNT |
+		syscall.MS_NOSUID |
+		syscall.MS_NOEXEC |
+		syscall.MS_NODEV |
+		syscall.MS_RDONLY
+	if err := syscall.Mount(cgroupFsPath, cgroupFsPath, "", flags, ""); err != nil {
+		return errwrap.Wrap(fmt.Errorf("error remounting RO %q", cgroupFsPath), err)
+	}
+
+	// Bind-mount sys filesystem read-only
+	flags = syscall.MS_BIND |
+		syscall.MS_REMOUNT |
+		syscall.MS_NOSUID |
+		syscall.MS_NOEXEC |
+		syscall.MS_NODEV |
+		syscall.MS_RDONLY
+	if err := syscall.Mount(sysPath, sysPath, "", flags, ""); err != nil {
+		return errwrap.Wrap(fmt.Errorf("error remounting RO %q", sysPath), err)
 	}
 
 	return nil

--- a/common/cgroup/cgroup_test.go
+++ b/common/cgroup/cgroup_test.go
@@ -100,7 +100,7 @@ net_prio	6	432	1`
 	}
 
 	for i, tt := range tests {
-		o, err := parseCgroups(tt.input)
+		o, err := parseLegacyCgroups(tt.input)
 		if err != nil {
 			t.Errorf("#%d: unexpected error `%v`", i, err)
 		}

--- a/common/cgroup/cgroup_test.go
+++ b/common/cgroup/cgroup_test.go
@@ -100,7 +100,7 @@ net_prio	6	432	1`
 	}
 
 	for i, tt := range tests {
-		o, err := parseLegacyCgroups(tt.input)
+		o, err := parseV1Cgroups(tt.input)
 		if err != nil {
 			t.Errorf("#%d: unexpected error `%v`", i, err)
 		}

--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -370,7 +370,7 @@ func getPodCgroup(p *pod, pid int) (string, error) {
 	// Get cgroup for the "name=systemd" controller; we assume the api-server is
 	// running on a system using systemd for returning cgroups, and will just not
 	// set it otherwise.
-	cgroup, err := cgroup.GetCgroupPathByPid(pid, "name=systemd")
+	cgroup, err := cgroup.GetV1CgroupPathByPid(pid, "name=systemd")
 	if err != nil {
 		return "", err
 	}

--- a/stage1/gc/gc.go
+++ b/stage1/gc/gc.go
@@ -132,7 +132,7 @@ func cleanupCgroups() error {
 	// if we're trying to clean up our own cgroup it means we're running in the
 	// same unit file as the rkt pod. We don't have to do anything, systemd
 	// will do the cleanup for us
-	ourCgroupPath, err := cgroup.GetOwnCgroupPath("name=systemd")
+	ourCgroupPath, err := cgroup.GetOwnLegacyCgroupPath("name=systemd")
 	if err == nil {
 		if strings.HasPrefix(ourCgroupPath, "/"+subcgroup) {
 			return nil

--- a/stage1/gc/gc.go
+++ b/stage1/gc/gc.go
@@ -67,7 +67,7 @@ func main() {
 		log.PrintE("error removing journal link", err)
 	}
 
-	if err := cleanupLegacyCgroups(); err != nil {
+	if err := cleanupV1Cgroups(); err != nil {
 		log.PrintE("error cleaning up cgroups", err)
 	}
 
@@ -122,7 +122,7 @@ func (c dirsByLength) Len() int           { return len(c) }
 func (c dirsByLength) Less(i, j int) bool { return len(c[i]) < len(c[j]) }
 func (c dirsByLength) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
 
-func cleanupLegacyCgroups() error {
+func cleanupV1Cgroups() error {
 	isUnified, err := cgroup.IsCgroupUnified("/")
 	if err != nil {
 		return errwrap.Wrap(errors.New("failed to determine the cgroup version"), err)
@@ -140,7 +140,7 @@ func cleanupLegacyCgroups() error {
 	// if we're trying to clean up our own cgroup it means we're running in the
 	// same unit file as the rkt pod. We don't have to do anything, systemd
 	// will do the cleanup for us
-	ourCgroupPath, err := cgroup.GetOwnLegacyCgroupPath("name=systemd")
+	ourCgroupPath, err := cgroup.GetOwnV1CgroupPath("name=systemd")
 	if err == nil {
 		if strings.HasPrefix(ourCgroupPath, "/"+subcgroup) {
 			return nil

--- a/stage1/gc/gc.go
+++ b/stage1/gc/gc.go
@@ -67,7 +67,7 @@ func main() {
 		log.PrintE("error removing journal link", err)
 	}
 
-	if err := cleanupCgroups(); err != nil {
+	if err := cleanupLegacyCgroups(); err != nil {
 		log.PrintE("error cleaning up cgroups", err)
 	}
 
@@ -122,7 +122,7 @@ func (c dirsByLength) Len() int           { return len(c) }
 func (c dirsByLength) Less(i, j int) bool { return len(c[i]) < len(c[j]) }
 func (c dirsByLength) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
 
-func cleanupCgroups() error {
+func cleanupLegacyCgroups() error {
 	isUnified, err := cgroup.IsCgroupUnified("/")
 	if err != nil {
 		return errwrap.Wrap(errors.New("failed to determine the cgroup version"), err)

--- a/stage1/gc/gc.go
+++ b/stage1/gc/gc.go
@@ -123,6 +123,14 @@ func (c dirsByLength) Less(i, j int) bool { return len(c[i]) < len(c[j]) }
 func (c dirsByLength) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
 
 func cleanupCgroups() error {
+	isUnified, err := cgroup.IsCgroupUnified("/")
+	if err != nil {
+		return errwrap.Wrap(errors.New("failed to determine the cgroup version"), err)
+	}
+	if isUnified {
+		return nil
+	}
+
 	b, err := ioutil.ReadFile("subcgroup")
 	if err != nil {
 		return errwrap.Wrap(errors.New("error reading subcgroup file"), err)

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -663,7 +663,7 @@ func stage1() int {
 
 	unifiedCgroup, err := cgroup.IsCgroupUnified("/")
 	if err != nil {
-		log.FatalE("error determing cgroup version", err)
+		log.FatalE("error determining cgroup version", err)
 		return 1
 	}
 

--- a/tests/inspect/inspect.go
+++ b/tests/inspect/inspect.go
@@ -412,7 +412,7 @@ func main() {
 
 		var limitPath string
 		if isUnified {
-			cgroupPath, err := cgroup.GetOwnCgroupPath()
+			cgroupPath, err := cgroup.GetOwnV2CgroupPath()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error getting own memory cgroup path: %v\n", err)
 				os.Exit(1)
@@ -420,7 +420,7 @@ func main() {
 			limitPath = filepath.Join("/proc/1/root/sys/fs/cgroup/", cgroupPath, "memory.max")
 			fmt.Fprintln(os.Stderr, "limitPath:", limitPath)
 		} else {
-			memCgroupPath, err := cgroup.GetOwnLegacyCgroupPath("memory")
+			memCgroupPath, err := cgroup.GetOwnV1CgroupPath("memory")
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error getting own memory cgroup path: %v\n", err)
 				os.Exit(1)
@@ -438,7 +438,7 @@ func main() {
 	}
 
 	if globalFlags.PrintCPUQuota {
-		cpuCgroupPath, err := cgroup.GetOwnLegacyCgroupPath("cpu")
+		cpuCgroupPath, err := cgroup.GetOwnV1CgroupPath("cpu")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error getting own cpu cgroup path: %v\n", err)
 			os.Exit(1)

--- a/tests/inspect/inspect.go
+++ b/tests/inspect/inspect.go
@@ -403,17 +403,34 @@ func main() {
 	}
 
 	if globalFlags.PrintMemoryLimit {
-		memCgroupPath, err := cgroup.GetOwnCgroupPath("memory")
+		// we use /proc/1/root to escape the chroot we're in and read the file
+		isUnified, err := cgroup.IsCgroupUnified("/proc/1/root/")
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting own memory cgroup path: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error getting cgroup type: %v\n", err)
 			os.Exit(1)
 		}
-		// we use /proc/1/root to escape the chroot we're in and read our
-		// memory limit
-		limitPath := filepath.Join("/proc/1/root/sys/fs/cgroup/memory", memCgroupPath, "memory.limit_in_bytes")
+
+		var limitPath string
+		if isUnified {
+			cgroupPath, err := cgroup.GetOwnCgroupPath()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error getting own memory cgroup path: %v\n", err)
+				os.Exit(1)
+			}
+			limitPath = filepath.Join("/proc/1/root/sys/fs/cgroup/", cgroupPath, "memory.max")
+			fmt.Fprintln(os.Stderr, "limitPath:", limitPath)
+		} else {
+			memCgroupPath, err := cgroup.GetOwnLegacyCgroupPath("memory")
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error getting own memory cgroup path: %v\n", err)
+				os.Exit(1)
+			}
+			limitPath = filepath.Join("/proc/1/root/sys/fs/cgroup/memory", memCgroupPath, "memory.limit_in_bytes")
+			fmt.Fprintln(os.Stderr, limitPath)
+		}
 		limit, err := ioutil.ReadFile(limitPath)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Can't read memory.limit_in_bytes\n")
+			fmt.Fprintf(os.Stderr, "Can't read %s\n", limitPath)
 			os.Exit(1)
 		}
 
@@ -421,7 +438,7 @@ func main() {
 	}
 
 	if globalFlags.PrintCPUQuota {
-		cpuCgroupPath, err := cgroup.GetOwnCgroupPath("cpu")
+		cpuCgroupPath, err := cgroup.GetOwnLegacyCgroupPath("cpu")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error getting own cpu cgroup path: %v\n", err)
 			os.Exit(1)

--- a/tests/rkt_app_isolator_test.go
+++ b/tests/rkt_app_isolator_test.go
@@ -58,7 +58,10 @@ var cgroupsTest = struct {
 }
 
 func TestAppIsolatorMemory(t *testing.T) {
-	ok := cgroup.IsIsolatorSupported("memory")
+	ok, err := cgroup.IsIsolatorSupported("memory")
+	if err != nil {
+		t.Fatalf("Error checking memory isolator support: %v", err)
+	}
 	if !ok {
 		t.Skip("Memory isolator not supported.")
 	}
@@ -81,7 +84,20 @@ func TestAppIsolatorMemory(t *testing.T) {
 }
 
 func TestAppIsolatorCPU(t *testing.T) {
-	ok := cgroup.IsIsolatorSupported("cpu")
+	isUnified, err := cgroup.IsCgroupUnified("/")
+	if err != nil {
+		t.Fatalf("Error determining the cgroup version: %v", err)
+	}
+
+	if isUnified {
+		// TODO: for now kernel does not support cpu isolator in cgroup2.
+		// Write a test when it does.
+		t.Skip("kernel does not support cpu isolator in cgroup2.")
+	}
+	ok, err := cgroup.IsIsolatorSupported("cpu")
+	if err != nil {
+		t.Fatalf("Error checking cpu isolator support: %v", err)
+	}
 	if !ok {
 		t.Skip("CPU isolator not supported.")
 	}

--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -1205,9 +1205,15 @@ func TestPodManifest(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		if tt.cgroup != "" && !cgroup.IsIsolatorSupported(tt.cgroup) {
-			t.Logf("Skip test #%v: cgroup %s not supported", i, tt.cgroup)
-			continue
+		if tt.cgroup != "" {
+			ok, err := cgroup.IsIsolatorSupported(tt.cgroup)
+			if err != nil {
+				t.Fatalf("Error checking memory isolator support: %v", err)
+			}
+			if !ok {
+				t.Logf("Skip test #%v: cgroup %s not supported", i, tt.cgroup)
+				continue
+			}
 		}
 
 		var hashesToRemove []string


### PR DESCRIPTION
This implements support for cgroups v2 along support for legacy version.

I took #2785 and fixed the conflicts.

Half of #1757

Based on work from: Michał Świętek <michalswietek88@gmail.com>

------

/cc @mike1729 @lucab 