### PR TITLE
export: test export for multi-app pods

### DIFF
--- a/tests/rkt_export_container_test.go
+++ b/tests/rkt_export_container_test.go
@@ -23,7 +23,11 @@ import (
 )
 
 func TestExport(t *testing.T) {
-	testCases := []ExportTestCase{noOverlaySimpleTest, specifiedAppTest}
+	testCases := []ExportTestCase{
+		noOverlaySimpleTest,
+		specifiedAppTest,
+		multiAppPodTest,
+	}
 
 	// Need to do both checks
 	if common.SupportsUserNS() && checkUserNS() == nil {


### PR DESCRIPTION
test uses app name specification and a patched test ACI which writes a
file with different content

Fixes #3054