### PR TITLE
rkt-monitor: bunch of improvements

### DIFF
--- a/tests/rkt-monitor/README.md
+++ b/tests/rkt-monitor/README.md
@@ -31,21 +31,46 @@ attempt to eat up resources in different ways.
 An example usage:
 
 ```
-$ ./tests/rkt-monitor/build-stresser.sh log
+$ ./tests/rkt-monitor/build-stresser.sh all
 Building worker...
 Beginning build with an empty ACI
+Setting name of ACI to appc.io/rkt-cpu-stresser
+Copying host:build-rkt-1.13.0+git/target/bin/cpu-stresser to aci:/worker
+Setting exec command [/worker]
+Writing ACI to cpu-stresser.aci
+Ending the build
+Beginning build with an empty ACI
+Setting name of ACI to appc.io/rkt-mem-stresser
+Copying host:build-rkt-1.13.0+git/target/bin/mem-stresser to aci:/worker
+Setting exec command [/worker]
+Writing ACI to mem-stresser.aci
+Ending the build
+Beginning build with an empty ACI
 Setting name of ACI to appc.io/rkt-log-stresser
-Copying host:worker-binary to aci:/worker
+Copying host:build-rkt-1.13.0+git/target/bin/log-stresser to aci:/worker
 Setting exec command [/worker]
 Writing ACI to log-stresser.aci
 Ending the build
-$ sudo ./build-rkt-1.10.0+git/target/bin/rkt-monitor log-stresser.aci 
-[sudo] password for derek: 
-rkt(13261): seconds alive: 10  avg CPU: 33.113897%  avg Mem: 4 kB  peak Mem: 4 kB
-systemd(13302): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB
-systemd-journal(13303): seconds alive: 9  avg CPU: 68.004584%  avg Mem: 7 mB  peak Mem: 7 mB
-worker(13307): seconds alive: 9  avg CPU: 13.004088%  avg Mem: 1 mB  peak Mem: 1 mB
-load average in a container: Load1: 0.280000 Load5: 0.250000 Load15: 0.200000
-container start time: 315621ns
-container stop time: 17280555ns
+$ sudo ./build-rkt-1.13.0+git/target/bin/rkt-monitor log-stresser.aci -r 3 -d 10s
+ld-linux-x86-64(29641): seconds alive: 10  avg CPU: 28.948348%  avg Mem: 3 mB  peak Mem: 3 mB
+systemd(29698): seconds alive: 10  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB
+systemd-journal(29700): seconds alive: 10  avg CPU: 89.878237%  avg Mem: 7 mB  peak Mem: 7 mB
+worker(29705): seconds alive: 10  avg CPU: 8.703743%  avg Mem: 5 mB  peak Mem: 6 mB
+load average: Load1: 2.430000 Load5: 1.560000 Load15: 1.100000
+container start time: 2539.947085ms
+container stop time: 14.724007ms
+systemd-journal(29984): seconds alive: 10  avg CPU: 88.553202%  avg Mem: 7 mB  peak Mem: 7 mB
+worker(29989): seconds alive: 10  avg CPU: 8.415344%  avg Mem: 5 mB  peak Mem: 6 mB
+ld-linux-x86-64(29890): seconds alive: 10  avg CPU: 28.863746%  avg Mem: 3 mB  peak Mem: 3 mB
+systemd(29982): seconds alive: 10  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB
+load average: Load1: 2.410000 Load5: 1.600000 Load15: 1.120000
+container start time: 2771.857209ms
+container stop time: 15.30096ms
+systemd(30270): seconds alive: 10  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB
+systemd-journal(30272): seconds alive: 10  avg CPU: 88.863170%  avg Mem: 7 mB  peak Mem: 7 mB
+worker(30277): seconds alive: 10  avg CPU: 8.503793%  avg Mem: 5 mB  peak Mem: 6 mB
+ld-linux-x86-64(30155): seconds alive: 10  avg CPU: 29.522864%  avg Mem: 3 mB  peak Mem: 3 mB
+load average: Load1: 2.270000 Load5: 1.600000 Load15: 1.120000
+container start time: 2641.468717ms
+container stop time: 14.610641ms
 ```

--- a/tests/rkt-monitor/build-stresser.sh
+++ b/tests/rkt-monitor/build-stresser.sh
@@ -6,30 +6,37 @@ if ! [[ "$0" =~ "tests/rkt-monitor/build-stresser.sh" ]]; then
 	exit 255
 fi
 
-stressers=(cpu mem log)
+stressers="cpu mem log"
 
 if [ -z "${1}" ]; then
-    echo Specify one of \""${stressers[@]}"\"
+    echo Specify one of \""${stressers[@]}"\" or all
     exit 1
 fi
-
 
 echo "Building worker..."
 make rkt-monitor
 
 acbuildEnd() {
     export EXIT=$?
-    acbuild --debug end && exit $EXIT
+    if [ -d ".acbuild" ]; then
+        acbuild --debug end && exit $EXIT
+    fi
 }
 
-acbuild --debug begin
+buildImages() {
+    acbuild --debug begin
+    trap acbuildEnd EXIT
+    acbuild --debug set-name appc.io/rkt-"${1}"-stresser
+    acbuild --debug copy build-rkt-1.14.0+git/target/bin/"${1}"-stresser /worker
+    acbuild --debug set-exec -- /worker
+    acbuild --debug write --overwrite "${1}"-stresser.aci
+    acbuild --debug end
+}
 
-trap acbuildEnd EXIT
-
-acbuild --debug set-name appc.io/rkt-"${1}"-stresser
-
-acbuild --debug copy build-rkt-1.14.0+git/target/bin/"${1}"-stresser /worker
-
-acbuild --debug set-exec -- /worker
-
-acbuild --debug write --overwrite "${1}"-stresser.aci
+if [ "${1}" = "all" ]; then
+    for stresser in ${stressers}; do
+        buildImages ${stresser}
+    done
+else
+    buildImages ${1}
+fi

--- a/tests/rkt-monitor/cpu-stresser/main.go
+++ b/tests/rkt-monitor/cpu-stresser/main.go
@@ -14,7 +14,10 @@
 
 package main
 
+import "fmt"
+
 func main() {
+	fmt.Print("APP-STARTED!\n")
 	for {
 		var x uint64
 		for i := 0; i < 1000000000; i++ {

--- a/tests/rkt-monitor/log-stresser/main.go
+++ b/tests/rkt-monitor/log-stresser/main.go
@@ -20,6 +20,7 @@ import (
 )
 
 func main() {
+	fmt.Print("APP-STARTED!\n")
 	for {
 		fmt.Printf("%s\n", time.Now().Format("Mon Jan 2 15:04:05 -0700 MST 2006"))
 	}

--- a/tests/rkt-monitor/mem-stresser/main.go
+++ b/tests/rkt-monitor/mem-stresser/main.go
@@ -15,10 +15,12 @@
 package main
 
 import (
+	"fmt"
 	"time"
 )
 
 func main() {
+	fmt.Print("APP-STARTED!\n")
 	var counter uint64
 	var numbers []uint64
 	for {

--- a/tests/rkt-monitor/sleeper/main.go
+++ b/tests/rkt-monitor/sleeper/main.go
@@ -15,10 +15,12 @@
 package main
 
 import (
+	"fmt"
 	"time"
 )
 
 func main() {
+	fmt.Print("APP-STARTED!\n")
 	for {
 		time.Sleep(time.Hour)
 	}


### PR DESCRIPTION
* Container start time is measured by reading output from app
* Using rkt stop instead of killing all processes
* Using rkt gc when container is in exit state
* Using milliseconds instead of nanoseconds
* Added test image name to output csv filename
* Option for build all test images by one command
* Readme updated
* Minior fixes

In the context of #3019