### PR TITLE
CRI: Created ${app}-created, ${app-started} file for recording timestamps

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -102,6 +102,28 @@ func PodManifestPath(root string) string {
 	return filepath.Join(root, "pod")
 }
 
+// AppsStatusesPath returns the path of the status dir for all apps.
+func AppsStatusesPath(root string) string {
+	return filepath.Join(Stage1RootfsPath(root), "/rkt/status")
+}
+
+// AppStatusPath returns the path of the status file of an app.
+func AppStatusPath(root, appName string) string {
+	return filepath.Join(AppsStatusesPath(root), appName)
+}
+
+// AppCreatedPath returns the path of the ${appname}-created file, which is used to record
+// the creation timestamp of the app.
+func AppCreatedPath(root, appName string) string {
+	return filepath.Join(AppsStatusesPath(root), fmt.Sprintf("%s-created", appName))
+}
+
+// AppStartedPath returns the path of the ${appname}-started file, which is used to record
+// the start timestamp of the app.
+func AppStartedPath(root, appName string) string {
+	return filepath.Join(AppsStatusesPath(root), fmt.Sprintf("%s-started", appName))
+}
+
 // AppsPath returns the path where the apps within a pod live.
 func AppsPath(root string) string {
 	return filepath.Join(Stage1RootfsPath(root), stage2Dir)

--- a/rkt/app_list.go
+++ b/rkt/app_list.go
@@ -33,6 +33,7 @@ var (
 
 func init() {
 	cmdApp.AddCommand(cmdAppList)
+	cmdAppList.Flags().BoolVar(&flagNoLegend, "no-legend", false, "suppress a legend with the list")
 }
 
 func runAppList(cmd *cobra.Command, args []string) int {
@@ -50,7 +51,9 @@ func runAppList(cmd *cobra.Command, args []string) int {
 	tabBuffer := new(bytes.Buffer)
 	tabOut := getTabOutWithWriter(tabBuffer)
 
-	fmt.Fprintf(tabOut, "NAME\tSTATE\n")
+	if !flagNoLegend {
+		fmt.Fprintf(tabOut, "NAME\tSTATE\n")
+	}
 
 	for _, app := range apps {
 		fmt.Fprintf(tabOut, "%s\t%s\n", app.Name, app.State)

--- a/stage0/app.go
+++ b/stage0/app.go
@@ -195,6 +195,10 @@ func AddApp(cfg RunConfig, dir string, img *types.Hash) error {
 		return err
 	}
 
+	if _, err := os.Create(common.AppCreatedPath(p.Root, appName.String())); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -427,6 +431,10 @@ func StartApp(cfg StartConfig) error {
 
 	if privateUsers != "" {
 		args = append(args, fmt.Sprintf("--private-users=%s", privateUsers))
+	}
+
+	if _, err := os.Create(common.AppStartedPath(p.Root, cfg.AppName.String())); err != nil {
+		log.FatalE(fmt.Sprintf("error creating %s-started file", cfg.AppName.String()), err)
 	}
 
 	if err := callEntrypoint(cfg.Dir, appStartEntrypoint, args); err != nil {


### PR DESCRIPTION
An ${app}-created file will be created under /rkt/status/ when the app is added.
An ${app}-started file will be created under /rkt/status/ when the app is started.

Also a little bit refactoring.

cc @iaguis @s-urbaniak 