### PR TITLE
stage0: don't copy image annotations to pod manifest RuntimeApp annotations.

### DIFF
--- a/stage0/run.go
+++ b/stage0/run.go
@@ -212,8 +212,7 @@ func generatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
 				ID:     img,
 				Labels: am.Labels,
 			},
-			Annotations: am.Annotations,
-			Mounts:      MergeMounts(cfg.Apps.Mounts, app.Mounts),
+			Mounts: MergeMounts(cfg.Apps.Mounts, app.Mounts),
 		}
 
 		if execOverride := app.Exec; execOverride != "" {


### PR DESCRIPTION
This PR requires appc/spec#649 to pass TestAceValidator.

When generating the pod manifest, RuntimeApp annotations shouldn't be copied
from the image annotations but, as explained in the appc spec, they should be
merged only when required by the metadata service.

