### PR TITLE
Documentation/trying-out-rkt: document the assigned pod IP address

### DIFF
--- a/Documentation/trying-out-rkt.md
+++ b/Documentation/trying-out-rkt.md
@@ -121,7 +121,7 @@ UUID		APP	IMAGE NAME					STATE	CREATED		STARTED		NETWORKS
 0c3ab969	nginx	registry-1.docker.io/library/nginx:latest	running	2 minutes ago	2 minutes ago	default:ip4=172.16.28.2
 ```
 
-The nginx container is now accessible on the host under http://172.16.28.2.
+In this example, the nginx container was assigned the IP address 172.16.28.2 (the address assigned on your system may vary). Since we established a route from the host to the `172.16.28.0/24` pod network the nginx container is now accessible on the host under http://172.16.28.2.
 
 Success! The rest of the guide can now be followed normally.
 


### PR DESCRIPTION
The tutorial doesn't make it obvious why the started pod is available
under http://172.16.28.2. This fixes it by improving the documentation.

Supersedes #3080