### PR TITLE
scripts/install-rkt: add wget as dependency

### DIFF
--- a/scripts/install-rkt.sh
+++ b/scripts/install-rkt.sh
@@ -14,7 +14,8 @@ apt-get install -y --no-install-recommends \
         gnupg2 \
         bash-completion \
         checkinstall \
-        curl
+        curl \
+        wget
 
 curl -sSL https://coreos.com/dist/pubkeys/app-signing-pubkey.gpg | gpg2 --import -
 key=$(gpg2 --with-colons --keyid-format LONG -k security@coreos.com | egrep ^pub | cut -d ':' -f5)


### PR DESCRIPTION
wget is not available in minimal debian installations (e.g. docker image debian:jessie)