### PR TITLE
CRI: Add app params to "rkt app add"

### DIFF
--- a/rkt/app_add.go
+++ b/rkt/app_add.go
@@ -114,13 +114,17 @@ func runAppAdd(cmd *cobra.Command, args []string) (exit int) {
 		rktgid = -1
 	}
 
+	pcfg := stage0.PrepareConfig{
+		CommonConfig: &ccfg,
+		Apps:         &rktApps,
+	}
 	rcfg := stage0.RunConfig{
 		CommonConfig: &ccfg,
 		UseOverlay:   p.UsesOverlay(),
 		RktGid:       rktgid,
 	}
 
-	err = stage0.AddApp(rcfg, p.Path(), img)
+	err = stage0.AddApp(pcfg, rcfg, p.Path(), img)
 	if err != nil {
 		stderr.PrintE("error adding app to pod", err)
 		return 1

--- a/rkt/app_add.go
+++ b/rkt/app_add.go
@@ -101,7 +101,7 @@ func runAppAdd(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	cfg := stage0.CommonConfig{
+	ccfg := stage0.CommonConfig{
 		Store:     s,
 		TreeStore: ts,
 		UUID:      p.UUID,
@@ -114,13 +114,13 @@ func runAppAdd(cmd *cobra.Command, args []string) (exit int) {
 		rktgid = -1
 	}
 
-	pcfg := stage0.RunConfig{
-		CommonConfig: &cfg,
+	rcfg := stage0.RunConfig{
+		CommonConfig: &ccfg,
 		UseOverlay:   p.UsesOverlay(),
 		RktGid:       rktgid,
 	}
 
-	err = stage0.AddApp(pcfg, p.Path(), img)
+	err = stage0.AddApp(rcfg, p.Path(), img)
 	if err != nil {
 		stderr.PrintE("error adding app to pod", err)
 		return 1

--- a/rkt/app_add.go
+++ b/rkt/app_add.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	cmdAppAdd = &cobra.Command{
-		Use:   "add UUID IMAGEID [--memory=LIMIT]...",
+		Use:   "add UUID IMAGEID ...",
 		Short: "Add an app to a pod",
 		Long:  `This allows addin an app that's present on the store to a running pod`,
 		Run:   runWrapper(runAppAdd),
@@ -38,7 +38,8 @@ var (
 
 func init() {
 	cmdApp.AddCommand(cmdAppAdd)
-	cmdAppAdd.Flags().Var((*appMemoryLimit)(&rktApps), "memory", "memory limit for the preceding image (example: '--memory=16Mi', '--memory=50M', '--memory=1G')")
+	addAppFlags(cmdAppAdd)
+	addIsolatorFlags(cmdAppAdd, false)
 
 	// Disable interspersed flags to stop parsing after the first non flag
 	// argument. All the subsequent parsing will be done by parseApps.

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -193,6 +193,14 @@ func installAssets() error {
 	if err != nil {
 		return err
 	}
+	mountBin, err := common.LookupPath("mount", os.Getenv("PATH"))
+	if err != nil {
+		return err
+	}
+	umountBin, err := common.LookupPath("umount", os.Getenv("PATH"))
+	if err != nil {
+		return err
+	}
 	// More paths could be added in that list if some Linux distributions install it in a different path
 	// Note that we look in /usr/lib/... first because of the merge:
 	// http://www.freedesktop.org/wiki/Software/systemd/TheCaseForTheUsrMerge/
@@ -216,6 +224,8 @@ func installAssets() error {
 		proj2aci.GetAssetString("/usr/bin/systemd-sysusers", systemdSysusersBin),
 		proj2aci.GetAssetString("/usr/lib/systemd/systemd-journald", systemdJournaldBin),
 		proj2aci.GetAssetString("/usr/bin/bash", bashBin),
+		proj2aci.GetAssetString("/bin/mount", mountBin),
+		proj2aci.GetAssetString("/bin/umount", umountBin),
 		proj2aci.GetAssetString(fmt.Sprintf("%s/systemd-journald.service", systemdUnitsPath), fmt.Sprintf("%s/systemd-journald.service", systemdUnitsPath)),
 		proj2aci.GetAssetString(fmt.Sprintf("%s/systemd-journald.socket", systemdUnitsPath), fmt.Sprintf("%s/systemd-journald.socket", systemdUnitsPath)),
 		proj2aci.GetAssetString(fmt.Sprintf("%s/systemd-journald-dev-log.socket", systemdUnitsPath), fmt.Sprintf("%s/systemd-journald-dev-log.socket", systemdUnitsPath)),

--- a/stage1/usr_from_coreos/manifest-amd64-usr.d/systemd.manifest
+++ b/stage1/usr_from_coreos/manifest-amd64-usr.d/systemd.manifest
@@ -1,6 +1,7 @@
 bin/coredumpctl
 bin/journalctl
 bin/mount
+bin/umount
 bin/systemctl
 bin/systemd-analyze
 bin/systemd-ask-password

--- a/stage1/usr_from_coreos/manifest-arm64-usr.d/systemd.manifest
+++ b/stage1/usr_from_coreos/manifest-arm64-usr.d/systemd.manifest
@@ -2,6 +2,7 @@ bin/bash
 bin/coredumpctl
 bin/journalctl
 bin/mount
+bin/umount
 bin/systemctl
 bin/systemd-analyze
 bin/systemd-ask-password

--- a/stage1/usr_from_src/mount.mk
+++ b/stage1/usr_from_src/mount.mk
@@ -1,0 +1,14 @@
+$(call setup-stamp-file,UFSM_STAMP)
+UFSM_MOUNT_ON_ACI := $(S1_RF_ACIROOTFSDIR)/usr/bin/mount
+UFSM_UMOUNT_ON_ACI := $(S1_RF_ACIROOTFSDIR)/usr/bin/umount
+
+S1_RF_SECONDARY_STAMPS += $(UFSM_STAMP)
+S1_RF_INSTALL_FILES += /bin/mount:$(UFSM_MOUNT_ON_ACI):-
+S1_RF_INSTALL_FILES += /bin/umount:$(UFSM_UMOUNT_ON_ACI):-
+S1_RF_INSTALL_DIRS += $(S1_RF_ACIROOTFSDIR)/usr/bin:-
+S1_RF_INSTALL_SYMLINKS += usr/bin:$(S1_RF_ACIROOTFSDIR)/bin
+
+$(call generate-stamp-rule,$(UFSM_STAMP),$(UFSM_MOUNT_ON_ACI),$(S1_RF_ACIROOTFSDIR)/bin)
+# TODO(krzesimir): add a stamp for umount
+
+$(call undefine-namespaces,UFSM)

--- a/stage1/usr_from_src/usr_from_src.mk
+++ b/stage1/usr_from_src/usr_from_src.mk
@@ -80,6 +80,7 @@ CLEAN_DIRS += \
 CLEAN_SYMLINKS += $(S1_RF_ACIROOTFSDIR)/flavor
 
 $(call inc-one,bash.mk)
+$(call inc-one,mount.mk)
 $(call inc-one,libnss.mk)
 
 # this makes sure everything is done - ACI rootfs is populated,


### PR DESCRIPTION
Adding the following flags in `rkt app add`: `--memory`, `--cpu`, `--caps-retain`, `--caps-remove`, `--seccomp`. Instead of adding the flags manually, the code for `rkt app add` and `rkt run` is factorised. Thanks to @krnowak for the patches. See also https://github.com/coreos/rkt/pull/3205#issuecomment-247551585

`--memory` and `--cpu` successfully update the manifest with the isolator. However, they are not enforced yet. I will need further work in another PR. The reason for that is that the cgroup filesystem for the memory & cpu controller are generally mounted read-only and rkt mount some files specific to the application in read-write mode. But at the time the pod is created (`rkt app sandbox`), the list of  applications is not known yet, so the mounts in read-write mode for the specific application is not done.

The refactoring commit is independent from CRI and might need to be applied to master first in order to avoid too much divergence between the "master" and "cri" branches. I would like to do that before merging this PR.

/cc @yifan-gu @s-urbaniak 