### PR TITLE
Merge new master into cri

### DIFF
--- a/Documentation/devel/architecture.md
+++ b/Documentation/devel/architecture.md
@@ -104,7 +104,7 @@ These flavors will:
 
 This process is slightly different for the qemu-kvm stage1 but a similar workflow starting at `exec()`'ing kvm instead of an nspawn.
 
-We will now detail how the starting, shutdown, and exist status collection of the apps in a pod are implemented internally.
+We will now detail how the starting, shutdown, and exit status collection of the apps in a pod are implemented internally.
 
 ![rkt-systemd](rkt-systemd.png)
 

--- a/tests/rkt_volume_mount_fly_test.go
+++ b/tests/rkt_volume_mount_fly_test.go
@@ -27,19 +27,20 @@ func TestVolumeMount(t *testing.T) {
 		volumeMountTestCasesNonRecursiveCLI,
 		volumeMountTestCasesRecursivePodManifest,
 		volumeMountTestCasesNonRecursivePodManifest,
+		volumeMountTestCasesNonRecursive,
 		{
 			{
 				"CLI: duplicate mount given",
 				[]imagePatch{
 					{
 						"rkt-test-run-read-file.aci",
-						[]string{fmt.Sprintf("--exec=/inspect --read-file --file-name %s", tmpdir2filepathpod)},
+						[]string{fmt.Sprintf("--exec=/inspect --read-file --file-name %s", mountFilePath)},
 					},
 				},
 				fmt.Sprintf(
 					"--volume=test1,kind=host,source=%s --mount volume=test1,target=%s --volume=test2,kind=host,source=%s --mount volume=test1,target=%s",
-					tmpdir, tmpdirpathpod,
-					tmpdir, tmpdirpathpod,
+					volDir, mountDir,
+					volDir, mountDir,
 				),
 				nil,
 				1, /* TODO: decide on consistency with other stage1s */

--- a/tests/rkt_volume_mount_generic_test.go
+++ b/tests/rkt_volume_mount_generic_test.go
@@ -27,23 +27,24 @@ func TestVolumeMount(t *testing.T) {
 		volumeMountTestCasesNonRecursiveCLI,
 		volumeMountTestCasesRecursivePodManifest,
 		volumeMountTestCasesNonRecursivePodManifest,
+		volumeMountTestCasesNonRecursive,
 		{
 			{
 				"CLI: duplicate mount given",
 				[]imagePatch{
 					{
 						"rkt-test-run-read-file.aci",
-						[]string{fmt.Sprintf("--exec=/inspect --read-file --file-name %s", tmpdir2filepathpod)},
+						[]string{fmt.Sprintf("--exec=/inspect --read-file --file-name %s", mountFilePath)},
 					},
 				},
 				fmt.Sprintf(
 					"--volume=test1,kind=host,source=%s --mount volume=test1,target=%s --volume=test2,kind=host,source=%s --mount volume=test1,target=%s",
-					tmpdir, tmpdirpathpod,
-					tmpdir, tmpdirpathpod,
+					volDir, mountDir,
+					volDir, mountDir,
 				),
 				nil,
 				0,
-				tmpdir2innerfilecontent,
+				innerFileContent,
 			},
 		}}).Execute(t)
 }


### PR DESCRIPTION
The conflict in the cri branch was caused by:
- master: changes in appToSystemd() via https://github.com/coreos/rkt/pull/3155
- cri: moving appToSystemd() to stage1/init/common/units.go: UnitWriter.AppUnit()

I resolved it by applying the change in the UnitWriter.AppUnit() and getting the 'flavor' again.

-----

/cc @jjlakis @yifan-gu @s-urbaniak @iaguis 