### PR TITLE
vendor: update appc/spec to 0.8.7

### DIFF
--- a/Documentation/app-container.md
+++ b/Documentation/app-container.md
@@ -33,8 +33,8 @@ To validate that `rkt` successfully implements the ACE part of the spec, use the
 # rkt --insecure-options=image run \
 	--mds-register \
 	--volume=database,kind=host,source=/tmp \
-	https://github.com/appc/spec/releases/download/v0.8.6/ace-validator-main.aci \
-	https://github.com/appc/spec/releases/download/v0.8.6/ace-validator-sidekick.aci
+	https://github.com/appc/spec/releases/download/v0.8.7/ace-validator-main.aci \
+	https://github.com/appc/spec/releases/download/v0.8.7/ace-validator-sidekick.aci
 ```
 
 [appc-repo]: https://github.com/appc/spec/

--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -137,7 +137,7 @@ The current version of the stage1 interface is 3.
 ```json
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.8.6",
+    "acVersion": "0.8.7",
     "name": "foo.com/rkt/stage1",
     "labels": [
         {

--- a/Documentation/subcommands/cat-manifest.md
+++ b/Documentation/subcommands/cat-manifest.md
@@ -5,7 +5,7 @@ For debugging or inspection you may want to extract the PodManifest to stdout.
 ```
 # rkt cat-manifest UUID
 {
-  "acVersion":"0.8.6",
+  "acVersion":"0.8.7",
   "acKind":"PodManifest"
 ...
 ```

--- a/Documentation/subcommands/image.md
+++ b/Documentation/subcommands/image.md
@@ -7,7 +7,7 @@ For debugging or inspection you may want to extract an ACI manifest to stdout.
 ```
 # rkt image cat-manifest coreos.com/etcd
 {
-  "acVersion": "0.8.6",
+  "acVersion": "0.8.7",
   "acKind": "ImageManifest",
 ...
 ```

--- a/Documentation/subcommands/version.md
+++ b/Documentation/subcommands/version.md
@@ -7,6 +7,6 @@ This command prints the rkt version, the appc version rkt is built against, and 
 ```
 $ rkt version
 rkt Version: 1.13.0
-appc Version: 0.8.6
+appc Version: 0.8.7
 Go Version: go1.5.3
 Go OS/Arch: linux/amd64

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 85887ddac777e118486cde0a7d15ce8b2e1f05aeab1af97600d74d8f22ebb109
-updated: 2016-08-29T07:52:29.649451159Z
+hash: f9a3d5488f0ccf2c1d7e3ee1d725a3c6bf4f4b5128950b44df34c3eee657c2e6
+updated: 2016-08-30T12:00:39.148220845Z
 imports:
 - name: github.com/appc/docker2aci
   version: 15d68b33bfee95a448c4da37dbe876baa8fcb5b6
@@ -20,7 +20,7 @@ imports:
   subpackages:
   - proj2aci
 - name: github.com/appc/spec
-  version: 01b1a0221620c2f394c0684686dcf111c484873e
+  version: f329150233aa3ac6c83ab5ba02a2b5a8bd03d365
   subpackages:
   - ace
   - aci

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,7 +20,7 @@ import:
   subpackages:
   - proj2aci
 - package: github.com/appc/spec
-  version: v0.8.6
+  version: v0.8.7
   subpackages:
   - ace
   - aci

--- a/pkg/aci/aci.go
+++ b/pkg/aci/aci.go
@@ -107,7 +107,7 @@ func (aw *imageArchiveWriter) Close() error {
 // NewBasicACI creates a new ACI in the given directory with the given name.
 // Used for testing.
 func NewBasicACI(dir string, name string) (*os.File, error) {
-	manifest := fmt.Sprintf(`{"acKind":"ImageManifest","acVersion":"0.8.6","name":"%s"}`, name)
+	manifest := fmt.Sprintf(`{"acKind":"ImageManifest","acVersion":"0.8.7","name":"%s"}`, name)
 	return NewACI(dir, manifest, nil)
 }
 

--- a/stage1/aci/aci-manifest.in
+++ b/stage1/aci/aci-manifest.in
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.8.6",
+    "acVersion": "0.8.7",
     "name": "@RKT_STAGE1_NAME@",
     "labels": [
         {

--- a/stage1_fly/aci/aci-manifest.in
+++ b/stage1_fly/aci/aci-manifest.in
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.8.6",
+    "acVersion": "0.8.7",
     "name": "coreos.com/rkt/stage1-fly",
     "labels": [
         {

--- a/store/imagestore/store_test.go
+++ b/store/imagestore/store_test.go
@@ -163,7 +163,7 @@ func TestGetImageManifest(t *testing.T) {
 
 	imj := `{
 			"acKind": "ImageManifest",
-			"acVersion": "0.8.6",
+			"acVersion": "0.8.7",
 			"name": "example.com/test01"
 		}`
 
@@ -228,7 +228,7 @@ func TestGetAci(t *testing.T) {
 				{
 					`{
 						"acKind": "ImageManifest",
-						"acVersion": "0.8.6",
+						"acVersion": "0.8.7",
 						"name": "example.com/test01"
 					}`,
 					false,
@@ -236,7 +236,7 @@ func TestGetAci(t *testing.T) {
 				{
 					`{
 						"acKind": "ImageManifest",
-						"acVersion": "0.8.6",
+						"acVersion": "0.8.7",
 						"name": "example.com/test02",
 						"labels": [
 							{
@@ -250,7 +250,7 @@ func TestGetAci(t *testing.T) {
 				{
 					`{
 						"acKind": "ImageManifest",
-						"acVersion": "0.8.6",
+						"acVersion": "0.8.7",
 						"name": "example.com/test02",
 						"labels": [
 							{
@@ -358,7 +358,7 @@ func TestRemoveACI(t *testing.T) {
 
 	imj := `{
                     "acKind": "ImageManifest",
-                    "acVersion": "0.8.6",
+                    "acVersion": "0.8.7",
                     "name": "example.com/test01"
                 }`
 
@@ -403,7 +403,7 @@ func TestRemoveACI(t *testing.T) {
 	// Simulate error removing from the
 	imj = `{
                    "acKind": "ImageManifest",
-                   "acVersion": "0.8.6",
+                   "acVersion": "0.8.7",
                    "name": "example.com/test01"
                }`
 

--- a/store/treestore/tree_test.go
+++ b/store/treestore/tree_test.go
@@ -34,7 +34,7 @@ func testStoreWriteACI(dir string, s *imagestore.Store) (string, error) {
 	imj := `
 		{
 		    "acKind": "ImageManifest",
-		    "acVersion": "0.8.6",
+		    "acVersion": "0.8.7",
 		    "name": "example.com/test01"
 		}
 	`
@@ -202,7 +202,7 @@ func TestTreeStore(t *testing.T) {
 	imj := `
 		{
 		    "acKind": "ImageManifest",
-		    "acVersion": "0.8.6",
+		    "acVersion": "0.8.7",
 		    "name": "example.com/test01"
 		}
 	`

--- a/tests/empty-image/manifest
+++ b/tests/empty-image/manifest
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.8.6",
+    "acVersion": "0.8.7",
     "name": "coreos.com/rkt-empty",
     "labels": [
         {

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.8.6",
+    "acVersion": "0.8.7",
     "name": "coreos.com/rkt-inspect",
     "labels": [
         {

--- a/tests/rkt-monitor/build-too-many-apps.sh
+++ b/tests/rkt-monitor/build-too-many-apps.sh
@@ -45,7 +45,7 @@ OUTPUT=${PWD}/too-many-apps.podmanifest
 
 cat <<EOF >${OUTPUT}
 {
-    "acVersion": "0.8.6",
+    "acVersion": "0.8.7",
     "acKind": "PodManifest",
     "apps": [
 EOF

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.8.6","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.13.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
+	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.13.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
 )
 
 func TestRunOverrideExec(t *testing.T) {

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -536,7 +536,7 @@ func TestDeferredSignatureDownload(t *testing.T) {
 }
 
 func TestDifferentDiscoveryLabels(t *testing.T) {
-	manifestTemplate := `{"acKind":"ImageManifest","acVersion":"0.8.6","name":"IMG_NAME","labels":[{"name":"version","value":"1.2.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
+	manifestTemplate := `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"IMG_NAME","labels":[{"name":"version","value":"1.2.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
 	emptyImage := getEmptyImagePath()
 	imageName := "localhost/rkt-test-different-discovery-labels-image"
 	manifest := strings.Replace(manifestTemplate, "IMG_NAME", imageName, -1)

--- a/tests/rkt_image_cat_manifest_test.go
+++ b/tests/rkt_image_cat_manifest_test.go
@@ -29,7 +29,7 @@ import (
 const (
 
 	// The expected image manifest of the 'rkt-inspect-image-cat-manifest.aci'.
-	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.6","name":"IMG_NAME","labels":[{"name":"version","value":"1.13.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"IMG_NAME","labels":[{"name":"version","value":"1.13.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageCatManifest tests 'rkt image cat-manifest', it will:

--- a/tests/rkt_image_dependencies_test.go
+++ b/tests/rkt_image_dependencies_test.go
@@ -33,7 +33,7 @@ const (
 	manifestDepsTemplate = `
 {
    "acKind" : "ImageManifest",
-   "acVersion" : "0.8.6",
+   "acVersion" : "0.8.7",
    "dependencies" : [
       DEPENDENCIES
    ],

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.6","name":"IMG_NAME","labels":[{"name":"version","value":"1.13.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"IMG_NAME","labels":[{"name":"version","value":"1.13.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageExport tests 'rkt image export', it will import some existing

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.6","name":"IMG_NAME","labels":[{"name":"version","value":"1.13.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"IMG_NAME","labels":[{"name":"version","value":"1.13.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageRender tests 'rkt image render', it will import some existing empty

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	manifestOSArchTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.6","name":"IMG_NAME","labels":[{"name":"version","value":"1.13.0"}ARCH_OS],"app":{"exec":["/inspect", "--print-msg=HelloWorld"],"user":"0","group":"0","workingDirectory":"/"}}`
+	manifestOSArchTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"IMG_NAME","labels":[{"name":"version","value":"1.13.0"}ARCH_OS],"app":{"exec":["/inspect", "--print-msg=HelloWorld"],"user":"0","group":"0","workingDirectory":"/"}}`
 )
 
 type osArchTest struct {

--- a/tests/stub-stage1/manifest
+++ b/tests/stub-stage1/manifest
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.8.6",
+    "acVersion": "0.8.7",
     "name": "localhost/rkt-stub-stage1",
     "labels": [
         {

--- a/vendor/github.com/appc/spec/ace/image_manifest_main.json.in
+++ b/vendor/github.com/appc/spec/ace/image_manifest_main.json.in
@@ -1,9 +1,9 @@
 {
-    "acVersion": "0.8.6",
+    "acVersion": "0.8.7",
     "acKind": "ImageManifest",
     "name": "coreos.com/ace-validator-main",
     "labels": [
-        { "name": "version", "value": "0.8.6" },
+        { "name": "version", "value": "0.8.7" },
         { "name": "os", "value": "@GOOS@" },
         { "name": "arch", "value": "@GOARCH@" }
     ],

--- a/vendor/github.com/appc/spec/ace/image_manifest_sidekick.json.in
+++ b/vendor/github.com/appc/spec/ace/image_manifest_sidekick.json.in
@@ -1,9 +1,9 @@
 {
-    "acVersion": "0.8.6",
+    "acVersion": "0.8.7",
     "acKind": "ImageManifest",
     "name": "coreos.com/ace-validator-sidekick",
     "labels": [
-        { "name": "version", "value": "0.8.6" },
+        { "name": "version", "value": "0.8.7" },
         { "name": "os", "value": "@GOOS@" },
         { "name": "arch", "value": "@GOARCH@" }
     ],

--- a/vendor/github.com/appc/spec/ace/validator.go
+++ b/vendor/github.com/appc/spec/ace/validator.go
@@ -328,14 +328,10 @@ func validatePodMetadata(metadataURL string, pm *schema.PodManifest) results {
 func validateAppAnnotations(metadataURL string, pm *schema.PodManifest, app *schema.RuntimeApp, img *schema.ImageManifest) results {
 	r := results{}
 
-	// build a map of expected annotations by merging app.Annotations
+	// build a map of expected annotations by merging img.Annotations
 	// with PodManifest overrides
-	expectedAnnots := app.Annotations
-	a := pm.Apps.Get(app.Name)
-	if a == nil {
-		panic("could not find app in manifest!")
-	}
-	for _, annot := range a.Annotations {
+	expectedAnnots := img.Annotations
+	for _, annot := range app.Annotations {
 		expectedAnnots.Set(annot.Name, annot.Value)
 	}
 	if len(expectedAnnots) == 0 {

--- a/vendor/github.com/appc/spec/discovery/http.go
+++ b/vendor/github.com/appc/spec/discovery/http.go
@@ -28,7 +28,7 @@ import (
 type InsecureOption int
 
 const (
-	defaultDialTimeout = 5 * time.Second
+	defaultDialTimeout = 20 * time.Second
 )
 
 const (

--- a/vendor/github.com/appc/spec/schema/types/isolator_unix.go
+++ b/vendor/github.com/appc/spec/schema/types/isolator_unix.go
@@ -1,0 +1,83 @@
+// Copyright 2016 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"encoding/json"
+)
+
+var (
+	UnixIsolatorNames = make(map[ACIdentifier]struct{})
+)
+
+const (
+	//TODO(lucab): add "ulimit" isolators
+	UnixSysctlName = "os/unix/sysctl"
+)
+
+func init() {
+	for name, con := range map[ACIdentifier]IsolatorValueConstructor{
+		UnixSysctlName: func() IsolatorValue { return &UnixSysctl{} },
+	} {
+		AddIsolatorName(name, UnixIsolatorNames)
+		AddIsolatorValueConstructor(name, con)
+	}
+}
+
+type UnixSysctl map[string]string
+
+func (s *UnixSysctl) UnmarshalJSON(b []byte) error {
+	var v map[string]string
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+	*s = UnixSysctl(v)
+	return err
+}
+
+func (s UnixSysctl) AssertValid() error {
+	return nil
+}
+
+func (s UnixSysctl) multipleAllowed() bool {
+	return false
+}
+func (s UnixSysctl) Conflicts() []ACIdentifier {
+	return nil
+}
+
+func (s UnixSysctl) AsIsolator() Isolator {
+	isol := isolatorMap[UnixSysctlName]()
+
+	b, err := json.Marshal(s)
+	if err != nil {
+		panic(err)
+	}
+	valRaw := json.RawMessage(b)
+	return Isolator{
+		Name:     UnixSysctlName,
+		ValueRaw: &valRaw,
+		value:    isol,
+	}
+}
+
+func NewUnixSysctlIsolator(cfg map[string]string) (*UnixSysctl, error) {
+	s := UnixSysctl(cfg)
+	if err := s.AssertValid(); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/vendor/github.com/appc/spec/schema/types/labels.go
+++ b/vendor/github.com/appc/spec/schema/types/labels.go
@@ -21,7 +21,7 @@ import (
 )
 
 var ValidOSArch = map[string][]string{
-	"linux":   {"amd64", "i386", "aarch64", "aarch64_be", "armv6l", "armv7l", "armv7b"},
+	"linux":   {"amd64", "i386", "aarch64", "aarch64_be", "armv6l", "armv7l", "armv7b", "ppc64", "ppc64le", "s390x"},
 	"freebsd": {"amd64", "i386", "arm"},
 	"darwin":  {"x86_64", "i386"},
 }

--- a/vendor/github.com/appc/spec/schema/version.go
+++ b/vendor/github.com/appc/spec/schema/version.go
@@ -22,7 +22,7 @@ const (
 	// version represents the canonical version of the appc spec and tooling.
 	// For now, the schema and tooling is coupled with the spec itself, so
 	// this must be kept in sync with the VERSION file in the root of the repo.
-	version string = "0.8.6"
+	version string = "0.8.7"
 )
 
 var (


### PR DESCRIPTION
This introduces support for ppc64 and s390x, a new `os/unix/sysctl` isolator, `sd-notify` annotation and unblocks several other PRs:
 * https://github.com/coreos/rkt/pull/2936
 * https://github.com/coreos/rkt/pull/3100