### PR TITLE
rkt: Implement distribution points

### DIFF
--- a/common/apps/apps.go
+++ b/common/apps/apps.go
@@ -25,28 +25,13 @@ import (
 	"github.com/appc/spec/schema/types"
 )
 
-// AppImageType describes a type of an image reference. The reference
-// can either be guessed or be a hash, a URL, a path, or a name. The
-// first option means that the application will have to deduce the
-// actual type (one of the last four).
-type AppImageType int
-
 var (
 	ErrInvalidSeccompMode     = errors.New("invalid seccomp mode command-line override")
 	ErrInvalidSeccompOverride = errors.New("invalid seccomp command-line override")
 )
 
-const (
-	AppImageGuess AppImageType = iota // image type to be guessed
-	AppImageHash                      // image hash
-	AppImageURL                       // image URL with a scheme
-	AppImagePath                      // absolute or relative path
-	AppImageName                      // image name
-)
-
 type App struct {
 	Image         string                            // the image reference as supplied by the user on the cli
-	ImType        AppImageType                      // the type of the image reference (to be guessed, url, path or hash)
 	Args          []string                          // any arguments the user supplied for this app
 	Asc           string                            // signature file override for image verification (if fetching occurs)
 	Exec          string                            // exec override for image

--- a/pkg/distribution/aciarchive.go
+++ b/pkg/distribution/aciarchive.go
@@ -1,0 +1,116 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distribution
+
+import (
+	"fmt"
+	"net/url"
+)
+
+const (
+	distACIArchiveVersion = 0
+
+	// DistTypeACIArchive represents the ACIArchive distribution type
+	DistTypeACIArchive DistType = "aci-archive"
+)
+
+func init() {
+	Register(DistTypeACIArchive, NewACIArchive)
+}
+
+// ACIArchive defines a distribution using an ACI file
+// The format is:
+// cmd:aci-archive:v=0:ArchiveURL?query...
+// The distribution type is "archive"
+// ArchiveURL must be query escaped
+// Examples:
+// cimd:aci-archive:v=0:file%3A%2F%2Fabsolute%2Fpath%2Fto%2Ffile
+// cimd:aci-archive:v=0:https%3A%2F%2Fexample.com%2Fapp.aci
+type ACIArchive struct {
+	u *url.URL
+	// The transport url
+	tu *url.URL
+}
+
+// NewACIArchive creates a new aci-archive distribution from the provided distribution uri
+// string
+func NewACIArchive(u *url.URL) (Distribution, error) {
+	dp, err := parseDist(u)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse URI: %q: %v", u.String(), err)
+	}
+	if dp.DistType != DistTypeACIArchive {
+		return nil, fmt.Errorf("wrong distribution type: %q", dp.DistType)
+	}
+	// This should be a valid URL
+	tus, err := url.QueryUnescape(dp.DistString)
+	if err != nil {
+		return nil, fmt.Errorf("wrong archive transport url %q: %v", dp.DistString, err)
+	}
+	tu, err := url.Parse(tus)
+	if err != nil {
+		return nil, fmt.Errorf("wrong archive transport url %q: %v", dp.DistString, err)
+	}
+
+	// save the URI as sorted to make it ready for comparison
+	sortQuery(u)
+
+	return &ACIArchive{u: u, tu: tu}, nil
+}
+
+// NewACIArchiveFromTransportURL creates a new aci-archive distribution from the provided transport URL
+// Example: file:///full/path/to/aci/file.aci -> archive:aci:file%3A%2F%2F%2Ffull%2Fpath%2Fto%2Faci%2Ffile.aci
+func NewACIArchiveFromTransportURL(u *url.URL) (Distribution, error) {
+	urlStr := DistBase(DistTypeACIArchive, distACIArchiveVersion) + url.QueryEscape(u.String())
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+	return NewACIArchive(u)
+}
+
+// URI returns a copy of the Distribution URI
+func (a *ACIArchive) URI() *url.URL {
+	// Create a copy of the URL
+	u, err := url.Parse(a.u.String())
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+// Type returns the Distribution type
+func (a *ACIArchive) Type() DistType {
+	return DistTypeACIArchive
+}
+
+// Compare compares with another Distribution
+func (a *ACIArchive) Compare(d Distribution) bool {
+	a2, ok := d.(*ACIArchive)
+	if !ok {
+		return false
+	}
+	return a.URI().String() == a2.URI().String()
+}
+
+// TransportURL returns a copy of the transport URL.
+func (a *ACIArchive) TransportURL() *url.URL {
+	// Create a copy of the transport URL
+	tu, err := url.Parse(a.tu.String())
+	if err != nil {
+		panic(fmt.Errorf("invalid transport URL: %v", err))
+	}
+	return tu
+}

--- a/pkg/distribution/aciarchive_test.go
+++ b/pkg/distribution/aciarchive_test.go
@@ -1,0 +1,86 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distribution
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestACIArchive(t *testing.T) {
+	tests := []struct {
+		transportURL string
+		uriStr       string
+		err          error
+	}{
+		{
+			"file:///full/path/to/aci/file.aci",
+			"cimd:aci-archive:v=0:file%3A%2F%2F%2Ffull%2Fpath%2Fto%2Faci%2Ffile.aci",
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		u, err := url.Parse(tt.transportURL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		d, err := NewACIArchiveFromTransportURL(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		u, err = url.Parse(tt.uriStr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		td, err := NewACIArchive(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !d.Compare(td) {
+			t.Fatalf("expected identical distribution but got %q != %q", td.URI().String(), d.URI().String())
+		}
+	}
+}
+
+func TestTransportURL(t *testing.T) {
+	tests := []struct {
+		transportURL string
+		uriString    string
+		err          error
+	}{
+		{
+			"file:///full/path/to/aci/file.aci",
+			"cimd:aci-archive:v=0:file%3A%2F%2F%2Ffull%2Fpath%2Fto%2Faci%2Ffile.aci",
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		u, err := url.Parse(tt.transportURL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		d, err := NewACIArchiveFromTransportURL(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		transportURL := d.(*ACIArchive).TransportURL()
+		if tt.transportURL != transportURL.String() {
+			t.Fatalf("expected transport url %q, but got %q", tt.transportURL, transportURL.String())
+		}
+	}
+}

--- a/pkg/distribution/appc.go
+++ b/pkg/distribution/appc.go
@@ -1,0 +1,125 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distribution
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/appc/spec/discovery"
+	"github.com/appc/spec/schema/types"
+)
+
+const (
+	distAppcVersion = 0
+
+	// DistTypeAppc represents the Appc distribution type
+	DistTypeAppc DistType = "appc"
+)
+
+func init() {
+	Register(DistTypeAppc, NewAppc)
+}
+
+// Appc defines a distribution using appc image discovery
+// Its format is cimd:appc:v=0:name?label01=....&label02=....
+// The distribution type is "appc"
+// The labels values must be Query escaped
+// Example appc:coreos.com/etcd?version=v3.0.3&os=linux&arch=amd64
+type Appc struct {
+	u   *url.URL
+	app *discovery.App
+}
+
+// NewAppc returns an Appc distribution from an Appc distribution URI
+func NewAppc(u *url.URL) (Distribution, error) {
+	dp, err := parseDist(u)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse URI: %q: %v", u.String(), err)
+	}
+	if dp.DistType != DistTypeAppc {
+		return nil, fmt.Errorf("wrong distribution type: %q", dp.DistType)
+	}
+
+	appcStr := dp.DistString
+	for n, v := range u.Query() {
+		appcStr += fmt.Sprintf(",%s=%s", n, v[0])
+	}
+	app, err := discovery.NewAppFromString(appcStr)
+	if err != nil {
+		return nil, fmt.Errorf("wrong appc image string %q: %v", u.String(), err)
+	}
+
+	return NewAppcFromApp(app), nil
+}
+
+// NewAppcFromApp returns an Appc distribution from an appc App discovery string
+func NewAppcFromApp(app *discovery.App) Distribution {
+	rawuri := DistBase(DistTypeAppc, distAppcVersion) + app.Name.String()
+
+	labels := types.Labels{}
+	for n, v := range app.Labels {
+		labels = append(labels, types.Label{Name: n, Value: v})
+	}
+
+	if len(labels) > 0 {
+		queries := make([]string, len(labels))
+		rawuri += "?"
+		for i, l := range labels {
+			queries[i] = fmt.Sprintf("%s=%s", l.Name, url.QueryEscape(l.Value))
+		}
+		rawuri += strings.Join(queries, "&")
+	}
+
+	u, err := url.Parse(rawuri)
+	if err != nil {
+		panic(fmt.Errorf("cannot parse URI %q: %v", rawuri, err))
+	}
+
+	// save the URI as sorted to make it ready for comparison
+	sortQuery(u)
+	return &Appc{u: u, app: app.Copy()}
+}
+
+// URI returns a copy of the Distribution URI
+func (a *Appc) URI() *url.URL {
+	// Create a copy of the URL
+	u, err := url.Parse(a.u.String())
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+// Type returns the Distribution type
+func (a *Appc) Type() DistType {
+	return DistTypeAppc
+}
+
+// Compare compares with another Distribution
+func (a *Appc) Compare(d Distribution) bool {
+	a2, ok := d.(*Appc)
+	if !ok {
+		return false
+	}
+	return a.u.String() == a2.u.String()
+}
+
+// App returns the discovery.App for an Appc distribution. It'll fail
+// if the distribution is not of type Appc.
+func (a *Appc) App() *discovery.App {
+	return a.app.Copy()
+}

--- a/pkg/distribution/appc_test.go
+++ b/pkg/distribution/appc_test.go
@@ -1,0 +1,115 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distribution
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/appc/spec/discovery"
+)
+
+func TestNewAppcFromAppString(t *testing.T) {
+	tests := []struct {
+		in     string
+		uriStr string
+	}{
+		{
+			"example.com/app01",
+			"cimd:appc:v=0:example.com/app01",
+		},
+		{
+			"example.com/app01:v1.0.0",
+			"cimd:appc:v=0:example.com/app01?version=v1.0.0",
+		},
+		{
+			"example.com/app01,version=v1.0.0",
+			"cimd:appc:v=0:example.com/app01?version=v1.0.0",
+		},
+		{
+			"example.com/app01,version=v1.0.0,label01=?&*/",
+			"cimd:appc:v=0:example.com/app01?label01=%3F%26%2A%2F&version=v1.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		app, err := discovery.NewAppFromString(tt.in)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		appc := NewAppcFromApp(app)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		u, err := url.Parse(tt.uriStr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		td, err := NewAppc(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !appc.Compare(td) {
+			t.Fatalf("expected identical distribution but got %q != %q", td.URI().String(), appc.URI().String())
+		}
+	}
+}
+
+func TestApp(t *testing.T) {
+	tests := []struct {
+		uriStr string
+		out    string
+	}{
+		{
+			"cimd:appc:v=0:example.com/app01",
+			"example.com/app01",
+		},
+		{
+			"cimd:appc:v=0:example.com/app01?version=v1.0.0",
+			"example.com/app01:v1.0.0",
+		},
+		{
+			"cimd:appc:v=0:example.com/app01?version=v1.0.0",
+			"example.com/app01,version=v1.0.0",
+		},
+		{
+			"cimd:appc:v=0:example.com/app01?label01=%3F%26%2A%2F&version=v1.0.0",
+			"example.com/app01,version=v1.0.0,label01=?&*/",
+		},
+	}
+
+	for _, tt := range tests {
+		u, err := url.Parse(tt.uriStr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		appc, err := NewAppc(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		app := appc.(*Appc).App()
+
+		expectedApp, err := discovery.NewAppFromString(tt.out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(app, expectedApp) {
+			t.Fatalf("expected app %s, but got %q", expectedApp.String(), app.String())
+		}
+	}
+}

--- a/pkg/distribution/dist.go
+++ b/pkg/distribution/dist.go
@@ -1,0 +1,95 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distribution
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// DistType represents the Distribution type
+type DistType string
+
+const (
+	// DistScheme represents the Distribution URI scheme
+	DistScheme = "cimd"
+)
+
+// A Distribution represent the way to retrieve an image starting from an input
+// string.
+// It's identified by an URI with a specific schema
+type Distribution interface {
+	// URI returns a copy of the Distribution URI
+	URI() *url.URL
+	// Type returns the distribution type
+	Type() DistType
+	// Compare compares with another Distribution
+	Compare(Distribution) bool
+}
+
+type newDistribution func(*url.URL) (Distribution, error)
+
+var distributions = make(map[DistType]newDistribution)
+
+// Register registers a function that returns a new instance of the given
+// distribution. This is intended to be called from the init function in
+// packages that implement distribution functions.
+func Register(distType DistType, f newDistribution) {
+	if _, ok := distributions[distType]; ok {
+		panic(fmt.Errorf("distribution %q already registered", distType))
+	}
+	distributions[distType] = f
+}
+
+// New returns a Distribution from the input URI.
+// It returns an error if the uri string is wrong or referencing an unknown
+// distribution type.
+func New(u *url.URL) (Distribution, error) {
+	dp, err := parseDist(u)
+	if err != nil {
+		return nil, fmt.Errorf("malformed distribution uri %q: %v", u.String(), err)
+	}
+	if u.Scheme != DistScheme {
+		return nil, fmt.Errorf("malformed distribution uri %q", u.String())
+	}
+	if _, ok := distributions[dp.DistType]; !ok {
+		return nil, fmt.Errorf("unknown distribution type: %q", dp.DistType)
+	}
+	return distributions[dp.DistType](u)
+}
+
+// Parse parses the provided distribution URI string and returns a
+// Distribution.
+func Parse(rawuri string) (Distribution, error) {
+	u, err := url.Parse(rawuri)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse uri: %q: %v", rawuri, err)
+	}
+	return New(u)
+}
+
+// Type returns the distribution type
+func Type(d Distribution) (DistType, error) {
+	dt := d.Type()
+	if _, ok := distributions[dt]; !ok {
+		return "", fmt.Errorf("unknown distribution type: %q", dt)
+	}
+	return dt, nil
+}
+
+// Compare returns true if the two provided distributions are identical
+func Compare(d1 Distribution, d2 Distribution) bool {
+	return d1.Compare(d2)
+}

--- a/pkg/distribution/docker.go
+++ b/pkg/distribution/docker.go
@@ -1,0 +1,116 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distribution
+
+import (
+	"fmt"
+	"net/url"
+
+	d2acommon "github.com/appc/docker2aci/lib/common"
+)
+
+const (
+	distDockerVersion = 0
+
+	// DistTypeDocker represents the Docker distribution type
+	DistTypeDocker DistType = "docker"
+
+	defaultIndexURL   = "registry-1.docker.io"
+	defaultTag        = "latest"
+	defaultRepoPrefix = "library/"
+)
+
+func init() {
+	Register(DistTypeDocker, NewDocker)
+}
+
+// Docker defines a distribution using a docker registry.
+// The format after the docker distribution type prefix (cimd:docker:v=0:) is the same
+// as the docker image string format (man docker-pull):
+// cimd:docker:v=0:[REGISTRY_HOST[:REGISTRY_PORT]/]NAME[:TAG|@DIGEST]
+// Examples:
+// cimd:docker:v=0:busybox
+// cimd:docker:v=0:busybox:latest
+// cimd:docker:v=0:registry-1.docker.io/library/busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6
+type Docker struct {
+	ds string
+}
+
+// NewDocker creates a new docker distribution from the provided distribution uri
+// string
+func NewDocker(u *url.URL) (Distribution, error) {
+	dp, err := parseDist(u)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse URI: %q: %v", u.String(), err)
+	}
+	if dp.DistType != DistTypeDocker {
+		return nil, fmt.Errorf("wrong distribution type: %q", dp.DistType)
+	}
+
+	if _, err = d2acommon.ParseDockerURL(dp.DistString); err != nil {
+		return nil, fmt.Errorf("bad docker string %q: %v", dp.DistString, err)
+	}
+	return &Docker{ds: dp.DistString}, nil
+}
+
+// NewDockerFromDockerString creates a new docker distribution from the provided
+// docker string (like "busybox", "busybox:1.0", "myregistry.example.com:4000/busybox"
+// etc...)
+func NewDockerFromDockerString(ds string) (Distribution, error) {
+	urlStr := DistBase(DistTypeDocker, distDockerVersion) + ds
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+	return NewDocker(u)
+}
+
+// URI returns a copy of the Distribution URI
+func (d *Docker) URI() *url.URL {
+	uriStr := DistBase(DistTypeDocker, distDockerVersion) + d.ds
+	// Create a copy of the URL
+	u, err := url.Parse(uriStr)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+// Type returns the Distribution type
+func (d *Docker) Type() DistType {
+	return DistTypeDocker
+}
+
+// Compare compares with another Distribution
+func (d *Docker) Compare(dist Distribution) bool {
+	d2, ok := dist.(*Docker)
+	if !ok {
+		return false
+	}
+	fds1, err := FullDockerString(d.ds)
+	if err != nil {
+		panic(err)
+	}
+	fds2, err := FullDockerString(d2.ds)
+	if err != nil {
+		panic(err)
+	}
+	return fds1 == fds2
+}
+
+// DockerString returns the docker string.
+func (d *Docker) DockerString() string {
+	return d.ds
+}

--- a/pkg/distribution/docker_test.go
+++ b/pkg/distribution/docker_test.go
@@ -1,0 +1,115 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distribution
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestDocker(t *testing.T) {
+	tests := []struct {
+		inDs        string
+		inURIString string
+		simpleStr   string
+		err         error
+	}{
+		{
+			"busybox",
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox:latest",
+			"busybox",
+			nil,
+		},
+		{
+			"busybox:latest",
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox:latest",
+			"busybox",
+			nil,
+		},
+		{
+			"registry-1.docker.io/library/busybox:latest",
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox:latest",
+			"busybox",
+			nil,
+		},
+		{
+			"busybox:1.0",
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox:1.0",
+			"busybox:1.0",
+			nil,
+		},
+		{
+			"repo/image",
+			"cimd:docker:v=0:registry-1.docker.io/repo/image:latest",
+			"repo/image",
+			nil,
+		},
+		{
+			"repo/image:latest",
+			"cimd:docker:v=0:registry-1.docker.io/repo/image:latest",
+			"repo/image",
+			nil,
+		},
+		{
+			"repo/image:1.0",
+			"cimd:docker:v=0:registry-1.docker.io/repo/image:1.0",
+			"repo/image:1.0",
+			nil,
+		},
+		{
+			"busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6",
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6",
+			"busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6",
+			nil,
+		},
+		{
+			"myregistry.example.com:4000/busybox",
+			"cimd:docker:v=0:myregistry.example.com:4000/busybox:latest",
+			"myregistry.example.com:4000/busybox",
+			nil,
+		},
+		{
+			"myregistry.example.com:4000/busybox:latest",
+			"cimd:docker:v=0:myregistry.example.com:4000/busybox:latest",
+			"myregistry.example.com:4000/busybox",
+			nil,
+		},
+		{
+			"myregistry.example.com:4000/busybox:1.0",
+			"cimd:docker:v=0:myregistry.example.com:4000/busybox:1.0",
+			"myregistry.example.com:4000/busybox:1.0",
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// Test NewDockerFromDockerString
+		d, err := NewDockerFromDockerString(tt.inDs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		u, err := url.Parse(tt.inURIString)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		td, err := NewDocker(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !d.Compare(td) {
+			t.Fatalf("expected identical distribution but got %q != %q", td.URI().String(), d.URI().String())
+		}
+	}
+}

--- a/pkg/distribution/utils.go
+++ b/pkg/distribution/utils.go
@@ -1,0 +1,144 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distribution
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+
+	d2acommon "github.com/appc/docker2aci/lib/common"
+)
+
+type distParts struct {
+	DistType   DistType
+	Version    uint32
+	DistString string
+}
+
+// parseDist parses and returns the dist type, version and remaining part of a
+// distribution URI
+func parseDist(u *url.URL) (*distParts, error) {
+	if u.Scheme != DistScheme {
+		return nil, fmt.Errorf("unsupported scheme: %q", u.Scheme)
+	}
+	parts := strings.SplitN(u.Opaque, ":", 3)
+	if len(parts) < 3 {
+		return nil, fmt.Errorf("malformed distribution uri: %q", u.String())
+	}
+	version, err := strconv.ParseUint(strings.TrimPrefix(parts[1], "v="), 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("malformed distribution version: %s", parts[1])
+	}
+	return &distParts{
+		DistType:   DistType(parts[0]),
+		Version:    uint32(version),
+		DistString: parts[2],
+	}, nil
+}
+
+func DistBase(distType DistType, version uint32) string {
+	return fmt.Sprintf("%s:%s:v=%d:", DistScheme, distType, version)
+}
+
+// from github.com/PuerkitoBio/purell
+func sortQuery(u *url.URL) {
+	q := u.Query()
+
+	if len(q) > 0 {
+		arKeys := make([]string, len(q))
+		i := 0
+		for k := range q {
+			arKeys[i] = k
+			i++
+		}
+		sort.Strings(arKeys)
+		buf := new(bytes.Buffer)
+		for _, k := range arKeys {
+			sort.Strings(q[k])
+			for _, v := range q[k] {
+				if buf.Len() > 0 {
+					buf.WriteRune('&')
+				}
+				buf.WriteString(fmt.Sprintf("%s=%s", k, url.QueryEscape(v)))
+			}
+		}
+
+		// Rebuild the raw query string
+		u.RawQuery = buf.String()
+	}
+}
+
+// SimpleDockerString returns a simplyfied docker string. This means removing
+// the index url if it's the default docker registry (registry-1.docker.io),
+// removing the default repo (library) when using the default docker registry
+// and removing the tag if it's "latest"
+func SimpleDockerString(ds string) (string, error) {
+	p, err := d2acommon.ParseDockerURL(ds)
+	if err != nil {
+		return "", fmt.Errorf("bad docker string %q: %v", ds, err)
+	}
+
+	var sds string
+	if p.IndexURL != defaultIndexURL {
+		sds += p.IndexURL
+	}
+
+	imageName := p.ImageName
+	if p.IndexURL == defaultIndexURL && strings.HasPrefix(p.ImageName, defaultRepoPrefix) {
+		imageName = strings.TrimPrefix(p.ImageName, defaultRepoPrefix)
+	}
+
+	if sds == "" {
+		sds = imageName
+	} else {
+		sds = path.Join(sds, imageName)
+	}
+
+	digest := p.Digest
+	tag := p.Tag
+	if digest != "" {
+		sds += "@" + digest
+	} else {
+		if tag != defaultTag {
+			sds += ":" + tag
+		}
+	}
+	return sds, nil
+}
+
+// FullDockerString return the docker uri populated with all the default values
+// docker strings like "busybox" or
+// "registry-1.docker.io/library/busybox:latest" will become the same docker
+// string "registry-1.docker.io/library/busybox:latest"
+func FullDockerString(ds string) (string, error) {
+	p, err := d2acommon.ParseDockerURL(ds)
+	if err != nil {
+		return "", fmt.Errorf("bad docker string %q: %v", ds, err)
+	}
+	fds := path.Join(p.IndexURL, p.ImageName)
+	digest := p.Digest
+	tag := p.Tag
+	if digest != "" {
+		fds += "@" + digest
+	} else {
+		fds += ":" + tag
+	}
+	return fds, nil
+}

--- a/pkg/distribution/utils_test.go
+++ b/pkg/distribution/utils_test.go
@@ -1,0 +1,98 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distribution
+
+import "testing"
+
+func TestSimpleDockerString(t *testing.T) {
+	tests := []struct {
+		inDs     string
+		simpleDs string
+		err      error
+	}{
+		{
+			"busybox",
+			"busybox",
+			nil,
+		},
+		{
+			"busybox:latest",
+			"busybox",
+			nil,
+		},
+		{
+			"registry-1.docker.io/library/busybox:latest",
+			"busybox",
+			nil,
+		},
+		{
+			"busybox:1.0",
+			"busybox:1.0",
+			nil,
+		},
+		{
+			"repo/image",
+			"repo/image",
+			nil,
+		},
+		{
+			"repo/image:latest",
+			"repo/image",
+			nil,
+		},
+		{
+			"repo/image:1.0",
+			"repo/image:1.0",
+			nil,
+		},
+		{
+			"busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6",
+			"busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6",
+			nil,
+		},
+		{
+			"myregistry.example.com:4000/busybox",
+			"myregistry.example.com:4000/busybox",
+			nil,
+		},
+		{
+			"myregistry.example.com:4000/busybox:latest",
+			"myregistry.example.com:4000/busybox",
+			nil,
+		},
+		{
+			"myregistry.example.com:4000/busybox:1.0",
+			"myregistry.example.com:4000/busybox:1.0",
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		// Test NewDockerFromDockerString
+		d, err := NewDockerFromDockerString(tt.inDs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		ds := d.(*Docker).DockerString()
+		simpleDs, err := SimpleDockerString(ds)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tt.simpleDs != simpleDs {
+			t.Fatalf("expected simple string %q, but got %q", tt.simpleDs, simpleDs)
+		}
+	}
+
+}

--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -112,11 +112,13 @@ func runFetch(cmd *cobra.Command, args []string) (exit int) {
 		WithDeps:  true,
 	}
 
+	err = ft.FetchImages(&rktApps)
+	if err != nil {
+		stderr.Error(err)
+		return 1
+	}
 	err = rktApps.Walk(func(app *apps.App) error {
-		hash, err := ft.FetchImage(app.Image, app.Asc, app.ImType)
-		if err != nil {
-			return err
-		}
+		hash := app.ImageID.String()
 		if !flagFullHash {
 			hash = types.ShortHash(hash)
 		}

--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -29,8 +29,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/coreos/rkt/common/apps"
 	"github.com/coreos/rkt/pkg/aci"
+	dist "github.com/coreos/rkt/pkg/distribution"
 	"github.com/coreos/rkt/pkg/keystore"
 	"github.com/coreos/rkt/pkg/keystore/keystoretest"
 	"github.com/coreos/rkt/rkt/config"
@@ -284,7 +284,15 @@ func TestDownloading(t *testing.T) {
 			Headers:       headers,
 			InsecureFlags: insecureFlags,
 		}
-		_, err = ft.FetchImage(tt.aciURL, "", apps.AppImageURL)
+		u, err := url.Parse(tt.aciURL)
+		if err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+		d, err := dist.NewACIArchiveFromTransportURL(u)
+		if err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+		_, err = ft.FetchImage(d, tt.aciURL, "")
 		if err != nil && !tt.authFail {
 			t.Fatalf("expected download to succeed, it failed: %v (server: %q, headers: `%v`)", err, urlToName[tt.aciURL], tt.options)
 		}
@@ -357,7 +365,16 @@ func TestFetchImage(t *testing.T) {
 		Ks:            ks,
 		InsecureFlags: secureFlags,
 	}
-	_, err = ft.FetchImage(fmt.Sprintf("%s/app.aci", ts.URL), "", apps.AppImageURL)
+
+	u, err := url.Parse(fmt.Sprintf("%s/app.aci", ts.URL))
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	d, err := dist.NewACIArchiveFromTransportURL(u)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	_, err = ft.FetchImage(d, u.String(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -546,7 +563,15 @@ func TestFetchImageCache(t *testing.T) {
 			// Skip local store
 			NoStore: true,
 		}
-		_, err = ft.FetchImage(aciURL, "", apps.AppImageURL)
+		u, err := url.Parse(aciURL)
+		if err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+		d, err := dist.NewACIArchiveFromTransportURL(u)
+		if err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+		_, err = ft.FetchImage(d, u.String(), "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -562,7 +587,7 @@ func TestFetchImageCache(t *testing.T) {
 		}
 
 		downloadTime := rem.DownloadTime
-		_, err = ft.FetchImage(aciURL, "", apps.AppImageURL)
+		_, err = ft.FetchImage(d, u.String(), "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/rkt/image/common.go
+++ b/rkt/image/common.go
@@ -20,10 +20,11 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
-	"github.com/coreos/rkt/common/apps"
+	dist "github.com/coreos/rkt/pkg/distribution"
 	"github.com/coreos/rkt/pkg/keystore"
 	rktlog "github.com/coreos/rkt/pkg/log"
 	"github.com/coreos/rkt/rkt/config"
@@ -32,9 +33,17 @@ import (
 	"github.com/coreos/rkt/store/treestore"
 	"github.com/hashicorp/errwrap"
 
+	"github.com/appc/spec/discovery"
 	"github.com/appc/spec/schema"
 	"github.com/appc/spec/schema/types"
 	"golang.org/x/crypto/openpgp"
+)
+
+type imageStringType int
+
+const (
+	imageStringName imageStringType = iota // image type to be guessed
+	imageStringPath                        // absolute or relative path
 )
 
 // action is a common type for Finder and Fetcher
@@ -150,15 +159,69 @@ func printIdentities(entity *openpgp.Entity) {
 	log.Print(strings.Join(lines, "\n"))
 }
 
-func guessImageType(image string) apps.AppImageType {
-	if _, err := types.NewHash(image); err == nil {
-		return apps.AppImageHash
+// DistFromImageString return the distribution for the given input image string
+func DistFromImageString(is string) (dist.Distribution, error) {
+	// Guess if an user friendly image string is an appc string or a file
+	if u, err := url.Parse(is); err == nil && u.Scheme == "" {
+		appImageType := guessAppcOrPath(is, []string{schema.ACIExtension})
+		switch appImageType {
+		case imageStringName:
+			app, err := discovery.NewAppFromString(is)
+			if err != nil {
+				return nil, fmt.Errorf("bad appc image string %q: %v", is, err)
+			}
+			return dist.NewAppcFromApp(app), nil
+		case imageStringPath:
+			absPath, err := filepath.Abs(is)
+			if err != nil {
+				return nil, errwrap.Wrap(fmt.Errorf("failed to get an absolute path for %q", is), err)
+			}
+			is = "file://" + absPath
+		default:
+			return nil, fmt.Errorf("wrong image string type")
+		}
 	}
-	if u, err := url.Parse(image); err == nil && u.Scheme != "" {
-		return apps.AppImageURL
+
+	// Now convert the user friendly URLs to a distribution
+	if u, err := url.Parse(is); err == nil && u.Scheme != "" {
+		// Convert user friendly image string names to internal distribution URIs
+		// file:///full/path/to/aci/file.aci -> archive:aci:file%3A%2F%2F%2Ffull%2Fpath%2Fto%2Faci%2Ffile.aci
+		switch u.Scheme {
+		case "file", "http", "https":
+			// An ACI archive with any transport type (file, http, s3 etc...) and final aci extension
+			if filepath.Ext(u.Path) == schema.ACIExtension {
+				dist, err := dist.NewACIArchiveFromTransportURL(u)
+				if err != nil {
+					return nil, fmt.Errorf("archive distribution creation error: %v", err)
+				}
+				return dist, nil
+			}
+		case "docker":
+			// Accept both docker: and docker:// uri
+			dockerStr := is
+			if strings.HasPrefix(dockerStr, "docker://") {
+				dockerStr = strings.TrimPrefix(dockerStr, "docker://")
+			} else if strings.HasPrefix(dockerStr, "docker:") {
+				dockerStr = strings.TrimPrefix(dockerStr, "docker:")
+			}
+
+			dist, err := dist.NewDockerFromDockerString(dockerStr)
+			if err != nil {
+				return nil, fmt.Errorf("docker distribution creation error: %v", err)
+			}
+			return dist, nil
+		default:
+			// Try to create a dist directly from the provided URI
+			return dist.Parse(is)
+
+		}
 	}
-	if filepath.IsAbs(image) {
-		return apps.AppImagePath
+	return nil, fmt.Errorf("bad image string %q", is)
+}
+
+func guessAppcOrPath(is string, extensions []string) imageStringType {
+	if filepath.IsAbs(is) {
+		return imageStringPath
 	}
 
 	// Well, at this point is basically heuristics time. The image
@@ -166,9 +229,9 @@ func guessImageType(image string) apps.AppImageType {
 
 	// First, let's try to stat whatever file the URL would specify. If it
 	// exists, that's probably what the user wanted.
-	f, err := os.Stat(image)
+	f, err := os.Stat(is)
 	if err == nil && f.Mode().IsRegular() {
-		return apps.AppImagePath
+		return imageStringPath
 	}
 
 	// Second, let's check if there is a colon in the image
@@ -177,21 +240,23 @@ func guessImageType(image string) apps.AppImageType {
 	// highly unlikely that the image parameter is a path. Colon
 	// in this context is often used for specifying a version of
 	// an image, like in "example.com/reduce-worker:1.0.0".
-	if strings.ContainsRune(image, ':') {
-		return apps.AppImageName
+	if strings.ContainsRune(is, ':') {
+		return imageStringName
 	}
 
 	// Third, let's check if there is a dot followed by a slash
 	// (./) - if so, it is likely that the image parameter is path
 	// like ./aci-in-this-dir or ../aci-in-parent-dir
-	if strings.Contains(image, "./") {
-		return apps.AppImagePath
+	if strings.Contains(is, "./") {
+		return imageStringPath
 	}
 
 	// Fourth, let's check if the image parameter has an .aci
 	// extension. If so, likely a path like "stage1-coreos.aci".
-	if filepath.Ext(image) == schema.ACIExtension {
-		return apps.AppImagePath
+	for _, e := range extensions {
+		if filepath.Ext(is) == e {
+			return imageStringPath
+		}
 	}
 
 	// At this point, if the image parameter is something like
@@ -201,7 +266,62 @@ func guessImageType(image string) apps.AppImageType {
 	// "stage1-coreos" in this directory tree, then you better be
 	// off prepending the parameter with "./", because I'm gonna
 	// treat this as an image name otherwise.
-	return apps.AppImageName
+	return imageStringName
+}
+
+// DistSimpleString returns an user friendly string representation of the distribution
+func DistSimpleString(d dist.Distribution) (string, error) {
+	distType, err := dist.Type(d)
+	if err != nil {
+		return "", err
+	}
+	switch distType {
+	case dist.DistTypeAppc:
+		return AppcSimpleString(d.(*dist.Appc))
+	case dist.DistTypeACIArchive:
+		// Return the simple string only if the archiveURL extension is .aci
+		transportURL := d.(*dist.ACIArchive).TransportURL()
+		path := transportURL.String()
+		if filepath.Ext(path) == schema.ACIExtension {
+			return path, nil
+		}
+		return d.URI().String(), nil
+	case dist.DistTypeDocker:
+		ds := d.(*dist.Docker).DockerString()
+		sds, err := dist.SimpleDockerString(ds)
+		return "docker:" + sds, err
+	default:
+		return "", fmt.Errorf("unknown distribution type")
+	}
+}
+
+// AppcSimpleString returns the simplest appc image format string from the Appc
+// distribution
+// To avoid random label position they are alphabetically ordered giving the
+// precedence to version, os, arch (in this order)
+func AppcSimpleString(d *dist.Appc) (string, error) {
+	app := d.App()
+	var version string
+	labels := types.Labels{}
+	for n, v := range app.Labels {
+		if n == "version" {
+			version = v
+		} else {
+			labels = append(labels, types.Label{Name: n, Value: v})
+		}
+	}
+	sort.Sort(labelsSlice(labels))
+
+	img := app.Name.String()
+	if version != "" {
+		img += fmt.Sprintf(":%s", version)
+	}
+	for _, l := range labels {
+		if l.Name != "version" {
+			img += fmt.Sprintf(",%s=%s", l.Name, l.Value)
+		}
+	}
+	return img, nil
 }
 
 func eTag(rem *imagestore.Remote) string {

--- a/rkt/image/common_test.go
+++ b/rkt/image/common_test.go
@@ -15,87 +15,73 @@
 package image
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/url"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/coreos/rkt/common/apps"
+	dist "github.com/coreos/rkt/pkg/distribution"
 )
 
-func TestGuessImageType(t *testing.T) {
+func TestGuessAppcOrPath(t *testing.T) {
 	tests := []struct {
 		image        string
-		expectedType apps.AppImageType
+		expectedType imageStringType
 	}{
-		// guess obvious hash as a hash
-		{
-			image:        "sha512-a8d0943eb94eb9da4a6dddfa51e5e3de84375de77271d26c41ac1ce6f588b618",
-			expectedType: apps.AppImageHash,
-		},
-		// guess obvious URL as a URL
-		{
-			image:        "http://example.com/image.aci",
-			expectedType: apps.AppImageURL,
-		},
 		// guess obvious absolute path as a path
 		{
 			image:        "/usr/libexec/rkt/stage1.aci",
-			expectedType: apps.AppImagePath,
+			expectedType: imageStringPath,
 		},
 		// guess stuff with colon as a name
 		{
 			image:        "example.com/stage1:1.2.3",
-			expectedType: apps.AppImageName,
+			expectedType: imageStringName,
 		},
 		// guess stuff with ./ as a path
 		{
 			image:        "some/relative/../path/with/dots/file",
-			expectedType: apps.AppImagePath,
+			expectedType: imageStringPath,
 		},
 		// the same
 		{
 			image:        "./another/obviously/relative/path",
-			expectedType: apps.AppImagePath,
+			expectedType: imageStringPath,
 		},
 		// guess stuff ending with .aci as a path
 		{
 			image:        "some/relative/path/with/aci/extension.aci",
-			expectedType: apps.AppImagePath,
+			expectedType: imageStringPath,
 		},
 		// guess stuff without .aci, ./ and : as a name
 		{
 			image:        "example.com/stage1",
-			expectedType: apps.AppImageName,
+			expectedType: imageStringName,
 		},
 		// another try
 		{
 			image:        "example.com/stage1,version=1.2.3,foo=bar",
-			expectedType: apps.AppImageName,
+			expectedType: imageStringName,
 		},
 	}
 	for _, tt := range tests {
-		guessed := guessImageType(tt.image)
+		guessed := guessAppcOrPath(tt.image, []string{".aci"})
 		if tt.expectedType != guessed {
 			t.Errorf("expected %q to be guessed as %q, but got %q", tt.image, imageTypeToString(tt.expectedType), imageTypeToString(guessed))
 		}
 	}
 }
 
-func imageTypeToString(imType apps.AppImageType) string {
+func imageTypeToString(imType imageStringType) string {
 	switch imType {
-	case apps.AppImageGuess:
-		return "to-be-guessed"
-	case apps.AppImageHash:
-		return "hash"
-	case apps.AppImageURL:
-		return "URL"
-	case apps.AppImagePath:
-		return "path"
-	case apps.AppImageName:
+	case imageStringName:
 		return "name"
+	case imageStringPath:
+		return "path"
 	default:
 		return "unknown"
 	}
@@ -227,4 +213,282 @@ func TestIsReallyNil(t *testing.T) {
 			t.Errorf("expected isReallyNil(%#v) to return %v, but got %v", tt.iface, tt.isNil, got)
 		}
 	}
+}
+
+func TestDistFromImageString(t *testing.T) {
+	relPath1 := "some/relative/../path/with/dots/file.aci"
+	absPath1, err := filepath.Abs(relPath1)
+	if err != nil {
+
+		t.Fatalf("unexpected error: %v", err)
+	}
+	relPath2 := "some/relative/../path/with/dots/file"
+	absPath2, err := filepath.Abs(relPath2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		in         string
+		distString string
+		err        error
+	}{
+		// Appc
+		{
+			"example.com/app01",
+			"cimd:appc:v=0:example.com/app01",
+			nil,
+		},
+		{
+			"example.com/app01:v1.0.0",
+			"cimd:appc:v=0:example.com/app01?version=v1.0.0",
+			nil,
+		},
+		{
+			"example.com/app01:v1.0.0,label01=?&*/",
+			"cimd:appc:v=0:example.com/app01?label01=%3F%26%2A%2F&version=v1.0.0",
+			nil,
+		},
+		// ACIArchive
+		{
+			"file:///absolute/path/to/file.aci",
+			"cimd:aci-archive:v=0:file%3A%2F%2F%2Fabsolute%2Fpath%2Fto%2Ffile.aci",
+			nil,
+		},
+		{
+			"/absolute/path/to/file.aci",
+			"cimd:aci-archive:v=0:file%3A%2F%2F%2Fabsolute%2Fpath%2Fto%2Ffile.aci",
+			nil,
+		},
+		{
+			relPath1,
+			"cimd:aci-archive:v=0:" + url.QueryEscape("file://"+absPath1),
+			nil,
+		},
+		{
+			"https://example.com/app.aci",
+			"cimd:aci-archive:v=0:https%3A%2F%2Fexample.com%2Fapp.aci",
+			nil,
+		},
+		// Path with no .aci extension
+		{
+			"/absolute/path/to/file",
+			"",
+			fmt.Errorf("bad image string %q", "file:///absolute/path/to/file"),
+		},
+		{
+			"/absolute/path/to/file.tar",
+			"",
+			fmt.Errorf("bad image string %q", "file:///absolute/path/to/file.tar"),
+		},
+		{
+			relPath2,
+			"",
+			fmt.Errorf("bad image string %q", "file://"+absPath2),
+		},
+		// Docker
+		{
+			"docker:busybox",
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox:latest",
+			nil,
+		},
+		{
+			"docker://busybox",
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox:latest",
+			nil,
+		},
+		{
+			"docker:busybox:latest",
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox:latest",
+			nil,
+		},
+		{
+			"docker://busybox:latest",
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox:latest",
+			nil,
+		},
+		{
+			"docker:busybox:1.0",
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox:1.0",
+			nil,
+		},
+		{
+			"docker:busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6",
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6",
+			nil,
+		},
+		{
+			"docker:myregistry.example.com:4000/busybox",
+			"cimd:docker:v=0:myregistry.example.com:4000/busybox:latest",
+			nil,
+		},
+		{
+			"docker:myregistry.example.com:4000/busybox",
+			"cimd:docker:v=0:myregistry.example.com:4000/busybox:latest",
+			nil,
+		},
+		{
+			"docker:myregistry.example.com:4000/busybox:1.0",
+			"cimd:docker:v=0:myregistry.example.com:4000/busybox:1.0",
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		d, err := DistFromImageString(tt.in)
+		if err != nil {
+			if tt.err == nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.err.Error() != err.Error() {
+				t.Fatalf("expected error %v, but got error %v", tt.err, err)
+			}
+			continue
+		} else {
+			if tt.err != nil {
+				t.Fatalf("expected error %v, but got nil error", tt.err)
+			}
+		}
+		td, err := dist.Parse(tt.distString)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !d.Compare(td) {
+			t.Fatalf("expected identical distribution but got %q != %q", tt.distString, d.URI().String())
+		}
+	}
+
+}
+func TestAppcSimpleString(t *testing.T) {
+	tests := []struct {
+		in           string
+		simpleString string
+	}{
+		{
+			"cimd:appc:v=0:example.com/app01",
+			"example.com/app01",
+		},
+		{
+			"cimd:appc:v=0:example.com/app01?version=v1.0.0",
+			"example.com/app01:v1.0.0",
+		},
+		{
+			"cimd:appc:v=0:example.com/app01?version=v1.0.0&label01=%3F%26%2A%2F",
+			"example.com/app01:v1.0.0,label01=?&*/",
+		},
+	}
+
+	for _, tt := range tests {
+		u, err := url.Parse(tt.in)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		d, err := dist.NewAppc(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		simpleString, err := AppcSimpleString(d.(*dist.Appc))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tt.simpleString != simpleString {
+			t.Fatalf("expected %q, but got %q", tt.simpleString, simpleString)
+		}
+	}
+
+}
+
+func TestDistSimpleString(t *testing.T) {
+	tests := []struct {
+		in           string
+		simpleString string
+	}{
+		// Appc
+		{
+			"cimd:appc:v=0:example.com/app01",
+			"example.com/app01",
+		},
+		{
+			"cimd:appc:v=0:example.com/app01?version=v1.0.0",
+			"example.com/app01:v1.0.0",
+		},
+		{
+			"cimd:appc:v=0:example.com/app01?version=v1.0.0&label01=%3F%26%2A%2F",
+			"example.com/app01:v1.0.0,label01=?&*/",
+		},
+		// ACIArchive
+		{
+			"cimd:aci-archive:v=0:file%3A%2F%2F%2Fabsolute%2Fpath%2Fto%2Ffile.aci",
+			"file:///absolute/path/to/file.aci",
+		},
+		{
+			"cimd:aci-archive:v=0:https%3A%2F%2Fexample.com%2Fapp.aci",
+			"https://example.com/app.aci",
+		},
+		// No .aci extension, so the simple url cannot be provided
+		{
+			"cimd:aci-archive:v=0:https%3A%2F%2Fexample.com%2Fapp.tar",
+			"cimd:aci-archive:v=0:https%3A%2F%2Fexample.com%2Fapp.tar",
+		},
+		// Docker
+		{
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox:latest",
+			"docker:busybox",
+		},
+		{
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox:latest",
+			"docker:busybox",
+		},
+		{
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox:latest",
+			"docker:busybox",
+		},
+		{
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox:1.0",
+			"docker:busybox:1.0",
+		},
+		{
+			"cimd:docker:v=0:registry-1.docker.io/repo/image:latest",
+			"docker:repo/image",
+		},
+		{
+			"cimd:docker:v=0:registry-1.docker.io/repo/image:latest",
+			"docker:repo/image",
+		},
+		{
+			"cimd:docker:v=0:registry-1.docker.io/repo/image:1.0",
+			"docker:repo/image:1.0",
+		},
+		{
+			"cimd:docker:v=0:registry-1.docker.io/library/busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6",
+			"docker:busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6",
+		},
+		{
+			"cimd:docker:v=0:myregistry.example.com:4000/busybox:latest",
+			"docker:myregistry.example.com:4000/busybox",
+		},
+		{
+			"cimd:docker:v=0:myregistry.example.com:4000/busybox:latest",
+			"docker:myregistry.example.com:4000/busybox",
+		},
+		{
+			"cimd:docker:v=0:myregistry.example.com:4000/busybox:1.0",
+			"docker:myregistry.example.com:4000/busybox:1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		d, err := dist.Parse(tt.in)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		simpleString, err := DistSimpleString(d)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tt.simpleString != simpleString {
+			t.Fatalf("expected %q, but got %q", tt.simpleString, simpleString)
+		}
+	}
+
 }

--- a/rkt/image/fetcher.go
+++ b/rkt/image/fetcher.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/common/apps"
+	dist "github.com/coreos/rkt/pkg/distribution"
 	"github.com/coreos/rkt/stage0"
 	"github.com/coreos/rkt/store/imagestore"
 	"github.com/hashicorp/errwrap"
@@ -32,25 +33,52 @@ import (
 	"github.com/appc/spec/schema/types"
 )
 
+// distBundle contains the distribution and the original image string
+// (primarily used for logging)
+type distBundle struct {
+	dist dist.Distribution
+	str  string
+}
+
 // Fetcher will try to fetch images into the store.
 type Fetcher action
+
+// FetchImages uses FetchImage to attain a list of image hashes
+func (f *Fetcher) FetchImages(al *apps.Apps) error {
+	return al.Walk(func(app *apps.App) error {
+		d, err := DistFromImageString(app.Image)
+		if err != nil {
+			return err
+		}
+		h, err := f.FetchImage(d, app.Image, app.Asc)
+		if err != nil {
+			return err
+		}
+		app.ImageID = *h
+		return nil
+	})
+}
 
 // FetchImage will take an image as either a path, a URL or a name
 // string and import it into the store if found. If ascPath is not "",
 // it must exist as a local file and will be used as the signature
 // file for verification, unless verification is disabled. If
 // f.WithDeps is true also image dependencies are fetched.
-func (f *Fetcher) FetchImage(img string, ascPath string, imgType apps.AppImageType) (string, error) {
+func (f *Fetcher) FetchImage(d dist.Distribution, str, ascPath string) (*types.Hash, error) {
 	ensureLogger(f.Debug)
+	db := &distBundle{
+		dist: d,
+		str:  str,
+	}
 	a := f.getAsc(ascPath)
-	hash, err := f.fetchSingleImage(img, a, imgType)
+	hash, err := f.fetchSingleImage(db, a)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if f.WithDeps {
 		err = f.fetchImageDeps(hash)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 
@@ -60,10 +88,15 @@ func (f *Fetcher) FetchImage(img string, ascPath string, imgType apps.AppImageTy
 	// 2) check if we're root
 	if common.SupportsOverlay() == nil && os.Geteuid() == 0 {
 		if _, _, err := f.Ts.Render(hash, false); err != nil {
-			return "", errwrap.Wrap(errors.New("error rendering tree store"), err)
+			return nil, errwrap.Wrap(errors.New("error rendering tree store"), err)
 		}
 	}
-	return hash, nil
+	h, err := types.NewHash(hash)
+	if err != nil {
+		// should never happen
+		log.PanicE("got an invalid hash, looks like it is corrupted", err)
+	}
+	return h, nil
 }
 
 func (f *Fetcher) getAsc(ascPath string) *asc {
@@ -79,12 +112,20 @@ func (f *Fetcher) getAsc(ascPath string) *asc {
 // fetchImageDeps will recursively fetch all the image dependencies
 func (f *Fetcher) fetchImageDeps(hash string) error {
 	imgsl := list.New()
-	seen := map[string]struct{}{}
+	seen := map[dist.Distribution]struct{}{}
 	f.addImageDeps(hash, imgsl, seen)
 	for el := imgsl.Front(); el != nil; el = el.Next() {
 		a := &asc{}
-		img := el.Value.(string)
-		hash, err := f.fetchSingleImage(img, a, apps.AppImageName)
+		d := el.Value.(*dist.Appc)
+		str, err := AppcSimpleString(d)
+		if err != nil {
+			return err
+		}
+		db := &distBundle{
+			dist: d,
+			str:  str,
+		}
+		hash, err := f.fetchSingleImage(db, a)
 		if err != nil {
 			return err
 		}
@@ -93,7 +134,7 @@ func (f *Fetcher) fetchImageDeps(hash string) error {
 	return nil
 }
 
-func (f *Fetcher) addImageDeps(hash string, imgsl *list.List, seen map[string]struct{}) error {
+func (f *Fetcher) addImageDeps(hash string, imgsl *list.List, seen map[dist.Distribution]struct{}) error {
 	dependencies, err := f.getImageDeps(hash)
 	if err != nil {
 		return errwrap.Wrap(fmt.Errorf("failed to get dependencies for image ID %q", hash), err)
@@ -104,12 +145,16 @@ func (f *Fetcher) addImageDeps(hash string, imgsl *list.List, seen map[string]st
 		if err != nil {
 			return errwrap.Wrap(fmt.Errorf("one of image ID's %q dependencies (image %q) is invalid", hash, imgName), err)
 		}
-		appStr := app.String()
-		if _, ok := seen[appStr]; ok {
-			continue
+		d := dist.NewAppcFromApp(app)
+		// To really catch already seen deps the saved string must be a
+		// reproducible string keeping the labels order
+		for sd := range seen {
+			if d.Compare(sd) {
+				continue
+			}
 		}
-		imgsl.PushBack(app.String())
-		seen[appStr] = struct{}{}
+		imgsl.PushBack(d)
+		seen[d] = struct{}{}
 	}
 	return nil
 }
@@ -126,43 +171,35 @@ func (f *Fetcher) getImageDeps(hash string) (types.Dependencies, error) {
 	return im.Dependencies, nil
 }
 
-func (f *Fetcher) fetchSingleImage(img string, a *asc, imgType apps.AppImageType) (string, error) {
-	if imgType == apps.AppImageGuess {
-		imgType = guessImageType(img)
+func (f *Fetcher) fetchSingleImage(db *distBundle, a *asc) (string, error) {
+	distType, err := dist.Type(db.dist)
+	if err != nil {
+		return "", err
 	}
-	if imgType == apps.AppImageHash {
-		return "", fmt.Errorf("cannot fetch a hash %q, expected either a URL, a path or an image name", img)
-	}
-
-	switch imgType {
-	case apps.AppImageURL:
-		return f.fetchSingleImageByURL(img, a)
-	case apps.AppImagePath:
-		return f.fetchSingleImageByPath(img, a)
-	case apps.AppImageName:
-		return f.fetchSingleImageByName(img, a)
+	switch distType {
+	case dist.DistTypeACIArchive:
+		return f.fetchACIArchive(db, a)
+	case dist.DistTypeAppc:
+		return f.fetchSingleImageByName(db, a)
+	case dist.DistTypeDocker:
+		return f.fetchSingleImageByDockerURL(db)
 	default:
-		return "", fmt.Errorf("unknown image type %d", imgType)
+		return "", fmt.Errorf("unknown distribution type %d", distType)
 	}
 }
 
-func (f *Fetcher) fetchSingleImageByURL(urlStr string, a *asc) (string, error) {
-	u, err := url.Parse(urlStr)
-	if err != nil {
-		return "", errwrap.Wrap(fmt.Errorf("invalid image URL %q", urlStr), err)
-	}
+func (f *Fetcher) fetchACIArchive(db *distBundle, a *asc) (string, error) {
+	u := db.dist.(*dist.ACIArchive).TransportURL()
 
 	switch u.Scheme {
 	case "http", "https":
 		return f.fetchSingleImageByHTTPURL(u, a)
-	case "docker":
-		return f.fetchSingleImageByDockerURL(u)
 	case "file":
 		return f.fetchSingleImageByPath(u.Path, a)
 	case "":
-		return "", fmt.Errorf("expected image URL %q to contain a scheme", urlStr)
+		return "", fmt.Errorf("expected image URL %q to contain a scheme", u.String())
 	default:
-		return "", fmt.Errorf("an unsupported URL scheme %q - the only URL schemes supported by rkt are docker, http, https and file", u.Scheme)
+		return "", fmt.Errorf("an unsupported URL scheme %q - the only URL schemes supported by rkt for an archive are http, https and file", u.Scheme)
 	}
 }
 
@@ -180,7 +217,15 @@ func (f *Fetcher) fetchSingleImageByHTTPURL(u *url.URL, a *asc) (string, error) 
 	return "", fmt.Errorf("unable to fetch image from URL %q: either image was not found in the store or store was disabled and fetching from remote yielded nothing or it was disabled", u.String())
 }
 
-func (f *Fetcher) fetchSingleImageByDockerURL(u *url.URL) (string, error) {
+func (f *Fetcher) fetchSingleImageByDockerURL(db *distBundle) (string, error) {
+	ds := db.dist.(*dist.Docker).DockerString()
+	// Convert to the docker2aci URL format
+	urlStr := "docker://" + ds
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return "", err
+	}
+
 	rem, err := remoteForURL(f.S, u)
 	if err != nil {
 		return "", err
@@ -243,16 +288,11 @@ func (f *Fetcher) fetchSingleImageByPath(path string, a *asc) (string, error) {
 	return ff.Hash(path, a)
 }
 
-type appBundle struct {
-	App *discovery.App
-	Str string
-}
-
-func newAppBundle(name string) (*appBundle, error) {
-	app, err := discovery.NewAppFromString(name)
-	if err != nil {
-		return nil, errwrap.Wrap(fmt.Errorf("invalid image name %q", name), err)
-	}
+// TODO(sgotti) I'm not sure setting default os and arch also for image
+// dependencies is correct since it may break noarch dependencies. Reference:
+// https://github.com/coreos/rkt/pull/2317
+func (db *distBundle) setAppDefaults() error {
+	app := db.dist.(*dist.Appc).App()
 	if _, ok := app.Labels["arch"]; !ok {
 		app.Labels["arch"] = runtime.GOARCH
 	}
@@ -260,34 +300,30 @@ func newAppBundle(name string) (*appBundle, error) {
 		app.Labels["os"] = runtime.GOOS
 	}
 	if err := types.IsValidOSArch(app.Labels, stage0.ValidOSArch); err != nil {
-		return nil, errwrap.Wrap(fmt.Errorf("invalid image name %q", name), err)
+		return errwrap.Wrap(fmt.Errorf("invalid Appc distribution %q", db.str), err)
 	}
-	bundle := &appBundle{
-		App: app,
-		Str: name,
-	}
-	return bundle, nil
+	db.dist = dist.NewAppcFromApp(app)
+	return nil
 }
 
-func (f *Fetcher) fetchSingleImageByName(name string, a *asc) (string, error) {
-	app, err := newAppBundle(name)
-	if err != nil {
+func (f *Fetcher) fetchSingleImageByName(db *distBundle, a *asc) (string, error) {
+	if err := db.setAppDefaults(); err != nil {
 		return "", err
 	}
-	if h, err := f.maybeCheckStoreForApp(app); h != "" || err != nil {
+	if h, err := f.maybeCheckStoreForApp(db); h != "" || err != nil {
 		return h, err
 	}
-	if h, err := f.maybeFetchImageFromRemote(app, a); h != "" || err != nil {
+	if h, err := f.maybeFetchImageFromRemote(db, a); h != "" || err != nil {
 		return h, err
 	}
-	return "", fmt.Errorf("unable to fetch image from image name %q: either image was not found in the store or store was disabled and fetching from remote yielded nothing or it was disabled", name)
+	return "", fmt.Errorf("unable to fetch image from image name %q: either image was not found in the store or store was disabled and fetching from remote yielded nothing or it was disabled", db.str)
 }
 
-func (f *Fetcher) maybeCheckStoreForApp(app *appBundle) (string, error) {
+func (f *Fetcher) maybeCheckStoreForApp(db *distBundle) (string, error) {
 	if !f.NoStore {
-		key, err := f.getStoreKeyFromApp(app)
+		key, err := f.getStoreKeyFromApp(db)
 		if err == nil {
-			log.Printf("using image from local store for image name %s", app.Str)
+			log.Printf("using image from local store for image name %s", db.str)
 			return key, nil
 		}
 		switch err.(type) {
@@ -300,25 +336,27 @@ func (f *Fetcher) maybeCheckStoreForApp(app *appBundle) (string, error) {
 	return "", nil
 }
 
-func (f *Fetcher) getStoreKeyFromApp(app *appBundle) (string, error) {
-	labels, err := types.LabelsFromMap(app.App.Labels)
+func (f *Fetcher) getStoreKeyFromApp(db *distBundle) (string, error) {
+	app := db.dist.(*dist.Appc).App()
+	labels, err := types.LabelsFromMap(app.Labels)
 	if err != nil {
-		return "", errwrap.Wrap(fmt.Errorf("invalid labels in the name %q", app.Str), err)
+		return "", errwrap.Wrap(fmt.Errorf("invalid labels in the name %q", db.str), err)
 	}
-	key, err := f.S.GetACI(app.App.Name, labels)
+	key, err := f.S.GetACI(app.Name, labels)
 	if err != nil {
 		switch err.(type) {
 		case imagestore.ACINotFoundError:
 			return "", err
 		default:
-			return "", errwrap.Wrap(fmt.Errorf("cannot find image %q", app.Str), err)
+			return "", errwrap.Wrap(fmt.Errorf("cannot find image %q", db.str), err)
 		}
 	}
 	return key, nil
 }
 
-func (f *Fetcher) maybeFetchImageFromRemote(app *appBundle, a *asc) (string, error) {
+func (f *Fetcher) maybeFetchImageFromRemote(db *distBundle, a *asc) (string, error) {
 	if !f.StoreOnly {
+		app := db.dist.(*dist.Appc).App()
 		nf := &nameFetcher{
 			InsecureFlags:      f.InsecureFlags,
 			S:                  f.S,
@@ -328,7 +366,7 @@ func (f *Fetcher) maybeFetchImageFromRemote(app *appBundle, a *asc) (string, err
 			Headers:            f.Headers,
 			TrustKeysFromHTTPS: f.TrustKeysFromHTTPS,
 		}
-		return nf.Hash(app.App, a)
+		return nf.Hash(app, a)
 	}
 	return "", nil
 }

--- a/rkt/image/utils.go
+++ b/rkt/image/utils.go
@@ -1,0 +1,62 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package image
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/appc/spec/schema/types"
+)
+
+func getLabelPriority(name types.ACIdentifier) int {
+	labelsPriority := map[types.ACIdentifier]int{
+		"version": 0,
+		"os":      1,
+		"arch":    2,
+	}
+	if i, ok := labelsPriority[name]; ok {
+		return i
+	}
+	return len(labelsPriority) + 1
+}
+
+// labelsSlice implements sort.Interface for types.Labels
+type labelsSlice types.Labels
+
+func (p labelsSlice) Len() int { return len(p) }
+func (p labelsSlice) Less(i, j int) bool {
+	pi := getLabelPriority(p[i].Name)
+	pj := getLabelPriority(p[j].Name)
+	if pi != pj {
+		return pi < pj
+	}
+	return p[i].Name < p[j].Name
+}
+
+func (p labelsSlice) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+
+func labelsToString(inLabels types.Labels) string {
+	// take a copy to avoid changing the original slice
+	labels := append(types.Labels(nil), inLabels...)
+	sort.Sort(labelsSlice(labels))
+
+	var out []string
+	for _, l := range labels {
+		out = append(out, fmt.Sprintf("%q:%q", l.Name, l.Value))
+	}
+	return "[" + strings.Join(out, ", ") + "]"
+}

--- a/rkt/stage1hash.go
+++ b/rkt/stage1hash.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/appc/spec/schema/types"
-	"github.com/coreos/rkt/common/apps"
 	"github.com/coreos/rkt/rkt/config"
 	"github.com/coreos/rkt/rkt/image"
 	"github.com/coreos/rkt/store/imagestore"
@@ -244,31 +243,15 @@ func getStage1HashFromFlag(s *imagestore.Store, ts *treestore.Store, loc stage1I
 		return nil, err
 	}
 
-	imgType := apps.AppImageGuess
 	switch loc.kind {
-	case stage1ImageLocationURL:
-		imgType = apps.AppImageURL
+	case stage1ImageLocationURL, stage1ImageLocationPath, stage1ImageLocationFromDir:
 		if trustedLocation {
 			withKeystore = false
 		}
-	case stage1ImageLocationPath:
-		imgType = apps.AppImagePath
-		if trustedLocation {
-			withKeystore = false
-		}
-	case stage1ImageLocationName:
-		imgType = apps.AppImageName
-	case stage1ImageLocationHash:
-		imgType = apps.AppImageHash
-	case stage1ImageLocationFromDir:
-		if trustedLocation {
-			withKeystore = false
-		}
-		imgType = apps.AppImagePath
 	}
 
 	fn := getStage1Finder(s, ts, withKeystore)
-	return fn.FindImage(location, "", imgType)
+	return fn.FindImage(location, "")
 }
 
 func getStage1DataFromConfig(c *config.Config) (string, string, string) {
@@ -320,7 +303,7 @@ func getConfiguredStage1Hash(s *imagestore.Store, ts *treestore.Store, imgRef, i
 	fn := getStage1Finder(s, ts, !trusted)
 	if !strings.HasSuffix(imgRef, "-dirty") {
 		fn.StoreOnly = true
-		if hash, err := fn.FindImage(imgRef, "", apps.AppImageName); err == nil {
+		if hash, err := fn.FindImage(imgRef, ""); err == nil {
 			return hash, nil
 		}
 		fn.StoreOnly = false
@@ -331,7 +314,7 @@ func getConfiguredStage1Hash(s *imagestore.Store, ts *treestore.Store, imgRef, i
 	// If imgLoc is not an absolute path, then it is a URL
 	imgLocIsURL := imgLoc != "" && !filepath.IsAbs(imgLoc)
 	if imgLocIsURL {
-		return fn.FindImage(imgLoc, "", apps.AppImageURL)
+		return fn.FindImage(imgLoc, "")
 	}
 	return getStage1HashFromPath(fn, imgLoc, imgFileName)
 }
@@ -358,7 +341,7 @@ func getStage1HashFromPath(fn *image.Finder, imgLoc, imgFileName string) (*types
 	var fetchErr error
 	var fallbackErr error
 	if imgLoc != "" {
-		hash, err := fn.FindImage(imgLoc, "", apps.AppImagePath)
+		hash, err := fn.FindImage(imgLoc, "")
 		if err == nil {
 			return hash, nil
 		}
@@ -373,7 +356,7 @@ func getStage1HashFromPath(fn *image.Finder, imgLoc, imgFileName string) (*types
 			fn.Ks = nil
 			rktDir := filepath.Dir(exePath)
 			imgPath := filepath.Join(rktDir, imgFileName)
-			hash, err := fn.FindImage(imgPath, "", apps.AppImagePath)
+			hash, err := fn.FindImage(imgPath, "")
 			if err == nil {
 				return hash, nil
 			}

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -313,7 +313,7 @@ func TestResumedFetch(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	cmd := fmt.Sprintf("%s --no-store --insecure-options=image fetch %s", ctx.Cmd(), server.URL)
+	cmd := fmt.Sprintf("%s --no-store --insecure-options=image fetch %s", ctx.Cmd(), server.URL+"/image.aci")
 	child := spawnOrFail(t, cmd)
 	<-kill
 	err := child.Close()
@@ -354,7 +354,7 @@ func TestResumedFetchInvalidCache(t *testing.T) {
 	// Fetch the first half of the image, and kill rkt once it reaches halfway.
 	server := httptest.NewServer(testServerHandler(t, shouldInterrupt, imagePath, kill, reportkill))
 	defer server.Close()
-	cmd := fmt.Sprintf("%s --no-store --insecure-options=image fetch %s", ctx.Cmd(), server.URL)
+	cmd := fmt.Sprintf("%s --no-store --insecure-options=image fetch %s", ctx.Cmd(), server.URL+"/image.aci")
 	child := spawnOrFail(t, cmd)
 	<-kill
 	err := child.Close()

--- a/tests/rkt_stage1_loading_test.go
+++ b/tests/rkt_stage1_loading_test.go
@@ -308,8 +308,8 @@ func TestStage1LoadingFromFlags(t *testing.T) {
 		// --stage1-path with a relative path
 		{
 			flag:              fmt.Sprintf("--stage1-path=%q", setup.getLocation(stubStage1PathRel)),
-			expectedFirstRun:  fmt.Sprintf("image: using image from file %s", setup.getLocation(stubStage1PathRel)),
-			expectedSecondRun: fmt.Sprintf("image: using image from file %s", setup.getLocation(stubStage1PathRel)),
+			expectedFirstRun:  fmt.Sprintf("image: using image from file %s", setup.getLocation(stubStage1PathAbs)),
+			expectedSecondRun: fmt.Sprintf("image: using image from file %s", setup.getLocation(stubStage1PathAbs)),
 		},
 
 		// --stage1-path with an absolute path


### PR DESCRIPTION
This is the implementation of the distribution concept proposed in #2953.
## 

This patch implements the distribution point concept with the three initial
kind of distributions already used by rkt (appc, aci-archive, docker).

It just makes the smallest required changes to the fetchers logic to make them
work and pass the functional tests.

This is the base for future fetchers (a future patch will refactor the
fetcher logic to better fit the distribution concept) and store refactors.
