### PR TITLE
functional tests: skip TestSocketProxyd

### DIFF
--- a/tests/rkt_socket_proxyd_test.go
+++ b/tests/rkt_socket_proxyd_test.go
@@ -34,6 +34,11 @@ import (
 )
 
 func TestSocketProxyd(t *testing.T) {
+	// Skip the test for now. See
+	// https://github.com/coreos/rkt/issues/2432#issuecomment-238858840 for
+	// details.
+	t.Skip("this test is racy, let's skip it until we fix it")
+
 	if !sd_util.IsRunningSystemd() {
 		t.Skip("Systemd is not running on the host.")
 	}


### PR DESCRIPTION
This test is currently racy. The socket-activated proxyd service depends
on a rkt service being ready. However, the application that runs inside
rkt doesn't have a way to signal when it's ready because of
https://github.com/coreos/rkt/issues/1464. Instead, systemd assumes it's
ready when the container starts, which is wrong, because the application
inside might not be listening on the port yet. This makes the test fail.

It fails a lot particularly in Fedora Rawhide with the flavor host:

https://jenkins-rkt-public.prod.coreos.systems/job/rkt-master-periodic/os_type=fedora-rawhide,stage1_flavor=host/

We can re-enable it when we fix https://github.com/coreos/rkt/issues/1464.

cc @woodbor 