### PR TITLE
stop: Don't treat 'rkt stop already-stopped-pods' as errors.

### DIFF
--- a/rkt/app_stop.go
+++ b/rkt/app_stop.go
@@ -56,6 +56,11 @@ func runAppStop(cmd *cobra.Command, args []string) (exit int) {
 	}
 	defer p.Close()
 
+	if p.AfterRun() {
+		stdout.Printf("pod %q is already stopped", p.UUID)
+		return 0
+	}
+
 	if p.State() != pkgPod.Running {
 		stderr.Printf("pod %q isn't currently running", p.UUID)
 		return 1

--- a/rkt/stop.go
+++ b/rkt/stop.go
@@ -71,6 +71,11 @@ func runStop(cmd *cobra.Command, args []string) (exit int) {
 			continue
 		}
 
+		if p.AfterRun() {
+			stdout.Printf("pod %q is already stopped", p.UUID)
+			continue
+		}
+
 		if p.State() != pkgPod.Running {
 			stderr.Error(fmt.Errorf("pod %q is not running", p.UUID))
 			errors++


### PR DESCRIPTION
Since 'rkt stop' is idempotent, 'rkt stop' on an already stopped
pod should not return error.

cc @s-urbaniak @lucab @iaguis @alban 