### PR TITLE
Allow `rkt app rm` on a stopped pod.

### DIFF
--- a/rkt/app_rm.go
+++ b/rkt/app_rm.go
@@ -56,20 +56,18 @@ func runAppRm(cmd *cobra.Command, args []string) (exit int) {
 	}
 	defer p.Close()
 
-	if p.State() != pkgPod.Running {
-		stderr.Printf("pod %q isn't currently running", p.UUID)
-		return 1
-	}
-
 	appName, err := types.NewACName(flagAppName)
 	if err != nil {
 		stderr.PrintE("invalid app name", err)
 	}
 
-	podPID, err := p.ContainerPid1()
-	if err != nil {
-		stderr.PrintE(fmt.Sprintf("unable to determine the pid for pod %q", p.UUID), err)
-		return 1
+	podPID := -1
+	if p.State() == pkgPod.Running {
+		podPID, err = p.ContainerPid1()
+		if err != nil {
+			stderr.PrintE(fmt.Sprintf("unable to determine the pid for pod %q", p.UUID), err)
+			return 1
+		}
 	}
 
 	err = stage0.RmApp(p.Path(), p.UUID, p.UsesOverlay(), appName, podPID)


### PR DESCRIPTION
When the pod is stopped, don't call app-add/app-rm entrypoint
because there is not much we can/need to do when the whole pod
is stopped.

Fix #3221 .

This is one approach of fixing it , the other way is to pass the -1 pid to the entrypoints, and make a contract saying `if the pid is negative, then it means the pod is not running`.

I am ok with both. cc @iaguis @lucab @s-urbaniak 