### PR TITLE
CRI: Add 'rkt app list/status'.

### DIFF
--- a/lib/app.go
+++ b/lib/app.go
@@ -1,0 +1,283 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lib
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/appc/spec/schema"
+	pkgPod "github.com/coreos/rkt/pkg/pod"
+)
+
+// AppState defines the state of the app.
+type AppState string
+
+const (
+	AppStateUnknown AppState = "unknown"
+	AppStateCreated AppState = "created"
+	AppStateRunning AppState = "running"
+	AppStateExited  AppState = "exited"
+)
+
+// Mount defines the mount point.
+type Mount struct {
+	// Name of the mount.
+	Name string `json:"name"`
+	// Container path of the mount.
+	ContainerPath string `json:"container_path"`
+	// Host path of the mount.
+	HostPath string `json:"host_path"`
+	// Whether the mount is read-only.
+	ReadOnly bool `json:"read_only"`
+	// TODO(yifan): What about 'SelinuxRelabel bool'?
+}
+
+// App defines the app object.
+type App struct {
+	// Name of the app.
+	Name string `json:"name"`
+	// State of the app, can be created, running, exited, or unknown.
+	State AppState `json:"state"`
+	// Creation time of the container, nanoseconds since epoch.
+	CreatedAt *int64 `json:"created_at,omitempty"`
+	// Start time of the container, nanoseconds since epoch.
+	StartedAt *int64 `json:"started_at,omitempty"`
+	// Finish time of the container, nanoseconds since epoch.
+	FinishedAt *int64 `json:"finished_at,omitempty"`
+	// Exit code of the container.
+	ExitCode *int `json:"exit_code,omitempty"`
+	// Image ID of the container.
+	ImageID string `json:"image_id"`
+	// Mount points of the container.
+	Mounts []*Mount `json:"mounts,omitempty"`
+	// Annotations of the container.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// Apps is a list of apps.
+type Apps struct {
+	AppList []App `json:"app_list,omitempty"`
+}
+
+// GetApps returns the app infos of the pod with the given uuid.
+// If appName is non-empty, then only the app with the given name will be returned.
+func GetApps(dataDir, uuid string, appName string) ([]*App, error) {
+	p, err := pkgPod.GetPodFromUUIDString(dataDir, uuid)
+	if err != nil {
+		return nil, err
+	}
+	defer p.Close()
+
+	_, podManifest, err := p.GetPodManifest()
+	if err != nil {
+		return nil, err
+	}
+
+	var apps []*App
+	for _, ra := range podManifest.Apps {
+		if appName != "" && appName != ra.Name.String() {
+			continue
+		}
+
+		app, err := getApp(&ra, podManifest, p)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Cannot get app status: %v", err)
+			continue
+		}
+
+		apps = append(apps, app)
+	}
+
+	return apps, nil
+}
+
+// getApp constructs the App object with the runtime app and pod manifest.
+func getApp(ra *schema.RuntimeApp, podManifest *schema.PodManifest, pod *pkgPod.Pod) (*App, error) {
+	app := &App{
+		Name:        ra.Name.String(),
+		ImageID:     ra.Image.ID.String(),
+		Annotations: make(map[string]string),
+	}
+
+	// Generate mounts
+	for _, mnt := range ra.App.MountPoints {
+		name := mnt.Name.String()
+		containerPath := mnt.Path
+		readOnly := mnt.ReadOnly
+
+		var hostPath string
+		for _, vol := range podManifest.Volumes {
+			if vol.Name != mnt.Name {
+				continue
+			}
+
+			hostPath = vol.Source
+			if vol.ReadOnly != nil && !readOnly {
+				readOnly = *vol.ReadOnly
+			}
+			break
+		}
+
+		if hostPath == "" { // This should not happen.
+			return nil, fmt.Errorf("cannot find corresponded volume for mount %v", mnt)
+		}
+
+		app.Mounts = append(app.Mounts, &Mount{
+			Name:          name,
+			ContainerPath: containerPath,
+			HostPath:      hostPath,
+			ReadOnly:      readOnly,
+		})
+	}
+
+	// Generate annotations.
+	for _, anno := range ra.Annotations {
+		app.Annotations[anno.Name.String()] = anno.Value
+	}
+
+	// Generate state.
+	if err := getAppState(app, pod); err != nil {
+		return nil, fmt.Errorf("error getting app's state: %v", err)
+	}
+
+	return app, nil
+}
+
+func getAppState(app *App, pod *pkgPod.Pod) error {
+	app.State = AppStateUnknown
+
+	appInfoDir, err := appInfoDir(pod, app.Name)
+	if err != nil {
+		return err
+	}
+	appStartedFile, err := appStartedFile(pod, app.Name)
+	if err != nil {
+		return err
+	}
+	appExitedFile, err := appExitedFile(pod, app.Name)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if pod.AfterRun() {
+			// If the pod is hard killed, set the app to 'exited' state.
+			// Other than this case, status file is guaranteed to be written.
+			if app.State != AppStateExited {
+				app.State = AppStateExited
+				t, err := pod.GCMarkedTime()
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Cannot get GC marked time: %v", err)
+				}
+				if !t.IsZero() {
+					finishedAt := t.UnixNano()
+					app.FinishedAt = &finishedAt
+				}
+			}
+		}
+	}()
+
+	// Check if the app is created.
+	fi, err := os.Stat(appInfoDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("cannot stat app creation file: %v", err)
+		}
+		return nil
+	}
+
+	app.State = AppStateCreated
+	createdAt := fi.ModTime().UnixNano()
+	app.CreatedAt = &createdAt
+
+	// Check if the app is started.
+	fi, err = os.Stat(appStartedFile)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("cannot stat app started file: %v", err)
+		}
+		return nil
+	}
+
+	app.State = AppStateRunning
+	startedAt := fi.ModTime().UnixNano()
+	app.StartedAt = &startedAt
+
+	// Check if the app is exited.
+	fi, err = os.Stat(appExitedFile)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("cannot stat app exited file: %v", err)
+		}
+		return nil
+	}
+
+	app.State = AppStateExited
+	finishedAt := fi.ModTime().UnixNano()
+	app.FinishedAt = &finishedAt
+
+	// Read exit code.
+	exitCode, err := readExitCode(appExitedFile)
+	if err != nil {
+		return fmt.Errorf("cannot read exit code: %v", err)
+	}
+	app.ExitCode = &exitCode
+
+	return nil
+}
+
+func readExitCode(path string) (int, error) {
+	var exitCode int
+
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return -1, fmt.Errorf("cannot read app exited file: %v", err)
+	}
+	if _, err := fmt.Sscanf(string(b), "%d", &exitCode); err != nil {
+		return -1, fmt.Errorf("cannot parse exit code: %v", err)
+	}
+	return exitCode, nil
+}
+
+func appStatusDir(pod *pkgPod.Pod) (string, error) {
+	stage1RootfsPath, err := pod.Stage1RootfsPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(stage1RootfsPath, "/rkt/status"), nil
+}
+
+func appInfoDir(pod *pkgPod.Pod, appName string) (string, error) {
+	return filepath.Join(pod.Path(), "/appsinfo", appName), nil
+}
+
+func appStartedFile(pod *pkgPod.Pod, appName string) (string, error) {
+	statusDir, err := appStatusDir(pod)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(statusDir, fmt.Sprintf("%s-started", appName)), nil
+}
+
+func appExitedFile(pod *pkgPod.Pod, appName string) (string, error) {
+	statusDir, err := appStatusDir(pod)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(statusDir, appName), nil
+}

--- a/lib/doc.go
+++ b/lib/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// lib package is expected to be used by other projects who want to integrate with rkt.
+package lib

--- a/pkg/pod/pods.go
+++ b/pkg/pod/pods.go
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build linux
-
-package main
+package pod
 
 import (
 	"errors"
@@ -42,23 +40,26 @@ import (
 
 // see Documentation/devel/pod-lifecycle.md for some explanation
 
-type pod struct {
-	*lock.FileLock
-	uuid        *types.UUID
-	createdByMe bool              // true if we're the creator of this pod (only the creator can xToPrepare or xToRun directly from preparing)
-	nets        []netinfo.NetInfo // list of networks (name, IP, iface) this pod is using
+type Pod struct {
+	UUID       *types.UUID
+	Nets       []netinfo.NetInfo // list of networks (name, IP, iface) this pod is using
+	MountLabel string            // Label to use for container image
 
-	isEmbryo         bool   // directory starts as embryo before entering preparing state, serves as stage for acquiring lock before rename to prepare/.
-	isPreparing      bool   // when locked at pods/prepare/$uuid the pod is actively being prepared
-	isAbortedPrepare bool   // when unlocked at pods/prepare/$uuid the pod never finished preparing
-	isPrepared       bool   // when at pods/prepared/$uuid the pod is prepared, serves as stage for acquiring lock before rename to run/.
-	isExited         bool   // when locked at pods/run/$uuid the pod is running, when unlocked it's exited.
-	isExitedGarbage  bool   // when unlocked at pods/exited-garbage/$uuid the pod is exited and is garbage
-	isExitedDeleting bool   // when locked at pods/exited-garbage/$uuid the pod is exited, garbage, and is being actively deleted
-	isGarbage        bool   // when unlocked at pods/garbage/$uuid the pod is garbage that never ran
-	isDeleting       bool   // when locked at pods/garbage/$uuid the pod is garbage that never ran, and is being actively deleted
-	isGone           bool   // when a pod no longer can be located at its uuid anywhere XXX: only set by refreshState()
-	mountLabel       string // Label to use for container image
+	*lock.FileLock
+	dataDir string // The data directory where the pod lives in.
+
+	createdByMe bool // true if we're the creator of this pod (only the creator can ToPrepare or ToRun directly from preparing)
+
+	isEmbryo         bool // directory starts as embryo before entering preparing state, serves as stage for acquiring lock before rename to prepare/.
+	isPreparing      bool // when locked at pods/prepare/$uuid the pod is actively being prepared
+	isAbortedPrepare bool // when unlocked at pods/prepare/$uuid the pod never finished preparing
+	isPrepared       bool // when at pods/prepared/$uuid the pod is prepared, serves as stage for acquiring lock before rename to run/.
+	isExited         bool // when locked at pods/run/$uuid the pod is running, when unlocked it's exited.
+	isExitedGarbage  bool // when unlocked at pods/exited-garbage/$uuid the pod is exited and is garbage
+	isExitedDeleting bool // when locked at pods/exited-garbage/$uuid the pod is exited, garbage, and is being actively deleted
+	isGarbage        bool // when unlocked at pods/garbage/$uuid the pod is garbage that never ran
+	isDeleting       bool // when locked at pods/garbage/$uuid the pod is garbage that never ran, and is being actively deleted
+	isGone           bool // when a pod no longer can be located at its uuid anywhere XXX: only set by refreshState()
 }
 
 // Exported state. See Documentation/devel/pod-lifecycle.md for some explanation
@@ -68,33 +69,65 @@ const (
 	AbortedPrepare = "aborted prepare"
 	Prepared       = "prepared"
 	Running        = "running"
-	Deleting       = "deleting" // This covers pod.isExitedDeleting and pod.isDeleting.
-	Exited         = "exited"   // This covers pod.isExited and pod.isExitedGarbage.
+	Deleting       = "deleting"
+	ExitedDeleting = "exited deleting"
+	Exited         = "exited"
+	ExitedGarbage  = "exited garbage"
 	Garbage        = "garbage"
 )
 
-type includeMask byte
+type IncludeMask byte
 
 const (
-	includeEmbryoDir includeMask = 1 << iota
-	includePrepareDir
-	includePreparedDir
-	includeRunDir
-	includeExitedGarbageDir
-	includeGarbageDir
+	IncludeEmbryoDir IncludeMask = 1 << iota
+	IncludePrepareDir
+	IncludePreparedDir
+	IncludeRunDir
+	IncludeExitedGarbageDir
+	IncludeGarbageDir
 
-	includeMostDirs includeMask = (includeRunDir | includeExitedGarbageDir | includePrepareDir | includePreparedDir)
-	includeAllDirs  includeMask = (includeMostDirs | includeEmbryoDir | includeGarbageDir)
+	IncludeMostDirs IncludeMask = (IncludeRunDir | IncludeExitedGarbageDir | IncludePrepareDir | IncludePreparedDir)
+	IncludeAllDirs  IncludeMask = (IncludeMostDirs | IncludeEmbryoDir | IncludeGarbageDir)
 )
 
 var (
 	podsInitialized = false
 )
 
+// where pod directories are created and locked before moving to prepared
+func embryoDir(dataDir string) string {
+	return filepath.Join(dataDir, "pods", "embryo")
+}
+
+// where pod trees reside during (locked) and after failing to complete preparation (unlocked)
+func prepareDir(dataDir string) string {
+	return filepath.Join(dataDir, "pods", "prepare")
+}
+
+// where pod trees reside upon successful preparation
+func preparedDir(dataDir string) string {
+	return filepath.Join(dataDir, "pods", "prepared")
+}
+
+// where pod trees reside once run
+func runDir(dataDir string) string {
+	return filepath.Join(dataDir, "pods", "run")
+}
+
+// where pod trees reside once exited & marked as garbage by a gc pass
+func exitedGarbageDir(dataDir string) string {
+	return filepath.Join(dataDir, "pods", "exited-garbage")
+}
+
+// where never-executed pod trees reside once marked as garbage by a gc pass (failed prepares, expired prepareds)
+func garbageDir(dataDir string) string {
+	return filepath.Join(dataDir, "pods", "garbage")
+}
+
 // initPods creates the required global directories
-func initPods() error {
+func initPods(dataDir string) error {
 	if !podsInitialized {
-		dirs := []string{embryoDir(), prepareDir(), preparedDir(), runDir(), exitedGarbageDir(), garbageDir()}
+		dirs := []string{embryoDir(dataDir), prepareDir(dataDir), preparedDir(dataDir), runDir(dataDir), exitedGarbageDir(dataDir), garbageDir(dataDir)}
 		for _, d := range dirs {
 			if err := os.MkdirAll(d, 0750); err != nil {
 				return errwrap.Wrap(errors.New("error creating directory"), err)
@@ -105,66 +138,23 @@ func initPods() error {
 	return nil
 }
 
-// walkPods iterates over the included directories calling function f for every pod found.
-func walkPods(include includeMask, f func(*pod)) error {
-	if err := initPods(); err != nil {
-		return err
-	}
-
-	ls, err := listPods(include)
-	if err != nil {
-		return errwrap.Wrap(errors.New("failed to get pods"), err)
-	}
-	sort.Strings(ls)
-
-	for _, uuid := range ls {
-		u, err := types.NewUUID(uuid)
-		if err != nil {
-			stderr.PrintE(fmt.Sprintf("skipping %q", uuid), err)
-			continue
-		}
-		p, err := getPod(u)
-		if err != nil {
-			stderr.PrintE(fmt.Sprintf("skipping %q", uuid), err)
-			continue
-		}
-
-		// omit pods found in unrequested states
-		// this is to cover a race between listPods finding the uuids and pod states changing
-		// it's preferable to keep these operations lock-free, for example a `rkt gc` shouldn't block `rkt run`.
-		if p.isEmbryo && include&includeEmbryoDir == 0 ||
-			p.isExitedGarbage && include&includeExitedGarbageDir == 0 ||
-			p.isGarbage && include&includeGarbageDir == 0 ||
-			p.isPrepared && include&includePreparedDir == 0 ||
-			((p.isPreparing || p.isAbortedPrepare) && include&includePrepareDir == 0) ||
-			p.isRunning() && include&includeRunDir == 0 {
-			p.Close()
-			continue
-		}
-
-		f(p)
-		p.Close()
-	}
-
-	return nil
-}
-
-// newPod creates a new pod directory in the "preparing" state, allocating a unique uuid for it in the process.
+// NewPod creates a new pod directory in the "preparing" state, allocating a unique uuid for it in the process.
 // The returned pod is always left in an exclusively locked state (preparing is locked in the prepared directory)
 // The pod must be closed using pod.Close()
-func newPod() (*pod, error) {
-	if err := initPods(); err != nil {
+func NewPod(dataDir string) (*Pod, error) {
+	if err := initPods(dataDir); err != nil {
 		return nil, err
 	}
 
-	p := &pod{
+	p := &Pod{
+		dataDir:     dataDir,
 		createdByMe: true,
-		isEmbryo:    true, // starts as an embryo, then xToPreparing locks, renames, and sets isPreparing
+		isEmbryo:    true, // starts as an embryo, then ToPreparing locks, renames, and sets isPreparing
 		// rest start false.
 	}
 
 	var err error
-	p.uuid, err = types.NewUUID(uuid.New())
+	p.UUID, err = types.NewUUID(uuid.New())
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("error creating UUID"), err)
 	}
@@ -180,7 +170,7 @@ func newPod() (*pod, error) {
 		return nil, err
 	}
 
-	err = p.xToPreparing()
+	err = p.ToPreparing()
 	if err != nil {
 		return nil, err
 	}
@@ -194,12 +184,12 @@ func newPod() (*pod, error) {
 // getPod returns a pod struct representing the given pod.
 // The returned lock is always left in an open but unlocked state.
 // The pod must be closed using pod.Close()
-func getPod(uuid *types.UUID) (*pod, error) {
-	if err := initPods(); err != nil {
+func getPod(dataDir string, uuid *types.UUID) (*Pod, error) {
+	if err := initPods(dataDir); err != nil {
 		return nil, err
 	}
 
-	p := &pod{uuid: uuid}
+	p := &Pod{UUID: uuid, dataDir: dataDir}
 
 	// we try open the pod in all possible directories, in the same order the states occur
 	l, err := lock.NewLock(p.embryoPath(), lock.Dir)
@@ -275,7 +265,7 @@ func getPod(uuid *types.UUID) (*pod, error) {
 		if err != nil {
 			return nil, errwrap.Wrap(fmt.Errorf("error acquiring pod %v dir fd", uuid), err)
 		}
-		p.nets, err = netinfo.LoadAt(cfd)
+		p.Nets, err = netinfo.LoadAt(cfd)
 		// ENOENT is ok -- assume running with --net=host
 		if err != nil && !os.IsNotExist(err) {
 			return nil, errwrap.Wrap(fmt.Errorf("error opening pod %v netinfo", uuid), err)
@@ -285,15 +275,15 @@ func getPod(uuid *types.UUID) (*pod, error) {
 	return p, nil
 }
 
-// getPodFromUUIDString attempts to resolve the supplied UUID and return a pod.
+// GetPodFromUUIDString attempts to resolve the supplied UUID and return a pod.
 // The pod must be closed using pod.Close()
-func getPodFromUUIDString(uuid string) (*pod, error) {
-	podUUID, err := resolveUUID(uuid)
+func GetPodFromUUIDString(dataDir, uuid string) (*Pod, error) {
+	podUUID, err := resolveUUID(dataDir, uuid)
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("unable to resolve UUID"), err)
 	}
 
-	p, err := getPod(podUUID)
+	p, err := getPod(dataDir, podUUID)
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("unable to get pod"), err)
 	}
@@ -301,58 +291,39 @@ func getPodFromUUIDString(uuid string) (*pod, error) {
 	return p, nil
 }
 
-// path returns the path to the pod according to the current (cached) state.
-func (p *pod) path() string {
-	if p.isEmbryo {
-		return p.embryoPath()
-	} else if p.isPreparing || p.isAbortedPrepare {
-		return p.preparePath()
-	} else if p.isPrepared {
-		return p.preparedPath()
-	} else if p.isExitedGarbage {
-		return p.exitedGarbagePath()
-	} else if p.isGarbage {
-		return p.garbagePath()
-	} else if p.isGone {
-		return "" // TODO(vc): anything better?
-	}
-
-	return p.runPath()
-}
-
 // embryoPath returns the path to the pod where it would be in the embryoDir in its embryonic state.
-func (p *pod) embryoPath() string {
-	return filepath.Join(embryoDir(), p.uuid.String())
+func (p *Pod) embryoPath() string {
+	return filepath.Join(embryoDir(p.dataDir), p.UUID.String())
 }
 
 // preparePath returns the path to the pod where it would be in the prepareDir in its preparing state.
-func (p *pod) preparePath() string {
-	return filepath.Join(prepareDir(), p.uuid.String())
+func (p *Pod) preparePath() string {
+	return filepath.Join(prepareDir(p.dataDir), p.UUID.String())
 }
 
 // preparedPath returns the path to the pod where it would be in the preparedDir.
-func (p *pod) preparedPath() string {
-	return filepath.Join(preparedDir(), p.uuid.String())
+func (p *Pod) preparedPath() string {
+	return filepath.Join(preparedDir(p.dataDir), p.UUID.String())
 }
 
 // runPath returns the path to the pod where it would be in the runDir.
-func (p *pod) runPath() string {
-	return filepath.Join(runDir(), p.uuid.String())
+func (p *Pod) runPath() string {
+	return filepath.Join(runDir(p.dataDir), p.UUID.String())
 }
 
 // exitedGarbagePath returns the path to the pod where it would be in the exitedGarbageDir.
-func (p *pod) exitedGarbagePath() string {
-	return filepath.Join(exitedGarbageDir(), p.uuid.String())
+func (p *Pod) exitedGarbagePath() string {
+	return filepath.Join(exitedGarbageDir(p.dataDir), p.UUID.String())
 }
 
 // garbagePath returns the path to the pod where it would be in the garbageDir.
-func (p *pod) garbagePath() string {
-	return filepath.Join(garbageDir(), p.uuid.String())
+func (p *Pod) garbagePath() string {
+	return filepath.Join(garbageDir(p.dataDir), p.UUID.String())
 }
 
-// xToPrepare transitions a pod from embryo -> preparing, leaves the pod locked in the prepare directory.
+// ToPrepare transitions a pod from embryo -> preparing, leaves the pod locked in the prepare directory.
 // only the creator of the pod (via newPod()) may do this, nobody to race with.
-func (p *pod) xToPreparing() error {
+func (p *Pod) ToPreparing() error {
 	if !p.createdByMe {
 		return fmt.Errorf("bug: only pods created by me may transition to preparing")
 	}
@@ -369,7 +340,7 @@ func (p *pod) xToPreparing() error {
 		return err
 	}
 
-	df, err := os.Open(prepareDir())
+	df, err := os.Open(prepareDir(p.dataDir))
 	if err != nil {
 		return err
 	}
@@ -384,9 +355,9 @@ func (p *pod) xToPreparing() error {
 	return nil
 }
 
-// xToPrepared transitions a pod from preparing -> prepared, leaves the pod unlocked in the prepared directory.
+// ToPrepared transitions a pod from preparing -> prepared, leaves the pod unlocked in the prepared directory.
 // only the creator of the pod (via newPod()) may do this, nobody to race with.
-func (p *pod) xToPrepared() error {
+func (p *Pod) ToPrepared() error {
 	if !p.createdByMe {
 		return fmt.Errorf("bug: only pods created by me may transition to prepared")
 	}
@@ -395,14 +366,14 @@ func (p *pod) xToPrepared() error {
 		return fmt.Errorf("bug: only preparing pods may transition to prepared")
 	}
 
-	if err := os.Rename(p.path(), p.preparedPath()); err != nil {
+	if err := os.Rename(p.Path(), p.preparedPath()); err != nil {
 		return err
 	}
 	if err := p.Unlock(); err != nil {
 		return err
 	}
 
-	df, err := os.Open(preparedDir())
+	df, err := os.Open(preparedDir(p.dataDir))
 	if err != nil {
 		return err
 	}
@@ -417,9 +388,9 @@ func (p *pod) xToPrepared() error {
 	return nil
 }
 
-// xToRun transitions a pod from prepared -> run, leaves the pod locked in the run directory.
+// ToRun transitions a pod from prepared -> run, leaves the pod locked in the run directory.
 // the creator of the pod (via newPod()) may also jump directly from preparing -> run
-func (p *pod) xToRun() error {
+func (p *Pod) ToRun() error {
 	if !p.createdByMe && !p.isPrepared {
 		return fmt.Errorf("bug: only prepared pods may transition to run")
 	}
@@ -432,13 +403,13 @@ func (p *pod) xToRun() error {
 		return err
 	}
 
-	label.Relabel(p.path(), p.mountLabel, "Z")
-	if err := os.Rename(p.path(), p.runPath()); err != nil {
-		// TODO(vc): we could race here with a concurrent xToRun(), let caller deal with the error.
+	label.Relabel(p.Path(), p.MountLabel, "Z")
+	if err := os.Rename(p.Path(), p.runPath()); err != nil {
+		// TODO(vc): we could race here with a concurrent ToRun(), let caller deal with the error.
 		return err
 	}
 
-	df, err := os.Open(runDir())
+	df, err := os.Open(runDir(p.dataDir))
 	if err != nil {
 		return err
 	}
@@ -453,18 +424,18 @@ func (p *pod) xToRun() error {
 	return nil
 }
 
-// xToExitedGarbage transitions a pod from run -> exitedGarbage
-func (p *pod) xToExitedGarbage() error {
+// ToExitedGarbage transitions a pod from run -> exitedGarbage
+func (p *Pod) ToExitedGarbage() error {
 	if !p.isExited || p.isExitedGarbage {
 		return fmt.Errorf("bug: only exited non-garbage pods may transition to exited-garbage")
 	}
 
 	if err := os.Rename(p.runPath(), p.exitedGarbagePath()); err != nil {
-		// TODO(vc): another case where we could race with a concurrent xToExitedGarbage(), let caller deal with the error.
+		// TODO(vc): another case where we could race with a concurrent ToExitedGarbage(), let caller deal with the error.
 		return err
 	}
 
-	df, err := os.Open(exitedGarbageDir())
+	df, err := os.Open(exitedGarbageDir(p.dataDir))
 	if err != nil {
 		return err
 	}
@@ -478,17 +449,17 @@ func (p *pod) xToExitedGarbage() error {
 	return nil
 }
 
-// xToGarbage transitions a pod from abortedPrepared -> garbage or prepared -> garbage
-func (p *pod) xToGarbage() error {
+// ToGarbage transitions a pod from abortedPrepared -> garbage or prepared -> garbage
+func (p *Pod) ToGarbage() error {
 	if !p.isAbortedPrepare && !p.isPrepared {
 		return fmt.Errorf("bug: only failed prepare or prepared pods may transition to garbage")
 	}
 
-	if err := os.Rename(p.path(), p.garbagePath()); err != nil {
+	if err := os.Rename(p.Path(), p.garbagePath()); err != nil {
 		return err
 	}
 
-	df, err := os.Open(garbageDir())
+	df, err := os.Open(garbageDir(p.dataDir))
 	if err != nil {
 		return err
 	}
@@ -504,44 +475,32 @@ func (p *pod) xToGarbage() error {
 	return nil
 }
 
-// isRunning does the annoying tests to infer if a pod is in a running state
-func (p *pod) isRunning() bool {
-	// when none of these things, running!
-	return !p.isEmbryo && !p.isAbortedPrepare && !p.isPreparing && !p.isPrepared &&
-		!p.isExited && !p.isExitedGarbage && !p.isExitedDeleting && !p.isGarbage && !p.isDeleting && !p.isGone
-}
-
-// afterRun tests if a pod is in a post-running state
-func (p *pod) afterRun() bool {
-	return p.isExitedDeleting || p.isDeleting || p.isExited || p.isGarbage
-}
-
 // listPods returns a list of pod uuids in string form.
-func listPods(include includeMask) ([]string, error) {
+func listPods(dataDir string, include IncludeMask) ([]string, error) {
 	// uniqued due to the possibility of a pod being renamed from across directories during the list operation
 	ups := make(map[string]struct{})
 	dirs := []struct {
-		kind includeMask
+		kind IncludeMask
 		path string
 	}{
 		{ // the order here is significant: embryo -> preparing -> prepared -> running -> exitedGarbage
-			kind: includeEmbryoDir,
-			path: embryoDir(),
+			kind: IncludeEmbryoDir,
+			path: embryoDir(dataDir),
 		}, {
-			kind: includePrepareDir,
-			path: prepareDir(),
+			kind: IncludePrepareDir,
+			path: prepareDir(dataDir),
 		}, {
-			kind: includePreparedDir,
-			path: preparedDir(),
+			kind: IncludePreparedDir,
+			path: preparedDir(dataDir),
 		}, {
-			kind: includeRunDir,
-			path: runDir(),
+			kind: IncludeRunDir,
+			path: runDir(dataDir),
 		}, {
-			kind: includeExitedGarbageDir,
-			path: exitedGarbageDir(),
+			kind: IncludeExitedGarbageDir,
+			path: exitedGarbageDir(dataDir),
 		}, {
-			kind: includeGarbageDir,
-			path: garbageDir(),
+			kind: IncludeGarbageDir,
+			path: garbageDir(dataDir),
 		},
 	}
 
@@ -579,7 +538,7 @@ func listPodsFromDir(cdir string) ([]string, error) {
 
 	for _, p := range ls {
 		if !p.IsDir() {
-			stderr.Printf("unrecognized entry: %q, ignoring", p.Name())
+			fmt.Fprintf(os.Stderr, "unrecognized entry: %q, ignoring", p.Name())
 			continue
 		}
 		ps = append(ps, p.Name())
@@ -590,7 +549,7 @@ func listPodsFromDir(cdir string) ([]string, error) {
 
 // refreshState() updates the cached members of c to reflect current reality
 // assumes p.FileLock is currently unlocked, and always returns with it unlocked.
-func (p *pod) refreshState() error {
+func (p *Pod) refreshState() error {
 	//  TODO(vc): this overlaps substantially with newPod(), could probably unify.
 	p.isEmbryo = false
 	p.isPreparing = false
@@ -641,7 +600,7 @@ func (p *pod) refreshState() error {
 	}
 
 	if err != nil && !os.IsNotExist(err) {
-		return errwrap.Wrap(fmt.Errorf("error refreshing state of pod %q", p.uuid.String()), err)
+		return errwrap.Wrap(fmt.Errorf("error refreshing state of pod %q", p.UUID.String()), err)
 	}
 
 	if !p.isPrepared && !p.isEmbryo && !p.isGone {
@@ -674,8 +633,8 @@ func (p *pod) refreshState() error {
 	return nil
 }
 
-// waitExited waits for a pod to (run and) exit.
-func (p *pod) waitExited() error {
+// WaitExited waits for a pod to (run and) exit.
+func (p *Pod) WaitExited() error {
 	// isExited implies isExitedGarbage.
 	for !p.isExited && !p.isAbortedPrepare && !p.isGarbage && !p.isGone {
 		if err := p.SharedLock(); err != nil {
@@ -702,7 +661,7 @@ func (p *pod) waitExited() error {
 }
 
 // readFile reads an entire file from a pod's directory.
-func (p *pod) readFile(path string) ([]byte, error) {
+func (p *Pod) readFile(path string) ([]byte, error) {
 	f, err := p.openFile(path, syscall.O_RDONLY)
 	if err != nil {
 		return nil, err
@@ -713,7 +672,7 @@ func (p *pod) readFile(path string) ([]byte, error) {
 }
 
 // readIntFromFile reads an int from a file in a pod's directory.
-func (p *pod) readIntFromFile(path string) (i int, err error) {
+func (p *Pod) readIntFromFile(path string) (i int, err error) {
 	b, err := p.readFile(path)
 	if err != nil {
 		return
@@ -723,7 +682,7 @@ func (p *pod) readIntFromFile(path string) (i int, err error) {
 }
 
 // openFile opens a file from a pod's directory returning a file descriptor.
-func (p *pod) openFile(path string, flags int) (*os.File, error) {
+func (p *Pod) openFile(path string, flags int) (*os.File, error) {
 	cdirfd, err := p.Fd()
 	if err != nil {
 		return nil, err
@@ -737,30 +696,7 @@ func (p *pod) openFile(path string, flags int) (*os.File, error) {
 	return os.NewFile(uintptr(fd), path), nil
 }
 
-// getState returns the current state of the pod
-func (p *pod) getState() string {
-	state := "running"
-
-	if p.isEmbryo {
-		state = Embryo
-	} else if p.isPreparing {
-		state = Preparing
-	} else if p.isAbortedPrepare {
-		state = AbortedPrepare
-	} else if p.isPrepared {
-		state = Prepared
-	} else if p.isExitedDeleting || p.isDeleting {
-		state = Deleting
-	} else if p.isExited { // this covers p.isExitedGarbage
-		state = Exited
-	} else if p.isGarbage {
-		state = Garbage
-	}
-
-	return state
-}
-
-func (p *pod) getModTime(path string) (time.Time, error) {
+func (p *Pod) getModTime(path string) (time.Time, error) {
 	f, err := p.openFile(path, syscall.O_RDONLY)
 	if err != nil {
 		return time.Time{}, err
@@ -773,61 +709,6 @@ func (p *pod) getModTime(path string) (time.Time, error) {
 	}
 
 	return fi.ModTime(), nil
-}
-
-// getCreationTime returns the time when the pod was created.
-// This happens at prepare time.
-func (p *pod) getCreationTime() (time.Time, error) {
-	if p.isPrepared || p.isRunning() || p.afterRun() {
-		return p.getModTime("pod")
-	}
-	return time.Time{}, nil
-}
-
-// getStartTime returns the time when the pod was started.
-func (p *pod) getStartTime() (time.Time, error) {
-	var (
-		t   time.Time
-		err error
-	)
-	if p.isRunning() || p.afterRun() {
-		// check pid and ppid files, since stage1 implementations can choose
-		// which one to implement.
-		t, err = p.getModTime("pid")
-		if os.IsNotExist(err) {
-			t, err = p.getModTime("ppid")
-			// if there's an error starting the pod, it can be "exited" without
-			// the "ppid" (or "pid") files being created, return an error only
-			// if it's different than ENOENT.
-			if os.IsNotExist(err) {
-				err = nil
-			}
-		}
-	}
-	return t, err
-}
-
-func (p *pod) getGCMarkedTime() (time.Time, error) {
-	if !p.isGarbage && !p.isExitedGarbage {
-		return time.Time{}, nil
-	}
-
-	// At this point, the pod is in either exited-garbage dir, garbage dir or gone already.
-	podPath := p.path()
-	if podPath == "" {
-		// Pod is gone.
-		return time.Time{}, nil
-	}
-
-	st := &syscall.Stat_t{}
-	if err := syscall.Lstat(podPath, st); err != nil {
-		if err == syscall.ENOENT {
-			// Pod is gone.
-			err = nil
-		}
-		return time.Time{}, err
-	}
-	return time.Unix(st.Ctim.Unix()), nil
 }
 
 type ErrChildNotReady struct {
@@ -899,8 +780,251 @@ func getChildPID(ppid int) (int, error) {
 	return -1, ErrChildNotReady{}
 }
 
-// getPID returns the pid of the stage1 process that started the pod.
-func (p *pod) getPID() (int, error) {
+// GetStage1TreeStoreID returns the treeStoreID of the stage1 image used in
+// this pod
+// TODO(yifan): Maybe make this unexported.
+func (p *Pod) GetStage1TreeStoreID() (string, error) {
+	s1IDb, err := p.readFile(common.Stage1TreeStoreIDFilename)
+	if err != nil {
+		return "", err
+	}
+	return string(s1IDb), nil
+}
+
+// GetAppTreeStoreID returns the treeStoreID of the provided app.
+// TODO(yifan): Maybe make this unexported.
+func (p *Pod) GetAppTreeStoreID(app types.ACName) (string, error) {
+	path, err := filepath.Rel("/", common.AppTreeStoreIDPath("", app))
+	if err != nil {
+		return "", err
+	}
+	treeStoreID, err := p.readFile(path)
+	if err != nil {
+		// When not using overlayfs, apps don't have a treeStoreID file. In
+		// other cases we've got a problem.
+		if !(os.IsNotExist(err) && !p.UsesOverlay()) {
+			return "", errwrap.Wrap(fmt.Errorf("no treeStoreID found for app %s", app), err)
+		}
+	}
+	return string(treeStoreID), nil
+}
+
+// GetAppsTreeStoreIDs returns the treeStoreIDs of the apps images used in
+// this pod.
+// TODO(yifan): Maybe make this unexported.
+func (p *Pod) GetAppsTreeStoreIDs() ([]string, error) {
+	var treeStoreIDs []string
+	apps, err := p.getApps()
+	if err != nil {
+		return nil, err
+	}
+	for _, a := range apps {
+		id, err := p.GetAppTreeStoreID(a.Name)
+		if err != nil {
+			return nil, err
+		}
+		if id != "" {
+			treeStoreIDs = append(treeStoreIDs, id)
+		}
+	}
+	return treeStoreIDs, nil
+}
+
+// getAppsHashes returns a list of the app hashes in the pod
+func (p *Pod) getAppsHashes() ([]types.Hash, error) {
+	apps, err := p.getApps()
+	if err != nil {
+		return nil, err
+	}
+
+	var hashes []types.Hash
+	for _, a := range apps {
+		hashes = append(hashes, a.Image.ID)
+	}
+
+	return hashes, nil
+}
+
+// getApps returns a list of apps in the pod
+func (p *Pod) getApps() (schema.AppList, error) {
+	_, pm, err := p.GetPodManifest()
+	if err != nil {
+		return nil, err
+	}
+	return pm.Apps, nil
+}
+
+// getDirNames returns the list of names from a pod's directory
+func (p *Pod) getDirNames(path string) ([]string, error) {
+	dir, err := p.openFile(path, syscall.O_RDONLY|syscall.O_DIRECTORY)
+	if err != nil {
+		return nil, errwrap.Wrap(errors.New("unable to open directory"), err)
+	}
+	defer dir.Close()
+
+	ld, err := dir.Readdirnames(0)
+	if err != nil {
+		return nil, errwrap.Wrap(errors.New("unable to read directory"), err)
+	}
+
+	return ld, nil
+}
+
+// UsesOverlay returns whether the pod Uses overlayfs.
+// TODO(yifan): Maybe make this function unexported.
+func (p *Pod) UsesOverlay() bool {
+	f, err := p.openFile(common.OverlayPreparedFilename, syscall.O_RDONLY)
+	defer f.Close()
+	return err == nil
+}
+
+// Sync syncs the pod data. By now it calls a syncfs on the filesystem
+// containing the pod's directory.
+func (p *Pod) Sync() error {
+	cfd, err := p.Fd()
+	if err != nil {
+		return errwrap.Wrap(fmt.Errorf("error acquiring pod %v dir fd", p.UUID.String()), err)
+	}
+	if err := sys.Syncfs(cfd); err != nil {
+		return errwrap.Wrap(fmt.Errorf("failed to sync pod %v data", p.UUID.String()), err)
+	}
+	return nil
+}
+
+// WalkPods iterates over the included directories calling function f for every pod found.
+func WalkPods(dataDir string, include IncludeMask, f func(*Pod)) error {
+	if err := initPods(dataDir); err != nil {
+		return err
+	}
+
+	ls, err := listPods(dataDir, include)
+	if err != nil {
+		return errwrap.Wrap(errors.New("failed to get pods"), err)
+	}
+	sort.Strings(ls)
+
+	for _, uuid := range ls {
+		u, err := types.NewUUID(uuid)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "skipping %q: %v", uuid, err)
+			continue
+		}
+		p, err := getPod(dataDir, u)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "skipping %q: %v", uuid, err)
+			continue
+		}
+
+		// omit pods found in unrequested states
+		// this is to cover a race between listPods finding the uuids and pod states changing
+		// it's preferable to keep these operations lock-free, for example a `rkt gc` shouldn't block `rkt run`.
+		if p.isEmbryo && include&IncludeEmbryoDir == 0 ||
+			p.isExitedGarbage && include&IncludeExitedGarbageDir == 0 ||
+			p.isGarbage && include&IncludeGarbageDir == 0 ||
+			p.isPrepared && include&IncludePreparedDir == 0 ||
+			((p.isPreparing || p.isAbortedPrepare) && include&IncludePrepareDir == 0) ||
+			p.isRunning() && include&IncludeRunDir == 0 {
+			p.Close()
+			continue
+		}
+
+		f(p)
+		p.Close()
+	}
+
+	return nil
+}
+
+// GetPodManifest reads the pod manifest, returns the raw bytes and the unmarshalled object.
+func (p *Pod) GetPodManifest() ([]byte, *schema.PodManifest, error) {
+	pmb, err := p.readFile("pod")
+	if err != nil {
+		return nil, nil, errwrap.Wrap(errors.New("error reading pod manifest"), err)
+	}
+	pm := &schema.PodManifest{}
+	if err = pm.UnmarshalJSON(pmb); err != nil {
+		return nil, nil, errwrap.Wrap(errors.New("invalid pod manifest"), err)
+	}
+	return pmb, pm, nil
+}
+
+// GetAppImageManifest returns an ImageManifest for the corresponding AppName.
+func (p *Pod) GetAppImageManifest(appName string) (*schema.ImageManifest, error) {
+	appACName, err := types.NewACName(appName)
+	if err != nil {
+		return nil, err
+	}
+	imb, err := ioutil.ReadFile(common.AppImageManifestPath(p.Path(), *appACName))
+	if err != nil {
+		return nil, err
+	}
+
+	aim := &schema.ImageManifest{}
+	if err := aim.UnmarshalJSON(imb); err != nil {
+		return nil, errwrap.Wrap(fmt.Errorf("invalid image manifest for app %q", appName), err)
+	}
+
+	return aim, nil
+}
+
+// CreationTime returns the time when the pod was created.
+// This happens at prepare time.
+func (p *Pod) CreationTime() (time.Time, error) {
+	if p.isPrepared || p.isRunning() || p.AfterRun() {
+		return p.getModTime("pod")
+	}
+	return time.Time{}, nil
+}
+
+// StartTime returns the time when the pod was started.
+func (p *Pod) StartTime() (time.Time, error) {
+	var (
+		t   time.Time
+		err error
+	)
+	if p.isRunning() || p.AfterRun() {
+		// check pid and ppid files, since stage1 implementations can choose
+		// which one to implement.
+		t, err = p.getModTime("pid")
+		if os.IsNotExist(err) {
+			t, err = p.getModTime("ppid")
+			// if there's an error starting the pod, it can be "exited" without
+			// the "ppid" (or "pid") files being created, return an error only
+			// if it's different than ENOENT.
+			if os.IsNotExist(err) {
+				err = nil
+			}
+		}
+	}
+	return t, err
+}
+
+// GCMarkedTime returns the time when the pod is marked by gc.
+func (p *Pod) GCMarkedTime() (time.Time, error) {
+	if !p.isGarbage && !p.isExitedGarbage {
+		return time.Time{}, nil
+	}
+
+	// At this point, the pod is in either exited-garbage dir, garbage dir or gone already.
+	podPath := p.Path()
+	if podPath == "" {
+		// Pod is gone.
+		return time.Time{}, nil
+	}
+
+	st := &syscall.Stat_t{}
+	if err := syscall.Lstat(podPath, st); err != nil {
+		if err == syscall.ENOENT {
+			// Pod is gone.
+			err = nil
+		}
+		return time.Time{}, err
+	}
+	return time.Unix(st.Ctim.Unix()), nil
+}
+
+// Pid returns the pid of the stage1 process that started the pod.
+func (p *Pod) Pid() (int, error) {
 	if pid, err := p.readIntFromFile("pid"); err == nil {
 		return pid, nil
 	}
@@ -911,8 +1035,8 @@ func (p *pod) getPID() (int, error) {
 	}
 }
 
-// getContainerPID1 returns the pid of the process with pid 1 in the pod.
-func (p *pod) getContainerPID1() (pid int, err error) {
+// ContainerPid1 returns the pid of the process with pid 1 in the pod.
+func (p *Pod) ContainerPid1() (pid int, err error) {
 	// rkt supports two methods to find the container's PID 1: the pid
 	// file and the ppid file.
 	// The ordering is not important and only one of them must be supplied.
@@ -949,202 +1073,101 @@ func (p *pod) getContainerPID1() (pid int, err error) {
 		}
 
 		if !p.isRunning() {
-			return -1, fmt.Errorf("pod %v is not running anymore", p.uuid)
+			return -1, fmt.Errorf("pod %v is not running anymore", p.UUID)
 		}
 	}
 }
 
-// getStage1TreeStoreID returns the treeStoreID of the stage1 image used in
-// this pod
-func (p *pod) getStage1TreeStoreID() (string, error) {
-	s1IDb, err := p.readFile(common.Stage1TreeStoreIDFilename)
-	if err != nil {
-		return "", err
+// Path returns the path to the pod according to the current (cached) state.
+func (p *Pod) Path() string {
+	if p.isEmbryo {
+		return p.embryoPath()
+	} else if p.isPreparing || p.isAbortedPrepare {
+		return p.preparePath()
+	} else if p.isPrepared {
+		return p.preparedPath()
+	} else if p.isExitedGarbage {
+		return p.exitedGarbagePath()
+	} else if p.isGarbage {
+		return p.garbagePath()
+	} else if p.isGone {
+		return "" // TODO(vc): anything better?
 	}
-	return string(s1IDb), nil
+
+	return p.runPath()
 }
 
-// getAppTreeStoreID returns the treeStoreID of the provided app.
-func (p *pod) getAppTreeStoreID(app types.ACName) (string, error) {
-	path, err := filepath.Rel("/", common.AppTreeStoreIDPath("", app))
-	if err != nil {
-		return "", err
-	}
-	treeStoreID, err := p.readFile(path)
-	if err != nil {
-		// When not using overlayfs, apps don't have a treeStoreID file. In
-		// other cases we've got a problem.
-		if !(os.IsNotExist(err) && !p.usesOverlay()) {
-			return "", errwrap.Wrap(fmt.Errorf("no treeStoreID found for app %s", app), err)
-		}
-	}
-	return string(treeStoreID), nil
-}
-
-// getAppsTreeStoreIDs returns the treeStoreIDs of the apps images used in
-// this pod.
-func (p *pod) getAppsTreeStoreIDs() ([]string, error) {
-	var treeStoreIDs []string
-	apps, err := p.getApps()
-	if err != nil {
-		return nil, err
-	}
-	for _, a := range apps {
-		id, err := p.getAppTreeStoreID(a.Name)
-		if err != nil {
-			return nil, err
-		}
-		if id != "" {
-			treeStoreIDs = append(treeStoreIDs, id)
-		}
-	}
-	return treeStoreIDs, nil
-}
-
-// getAppsHashes returns a list of the app hashes in the pod
-func (p *pod) getAppsHashes() ([]types.Hash, error) {
-	apps, err := p.getApps()
-	if err != nil {
-		return nil, err
-	}
-
-	var hashes []types.Hash
-	for _, a := range apps {
-		hashes = append(hashes, a.Image.ID)
-	}
-
-	return hashes, nil
-}
-
-// getAppImageManifest returns an ImageManifest for the corresponding AppName.
-func (p *pod) getAppImageManifest(appName types.ACName) (*schema.ImageManifest, error) {
-	imb, err := ioutil.ReadFile(common.AppImageManifestPath(p.path(), appName))
-	if err != nil {
-		return nil, err
-	}
-
-	aim := &schema.ImageManifest{}
-	if err := aim.UnmarshalJSON(imb); err != nil {
-		return nil, errwrap.Wrap(fmt.Errorf("invalid image manifest for app %q", appName.String()), err)
-	}
-
-	return aim, nil
-}
-
-// getManifest returns the PodManifest of the pod
-func (p *pod) getManifest() (*schema.PodManifest, error) {
-	pmb, err := p.readFile("pod")
-	if err != nil {
-		return nil, errwrap.Wrap(errors.New("error reading pod manifest"), err)
-	}
-	pm := &schema.PodManifest{}
-	if err = pm.UnmarshalJSON(pmb); err != nil {
-		return nil, errwrap.Wrap(errors.New("invalid pod manifest"), err)
-	}
-	return pm, nil
-}
-
-// getApps returns a list of apps in the pod
-func (p *pod) getApps() (schema.AppList, error) {
-	pm, err := p.getManifest()
-	if err != nil {
-		return nil, err
-	}
-	return pm.Apps, nil
-}
-
-// getAppCount returns the app count of a pod.
-func (p *pod) getAppCount() (int, error) {
-	apps, err := p.getApps()
-	return len(apps), err
-}
-
-// getDirNames returns the list of names from a pod's directory
-func (p *pod) getDirNames(path string) ([]string, error) {
-	dir, err := p.openFile(path, syscall.O_RDONLY|syscall.O_DIRECTORY)
-	if err != nil {
-		return nil, errwrap.Wrap(errors.New("unable to open directory"), err)
-	}
-	defer dir.Close()
-
-	ld, err := dir.Readdirnames(0)
-	if err != nil {
-		return nil, errwrap.Wrap(errors.New("unable to read directory"), err)
-	}
-
-	return ld, nil
-}
-
-func (p *pod) usesOverlay() bool {
-	f, err := p.openFile(common.OverlayPreparedFilename, syscall.O_RDONLY)
-	defer f.Close()
-	return err == nil
-}
-
-func (p *pod) getStatusDir() (string, error) {
-	if p.usesOverlay() {
-		// the pod uses overlay. Since the mount is in another mount
-		// namespace (or gone), return the status directory from the overlay
-		// upper layer
-		stage1TreeStoreID, err := p.getStage1TreeStoreID()
+// Stage1RootfsPath returns the stage1 path of the pod.
+func (p *Pod) Stage1RootfsPath() (string, error) {
+	stage1RootfsPath := "stage1/rootfs"
+	if p.UsesOverlay() {
+		stage1TreeStoreID, err := p.GetStage1TreeStoreID()
 		if err != nil {
 			return "", err
 		}
-		overlayStatusDir := fmt.Sprintf(overlayStatusDirTemplate, stage1TreeStoreID)
-
-		return overlayStatusDir, nil
+		stage1RootfsPath = fmt.Sprintf("overlay/%s/upper/", stage1TreeStoreID)
 	}
 
-	// not using overlay, return the regular status directory
-	return regularStatusDir, nil
+	return filepath.Join(p.Path(), stage1RootfsPath), nil
 }
 
-// getExitStatuses returns a map of the statuses of the pod.
-func (p *pod) getExitStatuses() (map[string]int, error) {
-	statusDir, err := p.getStatusDir()
+// JournalLogPath returns the path to the journal log dir of the pod.
+func (p *Pod) JournalLogPath() (string, error) {
+	stage1RootfsPath, err := p.Stage1RootfsPath()
 	if err != nil {
-		return nil, errwrap.Wrap(errors.New("unable to get status directory"), err)
+		return "", err
 	}
-	ls, err := p.getDirNames(statusDir)
-	if err != nil {
-		return nil, errwrap.Wrap(errors.New("unable to read status directory"), err)
-	}
+	return filepath.Join(stage1RootfsPath, "/var/log/journal/"), nil
+}
 
-	stats := make(map[string]int)
-	for _, name := range ls {
-		s, err := p.readIntFromFile(filepath.Join(statusDir, name))
-		if err != nil {
-			stderr.PrintE(fmt.Sprintf("unable to get status of app %q", name), err)
-			continue
+// State returns the current state of the pod
+func (p *Pod) State() string {
+	state := Running
+
+	if p.isEmbryo {
+		state = Embryo
+	} else if p.isPreparing {
+		state = Preparing
+	} else if p.isAbortedPrepare {
+		state = AbortedPrepare
+	} else if p.isPrepared {
+		state = Prepared
+	} else if p.isDeleting {
+		state = Deleting
+	} else if p.isExitedDeleting {
+		state = ExitedDeleting
+	} else if p.isExited { // this covers p.isExitedGarbage
+		state = Exited
+		if p.isExitedGarbage {
+			state = ExitedGarbage
 		}
-		stats[name] = s
+	} else if p.isGarbage {
+		state = Garbage
 	}
-	return stats, nil
+
+	return state
 }
 
-// sync syncs the pod data. By now it calls a syncfs on the filesystem
-// containing the pod's directory.
-func (p *pod) sync() error {
-	cfd, err := p.Fd()
-	if err != nil {
-		return errwrap.Wrap(fmt.Errorf("error acquiring pod %v dir fd", p.uuid.String()), err)
-	}
-	if err := sys.Syncfs(cfd); err != nil {
-		return errwrap.Wrap(fmt.Errorf("failed to sync pod %v data", p.uuid.String()), err)
-	}
-	return nil
+// isRunning does the annoying tests to infer if a pod is in a running state
+func (p *Pod) isRunning() bool {
+	// when none of these things, running!
+	return !p.isEmbryo && !p.isAbortedPrepare && !p.isPreparing && !p.isPrepared &&
+		!p.isExited && !p.isExitedGarbage && !p.isExitedDeleting && !p.isGarbage && !p.isDeleting && !p.isGone
 }
 
-// overlayPrepared returns true if the given pod was prepared using overlay else false.
-// It returns an error if the operation failed.
-func (p *pod) overlayPrepared() (bool, error) {
-	_, err := os.Stat(filepath.Join(p.path(), common.OverlayPreparedFilename))
-	if os.IsNotExist(err) {
-		return false, nil
-	}
+// AfterRun tests if a pod is in a post-running state
+func (p *Pod) AfterRun() bool {
+	return p.isExitedDeleting || p.isDeleting || p.isExited || p.isGarbage
+}
+
+// GetAppExitCode returns the app's exit code.
+// Returns error if the exit code file doesn't exit.
+func (p *Pod) GetAppExitCode(appName string) (int, error) {
+	stage1RootfsPath, err := p.Stage1RootfsPath()
 	if err != nil {
-		return false, err
+		return -1, err
 	}
 
-	return true, nil
+	statusFile := filepath.Join(stage1RootfsPath, "/rkt/status/", appName)
+	return p.readIntFromFile(statusFile)
 }

--- a/pkg/pod/pods_test.go
+++ b/pkg/pod/pods_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package pod
 
 import (
 	"io/ioutil"
@@ -119,11 +119,7 @@ func TestWalkPods(t *testing.T) {
 		}
 		defer os.RemoveAll(d)
 
-		// This will mark the flag as changed, so it will have
-		// precedence over the configuration and the default
-		// value.
-		cmdRkt.PersistentFlags().Set("dir", d)
-		if err := initPods(); err != nil {
+		if err := initPods(d); err != nil {
 			t.Fatalf("error initializing pods: %v", err)
 		}
 
@@ -131,18 +127,18 @@ func TestWalkPods(t *testing.T) {
 			n_expected int
 			n_walked   int
 			n_matched  int
-			included   includeMask
+			included   IncludeMask
 		)
 
 		// create the pod dirs as specified by the test
 		for _, ct := range tt {
 			var cp string
 			if ct.garbage {
-				cp = filepath.Join(exitedGarbageDir(), ct.uuid)
-				included |= includeExitedGarbageDir
+				cp = filepath.Join(exitedGarbageDir(d), ct.uuid)
+				included |= IncludeExitedGarbageDir
 			} else {
-				cp = filepath.Join(runDir(), ct.uuid)
-				included |= includeRunDir
+				cp = filepath.Join(runDir(d), ct.uuid)
+				included |= IncludeRunDir
 			}
 
 			if err := os.MkdirAll(cp, 0700); err != nil {
@@ -163,10 +159,10 @@ func TestWalkPods(t *testing.T) {
 		}
 
 		// match what walk provided against the set in the test
-		if err := walkPods(included, func(ch *pod) {
+		if err := WalkPods(d, included, func(ch *Pod) {
 			n_walked++
 			for _, ct := range tt {
-				if ch.uuid.String() == ct.uuid &&
+				if ch.UUID.String() == ct.uuid &&
 					ch.isExitedGarbage == ct.garbage &&
 					ch.isExited == ct.exited &&
 					ch.isExitedDeleting == ct.deleting {

--- a/pkg/pod/uuid.go
+++ b/pkg/pod/uuid.go
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build linux
-
-package main
+package pod
 
 import (
 	"bytes"
@@ -29,12 +27,12 @@ import (
 
 // matchUUID attempts to match the uuid specified as uuid against all pods present.
 // An array of matches is returned, which may be empty when nothing matches.
-func matchUUID(uuid string) ([]string, error) {
+func matchUUID(dataDir, uuid string) ([]string, error) {
 	if uuid == "" {
 		return nil, types.ErrNoEmptyUUID
 	}
 
-	ls, err := listPods(includePrepareDir | includePreparedDir | includeRunDir | includeExitedGarbageDir)
+	ls, err := listPods(dataDir, IncludePrepareDir|IncludePreparedDir|IncludeRunDir|IncludeExitedGarbageDir)
 	if err != nil {
 		return nil, err
 	}
@@ -51,9 +49,9 @@ func matchUUID(uuid string) ([]string, error) {
 
 // resolveUUID attempts to resolve the uuid specified as uuid against all pods present.
 // An unambiguously matched uuid or nil is returned.
-func resolveUUID(uuid string) (*types.UUID, error) {
+func resolveUUID(dataDir, uuid string) (*types.UUID, error) {
 	uuid = strings.ToLower(uuid)
-	m, err := matchUUID(uuid)
+	m, err := matchUUID(dataDir, uuid)
 	if err != nil {
 		return nil, err
 	}
@@ -74,16 +72,14 @@ func resolveUUID(uuid string) (*types.UUID, error) {
 	return u, nil
 }
 
-func readUUIDFromFile(path string) (*types.UUID, error) {
+func ReadUUIDFromFile(path string) (string, error) {
 	uuid, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	uuid = bytes.TrimSpace(uuid)
-
-	return resolveUUID(string(uuid))
+	return string(bytes.TrimSpace(uuid)), nil
 }
 
-func writeUUIDToFile(uuid *types.UUID, path string) error {
+func WriteUUIDToFile(uuid *types.UUID, path string) error {
 	return ioutil.WriteFile(path, []byte(uuid.String()), 0644)
 }

--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -17,6 +17,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"os/signal"
@@ -32,6 +33,7 @@ import (
 	"github.com/coreos/rkt/api/v1alpha"
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/common/cgroup"
+	pkgPod "github.com/coreos/rkt/pkg/pod"
 	"github.com/coreos/rkt/pkg/set"
 	"github.com/coreos/rkt/store/imagestore"
 	"github.com/coreos/rkt/version"
@@ -312,26 +314,6 @@ func satisfiesAnyPodFilters(pod *v1alpha.Pod, filters []*v1alpha.PodFilter) bool
 	return false
 }
 
-// getPodManifest returns the pod manifest of the pod.
-// It will try to find the manifest in the LRU cache first, if not found or the manifest is stale,
-// then it will read the manifest from the disk.
-// Both marshaled and unmarshaled manifest are returned.
-func (s *v1AlphaAPIServer) getPodManifest(p *pod) (*schema.PodManifest, []byte, error) {
-	data, err := p.readFile("pod")
-	if err != nil {
-		stderr.PrintE(fmt.Sprintf("failed to read pod manifest for pod %q", p.uuid), err)
-		return nil, nil, err
-	}
-
-	var manifest schema.PodManifest
-	if err := json.Unmarshal(data, &manifest); err != nil {
-		stderr.PrintE(fmt.Sprintf("failed to unmarshal pod manifest for pod %q", p.uuid), err)
-		return nil, nil, err
-	}
-
-	return &manifest, data, nil
-}
-
 // getPodCgroup gets the cgroup path for a pod. This can be done in one of a couple ways:
 //
 // 1) stage1-coreos
@@ -343,7 +325,7 @@ func (s *v1AlphaAPIServer) getPodManifest(p *pod) (*schema.PodManifest, []byte, 
 // 2) All others
 //
 // Assume that we can simply get the cgroup of the pod's init PID, and use that.
-func getPodCgroup(p *pod, pid int) (string, error) {
+func getPodCgroup(p *pkgPod.Pod, pid int) (string, error) {
 	// Note, this file should always exist if the pid is known since it is
 	// written before the pid file
 	// The contents are of the form:
@@ -352,7 +334,8 @@ func getPodCgroup(p *pod, pid int) (string, error) {
 	// no registration, ran as systemd-unit 'foo.service':
 	//   'system.slice/foo.service'
 	// stage1-fly: file does not exist
-	data, err := p.readFile("subcgroup")
+	subCgroupFile := filepath.Join(p.Path(), "subcgroup")
+	data, err := ioutil.ReadFile(subCgroupFile)
 	// normalize cgroup to include a leading '/'
 	if err == nil {
 		strCgroup := string(data)
@@ -410,9 +393,9 @@ func getApplist(manifest *schema.PodManifest) []*v1alpha.App {
 }
 
 // getNetworks returns the list of the info of the network that the pod belongs to.
-func getNetworks(p *pod) []*v1alpha.Network {
+func getNetworks(p *pkgPod.Pod) []*v1alpha.Network {
 	var networks []*v1alpha.Network
-	for _, n := range p.nets {
+	for _, n := range p.Nets {
 		networks = append(networks, &v1alpha.Network{
 			Name: n.NetName,
 			// There will be IPv6 support soon so distinguish between v4 and v6
@@ -433,7 +416,7 @@ func (e errs) Error() string {
 
 // fillStaticAppInfo will modify the 'v1pod' in place with the infomation retrived with 'pod'.
 // Today, these information are static and will not change during the pod's lifecycle.
-func fillStaticAppInfo(store *imagestore.Store, pod *pod, v1pod *v1alpha.Pod) error {
+func fillStaticAppInfo(store *imagestore.Store, pod *pkgPod.Pod, v1pod *v1alpha.Pod) error {
 	var errlist []error
 
 	// Fill static app image info.
@@ -451,7 +434,7 @@ func fillStaticAppInfo(store *imagestore.Store, pod *pod, v1pod *v1alpha.Pod) er
 			// info from store. Some of it is filled in below if possible.
 		}
 
-		im, err := pod.getAppImageManifest(*types.MustACName(app.Name))
+		im, err := pod.GetAppImageManifest(app.Name)
 		if err != nil {
 			stderr.PrintE(fmt.Sprintf("failed to get image manifests for app %q", app.Name), err)
 			errlist = append(errlist, err)
@@ -472,12 +455,12 @@ func fillStaticAppInfo(store *imagestore.Store, pod *pod, v1pod *v1alpha.Pod) er
 	return nil
 }
 
-func (s *v1AlphaAPIServer) getBasicPodFromDisk(p *pod) (*v1alpha.Pod, error) {
-	pod := &v1alpha.Pod{Id: p.uuid.String()}
+func (s *v1AlphaAPIServer) getBasicPodFromDisk(p *pkgPod.Pod) (*v1alpha.Pod, error) {
+	pod := &v1alpha.Pod{Id: p.UUID.String()}
 
-	manifest, data, err := s.getPodManifest(p)
+	data, manifest, err := p.GetPodManifest()
 	if err != nil {
-		stderr.PrintE(fmt.Sprintf("failed to get the pod manifest for pod %q", p.uuid), err)
+		stderr.PrintE(fmt.Sprintf("failed to get the pod manifest for pod %q", p.UUID), err)
 	} else {
 		pod.Annotations = convertAnnotationsToKeyValue(manifest.Annotations)
 		pod.Apps = getApplist(manifest)
@@ -488,15 +471,24 @@ func (s *v1AlphaAPIServer) getBasicPodFromDisk(p *pod) (*v1alpha.Pod, error) {
 	return pod, err
 }
 
+func getPodManifestModTime(p *pkgPod.Pod) (time.Time, error) {
+	podFile := filepath.Join(p.Path(), "pod")
+	fi, err := os.Stat(podFile)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return fi.ModTime(), nil
+}
+
 // getBasicPod returns v1alpha.Pod with basic pod information.
-func (s *v1AlphaAPIServer) getBasicPod(p *pod) *v1alpha.Pod {
-	mtime, mtimeErr := p.getModTime("pod")
+func (s *v1AlphaAPIServer) getBasicPod(p *pkgPod.Pod) *v1alpha.Pod {
+	mtime, mtimeErr := getPodManifestModTime(p)
 	if mtimeErr != nil {
-		stderr.PrintE(fmt.Sprintf("failed to read the pod manifest's mtime for pod %q", p.uuid), mtimeErr)
+		stderr.PrintE(fmt.Sprintf("failed to read the pod manifest's mtime for pod %q", p.UUID), mtimeErr)
 	}
 
 	// Couldn't use pod.uuid directly as it's a pointer.
-	itemValue, found := s.podCache.Get(p.uuid.String())
+	itemValue, found := s.podCache.Get(p.UUID.String())
 	if found && mtimeErr == nil {
 		cacheItem := itemValue.(*podCacheItem)
 
@@ -514,7 +506,7 @@ func (s *v1AlphaAPIServer) getBasicPod(p *pod) *v1alpha.Pod {
 	}
 
 	cacheItem := &podCacheItem{pod, mtime}
-	s.podCache.Add(p.uuid.String(), cacheItem)
+	s.podCache.Add(p.UUID.String(), cacheItem)
 
 	// Return a copy of the pod, so the cached pod is not mutated later.
 	return copyPod(cacheItem.pod)
@@ -523,72 +515,72 @@ func (s *v1AlphaAPIServer) getBasicPod(p *pod) *v1alpha.Pod {
 // fillPodDetails fills the v1pod's dynamic info in place, e.g. the pod's state,
 // the pod's network info, the apps' state, etc. Such information can change
 // during the lifecycle of the pod, so we need to read it in every request.
-func fillPodDetails(store *imagestore.Store, p *pod, v1pod *v1alpha.Pod) {
+func fillPodDetails(store *imagestore.Store, p *pkgPod.Pod, v1pod *v1alpha.Pod) {
 	v1pod.Pid = -1
 
-	switch p.getState() {
-	case Embryo:
+	switch p.State() {
+	case pkgPod.Embryo:
 		v1pod.State = v1alpha.PodState_POD_STATE_EMBRYO
 		// When a pod is in embryo state, there is not much
 		// information to return.
 		return
-	case Preparing:
+	case pkgPod.Preparing:
 		v1pod.State = v1alpha.PodState_POD_STATE_PREPARING
-	case AbortedPrepare:
+	case pkgPod.AbortedPrepare:
 		v1pod.State = v1alpha.PodState_POD_STATE_ABORTED_PREPARE
-	case Prepared:
+	case pkgPod.Prepared:
 		v1pod.State = v1alpha.PodState_POD_STATE_PREPARED
-	case Running:
+	case pkgPod.Running:
 		v1pod.State = v1alpha.PodState_POD_STATE_RUNNING
 		v1pod.Networks = getNetworks(p)
-	case Deleting:
+	case pkgPod.Deleting:
 		v1pod.State = v1alpha.PodState_POD_STATE_DELETING
-	case Exited:
+	case pkgPod.Exited:
 		v1pod.State = v1alpha.PodState_POD_STATE_EXITED
-	case Garbage:
+	case pkgPod.Garbage, pkgPod.ExitedGarbage:
 		v1pod.State = v1alpha.PodState_POD_STATE_GARBAGE
 	default:
 		v1pod.State = v1alpha.PodState_POD_STATE_UNDEFINED
 		return
 	}
 
-	createdAt, err := p.getCreationTime()
+	createdAt, err := p.CreationTime()
 	if err != nil {
-		stderr.PrintE(fmt.Sprintf("failed to get the creation time for pod %q", p.uuid), err)
+		stderr.PrintE(fmt.Sprintf("failed to get the creation time for pod %q", p.UUID), err)
 	} else if !createdAt.IsZero() {
 		v1pod.CreatedAt = createdAt.UnixNano()
 	}
 
-	startedAt, err := p.getStartTime()
+	startedAt, err := p.StartTime()
 	if err != nil {
-		stderr.PrintE(fmt.Sprintf("failed to get the start time for pod %q", p.uuid), err)
+		stderr.PrintE(fmt.Sprintf("failed to get the start time for pod %q", p.UUID), err)
 	} else if !startedAt.IsZero() {
 		v1pod.StartedAt = startedAt.UnixNano()
 
 	}
 
-	gcMarkedAt, err := p.getGCMarkedTime()
+	gcMarkedAt, err := p.GCMarkedTime()
 	if err != nil {
-		stderr.PrintE(fmt.Sprintf("failed to get the gc marked time for pod %q", p.uuid), err)
+		stderr.PrintE(fmt.Sprintf("failed to get the gc marked time for pod %q", p.UUID), err)
 	} else if !gcMarkedAt.IsZero() {
 		v1pod.GcMarkedAt = gcMarkedAt.UnixNano()
 	}
 
-	pid, err := p.getPID()
+	pid, err := p.Pid()
 	if err != nil {
-		stderr.PrintE(fmt.Sprintf("failed to get the PID for pod %q", p.uuid), err)
+		stderr.PrintE(fmt.Sprintf("failed to get the PID for pod %q", p.UUID), err)
 	} else {
 		v1pod.Pid = int32(pid)
 	}
 
 	if v1pod.State == v1alpha.PodState_POD_STATE_RUNNING {
-		pid, err := p.getContainerPID1()
+		pid, err := p.ContainerPid1()
 		if err != nil {
-			stderr.PrintE(fmt.Sprintf("failed to get the container PID1 for pod %q", p.uuid), err)
+			stderr.PrintE(fmt.Sprintf("failed to get the container PID1 for pod %q", p.UUID), err)
 		} else {
 			cgroup, err := getPodCgroup(p, pid)
 			if err != nil {
-				stderr.PrintE(fmt.Sprintf("failed to get the cgroup path for pod %q", p.uuid), err)
+				stderr.PrintE(fmt.Sprintf("failed to get the cgroup path for pod %q", p.UUID), err)
 			} else {
 				v1pod.Cgroup = cgroup
 			}
@@ -598,10 +590,10 @@ func fillPodDetails(store *imagestore.Store, p *pod, v1pod *v1alpha.Pod) {
 	for _, app := range v1pod.Apps {
 		readStatus := false
 
-		if p.isRunning() {
+		if p.State() == pkgPod.Running {
 			readStatus = true
 			app.State = v1alpha.AppState_APP_STATE_RUNNING
-		} else if p.afterRun() {
+		} else if p.AfterRun() {
 			readStatus = true
 			app.State = v1alpha.AppState_APP_STATE_EXITED
 		} else {
@@ -609,24 +601,18 @@ func fillPodDetails(store *imagestore.Store, p *pod, v1pod *v1alpha.Pod) {
 		}
 
 		if readStatus {
-			statusDir, err := p.getStatusDir()
+			exitCode, err := p.GetAppExitCode(app.Name)
 			if err != nil {
-				stderr.PrintE("failed to get pod exit status directory", err)
-			} else {
-				value, err := p.readIntFromFile(filepath.Join(statusDir, app.Name))
-				if err != nil && !os.IsNotExist(err) {
-					stderr.PrintE(fmt.Sprintf("failed to read status for app %q", app.Name), err)
-				} else {
-					app.ExitCode = int32(value)
-				}
+				stderr.PrintE(fmt.Sprintf("failed to read status for app %q", app.Name), err)
 			}
+			app.ExitCode = int32(exitCode)
 		}
 	}
 }
 
 func (s *v1AlphaAPIServer) ListPods(ctx context.Context, request *v1alpha.ListPodsRequest) (*v1alpha.ListPodsResponse, error) {
 	var pods []*v1alpha.Pod
-	if err := walkPods(includeMostDirs, func(p *pod) {
+	if err := pkgPod.WalkPods(getDataDir(), pkgPod.IncludeMostDirs, func(p *pkgPod.Pod) {
 		pod := s.getBasicPod(p)
 
 		fillPodDetails(s.store, p, pod)
@@ -649,13 +635,7 @@ func (s *v1AlphaAPIServer) ListPods(ctx context.Context, request *v1alpha.ListPo
 }
 
 func (s *v1AlphaAPIServer) InspectPod(ctx context.Context, request *v1alpha.InspectPodRequest) (*v1alpha.InspectPodResponse, error) {
-	uuid, err := types.NewUUID(request.Id)
-	if err != nil {
-		stderr.PrintE(fmt.Sprintf("invalid pod id %q", request.Id), err)
-		return nil, err
-	}
-
-	p, err := getPod(uuid)
+	p, err := pkgPod.GetPodFromUUIDString(getDataDir(), request.Id)
 	if err != nil {
 		stderr.PrintE(fmt.Sprintf("failed to get pod %q", request.Id), err)
 		return nil, err

--- a/rkt/api_service_sdjournal.go
+++ b/rkt/api_service_sdjournal.go
@@ -20,38 +20,24 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"time"
 
-	"github.com/appc/spec/schema/types"
 	"github.com/coreos/go-systemd/sdjournal"
 	"github.com/coreos/rkt/api/v1alpha"
 	"github.com/coreos/rkt/common"
+	pkgPod "github.com/coreos/rkt/pkg/pod"
 )
 
 func (s *v1AlphaAPIServer) constrainedGetLogs(request *v1alpha.GetLogsRequest, server v1alpha.PublicAPI_GetLogsServer) error {
-	uuid, err := types.NewUUID(request.PodId)
-	if err != nil {
-		return err
-	}
-	pod, err := getPod(uuid)
+	pod, err := pkgPod.GetPodFromUUIDString(getDataDir(), request.PodId)
 	if err != nil {
 		return err
 	}
 	defer pod.Close()
 
-	stage1Path := "stage1/rootfs"
-	if pod.usesOverlay() {
-		stage1TreeStoreID, err := pod.getStage1TreeStoreID()
-		if err != nil {
-			return err
-		}
-		stage1Path = fmt.Sprintf("/overlay/%s/upper/", stage1TreeStoreID)
-	}
-	path := filepath.Join(getDataDir(), "/pods/run/", request.PodId, stage1Path, "/var/log/journal/")
-
+	path, err := pod.JournalLogPath()
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return fmt.Errorf("%s: logging unsupported", uuid.String())
+		return fmt.Errorf("logging unsupported for pod %q", request.PodId)
 	}
 
 	jconf := sdjournal.JournalReaderConfig{

--- a/rkt/app.go
+++ b/rkt/app.go
@@ -1,0 +1,28 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "github.com/spf13/cobra"
+
+var (
+	cmdApp = &cobra.Command{
+		Use:   "app [command]",
+		Short: "Operate on app level operations",
+	}
+)
+
+func init() {
+	cmdRkt.AddCommand(cmdApp)
+}

--- a/rkt/app_list.go
+++ b/rkt/app_list.go
@@ -1,0 +1,62 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/coreos/rkt/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdAppList = &cobra.Command{
+		Use:   "list UUID",
+		Short: "List apps for the given pod",
+		Long:  "This only lists the name and state of the apps, app status will show more detailed info.",
+		Run:   runWrapper(runAppList),
+	}
+)
+
+func init() {
+	cmdApp.AddCommand(cmdAppList)
+}
+
+func runAppList(cmd *cobra.Command, args []string) int {
+	if len(args) != 1 {
+		cmd.Usage()
+		return 1
+	}
+
+	apps, err := lib.GetApps(getDataDir(), args[0], "")
+	if err != nil {
+		stderr.PrintE("error listing apps", err)
+		return 1
+	}
+
+	tabBuffer := new(bytes.Buffer)
+	tabOut := getTabOutWithWriter(tabBuffer)
+
+	fmt.Fprintf(tabOut, "NAME\tSTATE\n")
+
+	for _, app := range apps {
+		fmt.Fprintf(tabOut, "%s\t%s\n", app.Name, app.State)
+	}
+
+	tabOut.Flush()
+	stdout.Print(tabBuffer)
+	return 0
+}

--- a/rkt/app_status.go
+++ b/rkt/app_status.go
@@ -1,0 +1,125 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/coreos/rkt/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdAppStatus = &cobra.Command{
+		Use:   "status UUID --app=APP_NAME [--format=json]",
+		Short: "Check the status of an app in the given pod",
+		Long:  "This will print detailed status of an app",
+		Run:   runWrapper(runAppStatus),
+	}
+	flagFormat string
+)
+
+func init() {
+	cmdApp.AddCommand(cmdAppStatus)
+	cmdAppStatus.Flags().StringVar(&flagAppName, "app", "", "choose app within the pod, this flag must be set")
+	cmdAppStatus.Flags().StringVar(&flagFormat, "format", "", "choose the output format, allowed format includes 'json', 'json-pretty'. If empty, then the result is printed as key value pairs")
+}
+
+func printApp(app *lib.App) {
+	stdout.Printf("name=%s\n", app.Name)
+	stdout.Printf("state=%s\n", app.State)
+	stdout.Printf("image_id=%s\n", app.ImageID)
+	if app.CreatedAt != nil {
+		stdout.Printf("created_at=%v\n", time.Unix(0, *(app.CreatedAt)))
+	}
+	if app.StartedAt != nil {
+		stdout.Printf("started_at=%v\n", time.Unix(0, *(app.StartedAt)))
+	}
+	if app.FinishedAt != nil {
+		stdout.Printf("finished_at=%v\n", time.Unix(0, *(app.FinishedAt)))
+	}
+	if app.ExitCode != nil {
+		stdout.Printf("exit_code=%d\n", *(app.ExitCode))
+	}
+
+	if len(app.Mounts) > 0 {
+		stdout.Printf("mounts=")
+		var mnts []string
+		for _, mnt := range app.Mounts {
+			mnts = append(mnts, fmt.Sprintf("%s:%s:(read_only:%v)", mnt.HostPath, mnt.ContainerPath, mnt.ReadOnly))
+		}
+		stdout.Printf(strings.Join(mnts, ","))
+		stdout.Println()
+	}
+
+	if len(app.Annotations) > 0 {
+		stdout.Printf("annotations=")
+		var annos []string
+		for key, value := range app.Annotations {
+			annos = append(annos, fmt.Sprintf("%s:%s", key, value))
+		}
+		stdout.Printf(strings.Join(annos, ","))
+		stdout.Println()
+	}
+}
+
+func runAppStatus(cmd *cobra.Command, args []string) (exit int) {
+	if len(args) != 1 || flagAppName == "" {
+		cmd.Usage()
+		return 1
+	}
+
+	apps, err := lib.GetApps(getDataDir(), args[0], flagAppName)
+	if err != nil {
+		stderr.PrintE("error getting app status", err)
+		return 1
+	}
+
+	if len(apps) == 0 {
+		stderr.Error(fmt.Errorf("cannot find app %q in the pod", flagAppName))
+		return 1
+	}
+
+	// Must have only 1 app.
+	if len(apps) != 1 {
+		stderr.Error(fmt.Errorf("find more than one app with the name %q", flagAppName))
+		return 1
+	}
+
+	// TODO(yifan): Print yamls.
+	switch flagFormat {
+	case "json":
+		result, err := json.Marshal(apps[0])
+		if err != nil {
+			stderr.PrintE("error marshaling the app status", err)
+			return 1
+		}
+		stdout.Print(string(result))
+	case "json-pretty":
+		result, err := json.MarshalIndent(apps[0], "", "\t")
+		if err != nil {
+			stderr.PrintE("error marshaling the app status", err)
+			return 1
+		}
+		stdout.Print(string(result))
+	default:
+		printApp(apps[0])
+	}
+
+	return 0
+}

--- a/rkt/cat_manifest.go
+++ b/rkt/cat_manifest.go
@@ -17,6 +17,7 @@ package main
 import (
 	"encoding/json"
 
+	pkgPod "github.com/coreos/rkt/pkg/pod"
 	"github.com/spf13/cobra"
 )
 
@@ -41,14 +42,14 @@ func runCatManifest(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	pod, err := getPodFromUUIDString(args[0])
+	pod, err := pkgPod.GetPodFromUUIDString(getDataDir(), args[0])
 	if err != nil {
 		stderr.PrintE("problem retrieving pod", err)
 		return 1
 	}
 	defer pod.Close()
 
-	manifest, err := pod.getManifest()
+	_, manifest, err := pod.GetPodManifest()
 	if err != nil {
 		return 1
 	}

--- a/rkt/enter.go
+++ b/rkt/enter.go
@@ -19,11 +19,9 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 
-	"github.com/appc/spec/schema"
 	"github.com/appc/spec/schema/types"
-	"github.com/coreos/rkt/common"
+	pkgPod "github.com/coreos/rkt/pkg/pod"
 	"github.com/coreos/rkt/stage0"
 	"github.com/coreos/rkt/store/imagestore"
 	"github.com/coreos/rkt/store/treestore"
@@ -65,21 +63,21 @@ func runEnter(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	p, err := getPodFromUUIDString(args[0])
+	p, err := pkgPod.GetPodFromUUIDString(getDataDir(), args[0])
 	if err != nil {
 		stderr.PrintE("problem retrieving pod", err)
 		return 1
 	}
 	defer p.Close()
 
-	if !p.isRunning() {
-		stderr.Printf("pod %q isn't currently running", p.uuid)
+	if p.State() != pkgPod.Running {
+		stderr.Printf("pod %q isn't currently running", p.UUID)
 		return 1
 	}
 
-	podPID, err := p.getContainerPID1()
+	podPID, err := p.ContainerPid1()
 	if err != nil {
-		stderr.PrintE(fmt.Sprintf("unable to determine the pid for pod %q", p.uuid), err)
+		stderr.PrintE(fmt.Sprintf("unable to determine the pid for pod %q", p.UUID), err)
 		return 1
 	}
 
@@ -107,7 +105,7 @@ func runEnter(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	stage1TreeStoreID, err := p.getStage1TreeStoreID()
+	stage1TreeStoreID, err := p.GetStage1TreeStoreID()
 	if err != nil {
 		stderr.PrintE("error getting stage1 treeStoreID", err)
 		return 1
@@ -115,7 +113,7 @@ func runEnter(cmd *cobra.Command, args []string) (exit int) {
 
 	stage1RootFS := ts.GetRootFS(stage1TreeStoreID)
 
-	if err = stage0.Enter(p.path(), podPID, *appName, stage1RootFS, argv); err != nil {
+	if err = stage0.Enter(p.Path(), podPID, *appName, stage1RootFS, argv); err != nil {
 		stderr.PrintE("enter failed", err)
 		return 1
 	}
@@ -127,20 +125,15 @@ func runEnter(cmd *cobra.Command, args []string) (exit int) {
 // If one was supplied in the flags then it's simply returned
 // If the PM contains a single app, that app's name is returned
 // If the PM has multiple apps, the names are printed and an error is returned
-func getAppName(p *pod) (*types.ACName, error) {
+func getAppName(p *pkgPod.Pod) (*types.ACName, error) {
 	if flagAppName != "" {
 		return types.NewACName(flagAppName)
 	}
 
 	// figure out the app name, or show a list if multiple are present
-	b, err := ioutil.ReadFile(common.PodManifestPath(p.path()))
+	_, m, err := p.GetPodManifest()
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("error reading pod manifest"), err)
-	}
-
-	m := schema.PodManifest{}
-	if err = m.UnmarshalJSON(b); err != nil {
-		return nil, errwrap.Wrap(errors.New("invalid pod manifest"), err)
 	}
 
 	switch len(m.Apps) {
@@ -160,7 +153,7 @@ func getAppName(p *pod) (*types.ACName, error) {
 }
 
 // getEnterArgv returns the argv to use for entering the pod
-func getEnterArgv(p *pod, cmdArgs []string) ([]string, error) {
+func getEnterArgv(p *pkgPod.Pod, cmdArgs []string) ([]string, error) {
 	var argv []string
 	if len(cmdArgs) < 2 {
 		stderr.Printf("no command specified, assuming %q", defaultCmd)

--- a/rkt/export.go
+++ b/rkt/export.go
@@ -31,6 +31,7 @@ import (
 	"github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/common/overlay"
+	pkgPod "github.com/coreos/rkt/pkg/pod"
 	"github.com/coreos/rkt/pkg/user"
 	"github.com/coreos/rkt/store/imagestore"
 	"github.com/coreos/rkt/store/treestore"
@@ -98,14 +99,15 @@ func runExport(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	p, err := getPodFromUUIDString(args[0])
+	p, err := pkgPod.GetPodFromUUIDString(getDataDir(), args[0])
 	if err != nil {
 		stderr.PrintE("problem retrieving pod", err)
 		return 1
 	}
 	defer p.Close()
 
-	if !p.isExited {
+	state := p.State()
+	if state != pkgPod.Exited && state != pkgPod.ExitedGarbage {
 		stderr.Print("pod is not exited. Only exited pods can be exported")
 		return 1
 	}
@@ -116,15 +118,15 @@ func runExport(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	root := common.AppPath(p.path(), app.Name)
-	manifestPath := filepath.Join(common.AppInfoPath(p.path(), app.Name), aci.ManifestFile)
-	if p.usesOverlay() {
+	root := common.AppPath(p.Path(), app.Name)
+	manifestPath := filepath.Join(common.AppInfoPath(p.Path(), app.Name), aci.ManifestFile)
+	if p.UsesOverlay() {
 		tmpDir := filepath.Join(getDataDir(), "tmp")
 		if err := os.MkdirAll(tmpDir, common.DefaultRegularDirPerm); err != nil {
 			stderr.PrintE("unable to create temp directory", err)
 			return 1
 		}
-		podDir, err := ioutil.TempDir(tmpDir, fmt.Sprintf("rkt-export-%s", p.uuid))
+		podDir, err := ioutil.TempDir(tmpDir, fmt.Sprintf("rkt-export-%s", p.UUID))
 		if err != nil {
 			stderr.PrintE("unable to create export temp directory", err)
 			return 1
@@ -153,7 +155,7 @@ func runExport(cmd *cobra.Command, args []string) (exit int) {
 		}()
 		root = podDir
 	} else {
-		hasMPs, err := appHasMountpoints(p.path(), app.Name)
+		hasMPs, err := appHasMountpoints(p.Path(), app.Name)
 		if err != nil {
 			stderr.PrintE("error parsing mountpoints", err)
 			return 1
@@ -166,7 +168,7 @@ func runExport(cmd *cobra.Command, args []string) (exit int) {
 
 	// Check for user namespace (--private-user), if in use get uidRange
 	var uidRange *user.UidRange
-	privUserFile := filepath.Join(p.path(), common.PrivateUsersPreparedFilename)
+	privUserFile := filepath.Join(p.Path(), common.PrivateUsersPreparedFilename)
 	privUserContent, err := ioutil.ReadFile(privUserFile)
 	if err == nil {
 		uidRange = user.NewBlankUidRange()
@@ -188,11 +190,13 @@ func runExport(cmd *cobra.Command, args []string) (exit int) {
 // If one was supplied in the flags then it's returned if present
 // If the PM contains a single app, that app is returned
 // If the PM has multiple apps, the names are printed and an error is returned
-func getApp(p *pod) (*schema.RuntimeApp, error) {
-	apps, err := p.getApps()
+func getApp(p *pkgPod.Pod) (*schema.RuntimeApp, error) {
+	_, manifest, err := p.GetPodManifest()
 	if err != nil {
-		return nil, errwrap.Wrap(errors.New("problem getting the pod's app list"), err)
+		return nil, errwrap.Wrap(errors.New("problem getting the pod's manifest"), err)
 	}
+
+	apps := manifest.Apps
 
 	if flagExportAppName != "" {
 		exportAppName, err := types.NewACName(flagExportAppName)
@@ -224,7 +228,7 @@ func getApp(p *pod) (*schema.RuntimeApp, error) {
 }
 
 // mountOverlay mounts the app from the overlay-rendered pod to the destination directory.
-func mountOverlay(pod *pod, app *schema.RuntimeApp, dest string) error {
+func mountOverlay(pod *pkgPod.Pod, app *schema.RuntimeApp, dest string) error {
 	if _, err := os.Stat(dest); err != nil {
 		return err
 	}
@@ -239,12 +243,12 @@ func mountOverlay(pod *pod, app *schema.RuntimeApp, dest string) error {
 		return errwrap.Wrap(errors.New("cannot open treestore"), err)
 	}
 
-	treeStoreID, err := pod.getAppTreeStoreID(app.Name)
+	treeStoreID, err := pod.GetAppTreeStoreID(app.Name)
 	if err != nil {
 		return err
 	}
 	lower := ts.GetRootFS(treeStoreID)
-	imgDir := filepath.Join(filepath.Join(pod.path(), "overlay"), treeStoreID)
+	imgDir := filepath.Join(filepath.Join(pod.Path(), "overlay"), treeStoreID)
 	if _, err := os.Stat(imgDir); err != nil {
 		return err
 	}

--- a/rkt/help.go
+++ b/rkt/help.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/appc/spec/schema"
 	"github.com/coreos/rkt/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -155,4 +156,18 @@ func usageFunc(cmd *cobra.Command) error {
 	})
 	tabOut.Flush()
 	return nil
+}
+
+func printErrors(errors []error, operation string) {
+	sep := "----------------------------------------"
+	stderr.Printf("%d error(s) encountered when %s:", len(errors), operation)
+	stderr.Print(sep)
+	for _, err := range errors {
+		stderr.Error(err)
+		stderr.Print(sep)
+	}
+	stderr.Print("misc:")
+	stderr.Printf("  rkt's appc version: %s", schema.AppContainerVersion)
+	// make a visible break between errors and the listing
+	stderr.Print("")
 }

--- a/rkt/image_gc.go
+++ b/rkt/image_gc.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/pkg/lock"
+	pkgPod "github.com/coreos/rkt/pkg/pod"
 	"github.com/coreos/rkt/store/imagestore"
 	"github.com/coreos/rkt/store/treestore"
 	"github.com/hashicorp/errwrap"
@@ -111,15 +112,15 @@ func gcTreeStore(ts *treestore.Store) error {
 func getReferencedTreeStoreIDs() (map[string]struct{}, error) {
 	treeStoreIDs := map[string]struct{}{}
 	// Consider pods in preparing, prepared, run, exitedgarbage state
-	if err := walkPods(includeMostDirs, func(p *pod) {
-		stage1TreeStoreID, err := p.getStage1TreeStoreID()
+	if err := pkgPod.WalkPods(getDataDir(), pkgPod.IncludeMostDirs, func(p *pkgPod.Pod) {
+		stage1TreeStoreID, err := p.GetStage1TreeStoreID()
 		if err != nil {
-			stderr.PrintE(fmt.Sprintf("cannot get stage1 treestoreID for pod %s", p.uuid), err)
+			stderr.PrintE(fmt.Sprintf("cannot get stage1 treestoreID for pod %s", p.UUID), err)
 			return
 		}
-		appsTreeStoreIDs, err := p.getAppsTreeStoreIDs()
+		appsTreeStoreIDs, err := p.GetAppsTreeStoreIDs()
 		if err != nil {
-			stderr.PrintE(fmt.Sprintf("cannot get apps treestoreID for pod %s", p.uuid), err)
+			stderr.PrintE(fmt.Sprintf("cannot get apps treestoreID for pod %s", p.UUID), err)
 			return
 		}
 		allTreeStoreIDs := append(appsTreeStoreIDs, stage1TreeStoreID)

--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -243,18 +243,9 @@ func runImages(cmd *cobra.Command, args []string) int {
 	}
 
 	if len(errors) > 0 {
-		sep := "----------------------------------------"
-		stderr.Printf("%d error(s) encountered when listing images:", len(errors))
-		stderr.Print(sep)
-		for _, err := range errors {
-			stderr.Error(err)
-			stderr.Print(sep)
-		}
-		stderr.Print("misc:")
-		stderr.Printf("  rkt's appc version: %s", schema.AppContainerVersion)
-		// make a visible break between errors and the listing
-		stderr.Print("")
+		printErrors(errors, "listing images")
 	}
+
 	tabOut.Flush()
 	stdout.Print(tabBuffer.String())
 	return 0

--- a/rkt/list.go
+++ b/rkt/list.go
@@ -25,8 +25,8 @@ import (
 	"github.com/appc/spec/schema"
 	"github.com/appc/spec/schema/lastditch"
 	"github.com/appc/spec/schema/types"
-	common "github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/networking/netinfo"
+	pkgPod "github.com/coreos/rkt/pkg/pod"
 	"github.com/dustin/go-humanize"
 	"github.com/hashicorp/errwrap"
 	"github.com/spf13/cobra"
@@ -62,19 +62,17 @@ func runList(cmd *cobra.Command, args []string) int {
 		}
 	}
 
-	if err := walkPods(includeMostDirs, func(p *pod) {
-		pm := schema.PodManifest{}
+	if err := pkgPod.WalkPods(getDataDir(), pkgPod.IncludeMostDirs, func(p *pkgPod.Pod) {
+		var pm *schema.PodManifest
+		var err error
 
-		if !p.isPreparing && !p.isAbortedPrepare && !p.isExitedDeleting {
+		podState := p.State()
+		if podState != pkgPod.Preparing && podState != pkgPod.AbortedPrepare && podState != pkgPod.Deleting {
 			// TODO(vc): we should really hold a shared lock here to prevent gc of the pod
-			pmf, err := p.readFile(common.PodManifestPath(""))
+
+			_, pm, err = p.GetPodManifest()
 			if err != nil {
 				errors = append(errors, newPodListReadError(p, err))
-				return
-			}
-
-			if err := pm.UnmarshalJSON(pmf); err != nil {
-				errors = append(errors, newPodListLoadError(p, err, pmf))
 				return
 			}
 
@@ -96,11 +94,11 @@ func runList(cmd *cobra.Command, args []string) int {
 		}
 
 		var appsToPrint []printedApp
-		uuid := p.uuid.String()
-		state := p.getState()
-		nets := fmtNets(p.nets)
+		uuid := p.UUID.String()
+		state := p.State()
+		nets := fmtNets(p.Nets)
 
-		created, err := p.getCreationTime()
+		created, err := p.CreationTime()
 		if err != nil {
 			errors = append(errors, errwrap.Wrap(fmt.Errorf("unable to get creation time for pod %q", uuid), err))
 		}
@@ -111,7 +109,7 @@ func runList(cmd *cobra.Command, args []string) int {
 			createdStr = humanize.Time(created)
 		}
 
-		started, err := p.getStartTime()
+		started, err := p.StartTime()
 		if err != nil {
 			errors = append(errors, errwrap.Wrap(fmt.Errorf("unable to get start time for pod %q", uuid), err))
 		}
@@ -175,18 +173,7 @@ func runList(cmd *cobra.Command, args []string) int {
 	}
 
 	if len(errors) > 0 {
-		sep := "----------------------------------------"
-		stderr.Printf("%d error(s) encountered when listing pods:", len(errors))
-		stderr.Print(sep)
-		for _, err := range errors {
-			stderr.Error(err)
-			stderr.Print(sep)
-		}
-		stderr.Print("misc:")
-		stderr.Printf("  rkt's appc version: %s", schema.AppContainerVersion)
-		stderr.Print(sep)
-		// make a visible break between errors and the listing
-		stderr.Print("")
+		printErrors(errors, "listing pods")
 	}
 
 	tabOut.Flush()
@@ -194,42 +181,20 @@ func runList(cmd *cobra.Command, args []string) int {
 	return 0
 }
 
-func newPodListReadError(p *pod, err error) error {
+func newPodListReadError(p *pkgPod.Pod, err error) error {
 	lines := []string{
-		fmt.Sprintf("Unable to read pod %s manifest:", p.uuid.String()),
+		fmt.Sprintf("Unable to read pod %s manifest:", p.UUID.String()),
 		fmt.Sprintf("  %v", err),
 	}
 	return fmt.Errorf("%s", strings.Join(lines, "\n"))
 }
 
-func newPodListLoadError(p *pod, err error, pmj []byte) error {
-	lines := []string{
-		fmt.Sprintf("Unable to load pod %s manifest, because it is invalid:", p.uuid.String()),
-		fmt.Sprintf("  %v", err),
-	}
-	pm := lastditch.PodManifest{}
-	if err := pm.UnmarshalJSON(pmj); err != nil {
-		lines = append(lines, "  Also, failed to get any information about invalid pod manifest:")
-		lines = append(lines, fmt.Sprintf("    %v", err))
-	} else {
-		if len(pm.Apps) > 0 {
-			lines = append(lines, "Objects related to this error:")
-			for _, app := range pm.Apps {
-				lines = append(lines, fmt.Sprintf("  %s", appLine(app)))
-			}
-		} else {
-			lines = append(lines, "No other objects related to this error")
-		}
-	}
-	return fmt.Errorf("%s", strings.Join(lines, "\n"))
+func newPodListZeroAppsError(p *pkgPod.Pod) error {
+	return fmt.Errorf("pod %s contains zero apps", p.UUID.String())
 }
 
-func newPodListZeroAppsError(p *pod) error {
-	return fmt.Errorf("pod %s contains zero apps", p.uuid.String())
-}
-
-func newPodListLoadImageManifestError(p *pod, err error) error {
-	return errwrap.Wrap(fmt.Errorf("pod %s ImageManifest could not be loaded", p.uuid.String()), err)
+func newPodListLoadImageManifestError(p *pkgPod.Pod, err error) error {
+	return errwrap.Wrap(fmt.Errorf("pod %s ImageManifest could not be loaded", p.UUID.String()), err)
 }
 
 func appLine(app lastditch.RuntimeApp) string {
@@ -246,8 +211,8 @@ func fmtNets(nis []netinfo.NetInfo) string {
 	return strings.Join(parts, ", ")
 }
 
-func getImageName(p *pod, appName types.ACName) (string, error) {
-	aim, err := p.getAppImageManifest(appName)
+func getImageName(p *pkgPod.Pod, appName types.ACName) (string, error) {
+	aim, err := p.GetAppImageManifest(appName.String())
 	if err != nil {
 		return "", errwrap.Wrap(errors.New("problem retrieving ImageManifests from pod"), err)
 	}

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -22,6 +22,7 @@ import (
 	"github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/pkg/lock"
+	pkgPod "github.com/coreos/rkt/pkg/pod"
 	"github.com/coreos/rkt/pkg/user"
 	"github.com/coreos/rkt/rkt/image"
 	"github.com/coreos/rkt/stage0"
@@ -168,7 +169,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	p, err := newPod()
+	p, err := pkgPod.NewPod(getDataDir())
 	if err != nil {
 		stderr.PrintE("error creating new pod", err)
 		return 1
@@ -178,7 +179,7 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		Store:       s,
 		TreeStore:   ts,
 		Stage1Image: *s1img,
-		UUID:        p.uuid,
+		UUID:        p.UUID,
 		Debug:       globalFlags.Debug,
 	}
 
@@ -219,25 +220,25 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		stderr.PrintE("cannot get shared prepare lock", err)
 		return 1
 	}
-	if err = stage0.Prepare(pcfg, p.path(), p.uuid); err != nil {
+	if err = stage0.Prepare(pcfg, p.Path(), p.UUID); err != nil {
 		stderr.PrintE("error setting up stage0", err)
 		keyLock.Close()
 		return 1
 	}
 	keyLock.Close()
 
-	if err := p.sync(); err != nil {
+	if err := p.Sync(); err != nil {
 		stderr.PrintE("error syncing pod data", err)
 		return 1
 	}
 
-	if err := p.xToPrepared(); err != nil {
+	if err := p.ToPrepared(); err != nil {
 		stderr.PrintE("error transitioning to prepared", err)
 		return 1
 	}
 
 	os.Stdout = origStdout // restore output in case of --quiet
-	stdout.Printf("%s", p.uuid.String())
+	stdout.Printf("%s", p.UUID.String())
 
 	return 0
 }

--- a/rkt/rm.go
+++ b/rkt/rm.go
@@ -19,7 +19,7 @@ package main
 import (
 	"os"
 
-	"github.com/appc/spec/schema/types"
+	pkgPod "github.com/coreos/rkt/pkg/pod"
 	"github.com/spf13/cobra"
 )
 
@@ -39,14 +39,12 @@ func init() {
 }
 
 func runRm(cmd *cobra.Command, args []string) (exit int) {
-	var podUUID *types.UUID
-	var podUUIDs []*types.UUID
-	var err error
+	var podUUIDs []string
+	var ret int
 
-	ret := 0
 	switch {
 	case len(args) == 0 && flagUUIDFile != "":
-		podUUID, err = readUUIDFromFile(flagUUIDFile)
+		podUUID, err := pkgPod.ReadUUIDFromFile(flagUUIDFile)
 		if err != nil {
 			stderr.PrintE("unable to resolve UUID from file", err)
 			ret = 1
@@ -55,30 +53,23 @@ func runRm(cmd *cobra.Command, args []string) (exit int) {
 		}
 
 	case len(args) > 0 && flagUUIDFile == "":
-		for _, uuid := range args {
-			podUUID, err := resolveUUID(uuid)
-			if err != nil {
-				stderr.PrintE("unable to resolve UUID", err)
-				ret = 1
-			} else {
-				podUUIDs = append(podUUIDs, podUUID)
-			}
-		}
+		podUUIDs = args
 
 	default:
 		cmd.Usage()
 		return 1
 	}
 
-	for _, podUUID = range podUUIDs {
-		p, err := getPod(podUUID)
+	for _, podUUID := range podUUIDs {
+		p, err := pkgPod.GetPodFromUUIDString(getDataDir(), podUUID)
 		if err != nil {
 			ret = 1
 			stderr.PrintE("cannot get pod", err)
+			continue
 		}
 
 		if removePod(p) {
-			stdout.Printf("%q", p.uuid)
+			stdout.Printf("%q", p.UUID)
 		} else {
 			ret = 1
 		}
@@ -91,40 +82,40 @@ func runRm(cmd *cobra.Command, args []string) (exit int) {
 	return ret
 }
 
-func removePod(p *pod) bool {
-	switch {
-	case p.isRunning():
-		stderr.Printf("pod %q is currently running", p.uuid)
+func removePod(p *pkgPod.Pod) bool {
+	switch p.State() {
+	case pkgPod.Running:
+		stderr.Printf("pod %q is currently running", p.UUID)
 		return false
 
-	case p.isEmbryo, p.isPreparing:
-		stderr.Printf("pod %q is currently being prepared", p.uuid)
+	case pkgPod.Embryo, pkgPod.Preparing:
+		stderr.Printf("pod %q is currently being prepared", p.UUID)
 		return false
 
-	case p.isExitedDeleting, p.isDeleting:
-		stderr.Printf("pod %q is currently being deleted", p.uuid)
+	case pkgPod.Deleting:
+		stderr.Printf("pod %q is currently being deleted", p.UUID)
 		return false
 
-	case p.isAbortedPrepare:
-		stderr.Printf("moving failed prepare %q to garbage", p.uuid)
-		if err := p.xToGarbage(); err != nil && err != os.ErrNotExist {
+	case pkgPod.AbortedPrepare:
+		stderr.Printf("moving failed prepare %q to garbage", p.UUID)
+		if err := p.ToGarbage(); err != nil && err != os.ErrNotExist {
 			stderr.PrintE("rename error", err)
 			return false
 		}
 
-	case p.isPrepared:
-		stderr.Printf("moving expired prepared pod %q to garbage", p.uuid)
-		if err := p.xToGarbage(); err != nil && err != os.ErrNotExist {
+	case pkgPod.Prepared:
+		stderr.Printf("moving expired prepared pod %q to garbage", p.UUID)
+		if err := p.ToGarbage(); err != nil && err != os.ErrNotExist {
 			stderr.PrintE("rename error", err)
 			return false
 		}
 
 	// p.isExitedGarbage and p.isExited can be true at the same time. Test
 	// the most specific case first.
-	case p.isExitedGarbage, p.isGarbage:
+	case pkgPod.ExitedGarbage, pkgPod.Garbage:
 
-	case p.isExited:
-		if err := p.xToExitedGarbage(); err != nil && err != os.ErrNotExist {
+	case pkgPod.Exited:
+		if err := p.ToExitedGarbage(); err != nil && err != os.ErrNotExist {
 			stderr.PrintE("rename error", err)
 			return false
 		}

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -27,6 +27,7 @@ import (
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/pkg/label"
 	"github.com/coreos/rkt/pkg/lock"
+	pkgPod "github.com/coreos/rkt/pkg/pod"
 	"github.com/coreos/rkt/pkg/user"
 	"github.com/coreos/rkt/rkt/image"
 	"github.com/coreos/rkt/stage0"
@@ -224,7 +225,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	p, err := newPod()
+	p, err := pkgPod.NewPod(getDataDir())
 	if err != nil {
 		stderr.PrintE("error creating new pod", err)
 		return 1
@@ -233,7 +234,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 	// if requested, write out pod UUID early so "rkt rm" can
 	// clean it up even if something goes wrong
 	if flagUUIDFileSave != "" {
-		if err := writeUUIDToFile(p.uuid, flagUUIDFileSave); err != nil {
+		if err := pkgPod.WriteUUIDToFile(p.UUID, flagUUIDFileSave); err != nil {
 			stderr.PrintE("error saving pod UUID to file", err)
 			return 1
 		}
@@ -245,7 +246,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	p.mountLabel = mountLabel
+	p.MountLabel = mountLabel
 
 	cfg := stage0.CommonConfig{
 		MountLabel:   mountLabel,
@@ -253,7 +254,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		Store:        s,
 		TreeStore:    ts,
 		Stage1Image:  *s1img,
-		UUID:         p.uuid,
+		UUID:         p.UUID,
 		Debug:        globalFlags.Debug,
 	}
 
@@ -296,7 +297,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		stderr.PrintE("cannot get shared prepare lock", err)
 		return 1
 	}
-	err = stage0.Prepare(pcfg, p.path(), p.uuid)
+	err = stage0.Prepare(pcfg, p.Path(), p.UUID)
 	if err != nil {
 		stderr.PrintE("error setting up stage0", err)
 		keyLock.Close()
@@ -312,7 +313,7 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	// skip prepared by jumping directly to run, we own this pod
-	if err := p.xToRun(); err != nil {
+	if err := p.ToRun(); err != nil {
 		stderr.PrintE("unable to transition to run", err)
 		return 1
 	}
@@ -341,13 +342,13 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		UseOverlay:           useOverlay,
 	}
 
-	apps, err := p.getApps()
+	_, manifest, err := p.GetPodManifest()
 	if err != nil {
-		stderr.PrintE("cannot get the appList in the pod manifest", err)
+		stderr.PrintE("cannot get the pod manifest", err)
 		return 1
 	}
-	rcfg.Apps = apps
-	stage0.Run(rcfg, p.path(), getDataDir()) // execs, never returns
+	rcfg.Apps = manifest.Apps
+	stage0.Run(rcfg, p.Path(), getDataDir()) // execs, never returns
 
 	return 1
 }

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/coreos/rkt/common"
+	pkgPod "github.com/coreos/rkt/pkg/pod"
 	"github.com/coreos/rkt/stage0"
 	"github.com/coreos/rkt/store/imagestore"
 	"github.com/coreos/rkt/store/treestore"
@@ -56,7 +57,7 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	p, err := getPodFromUUIDString(args[0])
+	p, err := pkgPod.GetPodFromUUIDString(getDataDir(), args[0])
 	if err != nil {
 		stderr.PrintE("problem retrieving pod", err)
 		return 1
@@ -75,18 +76,19 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	if !p.isPrepared {
-		stderr.Printf("pod %q is not prepared", p.uuid)
+	if p.State() != pkgPod.Prepared {
+		stderr.Printf("pod %q is not prepared", p.UUID)
+		return 1
+	}
+
+	_, manifest, err := p.GetPodManifest()
+	if err != nil {
+		stderr.PrintE("cannot read pod manifest", err)
 		return 1
 	}
 
 	if flagInteractive {
-		ac, err := p.getAppCount()
-		if err != nil {
-			stderr.PrintE("cannot get pod's app count", err)
-			return 1
-		}
-		if ac > 1 {
+		if len(manifest.Apps) > 1 {
 			stderr.Print("interactive option only supports pods with one app")
 			return 1
 		}
@@ -102,7 +104,7 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	if err := p.xToRun(); err != nil {
+	if err := p.ToRun(); err != nil {
 		stderr.PrintE("cannot transition to run", err)
 		return 1
 	}
@@ -110,12 +112,6 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 	lfd, err := p.Fd()
 	if err != nil {
 		stderr.PrintE("unable to get lock fd", err)
-		return 1
-	}
-
-	apps, err := p.getApps()
-	if err != nil {
-		stderr.PrintE("unable to get app list", err)
 		return 1
 	}
 
@@ -136,11 +132,7 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		}
 	}
 
-	ovlPrep, err := p.overlayPrepared()
-	if err != nil {
-		stderr.PrintE("unable to determine prepared overlay state", err)
-		return 1
-	}
+	ovlPrep := p.UsesOverlay()
 
 	// should not happen, maybe the data directory moved from an overlay-enabled fs to another location
 	// between prepare and run-prepared
@@ -153,7 +145,7 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		CommonConfig: &stage0.CommonConfig{
 			Store:     s,
 			TreeStore: ts,
-			UUID:      p.uuid,
+			UUID:      p.UUID,
 			Debug:     globalFlags.Debug,
 		},
 		Net:                  flagNet,
@@ -163,7 +155,7 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 		DNSSearch:            flagDNSSearch,
 		DNSOpt:               flagDNSOpt,
 		MDSRegister:          flagMDSRegister,
-		Apps:                 apps,
+		Apps:                 manifest.Apps,
 		RktGid:               rktgid,
 		Hostname:             flagHostname,
 		InsecureCapabilities: globalFlags.InsecureFlags.SkipCapabilities(),
@@ -174,6 +166,6 @@ func runRunPrepared(cmd *cobra.Command, args []string) (exit int) {
 	if globalFlags.Debug {
 		stage0.InitDebug()
 	}
-	stage0.Run(rcfg, p.path(), getDataDir()) // execs, never returns
+	stage0.Run(rcfg, p.Path(), getDataDir()) // execs, never returns
 	return 1
 }

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -19,7 +19,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/hashicorp/errwrap"
+	pkgPod "github.com/coreos/rkt/pkg/pod"
 	"github.com/spf13/cobra"
 )
 
@@ -51,7 +51,7 @@ func runStatus(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	p, err := getPodFromUUIDString(args[0])
+	p, err := pkgPod.GetPodFromUUIDString(getDataDir(), args[0])
 	if err != nil {
 		stderr.PrintE("problem retrieving pod", err)
 		return 1
@@ -59,7 +59,7 @@ func runStatus(cmd *cobra.Command, args []string) (exit int) {
 	defer p.Close()
 
 	if flagWait {
-		if err := p.waitExited(); err != nil {
+		if err := p.WaitExited(); err != nil {
 			stderr.PrintE("unable to wait for pod", err)
 			return 1
 		}
@@ -73,21 +73,40 @@ func runStatus(cmd *cobra.Command, args []string) (exit int) {
 	return 0
 }
 
-// printStatus prints the pod's pid and per-app status codes
-func printStatus(p *pod) error {
-	stdout.Printf("state=%s", p.getState())
-
-	created, err := p.getCreationTime()
+// getExitStatuses returns a map of the statuses of the pod.
+func getExitStatuses(p *pkgPod.Pod) (map[string]int, error) {
+	_, manifest, err := p.GetPodManifest()
 	if err != nil {
-		return errwrap.Wrap(fmt.Errorf("unable to get creation time for pod %q", p.uuid), err)
+		return nil, err
+	}
+
+	stats := make(map[string]int)
+	for _, app := range manifest.Apps {
+		exitCode, err := p.GetAppExitCode(app.Name.String())
+		if err != nil {
+			continue
+		}
+		stats[app.Name.String()] = exitCode
+	}
+	return stats, nil
+}
+
+// printStatus prints the pod's pid and per-app status codes
+func printStatus(p *pkgPod.Pod) error {
+	state := p.State()
+	stdout.Printf("state=%s", state)
+
+	created, err := p.CreationTime()
+	if err != nil {
+		return fmt.Errorf("unable to get creation time for pod %q: %v", p.UUID, err)
 	}
 	createdStr := created.Format(defaultTimeLayout)
 
 	stdout.Printf("created=%s", createdStr)
 
-	started, err := p.getStartTime()
+	started, err := p.StartTime()
 	if err != nil {
-		return errwrap.Wrap(fmt.Errorf("unable to get start time for pod %q", p.uuid), err)
+		return fmt.Errorf("unable to get start time for pod %q: %v", p.UUID, err)
 	}
 	var startedStr string
 	if !started.IsZero() {
@@ -95,24 +114,26 @@ func printStatus(p *pod) error {
 		stdout.Printf("started=%s", startedStr)
 	}
 
-	if p.isRunning() {
-		stdout.Printf("networks=%s", fmtNets(p.nets))
+	if state == pkgPod.Running {
+		stdout.Printf("networks=%s", fmtNets(p.Nets))
 	}
 
-	if !p.isEmbryo && !p.isPreparing && !p.isPrepared && !p.isAbortedPrepare && !p.isGarbage && !p.isGone {
-		pid, err := p.getPID()
+	if state == pkgPod.Running || state == pkgPod.Deleting || state == pkgPod.ExitedDeleting || state == pkgPod.Exited || state == pkgPod.ExitedGarbage {
+		pid, err := p.Pid()
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to get PID for pod %q: %v", p.UUID, err)
 		}
 
-		stats, err := p.getExitStatuses()
-		if err != nil {
-			return err
-		}
+		stdout.Printf("pid=%d\nexited=%t", pid, (state == pkgPod.Exited || state == pkgPod.ExitedGarbage))
 
-		stdout.Printf("pid=%d\nexited=%t", pid, p.isExited)
-		for app, stat := range stats {
-			stdout.Printf("app-%s=%d", app, stat)
+		if state != pkgPod.Running {
+			stats, err := getExitStatuses(p)
+			if err != nil {
+				return fmt.Errorf("unable to get exit statuses for pod %q: %v", p.UUID, err)
+			}
+			for app, stat := range stats {
+				stdout.Printf("app-%s=%d", app, stat)
+			}
 		}
 	}
 	return nil

--- a/rkt/stop.go
+++ b/rkt/stop.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/coreos/rkt/stage0"
 
-	"github.com/appc/spec/schema/types"
+	pkgPod "github.com/coreos/rkt/pkg/pod"
 	"github.com/spf13/cobra"
 )
 
@@ -41,15 +41,13 @@ func init() {
 }
 
 func runStop(cmd *cobra.Command, args []string) (exit int) {
-	var podUUID *types.UUID
-	var podUUIDs []*types.UUID
-	var err error
+	var podUUIDs []string
 	var errors int
 
 	ret := 0
 	switch {
 	case len(args) == 0 && flagUUIDFile != "":
-		podUUID, err = readUUIDFromFile(flagUUIDFile)
+		podUUID, err := pkgPod.ReadUUIDFromFile(flagUUIDFile)
 		if err != nil {
 			stderr.PrintE("unable to resolve UUID from file", err)
 			ret = 1
@@ -58,38 +56,30 @@ func runStop(cmd *cobra.Command, args []string) (exit int) {
 		}
 
 	case len(args) > 0 && flagUUIDFile == "":
-		for _, uuid := range args {
-			podUUID, err := resolveUUID(uuid)
-			if err != nil {
-				stderr.PrintE("unable to resolve UUID", err)
-				ret = 1
-			} else {
-				podUUIDs = append(podUUIDs, podUUID)
-			}
-		}
+		podUUIDs = args
 
 	default:
 		cmd.Usage()
 		return 1
 	}
 
-	for _, podUUID = range podUUIDs {
-		p, err := getPod(podUUID)
+	for _, podUUID := range podUUIDs {
+		p, err := pkgPod.GetPodFromUUIDString(getDataDir(), podUUID)
 		if err != nil {
 			errors++
 			stderr.PrintE("cannot get pod", err)
 		}
 
-		if !p.isRunning() {
-			stderr.Error(fmt.Errorf("pod %q is not running", p.uuid))
+		if p.State() != pkgPod.Running {
+			stderr.Error(fmt.Errorf("pod %q is not running", p.UUID))
 			errors++
 			continue
 		}
 
-		if err := stage0.StopPod(p.path(), flagForce, podUUID); err == nil {
-			stdout.Printf("%q", p.uuid)
+		if err := stage0.StopPod(p.Path(), flagForce, p.UUID); err == nil {
+			stdout.Printf("%q", p.UUID)
 		} else {
-			stderr.PrintE(fmt.Sprintf("error stopping %q", p.uuid), err)
+			stderr.PrintE(fmt.Sprintf("error stopping %q", p.UUID), err)
 			errors++
 		}
 	}

--- a/tests/rkt_api_service_test.go
+++ b/tests/rkt_api_service_test.go
@@ -103,7 +103,7 @@ func checkPodState(t *testing.T, rawState string, apiState v1alpha.PodState) {
 		if apiState == v1alpha.PodState_POD_STATE_EXITED {
 			return
 		}
-	case "garbage":
+	case "garbage", "exited garbage":
 		if apiState == v1alpha.PodState_POD_STATE_GARBAGE {
 			return
 		}


### PR DESCRIPTION
Add lib package to export the functions as library later. So we can either use the CLI to get json output, or use `lib.GetApps(podDir, uuid, appName)` function to read the app infos.

Add CLI for 'rkt app list/status'.



```shell
$ sudo rkt app status 256c3776-ac8c-4af7-9fe1-0795202a3624 --app=nginx --format=json,pretty
{
	"name": "nginx",
	"state": "exited",
	"image_id": "sha512-ef61fd30978458917cf0348d9435ef2df2f06f401379df21ec1c58ccf11717f8",
	"mounts": [
		{
			"name": "34792e0c-6fca-11e6-b8da-28d244b00276",
			"container_path": "/var/run/secrets/kubernetes.io/serviceaccount",
			"host_path": "/var/lib/kubelet/pods/a153f508-6fc6-11e6-9fd1-28d244b00276/volumes/kubernetes.io~secret/default-token-jmg7b",
			"ReadOnly": true
		},
		{
			"name": "34792ec4-6fca-11e6-b8da-28d244b00276",
			"container_path": "/etc/hosts",
			"host_path": "/var/lib/kubelet/pods/a153f508-6fc6-11e6-9fd1-28d244b00276/etc-hosts",
			"ReadOnly": false
		},
		{
			"name": "34792f45-6fca-11e6-b8da-28d244b00276",
			"container_path": "/dev/termination-log",
			"host_path": "/var/lib/kubelet/pods/a153f508-6fc6-11e6-9fd1-28d244b00276/containers/nginx/34792bf2-6fca-11e6-b8da-28d244b00276",
			"ReadOnly": false
		}
	],
	"annotations": {
		"io.kubernetes.container.name": "nginx",
		"rkt.kubernetes.io/container-hash": "1494822627",
		"rkt.kubernetes.io/termination-message-path": "/var/lib/kubelet/pods/a153f508-6fc6-11e6-9fd1-28d244b00276/containers/nginx/34792bf2-6fca-11e6-b8da-28d244b00276"
	}
}
```

TODO: 
- [x] Support partial UUID (requires importing more code from `rkt/pods.go`, will do that if we think that's necessary)
- [ ] Make `rkt run/prepare/run-prepare` to create files under `stage1/rootfs/rkt/status` to satisfy the contract, so we can test `rkt app list/status` with running/created apps.
- [ ] Document newly added stage1 contract. Leave to follow up PRs.
- [x] Some code cleanup (`lib/pod.go`), maybe make existing code to use `lib/pod.go` instead of `rkt/pods.go`.
- [ ] Simple tests. Leave to follow up PRs.

cc @euank @s-urbaniak @lucab @tmrts 
