### PR TITLE
rkt: implement generic no volume policy

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -66,6 +66,11 @@ const (
 	// Default perm bits for the regular directories
 	// within the stage1 directory.
 	DefaultRegularDirPerm = os.FileMode(0750)
+
+	// pod manifest annotations
+	NoVolumePolicyAnnotation = "coreos.com/rkt/annotations/novolumepolicy"
+	NoVolumePolicyEmpty      = "empty"
+	NoVolumePolicyEmptyCopy  = "empty-copy"
 )
 
 const (

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -166,11 +166,17 @@ func MergeMounts(mounts []schema.Mount, appMounts []schema.Mount) []schema.Mount
 	return deduplicateMPs(ml)
 }
 
+func convertedFromDocker(am *schema.ImageManifest) bool {
+	ann := am.Annotations
+	_, ok := ann.Get("appc.io/docker/repository")
+	return ok
+}
+
 // generatePodManifest creates the pod manifest from the command line input.
 // It returns the pod manifest as []byte on success.
 // This is invoked if no pod manifest is specified at the command line.
-func generatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
-	pm := schema.PodManifest{
+func generatePodManifest(cfg PrepareConfig, dir string) (*schema.PodManifest, error) {
+	pm := &schema.PodManifest{
 		ACKind: "PodManifest",
 		Apps:   make(schema.AppList, 0),
 	}
@@ -327,23 +333,19 @@ func generatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
 	pm.Volumes = cfg.Apps.Volumes
 	pm.Ports = cfg.Ports
 
-	pmb, err := json.Marshal(pm)
-	if err != nil {
-		return nil, errwrap.Wrap(errors.New("error marshalling pod manifest"), err)
-	}
-	return pmb, nil
+	return pm, nil
 }
 
 // validatePodManifest reads the user-specified pod manifest, prepares the app images
 // and validates the pod manifest. If the pod manifest passes validation, it returns
 // the manifest as []byte.
 // TODO(yifan): More validation in the future.
-func validatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
+func validatePodManifest(cfg PrepareConfig, dir string) (*schema.PodManifest, error) {
 	pmb, err := ioutil.ReadFile(cfg.PodManifest)
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("error reading pod manifest"), err)
 	}
-	var pm schema.PodManifest
+	var pm *schema.PodManifest
 	if err := json.Unmarshal(pmb, &pm); err != nil {
 		return nil, errwrap.Wrap(errors.New("error unmarshaling pod manifest"), err)
 	}
@@ -369,8 +371,35 @@ func validatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
 		if ra.App == nil && am.App == nil {
 			return nil, fmt.Errorf("no app section in the pod manifest or the image manifest")
 		}
+		if a, ok := ra.Annotations.Get(common.NoVolumePolicyAnnotation); ok {
+			if a != common.NoVolumePolicyEmpty && a != common.NoVolumePolicyEmptyCopy {
+				return nil, fmt.Errorf("invalid no volume policy annotation value %q", a)
+			}
+		}
 	}
-	return pmb, nil
+
+	return pm, nil
+}
+
+// setRuntimeAppsNoVolumePolicy sets, for the runtime apps in the pod manifest, the NoVolumePolicyAnnotation.
+func setRuntimeAppsNoVolumePolicy(cfg PrepareConfig, pm *schema.PodManifest) (*schema.PodManifest, error) {
+	for i, ra := range pm.Apps {
+		// skip if the NoVolumePolicyAnnotation is already defined in the runtimeApp
+		if _, ok := ra.Annotations.Get(common.NoVolumePolicyAnnotation); ok {
+			continue
+		}
+		am, err := cfg.Store.GetImageManifest(ra.Image.ID.String())
+		if err != nil {
+			return nil, errwrap.Wrap(errors.New("error getting the image manifest"), err)
+		}
+		// If the image was converted from a docker registry set the empty-copy no volume policy.
+		if convertedFromDocker(am) {
+			ra.Annotations.Set(common.NoVolumePolicyAnnotation, common.NoVolumePolicyEmptyCopy)
+		}
+		// since appc spec define Apps as []RuntimeApp, ra is a copy of RuntimeApp, so we have to replace the whole app
+		pm.Apps[i] = ra
+	}
+	return pm, nil
 }
 
 // Prepare sets up a pod based on the given config.
@@ -383,15 +412,27 @@ func Prepare(cfg PrepareConfig, dir string, uuid *types.UUID) error {
 		return errwrap.Wrap(errors.New("error preparing stage1"), err)
 	}
 
-	var pmb []byte
+	var pm *schema.PodManifest
 	var err error
 	if len(cfg.PodManifest) > 0 {
-		pmb, err = validatePodManifest(cfg, dir)
+		pm, err = validatePodManifest(cfg, dir)
 	} else {
-		pmb, err = generatePodManifest(cfg, dir)
+		pm, err = generatePodManifest(cfg, dir)
 	}
 	if err != nil {
 		return err
+	}
+
+	// Sets the apps EmptyVolumePolicy, this is done for both generated or provided pod manifests.
+	pm, err = setRuntimeAppsNoVolumePolicy(cfg, pm)
+	if err != nil {
+		return err
+	}
+
+	var pmb []byte
+	pmb, err = json.Marshal(pm)
+	if err != nil {
+		return errwrap.Wrap(errors.New("error marshalling pod manifest"), err)
 	}
 
 	cfg.CommonConfig.ManifestData = string(pmb)

--- a/stage1/init/common/mount.go
+++ b/stage1/init/common/mount.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/pkg/fileutil"
 	"github.com/coreos/rkt/pkg/user"
 
@@ -32,7 +33,7 @@ import (
 // whether it is an implicit empty volume converted from a Docker image.
 type mountWrapper struct {
 	schema.Mount
-	DockerImplicit bool
+	CopyImageFiles bool
 }
 
 func isMPReadOnly(mountPoints []types.MountPoint, name types.ACName) bool {
@@ -56,16 +57,10 @@ func IsMountReadOnly(vol types.Volume, mountPoints []types.MountPoint) bool {
 	return isMPReadOnly(mountPoints, vol.Name)
 }
 
-func convertedFromDocker(im *schema.ImageManifest) bool {
-	ann := im.Annotations
-	_, ok := ann.Get("appc.io/docker/repository")
-	return ok
-}
-
 // GenerateMounts maps MountPoint paths to volumes, returning a list of mounts,
 // each with a parameter indicating if it's an implicit empty volume from a
 // Docker image.
-func GenerateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume, imageManifest *schema.ImageManifest) []mountWrapper {
+func GenerateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume) []mountWrapper {
 	app := ra.App
 
 	var genMnts []mountWrapper
@@ -76,7 +71,7 @@ func GenerateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume
 		genMnts = append(genMnts,
 			mountWrapper{
 				Mount:          m,
-				DockerImplicit: false,
+				CopyImageFiles: false,
 			})
 	}
 
@@ -101,10 +96,16 @@ func GenerateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume
 				GID:  &defaultGID,
 			}
 
-			dockerImplicit := convertedFromDocker(imageManifest)
+			copyImageFiles := false
+			if ann, ok := ra.Annotations.Get(common.NoVolumePolicyAnnotation); ok {
+				// assume that stage0 already checks if the annotation values are correct.
+				if ann == common.NoVolumePolicyEmptyCopy {
+					copyImageFiles = true
+				}
+			}
 			log.Printf("warning: no volume specified for mount point %q, implicitly creating an \"empty\" volume. This volume will be removed when the pod is garbage-collected.", mp.Name)
-			if dockerImplicit {
-				log.Printf("Docker converted image, initializing implicit volume with data contained at the mount point %q.", mp.Name)
+			if copyImageFiles {
+				log.Printf("Initializing implicit volume with data contained at the mount point %q.", mp.Name)
 			}
 
 			volumes[uniqName] = emptyVol
@@ -114,7 +115,7 @@ func GenerateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume
 						Volume: uniqName,
 						Path:   mp.Path,
 					},
-					DockerImplicit: dockerImplicit,
+					CopyImageFiles: copyImageFiles,
 				})
 		} else {
 			genMnts = append(genMnts,
@@ -123,7 +124,7 @@ func GenerateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume
 						Volume: vol.Name,
 						Path:   mp.Path,
 					},
-					DockerImplicit: false,
+					CopyImageFiles: false,
 				})
 		}
 	}

--- a/stage1/init/common/pod.go
+++ b/stage1/init/common/pod.go
@@ -551,8 +551,7 @@ func appToSystemd(p *stage1commontypes.Pod, ra *schema.RuntimeApp, interactive b
 	appRootfs := common.AppRootfsPath(absRoot, appName)
 
 	rwDirs := []string{}
-	imageManifest := p.Images[appName.String()]
-	mounts := GenerateMounts(ra, vols, imageManifest)
+	mounts := GenerateMounts(ra, vols)
 	for _, m := range mounts {
 		mntPath, err := EvaluateSymlinksInsideApp(appRootfs, m.Path)
 		if err != nil {
@@ -913,8 +912,7 @@ func appToNspawnArgs(p *stage1commontypes.Pod, ra *schema.RuntimeApp, insecureOp
 		vols[v.Name] = v
 	}
 
-	imageManifest := p.Images[appName.String()]
-	mounts := GenerateMounts(ra, vols, imageManifest)
+	mounts := GenerateMounts(ra, vols)
 	for _, m := range mounts {
 		vol := vols[m.Volume]
 
@@ -936,7 +934,7 @@ func appToNspawnArgs(p *stage1commontypes.Pod, ra *schema.RuntimeApp, insecureOp
 		}
 		mntAbsPath := filepath.Join(appRootfs, mntPath)
 
-		if err := PrepareMountpoints(shPath, mntAbsPath, &vol, m.DockerImplicit); err != nil {
+		if err := PrepareMountpoints(shPath, mntAbsPath, &vol, m.CopyImageFiles); err != nil {
 			return nil, err
 		}
 

--- a/stage1/init/kvm.go
+++ b/stage1/init/kvm.go
@@ -66,8 +66,7 @@ func mountSharedVolumes(root string, p *stage1commontypes.Pod, ra *schema.Runtim
 		return errwrap.Wrap(fmt.Errorf("could not change permissions of %q", sharedVolPath), err)
 	}
 
-	imageManifest := p.Images[appName.String()]
-	mounts := stage1initcommon.GenerateMounts(ra, vols, imageManifest)
+	mounts := stage1initcommon.GenerateMounts(ra, vols)
 	for _, m := range mounts {
 		vol := vols[m.Volume]
 
@@ -87,7 +86,7 @@ func mountSharedVolumes(root string, p *stage1commontypes.Pod, ra *schema.Runtim
 		}
 		absDestination := filepath.Join(absAppRootfs, mntPath)
 		shPath := filepath.Join(sharedVolPath, vol.Name.String())
-		if err := stage1initcommon.PrepareMountpoints(shPath, absDestination, &vol, m.DockerImplicit); err != nil {
+		if err := stage1initcommon.PrepareMountpoints(shPath, absDestination, &vol, m.CopyImageFiles); err != nil {
 			return err
 		}
 

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -197,54 +197,93 @@ func NewVolumesTest() testutils.Test {
 	})
 }
 
-var volDockerTests = []struct {
-	dir             string
-	expectedContent string
+// TODO(sgotti) actool doesn't provide a command to patch annotations so, at
+// the moment, we aren't going to test images not converted by docker2aci since
+// the inspect image has the docker2aci annotations defined.
+var noVolumePolicyTests = []struct {
+	runtimeAppVolumePolicy string
+	dir                    string
+	expectedContent        string
+	expectedError          bool
 }{
 	{
+		"",
 		"/dir1",
 		"dir1",
+		false,
 	},
 	{
+		"",
 		"/dir2",
 		"dir2",
+		false,
 	},
 	{
+		"",
 		"/dir1/link_rel_dir2",
 		"dir2",
+		false,
 	},
 	{
+		"",
 		"/dir1/link_abs_dir2",
 		"dir2",
+		false,
+	},
+	// runtimeApp in pod manifest with novolumepolicy = empty-copy
+	{
+		"empty-copy",
+		"/dir1",
+		"dir1",
+		false,
+	},
+	// runtimeApp in pod manifest with novolumepolicy = empty
+	{
+		"empty",
+		"/dir1",
+		"dir1",
+		true,
 	},
 }
 
-func TestDockerVolumeSemantics(t *testing.T) {
+func TestNoVolumePolicy(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
 	var dockerVolImage []string
-	for i, tt := range volDockerTests {
+	for i, tt := range noVolumePolicyTests {
 		img := patchTestACI(fmt.Sprintf("rkt-volume-image-%d.aci", i), fmt.Sprintf("--mounts=mydir,path=%s,readOnly=false", tt.dir))
 		defer os.Remove(img)
 		dockerVolImage = append(dockerVolImage, img)
 	}
 
-	for i, tt := range volDockerTests {
+	for i, tt := range noVolumePolicyTests {
+		// When running without a pod manifest there's currently now
+		// way to force to volume policy so skip these tests
+		if tt.runtimeAppVolumePolicy != "" {
+			continue
+		}
+
 		t.Logf("Running test #%v on directory %s", i, tt.dir)
 
-		cmd := fmt.Sprintf(`/bin/sh -c "export FILE=%s/file ; %s --debug --insecure-options=image run --inherit-env %s --exec /inspect -- --read-file"`, tt.dir, ctx.Cmd(), dockerVolImage[i])
+		fileName := fmt.Sprintf("%s/file", tt.dir)
+		cmd := fmt.Sprintf(`/bin/sh -c "export FILE=%s ; %s --debug --insecure-options=image run --inherit-env %s --exec /inspect -- --read-file"`, fileName, ctx.Cmd(), dockerVolImage[i])
 
-		expected := fmt.Sprintf("<<<%s>>>", tt.expectedContent)
-		runRktAndCheckOutput(t, cmd, expected, false)
+		var expected string
+		if !tt.expectedError {
+			expected = fmt.Sprintf("<<<%s>>>", tt.expectedContent)
+		} else {
+			expected = fmt.Sprintf("Cannot read file %q", fileName)
+		}
+		runRktAndCheckOutput(t, cmd, expected, tt.expectedError)
 	}
 }
 
-func TestDockerVolumeSemanticsPodManifest(t *testing.T) {
+func TestNoVolumePolicyPodManifest(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	for i, tt := range volDockerTests {
+	for i, tt := range noVolumePolicyTests {
 		t.Logf("Running test #%v on directory %s", i, tt.dir)
 
 		hash, err := patchImportAndFetchHash(fmt.Sprintf("rkt-volume-image-pm-%d.aci", i), []string{fmt.Sprintf("--mounts=mydir,path=%s,readOnly=false", tt.dir)}, t, ctx)
@@ -257,6 +296,8 @@ func TestDockerVolumeSemanticsPodManifest(t *testing.T) {
 			t.Fatalf("Cannot generate types.Hash from %v: %v", hash, err)
 		}
 
+		fileName := fmt.Sprintf("%s/file", tt.dir)
+
 		pm := &schema.PodManifest{
 			ACKind:    schema.PodManifestKind,
 			ACVersion: schema.AppContainerVersion,
@@ -268,7 +309,7 @@ func TestDockerVolumeSemanticsPodManifest(t *testing.T) {
 						User:  "0",
 						Group: "0",
 						Environment: []types.EnvironmentVariable{
-							{"FILE", fmt.Sprintf("%s/file", tt.dir)},
+							{"FILE", fmt.Sprintf("%s", fileName)},
 						},
 						MountPoints: []types.MountPoint{
 							{"mydir", tt.dir, false},
@@ -281,6 +322,10 @@ func TestDockerVolumeSemanticsPodManifest(t *testing.T) {
 			},
 		}
 
+		if tt.runtimeAppVolumePolicy != "" {
+			pm.Apps[0].Annotations.Set("coreos.com/rkt/annotations/novolumepolicy", tt.runtimeAppVolumePolicy)
+		}
+
 		manifestFile := generatePodManifestFile(t, pm)
 		defer os.Remove(manifestFile)
 
@@ -288,6 +333,11 @@ func TestDockerVolumeSemanticsPodManifest(t *testing.T) {
 
 		expected := fmt.Sprintf("<<<%s>>>", tt.expectedContent)
 
-		runRktAndCheckOutput(t, cmd, expected, false)
+		if !tt.expectedError {
+			expected = fmt.Sprintf("<<<%s>>>", tt.expectedContent)
+		} else {
+			expected = fmt.Sprintf("Cannot read file %q", fileName)
+		}
+		runRktAndCheckOutput(t, cmd, expected, tt.expectedError)
 	}
 }


### PR DESCRIPTION
This patch implements a generic no volume policy instead of a custom, per
stage1, behavior based on a docker2aci specific app annotation.

This also avoids stage1 having to read the app image manifest but just uses the
pod manifest as its unique source for app setup.

Since the behavior on unspecified volumes is not defined in the appc/spec but
left to the ACE, the idea is to use a pod.RuntimeApp annotation to define the
no volume policy per runtime app (instead of extending the appc PodManifest
with rkt specific fields).

The annotation is called `coreos.com/rkt/annotations/novolumepolicy` and
can have two possible values:

* `empty`: create an empty, per app, volume.
* `empty-copy`: create an empty, per app, volume and copy image contents.

`empty` is the default if the annotation doesn't exists.

rkt, in the stage0, will check if the annotation is already provided by the pod
manifest and, in such case, only validate it.
If not provided and the image has been converted using docker2aci then an
annotation with value `empty-copy` will be defined.

This has the additional effect to letting the user define (and override for
docker2aci converted images) the no volume policy for every app (with this
patch only by providing a --pod-manifest, in future, if needed, a per app
command line flag could be added)

Note that only pod.RuntimeApp annotations are checked for
`coreos.com/rkt/annotations/novolumepolicy` and not a app manifest
annotation (this, to correctly work, requires #3100).

**Notes**
Before this patch an user provided pod manifest was only validated without
changing it, now, instead, it's also enhanced.

**Questions**
* Currently the behavior of a missing volume for a mount point isn't defined in the spec and left to the ACE. Should the no volume policy behavior be explicitly defined in the appc/spec? I'm not sure about this and where to define it (per app in the pod runtimeApp or in the app manifest)? per mountpoint in the image manifest?)
* Currently rkt fly stage1 is different from other flavors as if a volume isn't specified it just doesn't mount nothing:
 * Should a new policy `none` be implemented to define the fly behavior?
 * Should rocket fly be adapted to also implement the 
* Should this no volume policy be explicitly defined in the stage1 implementors guide?

This fixes one part of #3098.