### PR TITLE
docs: use absolute url in api-service doc

### DIFF
--- a/Documentation/subcommands/api-service.md
+++ b/Documentation/subcommands/api-service.md
@@ -17,8 +17,8 @@ Typically, the API service will be run via a unit file similar to the one includ
 
 ## Using the API service
 
-The interfaces are defined in the [protobuf here](../../api/v1alpha/api.proto).
-Here is a small [Go program](../../api/v1alpha/client_example.go) that illustrates how to use the API service.
+The interfaces are defined in the [protobuf here](https://github.com/coreos/rkt/blob/master/api/v1alpha/api.proto).
+Here is a small [Go program](https://github.com/coreos/rkt/blob/master/api/v1alpha/client_example.go) that illustrates how to use the API service.
 
 ## Options
 


### PR DESCRIPTION
This is breaking links on the website, and this way every time we sync we won't have to remember to fix this for the latest version. We only sync the Documentation folder, so linking to things outside of it breaks.