### PR TITLE
scripts: add curl as build dependency

### DIFF
--- a/scripts/install-rkt.sh
+++ b/scripts/install-rkt.sh
@@ -13,7 +13,8 @@ apt-get install -y --no-install-recommends \
         ca-certificates \
         gnupg2 \
         bash-completion \
-        checkinstall
+        checkinstall \
+        curl
 
 curl -sSL https://coreos.com/dist/pubkeys/app-signing-pubkey.gpg | gpg2 --import -
 key=$(gpg2 --with-colons --keyid-format LONG -k security@coreos.com | egrep ^pub | cut -d ':' -f5)


### PR DESCRIPTION
Ubuntu doesn't install curl by default, so this adds support for Ubuntu.