### PR TITLE
common: fall back to non-overlay with ftype=0

### DIFF
--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -4,6 +4,24 @@ rkt can prepare images to run in a pod.
 This means it will fetch (if necessary) the images, extract them in its internal tree store, and allocate a pod UUID.
 If overlay fs is not supported or disabled, it will also copy the tree in the pod rootfs.
 
+Support for overlay fs will be auto-detected if `--no-overlay` is set to `false`. If an unsupported filesystem is detected, rkt will print a warning message and continue preparing the pod by falling back in non-overlay mode as described above:
+
+```
+# rkt prepare --insecure-options=image docker://busybox --exec=/bin/sh
+image: using image from local store for image name coreos.com/rkt/stage1-coreos:1.13.0
+image: remote fetching from URL "docker://busybox"
+Downloading sha256:8ddc19f1652 [===============================] 668 KB / 668 KB
+prepare: disabling overlay support: "unsupported filesystem: missing d_type support"
+```
+
+The following conditions can lead to non-overlay mode:
+
+The data directory (usually `/var/lib/rkt`) is on ...
+- an AUFS filesystem
+- a ZFS filesystem
+- a XFS filesystem having `ftype=0`
+- a file system where the `d_type` field is set to `DT_UNKNOWN`, see getdents(2)
+
 In this way, the pod is ready to be launched immediately by the [run-prepared](run-prepared.md) command.
 
 Running `rkt prepare` + `rkt run-prepared` is semantically equivalent to running [rkt run](run.md).

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -340,6 +340,16 @@ rkt expects stage1 images to be signed except in the following cases:
 
 For more details see the [hacking documentation](../hacking.md).
 
+## Disabling overlay
+
+rkt uses overlayfs by default when running application containers. This provides immense benefits to performance and efficiency: start times for large containers are much faster, and multiple pods using the same images will consume less disk space and can share page cache entries.
+
+This feature will be disabled automatically if the underlying filesystem does not support overlay fs, see the [prepare](prepare.md) subcommand for details. This feature can also be explicitly disabled with the `--no-overlay` option:
+
+```
+# rkt run --no-overlay=true --insecure-options=image coreos.com/etcd:v2.0.0
+```
+
 ## Options
 
 | Flag | Default | Options | Description |

--- a/rkt/image/fetcher.go
+++ b/rkt/image/fetcher.go
@@ -53,9 +53,12 @@ func (f *Fetcher) FetchImage(img string, ascPath string, imgType apps.AppImageTy
 			return "", err
 		}
 	}
+
 	// we need to be able to do a chroot and access to the tree store
-	// directories, check if we're root
-	if common.SupportsOverlay() && os.Geteuid() == 0 {
+	// directories, we need to
+	// 1) check if the system supports OverlayFS
+	// 2) check if we're root
+	if common.SupportsOverlay() == nil && os.Geteuid() == 0 {
 		if _, _, err := f.Ts.Render(hash, false); err != nil {
 			return "", errwrap.Wrap(errors.New("error rendering tree store"), err)
 		}

--- a/rkt/pods.go
+++ b/rkt/pods.go
@@ -1134,3 +1134,17 @@ func (p *pod) sync() error {
 	}
 	return nil
 }
+
+// overlayPrepared returns true if the given pod was prepared using overlay else false.
+// It returns an error if the operation failed.
+func (p *pod) overlayPrepared() (bool, error) {
+	_, err := os.Stat(filepath.Join(p.path(), common.OverlayPreparedFilename))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -182,9 +182,20 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		Debug:       globalFlags.Debug,
 	}
 
+	ovlOk := true
+	if err := common.PathSupportsOverlay(getDataDir()); err != nil {
+		if oerr, ok := err.(common.ErrOverlayUnsupported); ok {
+			stderr.Printf("disabling overlay support: %q", oerr.Error())
+			ovlOk = false
+		} else {
+			stderr.PrintE("error determining overlay support", err)
+			return 1
+		}
+	}
+
 	pcfg := stage0.PrepareConfig{
 		CommonConfig:       &cfg,
-		UseOverlay:         !flagNoOverlay && common.SupportsOverlay() && common.FSSupportsOverlay(getDataDir()),
+		UseOverlay:         !flagNoOverlay && ovlOk,
 		PrivateUsers:       privateUsers,
 		SkipTreeStoreCheck: globalFlags.InsecureFlags.SkipOnDiskCheck(),
 	}

--- a/tests/rkt_export_container_test.go
+++ b/tests/rkt_export_container_test.go
@@ -34,7 +34,7 @@ func TestExport(t *testing.T) {
 		testCases = append(testCases, userNS)
 	}
 
-	if common.SupportsOverlay() {
+	if common.SupportsOverlay() == nil {
 		testCases = append(testCases, overlaySimpleTest)
 		testCases = append(testCases, overlaySimulateReboot)
 	}

--- a/tests/rkt_export_fly_test.go
+++ b/tests/rkt_export_fly_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 func TestExport(t *testing.T) {
-	if !common.SupportsOverlay() {
-		t.Skip("Overlay fs not supported.")
+	if err := common.SupportsOverlay(); err != nil {
+		t.Skipf("Overlay fs not supported: %v", err)
 	}
 
 	// TODO(iaguis): we need a new function to unmount the fly pod so we can also test

--- a/tests/rkt_gc_test.go
+++ b/tests/rkt_gc_test.go
@@ -80,8 +80,8 @@ func podsRemaining(t *testing.T, ctx *testutils.RktRunCtx) []os.FileInfo {
 }
 
 func TestGCAfterUnmount(t *testing.T) {
-	if !common.SupportsOverlay() {
-		t.Skip("Overlay fs not supported.")
+	if err := common.SupportsOverlay(); err != nil {
+		t.Skipf("Overlay fs not supported: %v", err)
 	}
 
 	ctx := testutils.NewRktRunCtx()

--- a/tests/rkt_image_dependencies_test.go
+++ b/tests/rkt_image_dependencies_test.go
@@ -221,8 +221,8 @@ func TestImageDependencies(t *testing.T) {
 
 func TestRenderOnFetch(t *testing.T) {
 	// If overlayfs is not supported, we don't render images on fetch
-	if !common.SupportsOverlay() {
-		t.Skip("Overlay fs not supported.")
+	if err := common.SupportsOverlay(); err != nil {
+		t.Skipf("Overlay fs not supported: %v", err)
 	}
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()

--- a/tests/rkt_image_gc_test.go
+++ b/tests/rkt_image_gc_test.go
@@ -34,7 +34,7 @@ func TestImageGCTreeStore(t *testing.T) {
 
 	expectedTreeStores := 2
 	// If overlayfs is not supported only the stage1 image is rendered in the treeStore
-	if !common.SupportsOverlay() {
+	if common.SupportsOverlay() != nil {
 		expectedTreeStores = 1
 	}
 

--- a/tests/rkt_image_list_test.go
+++ b/tests/rkt_image_list_test.go
@@ -81,7 +81,7 @@ func TestImageSize(t *testing.T) {
 	imageListCmd := fmt.Sprintf("%s image list --no-legend --full", ctx.Cmd())
 
 	// if we don't support overlay fs, we don't render the image on fetch
-	if !common.SupportsOverlay() {
+	if common.SupportsOverlay() != nil {
 		// check that the printed size is the same as the actual image size
 		expectedStr := fmt.Sprintf("(?s)%s.*%d.*", imageHash, imageSize)
 


### PR DESCRIPTION
Previously FSSupportsOverlay only supported detection of filesystems
(aufs, zfs).

This adds support for detection of unknown file types which prevents
overlay to function properly.

Fixes #3040
Supersedes #3052