### PR TITLE
CRI: Add json, json-pretty format to the output of 'rkt list'.

### DIFF
--- a/lib/app.go
+++ b/lib/app.go
@@ -24,58 +24,6 @@ import (
 	pkgPod "github.com/coreos/rkt/pkg/pod"
 )
 
-// AppState defines the state of the app.
-type AppState string
-
-const (
-	AppStateUnknown AppState = "unknown"
-	AppStateCreated AppState = "created"
-	AppStateRunning AppState = "running"
-	AppStateExited  AppState = "exited"
-)
-
-type (
-	// Mount defines the mount point.
-	Mount struct {
-		// Name of the mount.
-		Name string `json:"name"`
-		// Container path of the mount.
-		ContainerPath string `json:"container_path"`
-		// Host path of the mount.
-		HostPath string `json:"host_path"`
-		// Whether the mount is read-only.
-		ReadOnly bool `json:"read_only"`
-		// TODO(yifan): What about 'SelinuxRelabel bool'?
-	}
-
-	// App defines the app object.
-	App struct {
-		// Name of the app.
-		Name string `json:"name"`
-		// State of the app, can be created, running, exited, or unknown.
-		State AppState `json:"state"`
-		// Creation time of the container, nanoseconds since epoch.
-		CreatedAt *int64 `json:"created_at,omitempty"`
-		// Start time of the container, nanoseconds since epoch.
-		StartedAt *int64 `json:"started_at,omitempty"`
-		// Finish time of the container, nanoseconds since epoch.
-		FinishedAt *int64 `json:"finished_at,omitempty"`
-		// Exit code of the container.
-		ExitCode *int32 `json:"exit_code,omitempty"`
-		// Image ID of the container.
-		ImageID string `json:"image_id"`
-		// Mount points of the container.
-		Mounts []*Mount `json:"mounts,omitempty"`
-		// Annotations of the container.
-		Annotations map[string]string `json:"annotations,omitempty"`
-	}
-
-	// Apps is a list of apps.
-	Apps struct {
-		AppList []App `json:"app_list,omitempty"`
-	}
-)
-
 // AppsForPod returns the apps of the pod with the given uuid in the given data directory.
 // If appName is non-empty, then only the app with the given name will be returned.
 func AppsForPod(uuid, dataDir string, appName string) ([]*App, error) {

--- a/lib/types.go
+++ b/lib/types.go
@@ -1,0 +1,76 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rkt
+
+import "github.com/coreos/rkt/networking/netinfo"
+
+// AppState defines the state of the app.
+type AppState string
+
+const (
+	AppStateUnknown AppState = "unknown"
+	AppStateCreated AppState = "created"
+	AppStateRunning AppState = "running"
+	AppStateExited  AppState = "exited"
+)
+
+type (
+	// Mount defines the mount point.
+	Mount struct {
+		// Name of the mount.
+		Name string `json:"name"`
+		// Container path of the mount.
+		ContainerPath string `json:"container_path"`
+		// Host path of the mount.
+		HostPath string `json:"host_path"`
+		// Whether the mount is read-only.
+		ReadOnly bool `json:"read_only"`
+		// TODO(yifan): What about 'SelinuxRelabel bool'?
+	}
+
+	// App defines the app object.
+	App struct {
+		// Name of the app.
+		Name string `json:"name"`
+		// State of the app, can be created, running, exited, or unknown.
+		State AppState `json:"state"`
+		// Creation time of the container, nanoseconds since epoch.
+		CreatedAt *int64 `json:"created_at,omitempty"`
+		// Start time of the container, nanoseconds since epoch.
+		StartedAt *int64 `json:"started_at,omitempty"`
+		// Finish time of the container, nanoseconds since epoch.
+		FinishedAt *int64 `json:"finished_at,omitempty"`
+		// Exit code of the container.
+		ExitCode *int32 `json:"exit_code,omitempty"`
+		// Image ID of the container.
+		ImageID string `json:"image_id"`
+		// Mount points of the container.
+		Mounts []*Mount `json:"mounts,omitempty"`
+		// Annotations of the container.
+		Annotations map[string]string `json:"annotations,omitempty"`
+	}
+
+	// Pod defines the pod object.
+	Pod struct {
+		// UUID of the pod.
+		UUID string `json:"name"`
+		// State of the pod, all valid values are defined in pkg/pod/pods.go.
+		State string `json:"state"`
+		// Networks are the information of the networks.
+		Networks []netinfo.NetInfo `json:"networks,omitempty"`
+		// AppNames are the names of the apps.
+		AppNames []string `json:"app_names,omitempty"`
+	}
+)


### PR DESCRIPTION
With json format, the parsing on the result is much easier and
consitent.

The json format is defined in coreos/rkt/lib/types.go.