### PR TITLE
*: Fix old appc/spec version in various files

### DIFF
--- a/Documentation/app-container.md
+++ b/Documentation/app-container.md
@@ -33,8 +33,8 @@ To validate that `rkt` successfully implements the ACE part of the spec, use the
 # rkt --insecure-options=image run \
 	--mds-register \
 	--volume=database,kind=host,source=/tmp \
-	https://github.com/appc/spec/releases/download/v0.7.4/ace-validator-main.aci \
-	https://github.com/appc/spec/releases/download/v0.7.4/ace-validator-sidekick.aci
+	https://github.com/appc/spec/releases/download/v0.8.5/ace-validator-main.aci \
+	https://github.com/appc/spec/releases/download/v0.8.5/ace-validator-sidekick.aci
 ```
 
 [appc-repo]: https://github.com/appc/spec/

--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -135,7 +135,7 @@ The current version of the stage1 interface is 3.
 ```json
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.7.4",
+    "acVersion": "0.8.5",
     "name": "foo.com/rkt/stage1",
     "labels": [
         {

--- a/Documentation/subcommands/cat-manifest.md
+++ b/Documentation/subcommands/cat-manifest.md
@@ -5,7 +5,7 @@ For debugging or inspection you may want to extract the PodManifest to stdout.
 ```
 # rkt cat-manifest UUID
 {
-  "acVersion":"0.7.0",
+  "acVersion":"0.8.5",
   "acKind":"PodManifest"
 ...
 ```

--- a/Documentation/subcommands/image.md
+++ b/Documentation/subcommands/image.md
@@ -7,7 +7,7 @@ For debugging or inspection you may want to extract an ACI manifest to stdout.
 ```
 # rkt image cat-manifest coreos.com/etcd
 {
-  "acVersion": "0.7.0",
+  "acVersion": "0.8.5",
   "acKind": "ImageManifest",
 ...
 ```

--- a/Documentation/subcommands/version.md
+++ b/Documentation/subcommands/version.md
@@ -7,6 +7,6 @@ This command prints the rkt version, the appc version rkt is built against, and 
 ```
 $ rkt version
 rkt Version: 1.12.0
-appc Version: 0.7.4
+appc Version: 0.8.5
 Go Version: go1.5.3
 Go OS/Arch: linux/amd64

--- a/pkg/aci/aci.go
+++ b/pkg/aci/aci.go
@@ -107,7 +107,7 @@ func (aw *imageArchiveWriter) Close() error {
 // NewBasicACI creates a new ACI in the given directory with the given name.
 // Used for testing.
 func NewBasicACI(dir string, name string) (*os.File, error) {
-	manifest := fmt.Sprintf(`{"acKind":"ImageManifest","acVersion":"0.7.4","name":"%s"}`, name)
+	manifest := fmt.Sprintf(`{"acKind":"ImageManifest","acVersion":"0.8.5","name":"%s"}`, name)
 	return NewACI(dir, manifest, nil)
 }
 

--- a/scripts/bump-appc-spec-version
+++ b/scripts/bump-appc-spec-version
@@ -1,0 +1,39 @@
+#!/bin/bash -e
+#
+# Attempt to bump the appc/spec version to the version specified in
+# glide.yaml by replacing all occurrences of the current/previous
+# version. The old version is taken from stage1/aci/aci-manifest.in.
+#
+# YMMV, no disclaimer or warranty, etc.
+
+# make sure we are running in a toplevel directory
+if ! [[ "$0" =~ "scripts/bump-appc-spec-version" ]]; then
+	echo "This script must be run in a toplevel rkt directory"
+	exit 255
+fi
+
+function replace_stuff() {
+	local FROM
+	local TO
+	local REPLACE
+
+	FROM=$1
+	TO=$2
+	# escape special characters
+	REPLACE=$(sed -e 's/[]\/$*.^|[]/\\&/g'<<< $FROM)
+	shift 2
+	echo $* | xargs sed -i --follow-symlinks -e "s/$REPLACE/$TO/g"
+}
+
+function replace_all() {
+	replace_stuff $1 $2 $(git ls-files | grep -Ev "(CHANGELOG.md|vendor|manifest\.d|glide.lock|glide.yaml)")
+}
+
+PREV=$(grep -Pe 'acVersion' stage1/aci/aci-manifest.in | grep -Po '\d+\.\d+\.\d+')
+NEXT=$(grep -A 1 -e '^- package: github.com/appc/spec$' glide.yaml | grep -Po '\d+\.\d+\.\d+')
+
+if [[ ${PREV} = ${NEXT} ]]; then
+	exit 0
+fi
+
+replace_all $PREV $NEXT

--- a/scripts/bump-release
+++ b/scripts/bump-release
@@ -34,14 +34,14 @@ function replace_stuff() {
 }
 
 function replace_all() {
-	replace_stuff $1 $2 $(git ls-files | grep -Ev "(CHANGELOG.md|vendor|manifest\.d)")
+	replace_stuff $1 $2 $(git ls-files | grep -Ev "(CHANGELOG.md|vendor|manifest\.d|glide.lock|glide.yaml)")
 }
 
 function replace_version() {
 	replace_stuff $1 $2 configure.ac scripts/build-rir.sh tests/rkt-monitor/build-stresser.sh
 }
 
-NEXT=${1:1} 	        # 0.2.3
+NEXT=${1:1}             # 0.2.3
 NEXTGIT="${NEXT}+git"   # 0.2.3+git
 
 PREVGIT=$(grep -Po 'AC_INIT\(\[rkt\], \[\K[^\]]*(?=])' configure.ac) # 0.1.2+git

--- a/stage1_fly/aci/aci-manifest.in
+++ b/stage1_fly/aci/aci-manifest.in
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.7.4",
+    "acVersion": "0.8.5",
     "name": "coreos.com/rkt/stage1-fly",
     "labels": [
         {

--- a/store/imagestore/store_test.go
+++ b/store/imagestore/store_test.go
@@ -163,7 +163,7 @@ func TestGetImageManifest(t *testing.T) {
 
 	imj := `{
 			"acKind": "ImageManifest",
-			"acVersion": "0.7.4",
+			"acVersion": "0.8.5",
 			"name": "example.com/test01"
 		}`
 
@@ -228,7 +228,7 @@ func TestGetAci(t *testing.T) {
 				{
 					`{
 						"acKind": "ImageManifest",
-						"acVersion": "0.7.4",
+						"acVersion": "0.8.5",
 						"name": "example.com/test01"
 					}`,
 					false,
@@ -236,7 +236,7 @@ func TestGetAci(t *testing.T) {
 				{
 					`{
 						"acKind": "ImageManifest",
-						"acVersion": "0.7.4",
+						"acVersion": "0.8.5",
 						"name": "example.com/test02",
 						"labels": [
 							{
@@ -250,7 +250,7 @@ func TestGetAci(t *testing.T) {
 				{
 					`{
 						"acKind": "ImageManifest",
-						"acVersion": "0.7.4",
+						"acVersion": "0.8.5",
 						"name": "example.com/test02",
 						"labels": [
 							{
@@ -358,7 +358,7 @@ func TestRemoveACI(t *testing.T) {
 
 	imj := `{
                     "acKind": "ImageManifest",
-                    "acVersion": "0.7.4",
+                    "acVersion": "0.8.5",
                     "name": "example.com/test01"
                 }`
 
@@ -403,7 +403,7 @@ func TestRemoveACI(t *testing.T) {
 	// Simulate error removing from the
 	imj = `{
                    "acKind": "ImageManifest",
-                   "acVersion": "0.7.4",
+                   "acVersion": "0.8.5",
                    "name": "example.com/test01"
                }`
 

--- a/store/treestore/tree_test.go
+++ b/store/treestore/tree_test.go
@@ -34,7 +34,7 @@ func testStoreWriteACI(dir string, s *imagestore.Store) (string, error) {
 	imj := `
 		{
 		    "acKind": "ImageManifest",
-		    "acVersion": "0.7.4",
+		    "acVersion": "0.8.5",
 		    "name": "example.com/test01"
 		}
 	`
@@ -202,7 +202,7 @@ func TestTreeStore(t *testing.T) {
 	imj := `
 		{
 		    "acKind": "ImageManifest",
-		    "acVersion": "0.7.4",
+		    "acVersion": "0.8.5",
 		    "name": "example.com/test01"
 		}
 	`

--- a/tests/empty-image/manifest
+++ b/tests/empty-image/manifest
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.7.4",
+    "acVersion": "0.8.5",
     "name": "coreos.com/rkt-empty",
     "labels": [
         {

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.7.4",
+    "acVersion": "0.8.5",
     "name": "coreos.com/rkt-inspect",
     "labels": [
         {

--- a/tests/rkt-monitor/build-too-many-apps.sh
+++ b/tests/rkt-monitor/build-too-many-apps.sh
@@ -45,7 +45,7 @@ OUTPUT=${PWD}/too-many-apps.podmanifest
 
 cat <<EOF >${OUTPUT}
 {
-    "acVersion": "0.7.4",
+    "acVersion": "0.8.5",
     "acKind": "PodManifest",
     "apps": [
 EOF

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.12.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
+	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.8.5","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.12.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
 )
 
 func TestRunOverrideExec(t *testing.T) {

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -536,7 +536,7 @@ func TestDeferredSignatureDownload(t *testing.T) {
 }
 
 func TestDifferentDiscoveryLabels(t *testing.T) {
-	manifestTemplate := `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"IMG_NAME","labels":[{"name":"version","value":"1.2.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
+	manifestTemplate := `{"acKind":"ImageManifest","acVersion":"0.8.5","name":"IMG_NAME","labels":[{"name":"version","value":"1.2.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
 	emptyImage := getEmptyImagePath()
 	imageName := "localhost/rkt-test-different-discovery-labels-image"
 	manifest := strings.Replace(manifestTemplate, "IMG_NAME", imageName, -1)

--- a/tests/rkt_image_cat_manifest_test.go
+++ b/tests/rkt_image_cat_manifest_test.go
@@ -29,7 +29,7 @@ import (
 const (
 
 	// The expected image manifest of the 'rkt-inspect-image-cat-manifest.aci'.
-	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"IMG_NAME","labels":[{"name":"version","value":"1.12.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.5","name":"IMG_NAME","labels":[{"name":"version","value":"1.12.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageCatManifest tests 'rkt image cat-manifest', it will:

--- a/tests/rkt_image_dependencies_test.go
+++ b/tests/rkt_image_dependencies_test.go
@@ -33,7 +33,7 @@ const (
 	manifestDepsTemplate = `
 {
    "acKind" : "ImageManifest",
-   "acVersion" : "0.7.4",
+   "acVersion" : "0.8.5",
    "dependencies" : [
       DEPENDENCIES
    ],

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"IMG_NAME","labels":[{"name":"version","value":"1.12.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.5","name":"IMG_NAME","labels":[{"name":"version","value":"1.12.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageExport tests 'rkt image export', it will import some existing

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"IMG_NAME","labels":[{"name":"version","value":"1.12.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.5","name":"IMG_NAME","labels":[{"name":"version","value":"1.12.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageRender tests 'rkt image render', it will import some existing empty

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	manifestOSArchTemplate = `{"acKind":"ImageManifest","acVersion":"0.7.4","name":"IMG_NAME","labels":[{"name":"version","value":"1.12.0"}ARCH_OS],"app":{"exec":["/inspect", "--print-msg=HelloWorld"],"user":"0","group":"0","workingDirectory":"/"}}`
+	manifestOSArchTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.5","name":"IMG_NAME","labels":[{"name":"version","value":"1.12.0"}ARCH_OS],"app":{"exec":["/inspect", "--print-msg=HelloWorld"],"user":"0","group":"0","workingDirectory":"/"}}`
 )
 
 type osArchTest struct {

--- a/tests/stub-stage1/manifest
+++ b/tests/stub-stage1/manifest
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.7.4",
+    "acVersion": "0.8.5",
     "name": "localhost/rkt-stub-stage1",
     "labels": [
         {


### PR DESCRIPTION
~~It is outdated compared to the acVersion in the ACI manifest of the coreos flavor.~~

There are more places where outdated appc/spec version is used. This PR replaced all of them and adds a new script for automating it. It could be used right after vendoring in the new version of appc/spec.