### PR TITLE
stage0,stage1: handle exit status from stop entrypoint

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -432,3 +432,18 @@ func RemoveEmptyLines(str string) []string {
 
 	return lines
 }
+
+// GetExitStatus converts an error to an exit status. If it wasn't an exit
+// status != 0 it returns the same error that it was called with
+func GetExitStatus(err error) (int, error) {
+	if err == nil {
+		return 0, nil
+	}
+	if exiterr, ok := err.(*exec.ExitError); ok {
+		// the program has exited with an exit code != 0
+		if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+			return status.ExitStatus(), nil
+		}
+	}
+	return -1, err
+}

--- a/stage0/app.go
+++ b/stage0/app.go
@@ -298,7 +298,7 @@ func callEntrypoint(dir, entrypoint string, args []string) error {
 	}
 
 	if err := c.Run(); err != nil {
-		return fmt.Errorf("error executing stage1's app rm: %v", err)
+		return err
 	}
 
 	if err := os.Chdir(previousDir); err != nil {
@@ -357,7 +357,14 @@ func RmApp(dir string, uuid *types.UUID, usesOverlay bool, appName *types.ACName
 		}
 
 		if err := callEntrypoint(dir, appStopEntrypoint, args); err != nil {
-			return err
+			status, err := common.GetExitStatus(err)
+			// ignore nonexistent units failing to stop. Exit status 5
+			// comes from systemctl and means the unit doesn't exist
+			if err != nil {
+				return err
+			} else if status != 5 {
+				return fmt.Errorf("exit status %d", status)
+			}
 		}
 
 		if err := callEntrypoint(dir, appRmEntrypoint, args); err != nil {
@@ -520,6 +527,12 @@ func StopApp(cfg StopConfig) error {
 	}
 
 	if err := callEntrypoint(cfg.Dir, appStopEntrypoint, args); err != nil {
+		status, err := common.GetExitStatus(err)
+		// exit status 5 comes from systemctl and means the unit doesn't exist
+		if status == 5 {
+			return fmt.Errorf("app %q is not running", app.Name)
+		}
+
 		return err
 	}
 

--- a/stage1/app-stop/app-stop.go
+++ b/stage1/app-stop/app-stop.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/coreos/rkt/common"
 	rktlog "github.com/coreos/rkt/pkg/log"
 	stage1initcommon "github.com/coreos/rkt/stage1/init/common"
 
@@ -71,8 +72,11 @@ func main() {
 	}
 
 	if err := cmd.Run(); err != nil {
-		log.PrintE(fmt.Sprintf("error stopping app %q", appName.String()), err)
-		os.Exit(1)
+		status, err := common.GetExitStatus(err)
+		if err != nil {
+			os.Exit(1)
+		}
+		os.Exit(status)
 	}
 
 	os.Exit(0)


### PR DESCRIPTION
If we try to stop an app that doesn't have a service file (either
because it was not started or because the starting failed) we should
give an appropriate error message.

Also, since `app rm` calls the stop entrypoint, we should identify this
error and continue removing the app.