### PR TITLE
Updated Nginx IP addy from host machine

### DIFF
--- a/Documentation/trying-out-rkt.md
+++ b/Documentation/trying-out-rkt.md
@@ -121,7 +121,7 @@ UUID		APP	IMAGE NAME					STATE	CREATED		STARTED		NETWORKS
 0c3ab969	nginx	registry-1.docker.io/library/nginx:latest	running	2 minutes ago	2 minutes ago	default:ip4=172.16.28.2
 ```
 
-The nginx container is now accessible on the host under http://172.16.28.2.
+The nginx container is now accessible on the host under http://172.16.28.3.
 
 Success! The rest of the guide can now be followed normally.
 


### PR DESCRIPTION
The ip address that was added in the notes was not accessible from the host machine. The container running within the VM was given the ip 172.28.128.2 and the ip for the VM was 172.28.128.3, so I updated the ip in the notes to be .3 vice .2.