### PR TITLE
stage0: check for ftype=0 filesystem before overlay

### DIFF
--- a/stage0/run.go
+++ b/stage0/run.go
@@ -881,5 +881,13 @@ func prepareOverlay(lower, treeStoreID, cdir, dest, appName, lbl string,
 		return nil, err
 	}
 
+	support, err := overlay.DirSupportsOverlay(imgDir)
+	if err != nil {
+		return nil, err
+	}
+	if !support {
+		return nil, fmt.Errorf("filesystem without ftype=1 cannot be used for overlay (%q)", imgDir)
+	}
+
 	return &overlay.MountCfg{lower, upper, work, dst, lbl}, nil
 }


### PR DESCRIPTION
This will print the error message in this way:
```
$ dd if=/dev/zero of=./xfs-ftype0 bs=4096k count=128
$ mkfs.xfs -n ftype=0 -m crc=0 xfs-ftype0
$ sudo mount -o loop -t xfs xfs-ftype0 /var/lib/rkt/
$ sudo rkt run --debug --insecure-options=all docker://busybox --interactive
...

stage0: error setting up stage1
  └─error rendering overlay filesystem
    └─problem preparing overlay directories
      └─filesystem without ftype=1 cannot be used for overlay ("/var/lib/rkt/pods/run/cd50b47c-7fb1-4d03-b5c9-33fa7cb0ff8f/overlay/deps-sha512-c7760aee857d743617bf63da01b28c7e4d4cff90be8fa1c673fc9bddb5aa309c")
```
Or, without --debug:
```
stage0: error setting up stage1: filesystem without ftype=1 cannot be used for overlay ("/var/lib/rkt/pods/run/c0c2e8e8-191e-46bb-93cf-872f205e3c40/overlay/deps-sha512-c7760aee857d743617bf63da01b28c7e4d4cff90be8fa1c673fc9bddb5aa309c")
```

Fixes https://github.com/coreos/rkt/issues/3040

-----

/cc @kayrus @sgotti @jellonek 

TODO:
- [ ] suggestion for a better error message welcome
- [ ] find a way to document that somewhere...
- [ ] add the check in `rkt export` too?
- [ ] tests?
