### PR TITLE
rkt/rm: fix the case where a pod is not found

### DIFF
--- a/rkt/rm.go
+++ b/rkt/rm.go
@@ -75,6 +75,7 @@ func runRm(cmd *cobra.Command, args []string) (exit int) {
 		if err != nil {
 			ret = 1
 			stderr.PrintE("cannot get pod", err)
+			continue
 		}
 
 		if removePod(p) {


### PR DESCRIPTION
We should not be trying to delete in this case

Closes #3130 