### PR TITLE
cri: add stage API documentation

### DIFF
--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -129,6 +129,40 @@ In the bundled rkt stage 1, the entrypoint is sending SIGTERM signal to systemd-
 * `--force` to force the stopping of the pod. E.g. in the bundled rkt stage 1, stop sends SIGKILL
 * UUID of the pod
 
+### rkt app start
+
+`coreos.com/rkt/stage1/app/start`
+
+#### Arguments
+
+`start $OPTIONS UUID APPNAME ENTERENTRYPOINT PID`
+
+* `--debug` to activate debugging
+* `--disable-capabilities-restriction` gives all capabilities to apps (overrides `retain-set` and `remove-set`)
+* `--disable-paths` disables inaccessible and read-only paths (such as `/proc/sysrq-trigger`)
+* `--disable-seccomp` disables seccomp (overrides `retain-set` and `remove-set`)
+* `--private-users=$SHIFT` to define a UID/GID shift when using user namespaces. SHIFT is a two-value colon-separated parameter, the first value is the host UID to assign to the container and the second one is the number of host UIDs to assign.
+
+### rkt app stop
+
+`coreos.com/rkt/stage1/app/stop`
+
+#### Arguments
+
+`stop $OPTIONS UUID APPNAME ENTERENTRYPOINT PID`
+
+* `--debug` to activate debugging
+
+### rkt app rm
+
+`coreos.com/rkt/stage1/app/rm`
+
+#### Arguments
+
+`rm $OPTIONS UUID APPNAME ENTERENTRYPOINT PID`
+
+* `--debug` to activate debugging
+
 ## Versioning
 
 The stage1 command line interface is versioned using an annotation with the name `coreos.com/rkt/stage1/interface-version`.

--- a/stage1/app-rm/app-rm.go
+++ b/stage1/app-rm/app-rm.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/coreos/rkt/common"
 	rktlog "github.com/coreos/rkt/pkg/log"
-	stage1types "github.com/coreos/rkt/stage1/common/types"
 	stage1initcommon "github.com/coreos/rkt/stage1/init/common"
 
 	"github.com/appc/spec/schema/types"
@@ -53,12 +52,6 @@ func main() {
 		diag.SetOutput(ioutil.Discard)
 	}
 
-	uuid, err := types.NewUUID(flag.Arg(0))
-	if err != nil {
-		log.PrintE("UUID is missing or malformed", err)
-		os.Exit(1)
-	}
-
 	appName, err := types.NewACName(flag.Arg(1))
 	if err != nil {
 		log.PrintE("invalid app name", err)
@@ -66,13 +59,6 @@ func main() {
 	}
 
 	enterEP := flag.Arg(2)
-
-	root := "."
-	_, err = stage1types.LoadPod(root, uuid)
-	if err != nil {
-		log.PrintE("failed to load pod", err)
-		os.Exit(1)
-	}
 
 	args := []string{enterEP}
 

--- a/stage1/app-stop/app-stop.go
+++ b/stage1/app-stop/app-stop.go
@@ -24,7 +24,6 @@ import (
 	"os/exec"
 
 	rktlog "github.com/coreos/rkt/pkg/log"
-	stage1types "github.com/coreos/rkt/stage1/common/types"
 	stage1initcommon "github.com/coreos/rkt/stage1/init/common"
 
 	"github.com/appc/spec/schema/types"
@@ -51,12 +50,6 @@ func main() {
 		diag.SetOutput(ioutil.Discard)
 	}
 
-	uuid, err := types.NewUUID(flag.Arg(0))
-	if err != nil {
-		log.PrintE("UUID is missing or malformed", err)
-		os.Exit(1)
-	}
-
 	appName, err := types.NewACName(flag.Arg(1))
 	if err != nil {
 		log.PrintE("invalid app name", err)
@@ -64,14 +57,6 @@ func main() {
 	}
 
 	enterEP := flag.Arg(2)
-
-	// FIXME: Don't need to load pod?
-	root := "."
-	_, err = stage1types.LoadPod(root, uuid)
-	if err != nil {
-		log.PrintE("failed to load pod", err)
-		os.Exit(1)
-	}
 
 	args := []string{enterEP}
 


### PR DESCRIPTION
While starting to document the stage1 new entrypoints "stop" and "rm", I noticed they don't use the pod uuid. We still pass the uuid as parameter for consistency and to allow future extension. However, I removed the dead code.

---

/cc @iaguis @s-urbaniak 