### PR TITLE
kvm/ssh: fix getcwd() error for qemu ssh

### DIFF
--- a/stage1/usr_from_kvm/files.mk
+++ b/stage1/usr_from_kvm/files.mk
@@ -12,7 +12,8 @@ UFKF_ACI_FILES := \
 	$(S1_RF_ACIROOTFSDIR)/etc/group \
 	$(S1_RF_ACIROOTFSDIR)/etc/ssh/sshd_config \
 	$(S1_RF_ACIROOTFSDIR)/usr/lib64/systemd/system/sshd-prep.service \
-	$(S1_RF_ACIROOTFSDIR)/usr/lib64/systemd/system/sshd@.service
+	$(S1_RF_ACIROOTFSDIR)/usr/lib64/systemd/system/sshd@.service \
+	$(S1_RF_ACIROOTFSDIR)/root/.ssh/environment
 
 UFKF_SRC_FILES := $(addprefix $(UFKF_DIR)/,$(notdir $(UFKF_ACI_FILES)))
 

--- a/stage1/usr_from_kvm/files/environment
+++ b/stage1/usr_from_kvm/files/environment
@@ -1,0 +1,1 @@
+PWD=/root

--- a/stage1/usr_from_kvm/files/sshd_config
+++ b/stage1/usr_from_kvm/files/sshd_config
@@ -3,6 +3,7 @@ HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_dsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 UsePrivilegeSeparation no
+PermitUserEnvironment yes
 
 KeyRegenerationInterval 3600
 ServerKeyBits 1024


### PR DESCRIPTION
Calling any command inside QEMU VM through SSH (especially `/enterexec` for entering) causes following error:
`shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory`
`getcwd()` is failing because of missing `PWD` enviroment variable when SSHing to the VM. Now, it's done by sshd_config. For lkvm, variable is set properly by default.

cc @coreos/rkt-kvm-maintainers 
