### PR TITLE
build,stage1: include systemd dir when checking libs

### DIFF
--- a/stage1/stdlibdirs.mk
+++ b/stage1/stdlibdirs.mk
@@ -10,6 +10,7 @@ ifeq ($(SLD_INCLUDED),)
 
 SLD_INCLUDED := x
 SLD_LOCATIONS := $(shell ld --verbose | grep SEARCH_DIR | sed -e 's/SEARCH_DIR("=*\([^"]*\)");*/\1/g')
+SLD_LOCATIONS += $(foreach l,$(SLD_LOCATIONS),$l/systemd)
 
 endif
 


### PR DESCRIPTION
In the src flavor, we have some code to copy missing libraries from the
host to stage1 if they're not already present after building systemd.

In systemd v231, libshared was converted into a private shared library
living in `/usr/lib/systemd` (systemd/systemd#3516).

However, the logic that detects if a library is present or not was not
taking into account `$ROOTFS/usr/lib/systemd`, only `$ROOTFS/usr/lib`.
So the host's library overwrote the `libsystemd-shared-231.so` generated
by the systemd build, causing general madness.

Add the systemd directory to the list of paths to check.