### PR TITLE
scripts: bump coreos.com/rkt/builder image version

### DIFF
--- a/scripts/build-rir.sh
+++ b/scripts/build-rir.sh
@@ -4,7 +4,7 @@ set -xe
 
 SRC_DIR="${SRC_DIR:-$PWD}"
 BUILDDIR="${BUILDDIR:-$PWD/build-rir}"
-RKT_BUILDER_ACI="${RKT_BUILDER_ACI:-coreos.com/rkt/builder:1.0.1}"
+RKT_BUILDER_ACI="${RKT_BUILDER_ACI:-coreos.com/rkt/builder:1.0.2}"
 
 mkdir -p $BUILDDIR
 


### PR DESCRIPTION
This bumps rkt-builder version to 1.0.2, in order to work with
seccomp filtering.

For reference https://github.com/coreos/rkt-builder/commit/8af31a2a2cfc51e1f36fdae328ced035f8f84b62