### PR TITLE
stage1: followup to limit device node creation/reading/writing

### DIFF
--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -245,7 +245,7 @@ func IsDeviceNode(path string) bool {
 	d, err := os.Lstat(path)
 	if err == nil {
 		m := d.Mode()
-		return m&os.ModeDevice == os.ModeDevice || m&os.ModeCharDevice == os.ModeCharDevice
+		return m&os.ModeDevice == os.ModeDevice
 	}
 	return false
 }

--- a/stage1/init/common/pod.go
+++ b/stage1/init/common/pod.go
@@ -406,12 +406,8 @@ func generateDeviceAllows(root string, appName types.ACName, mountPoints []types
 			link := filepath.Join(rktVolumeLinksPath, v.Name.String())
 
 			err := os.Symlink(tgt, link)
-			switch {
-			case err == nil:
-				toShift = append(toShift, tgt)
-			case os.IsExist(err):
-				// it already exists, do nothing
-			default:
+			// if the link already exists, we don't need to do anything
+			if err != nil && !os.IsExist(err) {
 				return nil, err
 			}
 


### PR DESCRIPTION
This is a followup to https://github.com/coreos/rkt/pull/3027 fixing some issues raised by a post-merge review.

cc @alban 