### PR TITLE
kvm/init: remove condition for kvm mutable pods

### DIFF
--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -274,10 +274,6 @@ func getArgsEnv(p *stage1commontypes.Pod, flavor string, canMachinedRegister boo
 			return nil, nil, fmt.Errorf("flag --private-users cannot be used with an lkvm stage1")
 		}
 
-		if mutable {
-			return nil, nil, fmt.Errorf("flag --mutable is not implemented in lkvm stage1")
-		}
-
 		// kernel and hypervisor binaries are located relative to the working directory
 		// of init (/var/lib/rkt/..../uuid)
 		// TODO: move to path.go


### PR DESCRIPTION
As agreed on Rkt sync. All implemented cri features works well for kvm, and we plan to be on track with cri for kvm.