### PR TITLE
docs/pods: fix path of documentation in a comment

### DIFF
--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -61,7 +61,7 @@ type pod struct {
 	mountLabel       string // Label to use for container image
 }
 
-// Exported state. See Documentation/container-lifecycle.md for some explanation
+// Exported state. See Documentation/devel/pod-lifecycle.md for some explanation
 const (
 	Embryo         = "embryo"
 	Preparing      = "preparing"


### PR DESCRIPTION
as Documentation/container-lifecycle.md does not exist anymore.