### PR TITLE
api_service: Rework cgroup detection

### DIFF
--- a/tests/rkt_api_service_test.go
+++ b/tests/rkt_api_service_test.go
@@ -617,6 +617,7 @@ func NewAPIServiceCgroupTest() testutils.Test {
 		}
 
 		// ListPods(detail=true). Filter according to the cgroup.
+		t.Logf("Calling ListPods with cgroup filter %v", cgroups)
 		resp, err = c.ListPods(context.Background(), &v1alpha.ListPodsRequest{
 			Detail:  true,
 			Filters: []*v1alpha.PodFilter{{Cgroups: cgroups}},
@@ -633,6 +634,7 @@ func NewAPIServiceCgroupTest() testutils.Test {
 			checkPodDetails(t, ctx, p)
 		}
 
+		t.Logf("Calling ListPods with subcgroup filter %v", subcgroups)
 		resp, err = c.ListPods(context.Background(), &v1alpha.ListPodsRequest{
 			Detail:  true,
 			Filters: []*v1alpha.PodFilter{{PodSubCgroups: subcgroups}},


### PR DESCRIPTION
Use the `subcgroup` file hint provided by some stage1s rather than
machined registration.

Fixes #3060

TODO still:

- [x] Validate this use of `subcgroup` makes sense / is correct.
- [x] Minimal validation this works with stage1-kvm.
- [ ] Minimum validation of cadvisor's consuming of this API.
- [x] Better tests? (though `TestAPIServiceCgroup` exists and passes)
- [ ] In the future move the contract to a `cgroup` file instead that all stage1's write perhaps.

cc @yifan-gu @alban @iaguis for opinions on if this implementaiton makes sense