### PR TITLE
Remove isReallyNil()

### DIFF
--- a/rkt/image/asc.go
+++ b/rkt/image/asc.go
@@ -50,16 +50,16 @@ type remoteAscFetcher struct {
 func (f *remoteAscFetcher) Get(location string) (readSeekCloser, error) {
 	roc, err := getTmpROC(f.S, location)
 	if err != nil {
-		return nil, err
+		return NopReadSeekCloser(nil), err
 	}
 	defer func() { maybeClose(roc) }()
 
 	u, err := url.Parse(location)
 	if err != nil {
-		return nil, errwrap.Wrap(errors.New("invalid signature location"), err)
+		return NopReadSeekCloser(nil), errwrap.Wrap(errors.New("invalid signature location"), err)
 	}
 	if err := f.F(u, roc.File); err != nil {
-		return nil, err
+		return NopReadSeekCloser(nil), err
 	}
 	retRoc := roc
 	roc = nil
@@ -81,5 +81,5 @@ func (a *asc) Get() (readSeekCloser, error) {
 	if a.Fetcher != nil {
 		return a.Fetcher.Get(a.Location)
 	}
-	return nil, nil
+	return NopReadSeekCloser(nil), nil
 }

--- a/rkt/image/asc.go
+++ b/rkt/image/asc.go
@@ -52,11 +52,7 @@ func (f *remoteAscFetcher) Get(location string) (readSeekCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if roc != nil {
-			roc.Close()
-		}
-	}()
+	defer func() { roc.Close() }()
 
 	u, err := url.Parse(location)
 	if err != nil {

--- a/rkt/image/asc.go
+++ b/rkt/image/asc.go
@@ -50,7 +50,7 @@ type remoteAscFetcher struct {
 func (f *remoteAscFetcher) Get(location string) (readSeekCloser, error) {
 	roc, err := getTmpROC(f.S, location)
 	if err != nil {
-		return NopReadSeekCloser(nil), err
+		return nil, err
 	}
 	defer func() {
 		if roc != nil {
@@ -60,10 +60,10 @@ func (f *remoteAscFetcher) Get(location string) (readSeekCloser, error) {
 
 	u, err := url.Parse(location)
 	if err != nil {
-		return NopReadSeekCloser(nil), errwrap.Wrap(errors.New("invalid signature location"), err)
+		return nil, errwrap.Wrap(errors.New("invalid signature location"), err)
 	}
 	if err := f.F(u, roc.File); err != nil {
-		return NopReadSeekCloser(nil), err
+		return nil, err
 	}
 	retRoc := roc
 	roc = nil

--- a/rkt/image/asc.go
+++ b/rkt/image/asc.go
@@ -61,9 +61,7 @@ func (f *remoteAscFetcher) Get(location string) (readSeekCloser, error) {
 	if err := f.F(u, roc.File); err != nil {
 		return nil, err
 	}
-	retRoc := roc
-	roc = nil
-	return retRoc, nil
+	return roc, nil
 }
 
 // asc is an abstraction for getting signature files.

--- a/rkt/image/asc.go
+++ b/rkt/image/asc.go
@@ -52,7 +52,6 @@ func (f *remoteAscFetcher) Get(location string) (readSeekCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer roc.Close()
 
 	u, err := url.Parse(location)
 	if err != nil {

--- a/rkt/image/asc.go
+++ b/rkt/image/asc.go
@@ -52,7 +52,11 @@ func (f *remoteAscFetcher) Get(location string) (readSeekCloser, error) {
 	if err != nil {
 		return NopReadSeekCloser(nil), err
 	}
-	defer func() { maybeClose(roc) }()
+	defer func() {
+		if roc != nil {
+			roc.Close()
+		}
+	}()
 
 	u, err := url.Parse(location)
 	if err != nil {

--- a/rkt/image/asc.go
+++ b/rkt/image/asc.go
@@ -52,7 +52,7 @@ func (f *remoteAscFetcher) Get(location string) (readSeekCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() { roc.Close() }()
+	defer roc.Close()
 
 	u, err := url.Parse(location)
 	if err != nil {

--- a/rkt/image/common.go
+++ b/rkt/image/common.go
@@ -19,7 +19,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"time"
 
@@ -85,36 +84,6 @@ func ensureLogger(debug bool) {
 	if log == nil {
 		log = rktlog.New(os.Stderr, "image", debug)
 	}
-}
-
-// isReallyNil makes sure that the passed value is really really
-// nil. So it returns true if value is plain nil or if it is e.g. an
-// interface with non-nil type but nil-value (which normally is
-// different from nil itself).
-func isReallyNil(iface interface{}) bool {
-	// this catches the cases when you pass non-interface nil
-	// directly, like:
-	//
-	// isReallyNil(nil)
-	// var m map[string]string
-	// isReallyNil(m)
-	if iface == nil {
-		return true
-	}
-	// get a reflect value
-	v := reflect.ValueOf(iface)
-	// only channels, functions, interfaces, maps, pointers and
-	// slices are nillable
-	switch v.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
-		// this catches the cases when you pass some interface
-		// with nil value, like:
-		//
-		// var v io.Closer = func(){var f *os.File; return f}()
-		// isReallyNil(v)
-		return v.IsNil()
-	}
-	return false
 }
 
 // useCached checks if downloadTime plus maxAge is before/after the current time.

--- a/rkt/image/common_test.go
+++ b/rkt/image/common_test.go
@@ -15,10 +15,7 @@
 package image
 
 import (
-	"io"
-	"io/ioutil"
 	"net/url"
-	"os"
 	"testing"
 	"time"
 
@@ -179,52 +176,6 @@ func TestUseCached(t *testing.T) {
 		got := useCached(age, maxAge)
 		if got != tt.use {
 			t.Errorf("expected useCached(%v, %v) to return %v, but it returned %v", age, maxAge, tt.use, got)
-		}
-	}
-}
-
-func TestIsReallyNil(t *testing.T) {
-	tests := []struct {
-		name  string
-		iface interface{}
-		isNil bool
-	}{
-		// plain nil
-		{
-			name:  "plain nil",
-			iface: nil,
-			isNil: true,
-		},
-		// some pointer
-		{
-			name:  "some pointer",
-			iface: &struct{}{},
-			isNil: false,
-		},
-		// a nil interface
-		{
-			name:  "a nil interface",
-			iface: func() io.Closer { return nil }(),
-			isNil: true,
-		},
-		// a non-nil interface with nil value
-		{
-			name:  "a non-nil interface with nil value",
-			iface: func() io.Closer { var v *os.File; return v }(),
-			isNil: true,
-		},
-		// a non-nil interface with non-nil value
-		{
-			name:  "a non-nil interface with non-nil value",
-			iface: func() io.Closer { return ioutil.NopCloser(nil) }(),
-			isNil: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Log(tt.name)
-		got := isReallyNil(tt.iface)
-		if tt.isNil != got {
-			t.Errorf("expected isReallyNil(%#v) to return %v, but got %v", tt.iface, tt.isNil, got)
 		}
 	}
 }

--- a/rkt/image/downloader.go
+++ b/rkt/image/downloader.go
@@ -52,7 +52,6 @@ type downloader struct {
 // Download tries to fetch the passed URL and write the contents into
 // a given writeSyncer instance.
 func (d *downloader) Download(u *url.URL, out writeSyncer) error {
-	d.ensureSession()
 	client, err := d.Session.Client()
 	if err != nil {
 		return err
@@ -84,12 +83,6 @@ func (d *downloader) Download(u *url.URL, out writeSyncer) error {
 	}
 
 	return nil
-}
-
-func (d *downloader) ensureSession() {
-	if isReallyNil(d.Session) {
-		d.Session = &defaultDownloadSession{}
-	}
 }
 
 // default DownloadSession is very simple implementation of

--- a/rkt/image/filefetcher.go
+++ b/rkt/image/filefetcher.go
@@ -91,7 +91,6 @@ func (f *fileFetcher) getVerifiedFile(aciPath string, a *asc) (*os.File, error) 
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("error opening ACI file"), err)
 	}
-	defer aciFile.Close()
 
 	validator, err := newValidator(aciFile)
 	if err != nil {
@@ -104,9 +103,7 @@ func (f *fileFetcher) getVerifiedFile(aciPath string, a *asc) (*os.File, error) 
 	}
 	printIdentities(entity)
 
-	retAciFile := aciFile
-	aciFile = nil
-	return retAciFile, nil
+	return aciFile, nil
 }
 
 func (f *fileFetcher) maybeOverrideAsc(aciPath string, a *asc) {

--- a/rkt/image/filefetcher.go
+++ b/rkt/image/filefetcher.go
@@ -48,7 +48,7 @@ func (f *fileFetcher) Hash(aciPath string, a *asc) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func() { aciFile.Close() }()
+	defer aciFile.Close()
 
 	key, err := f.S.WriteACI(aciFile, imagestore.ACIFetchInfo{
 		Latest: false,
@@ -85,13 +85,13 @@ func (f *fileFetcher) getVerifiedFile(aciPath string, a *asc) (*os.File, error) 
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("error opening signature file"), err)
 	}
-	defer func() { ascFile.Close() }()
+	defer ascFile.Close()
 
 	aciFile, err := os.Open(aciPath)
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("error opening ACI file"), err)
 	}
-	defer func() { aciFile.Close() }()
+	defer aciFile.Close()
 
 	validator, err := newValidator(aciFile)
 	if err != nil {

--- a/rkt/image/filefetcher.go
+++ b/rkt/image/filefetcher.go
@@ -48,11 +48,7 @@ func (f *fileFetcher) Hash(aciPath string, a *asc) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func() {
-		if aciFile != nil {
-			aciFile.Close()
-		}
-	}()
+	defer func() { aciFile.Close() }()
 
 	key, err := f.S.WriteACI(aciFile, imagestore.ACIFetchInfo{
 		Latest: false,
@@ -89,21 +85,13 @@ func (f *fileFetcher) getVerifiedFile(aciPath string, a *asc) (*os.File, error) 
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("error opening signature file"), err)
 	}
-	defer func() {
-		if ascFile != nil {
-			ascFile.Close()
-		}
-	}()
+	defer func() { ascFile.Close() }()
 
 	aciFile, err := os.Open(aciPath)
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("error opening ACI file"), err)
 	}
-	defer func() {
-		if aciFile != nil {
-			aciFile.Close()
-		}
-	}()
+	defer func() { aciFile.Close() }()
 
 	validator, err := newValidator(aciFile)
 	if err != nil {

--- a/rkt/image/filefetcher.go
+++ b/rkt/image/filefetcher.go
@@ -48,7 +48,11 @@ func (f *fileFetcher) Hash(aciPath string, a *asc) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer aciFile.Close()
+	defer func() {
+		if aciFile != nil {
+			aciFile.Close()
+		}
+	}()
 
 	key, err := f.S.WriteACI(aciFile, imagestore.ACIFetchInfo{
 		Latest: false,
@@ -85,13 +89,21 @@ func (f *fileFetcher) getVerifiedFile(aciPath string, a *asc) (*os.File, error) 
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("error opening signature file"), err)
 	}
-	defer func() { maybeClose(ascFile) }()
+	defer func() {
+		if ascFile != nil {
+			ascFile.Close()
+		}
+	}()
 
 	aciFile, err := os.Open(aciPath)
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("error opening ACI file"), err)
 	}
-	defer func() { maybeClose(aciFile) }()
+	defer func() {
+		if aciFile != nil {
+			aciFile.Close()
+		}
+	}()
 
 	validator, err := newValidator(aciFile)
 	if err != nil {

--- a/rkt/image/httpfetcher.go
+++ b/rkt/image/httpfetcher.go
@@ -128,7 +128,6 @@ func (f *httpFetcher) fetchVerifiedURL(u *url.URL, a *asc, etag string) (readSee
 	if err != nil {
 		return nil, nil, err
 	}
-	defer aciFile.Close()
 
 	if cd.UseCached {
 		return NopReadSeekCloser(nil), cd, nil

--- a/rkt/image/httpfetcher.go
+++ b/rkt/image/httpfetcher.go
@@ -61,7 +61,11 @@ func (f *httpFetcher) Hash(u *url.URL, a *asc) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func() { maybeClose(aciFile) }()
+	defer func() {
+		if aciFile != nil {
+			aciFile.Close()
+		}
+	}()
 
 	if key := maybeUseCached(f.Rem, cd); key != "" {
 		// TODO(krnowak): that does not update the store with
@@ -122,13 +126,22 @@ func (f *httpFetcher) fetchVerifiedURL(u *url.URL, a *asc, etag string) (readSee
 	if err != nil {
 		return NopReadSeekCloser(nil), nil, err
 	}
-	defer func() { maybeClose(ascFile) }()
+	defer func() {
+		if ascFile != nil {
+			ascFile.Close()
+		}
+	}()
 
 	aciFile, cd, err := o.DownloadImageWithETag(u, etag)
 	if err != nil {
 		return NopReadSeekCloser(nil), nil, err
 	}
-	defer func() { maybeClose(aciFile) }()
+	defer func() {
+		if aciFile != nil {
+			aciFile.Close()
+		}
+	}()
+
 	if cd.UseCached {
 		return NopReadSeekCloser(nil), cd, nil
 	}

--- a/rkt/image/httpfetcher.go
+++ b/rkt/image/httpfetcher.go
@@ -131,7 +131,7 @@ func (f *httpFetcher) fetchVerifiedURL(u *url.URL, a *asc, etag string) (readSee
 	defer func() { aciFile.Close() }()
 
 	if cd.UseCached {
-		return nil, cd, nil
+		return NopReadSeekCloser(nil), cd, nil
 	}
 
 	if retry {

--- a/rkt/image/httpfetcher.go
+++ b/rkt/image/httpfetcher.go
@@ -111,7 +111,7 @@ func (f *httpFetcher) fetchURL(u *url.URL, a *asc, etag string) (readSeekCloser,
 		o := f.httpOps()
 		aciFile, cd, err := o.DownloadImageWithETag(u, etag)
 		if err != nil {
-			return NopReadSeekCloser(nil), nil, err
+			return nil, nil, err
 		}
 		return aciFile, cd, err
 	}
@@ -124,7 +124,7 @@ func (f *httpFetcher) fetchVerifiedURL(u *url.URL, a *asc, etag string) (readSee
 	f.maybeOverrideAscFetcherWithRemote(o, u, a)
 	ascFile, retry, err := o.DownloadSignature(a)
 	if err != nil {
-		return NopReadSeekCloser(nil), nil, err
+		return nil, nil, err
 	}
 	defer func() {
 		if ascFile != nil {
@@ -134,7 +134,7 @@ func (f *httpFetcher) fetchVerifiedURL(u *url.URL, a *asc, etag string) (readSee
 
 	aciFile, cd, err := o.DownloadImageWithETag(u, etag)
 	if err != nil {
-		return NopReadSeekCloser(nil), nil, err
+		return nil, nil, err
 	}
 	defer func() {
 		if aciFile != nil {
@@ -143,18 +143,18 @@ func (f *httpFetcher) fetchVerifiedURL(u *url.URL, a *asc, etag string) (readSee
 	}()
 
 	if cd.UseCached {
-		return NopReadSeekCloser(nil), cd, nil
+		return nil, cd, nil
 	}
 
 	if retry {
 		ascFile, err = o.DownloadSignatureAgain(a)
 		if err != nil {
-			return NopReadSeekCloser(nil), nil, err
+			return nil, nil, err
 		}
 	}
 
 	if err := f.validate(aciFile, ascFile); err != nil {
-		return NopReadSeekCloser(nil), nil, err
+		return nil, nil, err
 	}
 	retAciFile := aciFile
 	aciFile = nil

--- a/rkt/image/httpfetcher.go
+++ b/rkt/image/httpfetcher.go
@@ -144,9 +144,7 @@ func (f *httpFetcher) fetchVerifiedURL(u *url.URL, a *asc, etag string) (readSee
 	if err := f.validate(aciFile, ascFile); err != nil {
 		return nil, nil, err
 	}
-	retAciFile := aciFile
-	aciFile = nil
-	return retAciFile, cd, nil
+	return aciFile, cd, nil
 }
 
 func (f *httpFetcher) httpOps() *httpOps {

--- a/rkt/image/httpfetcher.go
+++ b/rkt/image/httpfetcher.go
@@ -107,7 +107,7 @@ func (f *httpFetcher) fetchURL(u *url.URL, a *asc, etag string) (readSeekCloser,
 		o := f.httpOps()
 		aciFile, cd, err := o.DownloadImageWithETag(u, etag)
 		if err != nil {
-			return nil, nil, err
+			return NopReadSeekCloser(nil), nil, err
 		}
 		return aciFile, cd, err
 	}
@@ -120,28 +120,28 @@ func (f *httpFetcher) fetchVerifiedURL(u *url.URL, a *asc, etag string) (readSee
 	f.maybeOverrideAscFetcherWithRemote(o, u, a)
 	ascFile, retry, err := o.DownloadSignature(a)
 	if err != nil {
-		return nil, nil, err
+		return NopReadSeekCloser(nil), nil, err
 	}
 	defer func() { maybeClose(ascFile) }()
 
 	aciFile, cd, err := o.DownloadImageWithETag(u, etag)
 	if err != nil {
-		return nil, nil, err
+		return NopReadSeekCloser(nil), nil, err
 	}
 	defer func() { maybeClose(aciFile) }()
 	if cd.UseCached {
-		return nil, cd, nil
+		return NopReadSeekCloser(nil), cd, nil
 	}
 
 	if retry {
 		ascFile, err = o.DownloadSignatureAgain(a)
 		if err != nil {
-			return nil, nil, err
+			return NopReadSeekCloser(nil), nil, err
 		}
 	}
 
 	if err := f.validate(aciFile, ascFile); err != nil {
-		return nil, nil, err
+		return NopReadSeekCloser(nil), nil, err
 	}
 	retAciFile := aciFile
 	aciFile = nil

--- a/rkt/image/httpfetcher.go
+++ b/rkt/image/httpfetcher.go
@@ -61,7 +61,7 @@ func (f *httpFetcher) Hash(u *url.URL, a *asc) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func() { aciFile.Close() }()
+	defer aciFile.Close()
 
 	if key := maybeUseCached(f.Rem, cd); key != "" {
 		// TODO(krnowak): that does not update the store with
@@ -122,13 +122,13 @@ func (f *httpFetcher) fetchVerifiedURL(u *url.URL, a *asc, etag string) (readSee
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() { ascFile.Close() }()
+	defer ascFile.Close()
 
 	aciFile, cd, err := o.DownloadImageWithETag(u, etag)
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() { aciFile.Close() }()
+	defer aciFile.Close()
 
 	if cd.UseCached {
 		return NopReadSeekCloser(nil), cd, nil

--- a/rkt/image/httpfetcher.go
+++ b/rkt/image/httpfetcher.go
@@ -61,11 +61,7 @@ func (f *httpFetcher) Hash(u *url.URL, a *asc) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer func() {
-		if aciFile != nil {
-			aciFile.Close()
-		}
-	}()
+	defer func() { aciFile.Close() }()
 
 	if key := maybeUseCached(f.Rem, cd); key != "" {
 		// TODO(krnowak): that does not update the store with
@@ -126,21 +122,13 @@ func (f *httpFetcher) fetchVerifiedURL(u *url.URL, a *asc, etag string) (readSee
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() {
-		if ascFile != nil {
-			ascFile.Close()
-		}
-	}()
+	defer func() { ascFile.Close() }()
 
 	aciFile, cd, err := o.DownloadImageWithETag(u, etag)
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() {
-		if aciFile != nil {
-			aciFile.Close()
-		}
-	}()
+	defer func() { aciFile.Close() }()
 
 	if cd.UseCached {
 		return nil, cd, nil

--- a/rkt/image/httpops.go
+++ b/rkt/image/httpops.go
@@ -49,7 +49,7 @@ func (o *httpOps) DownloadSignature(a *asc) (readSeekCloser, bool, error) {
 	}
 	if _, ok := err.(*statusAcceptedError); ok {
 		log.Printf("server requested deferring the signature download")
-		return nil, true, nil
+		return NopReadSeekCloser(nil), true, nil
 	}
 	return nil, false, errwrap.Wrap(errors.New("error downloading the signature file"), err)
 }

--- a/rkt/image/httpops.go
+++ b/rkt/image/httpops.go
@@ -91,7 +91,7 @@ func (o *httpOps) DownloadImageWithETag(u *url.URL, etag string) (readSeekCloser
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() { aciFile.Close() }()
+	defer aciFile.Close()
 
 	session := o.getSession(u, aciFile.File, "ACI", etag)
 	dl := o.getDownloader(session)

--- a/rkt/image/httpops.go
+++ b/rkt/image/httpops.go
@@ -49,9 +49,9 @@ func (o *httpOps) DownloadSignature(a *asc) (readSeekCloser, bool, error) {
 	}
 	if _, ok := err.(*statusAcceptedError); ok {
 		log.Printf("server requested deferring the signature download")
-		return nil, true, nil
+		return NopReadSeekCloser(nil), true, nil
 	}
-	return nil, false, errwrap.Wrap(errors.New("error downloading the signature file"), err)
+	return NopReadSeekCloser(nil), false, errwrap.Wrap(errors.New("error downloading the signature file"), err)
 }
 
 // DownloadSignatureAgain does a similar thing to DownloadSignature,
@@ -61,10 +61,10 @@ func (o *httpOps) DownloadSignatureAgain(a *asc) (readSeekCloser, error) {
 	ensureLogger(o.Debug)
 	ascFile, retry, err := o.DownloadSignature(a)
 	if err != nil {
-		return nil, err
+		return NopReadSeekCloser(nil), err
 	}
 	if retry {
-		return nil, fmt.Errorf("error downloading the signature file: server asked to defer the download again")
+		return NopReadSeekCloser(nil), fmt.Errorf("error downloading the signature file: server asked to defer the download again")
 	}
 	return ascFile, nil
 }
@@ -75,10 +75,10 @@ func (o *httpOps) DownloadImage(u *url.URL) (readSeekCloser, *cacheData, error) 
 	ensureLogger(o.Debug)
 	image, cd, err := o.DownloadImageWithETag(u, "")
 	if err != nil {
-		return nil, nil, err
+		return NopReadSeekCloser(nil), nil, err
 	}
 	if cd.UseCached {
-		return nil, nil, fmt.Errorf("asked to use cached image even if not asked for that")
+		return NopReadSeekCloser(nil), nil, fmt.Errorf("asked to use cached image even if not asked for that")
 	}
 	return image, cd, nil
 }
@@ -89,17 +89,17 @@ func (o *httpOps) DownloadImageWithETag(u *url.URL, etag string) (readSeekCloser
 	ensureLogger(o.Debug)
 	aciFile, err := getTmpROC(o.S, u.String())
 	if err != nil {
-		return nil, nil, err
+		return NopReadSeekCloser(nil), nil, err
 	}
 	defer func() { maybeClose(aciFile) }()
 
 	session := o.getSession(u, aciFile.File, "ACI", etag)
 	dl := o.getDownloader(session)
 	if err := dl.Download(u, aciFile.File); err != nil {
-		return nil, nil, errwrap.Wrap(errors.New("error downloading ACI"), err)
+		return NopReadSeekCloser(nil), nil, errwrap.Wrap(errors.New("error downloading ACI"), err)
 	}
 	if session.Cd.UseCached {
-		return nil, session.Cd, nil
+		return NopReadSeekCloser(nil), session.Cd, nil
 	}
 	retAciFile := aciFile
 	aciFile = nil

--- a/rkt/image/httpops.go
+++ b/rkt/image/httpops.go
@@ -91,7 +91,11 @@ func (o *httpOps) DownloadImageWithETag(u *url.URL, etag string) (readSeekCloser
 	if err != nil {
 		return NopReadSeekCloser(nil), nil, err
 	}
-	defer func() { maybeClose(aciFile) }()
+	defer func() {
+		if aciFile != nil {
+			aciFile.Close()
+		}
+	}()
 
 	session := o.getSession(u, aciFile.File, "ACI", etag)
 	dl := o.getDownloader(session)

--- a/rkt/image/httpops.go
+++ b/rkt/image/httpops.go
@@ -49,9 +49,9 @@ func (o *httpOps) DownloadSignature(a *asc) (readSeekCloser, bool, error) {
 	}
 	if _, ok := err.(*statusAcceptedError); ok {
 		log.Printf("server requested deferring the signature download")
-		return NopReadSeekCloser(nil), true, nil
+		return nil, true, nil
 	}
-	return NopReadSeekCloser(nil), false, errwrap.Wrap(errors.New("error downloading the signature file"), err)
+	return nil, false, errwrap.Wrap(errors.New("error downloading the signature file"), err)
 }
 
 // DownloadSignatureAgain does a similar thing to DownloadSignature,
@@ -61,10 +61,10 @@ func (o *httpOps) DownloadSignatureAgain(a *asc) (readSeekCloser, error) {
 	ensureLogger(o.Debug)
 	ascFile, retry, err := o.DownloadSignature(a)
 	if err != nil {
-		return NopReadSeekCloser(nil), err
+		return nil, err
 	}
 	if retry {
-		return NopReadSeekCloser(nil), fmt.Errorf("error downloading the signature file: server asked to defer the download again")
+		return nil, fmt.Errorf("error downloading the signature file: server asked to defer the download again")
 	}
 	return ascFile, nil
 }
@@ -75,10 +75,10 @@ func (o *httpOps) DownloadImage(u *url.URL) (readSeekCloser, *cacheData, error) 
 	ensureLogger(o.Debug)
 	image, cd, err := o.DownloadImageWithETag(u, "")
 	if err != nil {
-		return NopReadSeekCloser(nil), nil, err
+		return nil, nil, err
 	}
 	if cd.UseCached {
-		return NopReadSeekCloser(nil), nil, fmt.Errorf("asked to use cached image even if not asked for that")
+		return nil, nil, fmt.Errorf("asked to use cached image even if not asked for that")
 	}
 	return image, cd, nil
 }
@@ -89,7 +89,7 @@ func (o *httpOps) DownloadImageWithETag(u *url.URL, etag string) (readSeekCloser
 	ensureLogger(o.Debug)
 	aciFile, err := getTmpROC(o.S, u.String())
 	if err != nil {
-		return NopReadSeekCloser(nil), nil, err
+		return nil, nil, err
 	}
 	defer func() {
 		if aciFile != nil {
@@ -100,7 +100,7 @@ func (o *httpOps) DownloadImageWithETag(u *url.URL, etag string) (readSeekCloser
 	session := o.getSession(u, aciFile.File, "ACI", etag)
 	dl := o.getDownloader(session)
 	if err := dl.Download(u, aciFile.File); err != nil {
-		return NopReadSeekCloser(nil), nil, errwrap.Wrap(errors.New("error downloading ACI"), err)
+		return nil, nil, errwrap.Wrap(errors.New("error downloading ACI"), err)
 	}
 	if session.Cd.UseCached {
 		return NopReadSeekCloser(nil), session.Cd, nil

--- a/rkt/image/httpops.go
+++ b/rkt/image/httpops.go
@@ -91,11 +91,7 @@ func (o *httpOps) DownloadImageWithETag(u *url.URL, etag string) (readSeekCloser
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() {
-		if aciFile != nil {
-			aciFile.Close()
-		}
-	}()
+	defer func() { aciFile.Close() }()
 
 	session := o.getSession(u, aciFile.File, "ACI", etag)
 	dl := o.getDownloader(session)

--- a/rkt/image/io.go
+++ b/rkt/image/io.go
@@ -103,6 +103,9 @@ func (f *removeOnClose) Seek(offset int64, whence int) (int64, error) {
 // Close closes the file and then removes it from disk. No error is
 // returned if the file did not exist at the point of removal.
 func (f *removeOnClose) Close() error {
+	if f == nil || f.File == nil {
+		return nil
+	}
 	name := f.File.Name()
 	if err := f.File.Close(); err != nil {
 		return err
@@ -140,12 +143,4 @@ func getTmpROC(s *imagestore.Store, path string) (*removeOnClose, error) {
 	}
 	roc := &removeOnClose{File: tmp}
 	return roc, nil
-}
-
-// maybeClose is a convenient function for closing io.Closers if they
-// are not nil. Useful in defers.
-func maybeClose(c io.Closer) {
-	if !isReallyNil(c) {
-		c.Close()
-	}
 }

--- a/rkt/image/io.go
+++ b/rkt/image/io.go
@@ -43,6 +43,16 @@ type readSeekCloser interface {
 	io.Closer
 }
 
+type nopReadSeekCloser struct {
+	readSeekCloser
+}
+
+func (nopReadSeekCloser) Close() error { return nil }
+
+func NopReadSeekCloser(rsc readSeekCloser) readSeekCloser {
+	return nopReadSeekCloser{rsc}
+}
+
 // getIoProgressReader returns a reader that wraps the HTTP response
 // body, so it prints a pretty progress bar when reading data from it.
 func getIoProgressReader(label string, res *http.Response) io.Reader {

--- a/rkt/image/namefetcher.go
+++ b/rkt/image/namefetcher.go
@@ -124,7 +124,7 @@ func (f *nameFetcher) fetchImageFromSingleEndpoint(app *discovery.App, aciURL st
 	if err != nil {
 		return "", err
 	}
-	defer func() { maybeClose(aciFile) }()
+	defer func() { aciFile.Close() }()
 
 	if key := maybeUseCached(rem, cd); key != "" {
 		return key, nil
@@ -185,7 +185,11 @@ func (f *nameFetcher) fetchVerifiedURL(app *discovery.App, u *url.URL, a *asc) (
 	if err != nil {
 		return NopReadSeekCloser(nil), nil, err
 	}
-	defer func() { maybeClose(ascFile) }()
+	defer func() {
+		if ascFile != nil {
+			ascFile.Close()
+		}
+	}()
 
 	if !retry {
 		if err := f.checkIdentity(appName, ascFile); err != nil {
@@ -197,7 +201,11 @@ func (f *nameFetcher) fetchVerifiedURL(app *discovery.App, u *url.URL, a *asc) (
 	if err != nil {
 		return NopReadSeekCloser(nil), nil, err
 	}
-	defer func() { maybeClose(aciFile) }()
+	defer func() {
+		if aciFile != nil {
+			aciFile.Close()
+		}
+	}()
 
 	if retry {
 		ascFile, err = o.DownloadSignatureAgain(a)

--- a/rkt/image/namefetcher.go
+++ b/rkt/image/namefetcher.go
@@ -185,11 +185,7 @@ func (f *nameFetcher) fetchVerifiedURL(app *discovery.App, u *url.URL, a *asc) (
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() {
-		if ascFile != nil {
-			ascFile.Close()
-		}
-	}()
+	defer func() { ascFile.Close() }()
 
 	if !retry {
 		if err := f.checkIdentity(appName, ascFile); err != nil {
@@ -201,11 +197,7 @@ func (f *nameFetcher) fetchVerifiedURL(app *discovery.App, u *url.URL, a *asc) (
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() {
-		if aciFile != nil {
-			aciFile.Close()
-		}
-	}()
+	defer func() { aciFile.Close() }()
 
 	if retry {
 		ascFile, err = o.DownloadSignatureAgain(a)

--- a/rkt/image/namefetcher.go
+++ b/rkt/image/namefetcher.go
@@ -124,7 +124,7 @@ func (f *nameFetcher) fetchImageFromSingleEndpoint(app *discovery.App, aciURL st
 	if err != nil {
 		return "", err
 	}
-	defer func() { aciFile.Close() }()
+	defer aciFile.Close()
 
 	if key := maybeUseCached(rem, cd); key != "" {
 		return key, nil
@@ -185,7 +185,7 @@ func (f *nameFetcher) fetchVerifiedURL(app *discovery.App, u *url.URL, a *asc) (
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() { ascFile.Close() }()
+	defer ascFile.Close()
 
 	if !retry {
 		if err := f.checkIdentity(appName, ascFile); err != nil {
@@ -197,7 +197,7 @@ func (f *nameFetcher) fetchVerifiedURL(app *discovery.App, u *url.URL, a *asc) (
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() { aciFile.Close() }()
+	defer aciFile.Close()
 
 	if retry {
 		ascFile, err = o.DownloadSignatureAgain(a)

--- a/rkt/image/namefetcher.go
+++ b/rkt/image/namefetcher.go
@@ -161,14 +161,14 @@ func (f *nameFetcher) fetch(app *discovery.App, aciURL string, a *asc, etag stri
 
 	u, err := url.Parse(aciURL)
 	if err != nil {
-		return NopReadSeekCloser(nil), nil, errwrap.Wrap(errors.New("error parsing ACI url"), err)
+		return nil, nil, errwrap.Wrap(errors.New("error parsing ACI url"), err)
 	}
 
 	if f.InsecureFlags.SkipImageCheck() || f.Ks == nil {
 		o := f.httpOps()
 		aciFile, cd, err := o.DownloadImageWithETag(u, etag)
 		if err != nil {
-			return NopReadSeekCloser(nil), nil, err
+			return nil, nil, err
 		}
 		return aciFile, cd, nil
 	}
@@ -183,7 +183,7 @@ func (f *nameFetcher) fetchVerifiedURL(app *discovery.App, u *url.URL, a *asc) (
 	o := f.httpOps()
 	ascFile, retry, err := o.DownloadSignature(a)
 	if err != nil {
-		return NopReadSeekCloser(nil), nil, err
+		return nil, nil, err
 	}
 	defer func() {
 		if ascFile != nil {
@@ -193,13 +193,13 @@ func (f *nameFetcher) fetchVerifiedURL(app *discovery.App, u *url.URL, a *asc) (
 
 	if !retry {
 		if err := f.checkIdentity(appName, ascFile); err != nil {
-			return NopReadSeekCloser(nil), nil, err
+			return nil, nil, err
 		}
 	}
 
 	aciFile, cd, err := o.DownloadImage(u)
 	if err != nil {
-		return NopReadSeekCloser(nil), nil, err
+		return nil, nil, err
 	}
 	defer func() {
 		if aciFile != nil {
@@ -210,12 +210,12 @@ func (f *nameFetcher) fetchVerifiedURL(app *discovery.App, u *url.URL, a *asc) (
 	if retry {
 		ascFile, err = o.DownloadSignatureAgain(a)
 		if err != nil {
-			return NopReadSeekCloser(nil), nil, err
+			return nil, nil, err
 		}
 	}
 
 	if err := f.validate(app, aciFile, ascFile); err != nil {
-		return NopReadSeekCloser(nil), nil, err
+		return nil, nil, err
 	}
 	retAciFile := aciFile
 	aciFile = nil


### PR DESCRIPTION
This PR implements the NopCloser()-like function `NopReadSeekCloser()` and some other cleanups related to the removing of `isReallyNil()`.

This fixes #2922 
