### PR TITLE
docs: fix relative links for code on github

### DIFF
--- a/Documentation/subcommands/api-service.md
+++ b/Documentation/subcommands/api-service.md
@@ -13,12 +13,12 @@ The API service listens for gRPC requests on the address and port specified by t
 The default is to listen on the loopback interface on port number `15441`, equivalent to invoking `rkt api-service --listen=localhost:15441`.
 Specify the address `0.0.0.0` to listen on all interfaces.
 
-Typically, the API service will be run via a unit file similar to the one included in the [dist directory](../../dist/init/systemd/rkt-api.service).
+Typically, the API service will be run via a unit file similar to the one included in the [dist directory](https://github.com/coreos/rkt/blob/master/dist/init/systemd/rkt-api.service).
 
 ## Using the API service
 
-The interfaces are defined in the [protobuf here](../../api/v1alpha/api.proto).
-Here is a small [Go program](../../api/v1alpha/client_example.go) that illustrates how to use the API service.
+The interfaces are defined in the [protobuf here](https://github.com/coreos/rkt/blob/master/api/v1alpha/api.proto).
+Here is a small [Go program](https://github.com/coreos/rkt/blob/master/api/v1alpha/client_example.go) that illustrates how to use the API service.
 
 ## Options
 


### PR DESCRIPTION
links to code snippets on
https://coreos.com/rkt/docs/latest/subcommands/api-service.html are not working
as they are not compiled to html, therefore fix is to hardlink to github