### PR TITLE
build: build simple .deb and .rpm packages

### DIFF
--- a/scripts/build-rir.sh
+++ b/scripts/build-rir.sh
@@ -4,11 +4,13 @@ set -xe
 
 SRC_DIR="${SRC_DIR:-$PWD}"
 BUILDDIR="${BUILDDIR:-$PWD/build-rir}"
-RKT_BUILDER_ACI="${RKT_BUILDER_ACI:-coreos.com/rkt/builder:1.0.2}"
+RKT_BUILDER_ACI="${RKT_BUILDER_ACI:-coreos.com/rkt/builder:1.1.0}"
+RKT_CMD="${RKT_CMD:-rkt}"
 
 mkdir -p $BUILDDIR
 
-rkt run \
+$RKT_CMD run \
+    --dns=8.8.8.8 \
     --volume src-dir,kind=host,source="${SRC_DIR}" \
     --volume build-dir,kind=host,source="${BUILDDIR}" \
     --interactive \

--- a/scripts/pkg/after-install
+++ b/scripts/pkg/after-install
@@ -1,0 +1,2 @@
+systemd-tmpfiles --create /usr/lib/tmpfiles.d/rkt.conf
+systemctl daemon-reload || true

--- a/scripts/pkg/after-remove
+++ b/scripts/pkg/after-remove
@@ -1,0 +1,2 @@
+rm -rf /var/lib/rkt
+systemctl daemon-reload || true

--- a/scripts/pkg/before-install
+++ b/scripts/pkg/before-install
@@ -1,0 +1,2 @@
+groupadd --force --system rkt-admin
+groupadd --force --system rkt

--- a/scripts/pkg/before-remove
+++ b/scripts/pkg/before-remove
@@ -1,0 +1,11 @@
+if [ -f /usr/bin/rkt ]; then
+    if [ -n "$(/usr/bin/rkt list --no-legend | awk '{print $4}' | grep running)" ]; then
+        printf "rkt/before-remove error: detected running containers.\n"
+        exit 1
+    fi
+    /usr/bin/rkt gc --grace-period=0s
+    if [ -n "$(grep "/var/lib/rkt" /proc/mounts)" ]; then
+        printf "rkt/before-remove error: detected active mounts in [/var/lib/rkt].\n"
+        exit 1
+    fi
+fi

--- a/scripts/pkg/build-pkgs.sh
+++ b/scripts/pkg/build-pkgs.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+##
+## build .deb and .rpm packages from an already-built
+## version of rkt
+
+set -e
+set -x
+
+version=$1
+
+MAINTAINER=security@coreos.com
+LICENSE="APLv2"
+VENDOR="CoreOS, Inc."
+HOMEPAGE="https://www.github.com/coreos/rkt"
+#iteration is the package version; bump if you need to repackage without
+#changing the rkt version
+ITERATION="${ITERATION:-1}" 
+builddir="${BUILDDIR:-/opt/build-rkt}"
+
+function usage {
+    echo "usage: BUILDDIR=<builddir> $0 <version>" >&2 
+    exit 1
+}
+
+if [ ! -d $builddir ]; then
+    echo "could not find build dir $builddir" >&2
+    usage
+fi
+
+if [ -z $version ]; then
+    echo "version not specified" >&2
+    usage
+fi
+
+srcdir=`dirname "$0"`
+projectdir=$srcdir/../..
+
+###################################
+## INSTALL RKT
+#################################
+workdir=$(mktemp -d /tmp/rkt-pkg.XXXXXX)
+prefix=$workdir/rootfs
+mkdir -p $prefix
+
+## install binary
+install -Dm755 $builddir/target/bin/rkt $prefix/usr/bin/rkt
+
+## install stage1s
+for flavor in fly coreos kvm; do
+    install -Dm644 $builddir/target/bin/stage1-${flavor}.aci $prefix/usr/lib/rkt/stage1-images/stage1-${flavor}.aci
+done
+
+## manpages & doc
+for f in $projectdir/dist/manpages/*; do 
+    install -Dm644 -t $prefix/usr/share/man/man1 "${f}" 
+done
+
+for dir in . subcommands networking performance; do
+    for f in $projectdir/Documentation/$dir/*.*; do
+        install -Dm644 -t $prefix/usr/share/doc/rkt "${f}"
+    done
+done
+
+install -Dm644 $projectdir/dist/bash_completion/rkt.bash $prefix/usr/share/bash-completion/completions/rkt
+install -Dm644 $projectdir/dist/init/systemd/tmpfiles.d/rkt.conf $prefix/usr/lib/tmpfiles.d/rkt.conf
+
+for unit in rkt-gc.{timer,service} rkt-metadata.{socket,service}; do
+    install -Dm644 -t $prefix/usr/lib/systemd/system/  $projectdir/dist/init/systemd/${unit}
+done
+
+## Copy before and after-install
+cp $srcdir/*-{install,remove} $workdir/
+
+
+#######################
+## BUILD THE PACKAGES
+#######################
+cd $builddir/target/bin
+fpm -s dir -t deb \
+    -n "rkt" -v "$version" --iteration "$ITERATION" \
+    --after-install $workdir/after-install \
+    --before-install $workdir/before-install \
+	--after-remove $workdir/after-remove \
+	--before-remove $workdir/before-remove \
+	--after-upgrade $workdir/after-install \
+	--before-upgrade $workdir/before-remove \
+    --license "$LICENSE" --vendor "$VENDOR" --url "$HOMEPAGE" -m "$MAINTAINER" --category utils \
+    -d adduser \
+    -d dbus \
+    -d libc6 \
+    -d systemd \
+    --deb-suggests ca-certificates \
+    -C ${prefix} 
+
+fpm -s dir -t rpm \
+    -n "rkt" -v "$version" --iteration "$ITERATION" \
+    --after-install $workdir/after-install \
+    --before-install $workdir/before-install \
+	--after-remove $workdir/after-remove \
+	--before-remove $workdir/before-remove \
+	--after-upgrade $workdir/after-install \
+	--before-upgrade $workdir/before-remove \
+    --license "$LICENSE" --vendor "$VENDOR" --url "$HOMEPAGE" -m "$MAINTAINER" --category utils \
+    --provides rkt \
+    -d 'shadow-utils' \
+    -C ${prefix} 
+
+rm -rf $workdir


### PR DESCRIPTION
Add a simple script to build .deb and .rpm packages. This is not a substitute for a proper distro-maintained package.

This depends on coreos/rkt-builder#3