### PR TITLE
build: Make generating clean files simpler to do

### DIFF
--- a/makelib/misc.mk
+++ b/makelib/misc.mk
@@ -469,6 +469,52 @@ define add-dependency
 $(eval $(call add-dependency-template,$1,$2))
 endef
 
+# 1 - stamp file, which will depend on the generated clean stamp
+# 2 - file list
+# 3 - a list of directory mappings
+# 4 - descriptor
+define generate-clean-mk-from-filelist
+$(strip \
+	$(eval _MISC_GCMFF_MAIN_STAMP_ := $(strip $1)) \
+	$(eval _MISC_GCMFF_FILELIST_ := $(strip $2)) \
+	$(eval _MISC_GCMFF_DIR_MAPS_ := $(strip $3)) \
+	$(eval _MISC_GCMFF_DESCRIPTOR_ := $(strip $4)) \
+	\
+	$(call setup-stamp-file,_MISC_GCMFF_CLEAN_STAMP_,$(_MISC_GCMFF_DESCRIPTOR_)-gcmff-generated-clean-stamp) \
+	$(call setup-clean-file,_MISC_GCMFF_CLEANMK_,$(_MISC_GCMFF_DESCRIPTOR_)-gcmff-generated-cleanmk) \
+	\
+	$(call add-dependency,$(_MISC_GCMFF_MAIN_STAMP_),$(_MISC_GCMFF_CLEAN_STAMP_)) \
+	$(call generate-clean-mk,$(_MISC_GCMFF_CLEAN_STAMP_),$(_MISC_GCMFF_CLEANMK_),$(_MISC_GCMFF_FILELIST_),$(_MISC_GCMFF_DIR_MAPS_)) \
+	\
+	$(call undefine-namespaces,_MISC_GCMFF))
+endef
+
+# 1 - stamp file, which will depend on the generated clean stamp
+# 2 - source directory
+# 3 - a list of directory mappings
+# 4 - filelist deps
+# 5 - descriptor
+define generate-clean-mk-simple
+$(strip \
+	$(eval _MISC_GCMS_MAIN_STAMP_ := $(strip $1)) \
+	$(eval _MISC_GCMS_SRCDIR_ := $(strip $2)) \
+	$(eval _MISC_GCMS_DIR_MAPS_ := $(strip $3)) \
+	$(eval _MISC_GCMS_DEPS_ := $(strip $4)) \
+	$(eval _MISC_GCMS_DESCRIPTOR_ := $(strip $5)) \
+	\
+	$(call setup-filelist-file,_MISC_GCMS_FILELIST_,$(_MISC_GCMS_DESCRIPTOR_)-gcms-generated-filelist) \
+	$(call add-dependency,$(_MISC_GCMS_FILELIST_),$(_MISC_GCMS_DEPS_)) \
+	$(call generate-deep-filelist,$(_MISC_GCMS_FILELIST_),$(_MISC_GCMS_SRCDIR_)) \
+	\
+	$(call generate-clean-mk-from-filelist, \
+		$(_MISC_GCMS_MAIN_STAMP_), \
+		$(_MISC_GCMS_FILELIST_), \
+		$(_MISC_GCMS_DIR_MAPS_), \
+		$(_MISC_GCMS_DESCRIPTOR_)) \
+	\
+	$(call undefine-namespaces,_MISC_GCMS))
+endef
+
 # Formats given lists of source and destination files for the
 # INSTALL_FILES variable.
 #

--- a/stage1/usr_from_coreos/build-usr.mk
+++ b/stage1/usr_from_coreos/build-usr.mk
@@ -58,11 +58,6 @@ $(call setup-dep-file,CBU_MANIFEST_DEPMK,$(CBU_DIFF)-manifest)
 $(call setup-stamp-file,CBU_TMPROOTFS_DEPMK_STAMP,$(CBU_DIFF)-tmprootfs-deps)
 $(call setup-dep-file,CBU_TMPROOTFS_DEPMK,$(CBU_DIFF)-tmprootfs)
 
-# Stamp and clean file for cleaning partially ACI rootfs and whole tmp
-# rootfs.
-$(call setup-stamp-file,CBU_ROOTFS_CLEAN_STAMP,$(CBU_DIFF)-rootfs-clean)
-$(call setup-clean-file,CBU_ROOTFSDIR_CLEANMK,$(CBU_DIFF)-rootfs)
-
 # Filelist for stuff taken from squashfs - it is more detailed when
 # compared to complete manifest.
 $(call setup-filelist-file,CBU_DETAILED_FILELIST,$(CBU_DIFF)-acirootfs)
@@ -83,11 +78,10 @@ $(call setup-dep-file,CBU_ACIROOTFS_SYMLINKS_KV_DEPMK,$(CBU_DIFF)-acirootfs-syml
 $(call setup-stamp-file,CBU_ACIROOTFS_SYSTEMD_VERSION_KV_DEPMK_STAMP,$(CBU_DIFF)-systemd-version)
 $(call setup-dep-file,CBU_ACIROOTFS_SYSTEMD_VERSION_KV_DEPMK,$(CBU_DIFF)-systemd-version-kv)
 
-# All stamps in this file that generate deps or clean files
-CBU_DEPS_AND_CLEAN_STAMPS := \
+# All stamps in this file that generate deps files
+CBU_DEPS_STAMPS := \
 	$(CBU_TMPROOTFS_DEPMK_STAMP) \
 	$(CBU_MANIFEST_DEPS_STAMP) \
-	$(CBU_ROOTFS_CLEAN_STAMP) \
 	$(CBU_ACIROOTFS_SYMLINKS_KV_DEPMK_STAMP) \
 	$(CBU_ACIROOTFS_SYSTEMD_VERSION_KV_DEPMK_STAMP)
 
@@ -115,7 +109,7 @@ INSTALL_SYMLINKS += \
 
 # The main stamp - makes sure that ACI rootfs directory is prepared
 # with initial contents and all deps/clean files are generated.
-$(call generate-stamp-rule,$(CBU_STAMP),$(CBU_ACI_ROOTFS_STAMP) $(CBU_DEPS_AND_CLEAN_STAMPS))
+$(call generate-stamp-rule,$(CBU_STAMP),$(CBU_ACI_ROOTFS_STAMP) $(CBU_DEPS_STAMPS))
 
 # This stamp makes sure that ACI rootfs is fully populated - stuff is
 # copied, symlinks and systemd-version file are created.
@@ -156,9 +150,13 @@ $(call generate-kv-deps,$(CBU_ACIROOTFS_SYMLINKS_KV_DEPMK_STAMP),$(CBU_REMOVE_AC
 # temporary rootfs change.
 $(call generate-glob-deps,$(CBU_TMPROOTFS_DEPMK_STAMP),$(CBU_REMOVE_ACIROOTFSDIR_STAMP),$(CBU_TMPROOTFS_DEPMK),,$(CBU_DETAILED_FILELIST),$(CBU_ROOTFS))
 
-# This cleanmk can be generated only after the detailed filelist was
-# generated.
-$(call generate-clean-mk,$(CBU_ROOTFS_CLEAN_STAMP),$(CBU_ROOTFSDIR_CLEANMK),$(CBU_DETAILED_FILELIST),$(CBU_ACIROOTFSDIR) $(CBU_ROOTFS))
+# Generate clean file for files put in the ACI rootfs and in the
+# temporary rootfs.
+$(call generate-clean-mk-from-filelist, \
+	$(CBU_STAMP), \
+	$(CBU_DETAILED_FILELIST), \
+	$(CBU_ACIROOTFSDIR) $(CBU_ROOTFS), \
+	$(CBU_DIFF)-rootfs-cleanup)
 
 # This unpacks squashfs image to a temporary rootfs.
 $(call generate-stamp-rule,$(CBU_MKBASE_STAMP),$(CCN_SQUASHFS) $(CBU_COMPLETE_MANIFEST),$(CBU_ROOTFS), \

--- a/stage1/usr_from_kvm/lkvm.mk
+++ b/stage1/usr_from_kvm/lkvm.mk
@@ -14,10 +14,7 @@ LKVM_PATCHES := $(abspath $(LKVM_PATCHESDIR)/*.patch)
 $(call setup-stamp-file,LKVM_BUILD_STAMP,/build)
 $(call setup-stamp-file,LKVM_PATCH_STAMP,/patch_lkvm)
 $(call setup-stamp-file,LKVM_DEPS_STAMP,/deps)
-$(call setup-stamp-file,LKVM_DIR_CLEAN_STAMP,/dir-clean)
 $(call setup-dep-file,LKVM_PATCHES_DEPMK)
-$(call setup-clean-file,LKVM_CLEANMK,/src)
-$(call setup-filelist-file,LKVM_DIR_FILELIST,/dir)
 $(call setup-filelist-file,LKVM_PATCHES_FILELIST,/patches)
 
 S1_RF_SECONDARY_STAMPS += $(LKVM_STAMP)
@@ -26,7 +23,7 @@ INSTALL_DIRS += \
 	$(LKVM_SRCDIR):- \
 	$(LKVM_TMPDIR):-
 
-$(call generate-stamp-rule,$(LKVM_STAMP),$(LKVM_ACI_BINARY) $(LKVM_DEPS_STAMP) $(LKVM_DIR_CLEAN_STAMP))
+$(call generate-stamp-rule,$(LKVM_STAMP),$(LKVM_ACI_BINARY) $(LKVM_DEPS_STAMP))
 
 $(LKVM_BINARY): $(LKVM_BUILD_STAMP)
 
@@ -34,13 +31,14 @@ $(call generate-stamp-rule,$(LKVM_BUILD_STAMP),$(LKVM_PATCH_STAMP),, \
 	$(call vb,vt,BUILD EXT,lkvm) \
 	$$(MAKE) $(call vl2,--silent) -C "$(LKVM_SRCDIR)" V= lkvm-static $(call vl2,>/dev/null))
 
-# Generate filelist of lkvm directory (this is both srcdir and
+# Generate clean file for lkvm directory (this is both srcdir and
 # builddir). Can happen after build finished.
-$(LKVM_DIR_FILELIST): $(LKVM_BUILD_STAMP)
-$(call generate-deep-filelist,$(LKVM_DIR_FILELIST),$(LKVM_SRCDIR))
-
-# Generate clean.mk cleaning lkvm directory
-$(call generate-clean-mk,$(LKVM_DIR_CLEAN_STAMP),$(LKVM_CLEANMK),$(LKVM_DIR_FILELIST),$(LKVM_SRCDIR))
+$(call generate-clean-mk-simple, \
+	$(LKVM_STAMP), \
+	$(LKVM_SRCDIR), \
+	$(LKVM_SRCDIR), \
+	$(LKVM_BUILD_STAMP), \
+	cleanup)
 
 $(call generate-stamp-rule,$(LKVM_PATCH_STAMP),,, \
 	shopt -s nullglob; \


### PR DESCRIPTION
This adds two simpler-to-use functions to generate clean files, so we don't have to deal with additional stamps and cleanmk files openly.