### PR TITLE
app sandbox port forwarding

### DIFF
--- a/common/networking/doc.go
+++ b/common/networking/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// networking is the package that implements small functionality shared
+// between state0 and stage1.
+package networking

--- a/common/networking/ports.go
+++ b/common/networking/ports.go
@@ -1,0 +1,119 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networking
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
+)
+
+// ForwardedPort describes a port that will be
+// forwarded (mapped) from the host to the pod
+type ForwardedPort struct {
+	PodPort  types.Port
+	HostPort types.ExposedPort
+}
+
+// findAppPort looks through the manifest to find a port with a given name.
+// If multiple apps expose the same port name, it will fail
+func findAppPort(manifest *schema.PodManifest, portName types.ACName) (*types.Port, error) {
+	var foundPort *types.Port
+
+	for _, app := range manifest.Apps {
+		for _, port := range app.App.Ports {
+			if portName == port.Name {
+				if foundPort != nil { // error: ambiguous
+					return nil, fmt.Errorf("port name %q defined multiple apps", portName)
+				}
+				p := port // duplicate b/c port gets overwritten
+				foundPort = &p
+			}
+		}
+	}
+	return foundPort, nil
+}
+
+// ForwardedPorts matches up ExposedPorts (host ports) with Ports on the app side.
+// By default, it tries to match up by name - apps expose ports, and the podspec
+// maps them. The podspec can also map from host to pod, without a corresponding app
+// (which is needed for CRI)
+// This will error if:
+// - a name is ambiguous
+// - the same port:proto combination is forwarded
+func ForwardedPorts(manifest *schema.PodManifest) ([]ForwardedPort, error) {
+	var fps []ForwardedPort
+	var err error
+
+	// For every ExposedPort, find its corresponding PodPort
+	for _, ep := range manifest.Ports {
+		podPort := ep.PodPort
+
+		// If there is no direct mapping, search for the port by name
+		if podPort == nil {
+			podPort, err = findAppPort(manifest, ep.Name)
+			if err != nil {
+				return nil, err
+			}
+			if podPort == nil {
+				return nil, fmt.Errorf("port name %q could not be found in any apps", ep.Name)
+			}
+		}
+		fp := ForwardedPort{
+			HostPort: ep,
+			PodPort:  *podPort,
+		}
+		fp.HostPort.PodPort = &fp.PodPort
+		if fp.HostPort.HostIP == nil {
+			fp.HostPort.HostIP = net.IPv4(0, 0, 0, 0)
+		}
+
+		// Check all already-existing ports for conflicts
+		for idx := range fps {
+			if fp.conflicts(&fps[idx]) {
+				return nil, fmt.Errorf("port %s-%s:%d already mapped to pod port %d",
+					fp.PodPort.Protocol, fp.HostPort.HostIP.String(), fp.HostPort.HostPort, fps[idx].PodPort.Port)
+			}
+		}
+
+		fps = append(fps, fp)
+	}
+	return fps, nil
+}
+
+// conflicts checks if two ports conflict with each other
+func (fp *ForwardedPort) conflicts(fp1 *ForwardedPort) bool {
+	if fp.PodPort.Protocol != fp1.PodPort.Protocol {
+		return false
+	}
+
+	if fp.HostPort.HostPort != fp1.HostPort.HostPort {
+		return false
+	}
+
+	// If either port has the 0.0.0.0 address, they conflict
+	zeroAddr := net.IPv4(0, 0, 0, 0)
+	if fp.HostPort.HostIP.Equal(zeroAddr) || fp1.HostPort.HostIP.Equal(zeroAddr) {
+		return true
+	}
+
+	if fp.HostPort.HostIP.Equal(fp1.HostPort.HostIP) {
+		return true
+	}
+
+	return false
+}

--- a/rkt/app_sandbox.go
+++ b/rkt/app_sandbox.go
@@ -15,6 +15,12 @@
 package main
 
 import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/pkg/label"
 	"github.com/coreos/rkt/pkg/lock"
@@ -33,6 +39,7 @@ var (
 		Long:  "Initializes an empty pod having no applications.",
 		Run:   runWrapper(runAppSandbox),
 	}
+	flagAppPorts appPortList
 )
 
 func init() {
@@ -47,6 +54,9 @@ func init() {
 	cmdAppSandbox.Flags().Var(&flagDNSSearch, "dns-search", "DNS search domains to write in /etc/resolv.conf")
 	cmdAppSandbox.Flags().Var(&flagDNSOpt, "dns-opt", "DNS options to write in /etc/resolv.conf")
 	cmdAppSandbox.Flags().StringVar(&flagHostname, "hostname", "", `pod's hostname. If empty, it will be "rkt-$PODUUID"`)
+	cmdAppSandbox.Flags().Var(&flagAppPorts, "port", "ports to forward. format: \"name:proto:podPort:hostIP:hostPort\"")
+
+	flagAppPorts = appPortList{}
 }
 
 func runAppSandbox(cmd *cobra.Command, args []string) int {
@@ -124,6 +134,7 @@ func runAppSandbox(cmd *cobra.Command, args []string) int {
 		PrivateUsers:       user.NewBlankUidRange(),
 		SkipTreeStoreCheck: globalFlags.InsecureFlags.SkipOnDiskCheck(),
 		Apps:               &rktApps,
+		Ports:              []types.ExposedPort(flagAppPorts),
 	}
 
 	if globalFlags.Debug {
@@ -196,4 +207,83 @@ func runAppSandbox(cmd *cobra.Command, args []string) int {
 	stage0.Run(rcfg, p.Path(), getDataDir()) // execs, never returns
 
 	return 1
+}
+
+/*
+ * The sandbox uses a different style of port forwarding - instead of mapping
+ * from port to app (via name), we just map ports directly.
+ *
+ * The format is name:proto:podPort:hostIP:hostPort
+ * e.g. http:tcp:8080:0.0.0.0:80
+ */
+type appPortList []types.ExposedPort
+
+func (apl *appPortList) Set(s string) error {
+	parts := strings.SplitN(s, ":", 5)
+	if len(parts) != 5 {
+		return fmt.Errorf("--port invalid format")
+	}
+
+	// parsey parsey
+	name, err := types.NewACName(parts[0])
+	if err != nil {
+		return err
+	}
+
+	proto := parts[1]
+	switch proto {
+	case "tcp", "udp":
+	default:
+		return fmt.Errorf("invalid protocol %q", proto)
+	}
+
+	p, err := strconv.ParseUint(parts[2], 10, 16)
+	if err != nil {
+		return err
+	}
+	podPortNo := uint(p)
+
+	ip := net.ParseIP(parts[3])
+	if ip == nil {
+		return fmt.Errorf("could not parse IP %q", ip)
+	}
+
+	p, err = strconv.ParseUint(parts[4], 10, 16)
+	if err != nil {
+		return err
+	}
+	hostPortNo := uint(p)
+
+	podSide := types.Port{
+		Name:            *name,
+		Protocol:        proto,
+		Port:            podPortNo,
+		Count:           1,
+		SocketActivated: false,
+	}
+
+	hostSide := types.ExposedPort{
+		Name:     *name,
+		HostPort: hostPortNo,
+		HostIP:   ip,
+		PodPort:  &podSide,
+	}
+
+	*apl = append(*apl, hostSide)
+	return nil
+}
+
+func (apl *appPortList) String() string {
+	ss := make([]string, 0, len(*apl))
+	for _, p := range *apl {
+		ss = append(ss, fmt.Sprintf("%s:%s:%d:%s:%d",
+			p.Name, p.PodPort.Protocol, p.PodPort.Port,
+			p.HostIP, p.HostPort))
+
+	}
+	return strings.Join(ss, ",")
+}
+
+func (apl *appPortList) Type() string {
+	return "appPortList"
 }

--- a/tests/rkt_net_nspawn_test.go
+++ b/tests/rkt_net_nspawn_test.go
@@ -30,6 +30,8 @@ func TestNetPortFwdConnectivity(t *testing.T) {
 	NewNetPortFwdConnectivityTest(
 		defaultSamePortFwdCase,
 		defaultDiffPortFwdCase,
+		defaultSpecificIPFwdCase,
+		defaultSpecificIPFwdFailCase,
 		defaultLoSamePortFwdCase,
 		defaultLoDiffPortFwdCase,
 		bridgeSamePortFwdCase,


### PR DESCRIPTION
Allow the app sandbox to set up port forwarding without actually having any apps.

This also adds the ability to forward from a specific IP in `rkt run`, since we had to implement this anyway.