### PR TITLE
scripts: install-rkt.sh: fail install-pak on errors

### DIFF
--- a/scripts/install-rkt.sh
+++ b/scripts/install-rkt.sh
@@ -29,6 +29,9 @@ tar xvzf rkt-v"${version}".tar.gz
 cat <<EOF >install-pak
 #!/bin/bash
 
+# abort/fail on any error
+set -e
+
 # fix mkdir issues with checkinstall and fstrans
 for dir in /usr/lib/rkt/stage1-images/\\
         /usr/share/man/man1/\\


### PR DESCRIPTION
When install-pak (called from install-rkt.sh) fails at some point
abort packaging.

This is based on a discussion in
https://github.com/coreos/rkt/pull/3127#discussion-diff-76763179 where
it was agreed upon that aborting on unexpected failures would be
desirable.