### PR TITLE
stop.go: Should continue when it fails to read the pod.

### DIFF
--- a/rkt/stop.go
+++ b/rkt/stop.go
@@ -68,6 +68,7 @@ func runStop(cmd *cobra.Command, args []string) (exit int) {
 		if err != nil {
 			errors++
 			stderr.PrintE("cannot get pod", err)
+			continue
 		}
 
 		if p.State() != pkgPod.Running {


### PR DESCRIPTION
The loop should continue if there's an error in retrieving the pod.
The bug also appears in master, however it's slightly different, because in master, the uuid is tested before passing it to getPod(). but still, there could be race that causes getPod() to fail.

This fixes a panic caused by this when removing a non-existed pod.
```
$ sudo rkt stop dc688be9-7c79-11e6-97ff-28d244b00276
stop: cannot get pod: no matches found for "dc688be9-7c79-11e6-97ff-28d244b00276"
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x49 pc=0x5b36f7]

goroutine 1 [running, locked to thread]:
panic(0xe2db40, 0xc820010120)
	/usr/local/go/src/runtime/panic.go:481 +0x3e6
github.com/coreos/rkt/pkg/pod.(*Pod).State(0x0, 0xf71ae0, 0xe)
	/home/yifan/gopher/src/github.com/coreos/rkt/build-rkt-1.14.0+git/gopath/src/github.com/coreos/rkt/pkg/pod/pods.go:1128 +0x7
main.runStop(0x1673820, 0xc820164d00, 0x1, 0x1, 0x7f4b9e263360)
	/home/yifan/gopher/src/github.com/coreos/rkt/build-rkt-1.14.0+git/gopath/src/github.com/coreos/rkt/rkt/stop.go:73 +0x255
main.runWrapper.func1(0x1673820, 0xc820164d00, 0x1, 0x1)
	/home/yifan/gopher/src/github.com/coreos/rkt/build-rkt-1.14.0+git/gopath/src/github.com/coreos/rkt/rkt/rkt.go:242 +0xe5
github.com/coreos/rkt/vendor/github.com/spf13/cobra.(*Command).execute(0x1673820, 0xc820164cb0, 0x1, 0x1, 0x0, 0x0)
	/home/yifan/gopher/src/github.com/coreos/rkt/build-rkt-1.14.0+git/gopath/src/github.com/coreos/rkt/vendor/github.com/spf13/cobra/command.go:565 +0x85a
github.com/coreos/rkt/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x166f820, 0x1673820, 0x0, 0x0)
	/home/yifan/gopher/src/github.com/coreos/rkt/build-rkt-1.14.0+git/gopath/src/github.com/coreos/rkt/vendor/github.com/spf13/cobra/command.go:651 +0x55c
github.com/coreos/rkt/vendor/github.com/spf13/cobra.(*Command).Execute(0x166f820, 0x0, 0x0)
	/home/yifan/gopher/src/github.com/coreos/rkt/build-rkt-1.14.0+git/gopath/src/github.com/coreos/rkt/vendor/github.com/spf13/cobra/command.go:610 +0x2d
main.main()
	/home/yifan/gopher/src/github.com/coreos/rkt/build-rkt-1.14.0+git/gopath/src/github.com/coreos/rkt/rkt/main.go:32 +0x98
yifan@yifan-coreos:~/kubernetes$ sudo rkt stop dc688be9-7c79-11e6-97ff-28d244b00276
stop: unable to resolve UUID: no matches found for "dc688be9-7c79-11e6-97ff-28d244b00276"
yifan@yifan-coreos:~/kubernetes$ sudo rkt stop dc688be9-7c79-11e6-97ff-28d244b00276
yifan@yifan-coreos:~/kubernetes$ sudo rkt stop dc688be9-7c79-11e6-97ff-28d244b00276
stop: unable to resolve UUID: no matches found for "dc688be9-7c79-11e6-97ff-28d244b00276"
yifan@yifan-coreos:~/kubernetes$ sudo rkt stop dc688be9-7c79-11e6-97ff-28d244b00276
stop: unable to resolve UUID: no matches found for "dc688be9-7c79-11e6-97ff-28d244b00276"
yifan@yifan-coreos:~/kubernetes$ sudo killall hyperkube^C
yifan@yifan-coreos:~/kubernetes$ ^C
yifan@yifan-coreos:~/kubernetes$ sudo rkt stop dc688be9-7c79-11e6-97ff-28d244b00276
stop: cannot get pod: no matches found for "dc688be9-7c79-11e6-97ff-28d244b00276"
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x49 pc=0x5b36f7]

goroutine 1 [running, locked to thread]:
panic(0xe2db40, 0xc820010120)
	/usr/local/go/src/runtime/panic.go:481 +0x3e6
github.com/coreos/rkt/pkg/pod.(*Pod).State(0x0, 0xf71ae0, 0xe)
	/home/yifan/gopher/src/github.com/coreos/rkt/build-rkt-1.14.0+git/gopath/src/github.com/coreos/rkt/pkg/pod/pods.go:1128 +0x7
main.runStop(0x1673820, 0xc82015eed0, 0x1, 0x1, 0x7fb57d5f6360)
	/home/yifan/gopher/src/github.com/coreos/rkt/build-rkt-1.14.0+git/gopath/src/github.com/coreos/rkt/rkt/stop.go:73 +0x255
main.runWrapper.func1(0x1673820, 0xc82015eed0, 0x1, 0x1)
	/home/yifan/gopher/src/github.com/coreos/rkt/build-rkt-1.14.0+git/gopath/src/github.com/coreos/rkt/rkt/rkt.go:242 +0xe5
github.com/coreos/rkt/vendor/github.com/spf13/cobra.(*Command).execute(0x1673820, 0xc82015ee80, 0x1, 0x1, 0x0, 0x0)
	/home/yifan/gopher/src/github.com/coreos/rkt/build-rkt-1.14.0+git/gopath/src/github.com/coreos/rkt/vendor/github.com/spf13/cobra/command.go:565 +0x85a
github.com/coreos/rkt/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x166f820, 0x1673820, 0x0, 0x0)
	/home/yifan/gopher/src/github.com/coreos/rkt/build-rkt-1.14.0+git/gopath/src/github.com/coreos/rkt/vendor/github.com/spf13/cobra/command.go:651 +0x55c
github.com/coreos/rkt/vendor/github.com/spf13/cobra.(*Command).Execute(0x166f820, 0x0, 0x0)
	/home/yifan/gopher/src/github.com/coreos/rkt/build-rkt-1.14.0+git/gopath/src/github.com/coreos/rkt/vendor/github.com/spf13/cobra/command.go:610 +0x2d
main.main()
	/home/yifan/gopher/src/github.com/coreos/rkt/build-rkt-1.14.0+git/gopath/src/github.com/coreos/rkt/rkt/main.go:32 +0x98

```