### PR TITLE
run/prepare: Support mutating the app for 'rkt run/prepare' as well.

### DIFF
--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -52,12 +52,16 @@ c9fad0e6-8236-4fc2-ad17-55d0a4c7d742
 
 | Flag | Default | Options | Description |
 | --- | --- | --- | --- |
+| `--user-annotation` | none | annotation add to the app's UserAnnotations field | Set the app's annotations (example: '--annotation=foo=bar'). |
 | `--caps-remove` | none | capability to remove (example: '--caps-remove=CAP\_SYS\_CHROOT,CAP\_MKNOD') | Capabilities to remove from the process's capabilities bounding set, all others from the default set will be included |
 | `--caps-retain` | none | capability to retain (example: '--caps-remove=CAP\_SYS\_ADMIN,CAP\_NET\_ADMIN') | Capabilities to retain in the process's capabilities bounding set, all others will be removed |
+| `--environment` | none | environment variables add to the app's environment variables | Set the app's environment variables (example: '--environment=foo=bar'). |
 | `--exec` | none | Path to executable | Override the exec command for the preceding image. |
 | `--group` | root | gid, groupname or file path | Group override for the preceding image (example: '--group=group') |
 | `--inherit-env` | `false` | `true` or `false` | Inherit all environment variables not set by apps. |
+| `--user-label` | none | label add to the apps' UserLabels field | Set the app's labels (example: '--label=foo=bar'). |
 | `--mount` | none | Mount syntax (ex. `--mount volume=NAME,target=PATH`) | Mount point binding a volume to a path within an app. See [Mounting Volumes without Mount Points](#mounting-volumes-without-mount-points). |
+| `--name` | none | Name of the app | Set the name of the app (example: '--name=foo'). If not set, then the app name default to the image's name |
 | `--no-overlay` | `false` | `true` or `false` | Disable the overlay filesystem. |
 | `--no-store` | `false` | `true` or `false` | Fetch images, ignoring the local store. See [image fetching behavior](../image-fetching-behavior.md) |
 | `--pod-manifest` | none | A path | The path to the pod manifest. If it's non-empty, then only `--net`, `--no-overlay` and `--interactive` will have effect. |

--- a/common/apps/apps.go
+++ b/common/apps/apps.go
@@ -62,8 +62,8 @@ type App struct {
 	CapsRemove        *types.LinuxCapabilitiesRevokeSet // os/linux/capabilities-remove-set overrides
 	SeccompFilter     string                            // seccomp CLI overrides
 	OOMScoreAdj       *types.LinuxOOMScoreAdj           // oom-score-adj isolator override
-	CRIAnnotations    map[string]string                 // the CRI annotations of the app.
-	CRILabels         map[string]string                 // the CRI labels of the app.
+	UserAnnotations   map[string]string                 // the user annotations of the app.
+	UserLabels        map[string]string                 // the user labels of the app.
 	Environments      map[string]string                 // the environments of the app.
 
 	// TODO(jonboulle): These images are partially-populated hashes, this should be clarified.

--- a/lib/app.go
+++ b/lib/app.go
@@ -59,10 +59,10 @@ func AppsForPod(uuid, dataDir string, appName string) ([]*App, error) {
 // newApp constructs the App object with the runtime app and pod manifest.
 func newApp(ra *schema.RuntimeApp, podManifest *schema.PodManifest, pod *pkgPod.Pod) (*App, error) {
 	app := &App{
-		Name:           ra.Name.String(),
-		ImageID:        ra.Image.ID.String(),
-		CRIAnnotations: ra.App.CRIAnnotations,
-		CRILabels:      ra.App.CRILabels,
+		Name:            ra.Name.String(),
+		ImageID:         ra.Image.ID.String(),
+		UserAnnotations: ra.App.CRIAnnotations,
+		UserLabels:      ra.App.CRILabels,
 	}
 
 	// Generate mounts

--- a/lib/pod.go
+++ b/lib/pod.go
@@ -34,16 +34,16 @@ func NewPodFromInternalPod(p *pkgPod.Pod) (*Pod, error) {
 	}
 
 	if len(manifest.CRIAnnotations) > 0 {
-		pod.CRIAnnotations = make(map[string]string)
+		pod.UserAnnotations = make(map[string]string)
 		for name, value := range manifest.CRIAnnotations {
-			pod.CRIAnnotations[name] = value
+			pod.UserAnnotations[name] = value
 		}
 	}
 
 	if len(manifest.CRILabels) > 0 {
-		pod.CRILabels = make(map[string]string)
+		pod.UserLabels = make(map[string]string)
 		for name, value := range manifest.CRILabels {
-			pod.CRILabels[name] = value
+			pod.UserLabels[name] = value
 		}
 	}
 

--- a/lib/types.go
+++ b/lib/types.go
@@ -58,10 +58,10 @@ type (
 		ImageID string `json:"image_id"`
 		// Mount points of the container.
 		Mounts []*Mount `json:"mounts,omitempty"`
-		// CRIAnnotations of the container.
-		CRIAnnotations map[string]string `json:"cri_annotations,omitempty"`
-		// CRILabels of the container.
-		CRILabels map[string]string `json:"cri_labels,omitempty"`
+		// User annotations of the container.
+		UserAnnotations map[string]string `json:"user_annotations,omitempty"`
+		// User labels of the container.
+		UserLabels map[string]string `json:"user_labels,omitempty"`
 	}
 
 	// Pod defines the pod object.
@@ -76,9 +76,9 @@ type (
 		AppNames []string `json:"app_names,omitempty"`
 		// The start time of the pod.
 		StartedAt *int64 `json:"started_at,omitempty"`
-		// CRIAnnotations are the pod annotations used for CRI.
-		CRIAnnotations map[string]string `json:"cri_annotations,omitempty"`
-		// CRILabels are the pod labels used for CRI.
-		CRILabels map[string]string `json:"cri_labels,omitempty"`
+		// UserAnnotations are the pod user annotations.
+		UserAnnotations map[string]string `json:"user_annotations,omitempty"`
+		// UserLabels are the pod user labels.
+		UserLabels map[string]string `json:"user_labels,omitempty"`
 	}
 )

--- a/rkt/app_add.go
+++ b/rkt/app_add.go
@@ -15,9 +15,6 @@
 package main
 
 import (
-	"fmt"
-
-	"github.com/appc/spec/schema/types"
 	"github.com/coreos/rkt/common/apps"
 
 	"github.com/coreos/rkt/common"
@@ -28,7 +25,6 @@ import (
 	"github.com/coreos/rkt/store/treestore"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var (
@@ -136,36 +132,4 @@ func runAppAdd(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	return 0
-}
-
-// generateAddConfig converts command line flags into stage0.AddConfig.
-func generateAddConfig(flags *pflag.FlagSet) (*stage0.AddConfig, error) {
-	var addConfig stage0.AddConfig
-
-	flag := flags.Lookup("name")
-	if flag != nil {
-		value := flag.Value.String()
-		if value != "" {
-			name, err := types.NewACName(value)
-			if err != nil {
-				return nil, fmt.Errorf("invalid format for app name: %v", err)
-			}
-			addConfig.Name = name
-		}
-	}
-
-	flag = flags.Lookup("set-annotation")
-	if flag != nil {
-		var annotations types.Annotations
-		for k, value := range flag.Value.(*kvMap).mapping {
-			key, err := types.NewACIdentifier(k)
-			if err != nil {
-				return nil, fmt.Errorf("invalid format for annotation key %q: %v", k, err)
-			}
-			annotations.Set(*key, value)
-		}
-		addConfig.Annotations = annotations
-	}
-
-	return &addConfig, nil
 }

--- a/rkt/app_sandbox.go
+++ b/rkt/app_sandbox.go
@@ -59,8 +59,8 @@ func init() {
 	cmdAppSandbox.Flags().Var(&flagAppPorts, "port", "ports to forward. format: \"name:proto:podPort:hostIP:hostPort\"")
 
 	flagAppPorts = appPortList{}
-	cmdAppSandbox.Flags().Var(&flagAnnotations, "annotation", "optional, set the pod's annotations in the form of key=value")
-	cmdAppSandbox.Flags().Var(&flagLabels, "label", "optional, set the pod's label in the form of key=value")
+	cmdAppSandbox.Flags().Var(&flagAnnotations, "user-annotation", "optional, set the pod's annotations in the form of key=value")
+	cmdAppSandbox.Flags().Var(&flagLabels, "user-label", "optional, set the pod's label in the form of key=value")
 }
 
 func runAppSandbox(cmd *cobra.Command, args []string) int {
@@ -139,8 +139,8 @@ func runAppSandbox(cmd *cobra.Command, args []string) int {
 		SkipTreeStoreCheck: globalFlags.InsecureFlags.SkipOnDiskCheck(),
 		Apps:               &rktApps,
 		Ports:              []types.ExposedPort(flagAppPorts),
-		CRIAnnotations:     parseAnnotations(&flagAnnotations),
-		CRILabels:          parseLabels(&flagLabels),
+		UserAnnotations:    parseAnnotations(&flagAnnotations),
+		UserLabels:         parseLabels(&flagLabels),
 	}
 
 	if globalFlags.Debug {
@@ -294,7 +294,7 @@ func (apl *appPortList) Type() string {
 	return "appPortList"
 }
 
-// parseAnnotations converts the annotations set by '--set-annotation' flag,
+// parseAnnotations converts the annotations set by '--user-annotation' flag,
 // and returns types.CRIAnnotations.
 func parseAnnotations(flagAnnotations *kvMap) types.CRIAnnotations {
 	if flagAnnotations.IsEmpty() {
@@ -307,7 +307,7 @@ func parseAnnotations(flagAnnotations *kvMap) types.CRIAnnotations {
 	return annotations
 }
 
-// parseLabels converts the labels set by '--set-label' flag,
+// parseLabels converts the labels set by '--user-label' flag,
 // and returns types.CRILabels.
 func parseLabels(flagLabels *kvMap) types.CRILabels {
 	if flagLabels.IsEmpty() {

--- a/rkt/app_status.go
+++ b/rkt/app_status.go
@@ -66,20 +66,20 @@ func printApp(app *rkt.App) {
 		stdout.Println()
 	}
 
-	if len(app.CRIAnnotations) > 0 {
-		stdout.Printf("cri_annotations=")
+	if len(app.UserAnnotations) > 0 {
+		stdout.Printf("user_annotations=")
 		var annos []string
-		for key, value := range app.CRIAnnotations {
+		for key, value := range app.UserAnnotations {
 			annos = append(annos, fmt.Sprintf("%s:%s", key, value))
 		}
 		stdout.Printf(strings.Join(annos, ","))
 		stdout.Println()
 	}
 
-	if len(app.CRILabels) > 0 {
-		stdout.Printf("cri_labels=")
+	if len(app.UserLabels) > 0 {
+		stdout.Printf("user_labels=")
 		var labels []string
-		for key, value := range app.CRILabels {
+		for key, value := range app.UserLabels {
 			labels = append(labels, fmt.Sprintf("%s:%s", key, value))
 		}
 		stdout.Printf(strings.Join(labels, ","))

--- a/rkt/cli_apps.go
+++ b/rkt/cli_apps.go
@@ -502,24 +502,24 @@ func (au *appName) Type() string {
 	return "appName"
 }
 
-// appAnnotation is for --annotation flags in the form of: --annotation=NAME=VALUE.
+// appAnnotation is for --user-annotation flags in the form of: --user-annotation=NAME=VALUE.
 type appAnnotation apps.Apps
 
 func (au *appAnnotation) Set(s string) error {
 	app := (*apps.Apps)(au).Last()
 	if app == nil {
-		return fmt.Errorf("--annotation must follow an image")
+		return fmt.Errorf("--user-annotation must follow an image")
 	}
 
 	fields := strings.SplitN(s, "=", 2)
 	if len(fields) != 2 {
-		return fmt.Errorf("invalid format of --annotation flag %q", s)
+		return fmt.Errorf("invalid format of --user-annotation flag %q", s)
 	}
 
-	if app.CRIAnnotations == nil {
-		app.CRIAnnotations = make(map[string]string)
+	if app.UserAnnotations == nil {
+		app.UserAnnotations = make(map[string]string)
 	}
-	app.CRIAnnotations[fields[0]] = fields[1]
+	app.UserAnnotations[fields[0]] = fields[1]
 	return nil
 }
 
@@ -529,7 +529,7 @@ func (au *appAnnotation) String() string {
 		return ""
 	}
 	var annotations []string
-	for name, value := range app.CRIAnnotations {
+	for name, value := range app.UserAnnotations {
 		annotations = append(annotations, fmt.Sprintf("%s=%s", name, value))
 	}
 	return strings.Join(annotations, ",")
@@ -539,24 +539,24 @@ func (au *appAnnotation) Type() string {
 	return "appAnnotation"
 }
 
-// appLabel is for --label flags in the form of: --label=NAME=VALUE.
+// appLabel is for --user-label flags in the form of: --user-label=NAME=VALUE.
 type appLabel apps.Apps
 
 func (au *appLabel) Set(s string) error {
 	app := (*apps.Apps)(au).Last()
 	if app == nil {
-		return fmt.Errorf("--label must follow an image")
+		return fmt.Errorf("--user-label must follow an image")
 	}
 
 	fields := strings.SplitN(s, "=", 2)
 	if len(fields) != 2 {
-		return fmt.Errorf("invalid format of --Label flag %q", s)
+		return fmt.Errorf("invalid format of --user-label flag %q", s)
 	}
 
-	if app.CRILabels == nil {
-		app.CRILabels = make(map[string]string)
+	if app.UserLabels == nil {
+		app.UserLabels = make(map[string]string)
 	}
-	app.CRILabels[fields[0]] = fields[1]
+	app.UserLabels[fields[0]] = fields[1]
 	return nil
 }
 
@@ -566,7 +566,7 @@ func (au *appLabel) String() string {
 		return ""
 	}
 	var labels []string
-	for name, value := range app.CRILabels {
+	for name, value := range app.UserLabels {
 		labels = append(labels, fmt.Sprintf("%s=%s", name, value))
 	}
 	return strings.Join(labels, ",")

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -61,7 +61,7 @@ func init() {
 	cmdPrepare.Flags().BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	cmdPrepare.Flags().BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
 	cmdPrepare.Flags().BoolVar(&flagPrivateUsers, "private-users", false, "run within user namespaces.")
-	cmdPrepare.Flags().Var(&flagExplicitEnv, "set-env", "environment variable to set for apps in the form name=value")
+	cmdPrepare.Flags().Var(&flagExplicitEnv, "set-env", "environment variable to set for all the apps in the form key=value, this will be overriden by --environment")
 	cmdPrepare.Flags().Var(&flagEnvFromFile, "set-env-file", "the path to an environment variables file")
 	cmdPrepare.Flags().BoolVar(&flagStoreOnly, "store-only", false, "use only available images in the store (do not discover or download from remote URLs)")
 	cmdPrepare.Flags().BoolVar(&flagNoStore, "no-store", false, "fetch images ignoring the local store")
@@ -108,11 +108,10 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		return 1
 	}
 
-	if len(flagPodManifest) > 0 && (len(flagPorts) > 0 || flagStoreOnly || flagNoStore ||
-		flagInheritEnv || !flagExplicitEnv.IsEmpty() || !flagEnvFromFile.IsEmpty() ||
-		(*appsVolume)(&rktApps).String() != "" || (*appMount)(&rktApps).String() != "" || (*appExec)(&rktApps).String() != "" ||
-		(*appUser)(&rktApps).String() != "" || (*appGroup)(&rktApps).String() != "" ||
-		(*appCapsRetain)(&rktApps).String() != "" || (*appCapsRemove)(&rktApps).String() != "") {
+	if len(flagPodManifest) > 0 && (rktApps.Count() > 0 ||
+		(*appsVolume)(&rktApps).String() != "" || (*appMount)(&rktApps).String() != "" ||
+		len(flagPorts) > 0 || flagStoreOnly || flagNoStore ||
+		flagInheritEnv || !flagExplicitEnv.IsEmpty() || !flagEnvFromFile.IsEmpty()) {
 		stderr.Print("conflicting flags set with --pod-manifest (see --help)")
 		return 1
 	}

--- a/stage0/app.go
+++ b/stage0/app.go
@@ -233,12 +233,12 @@ func AddApp(pcfg PrepareConfig, cfg RunConfig, dir string, img *types.Hash) erro
 		ra.App.SupplementaryGIDs = app.SupplementaryGIDs
 	}
 
-	if app.CRIAnnotations != nil {
-		ra.App.CRIAnnotations = app.CRIAnnotations
+	if app.UserAnnotations != nil {
+		ra.App.CRIAnnotations = app.UserAnnotations
 	}
 
-	if app.CRILabels != nil {
-		ra.App.CRILabels = app.CRILabels
+	if app.UserLabels != nil {
+		ra.App.CRILabels = app.UserLabels
 	}
 
 	if app.Environments != nil {


### PR DESCRIPTION
Also removed unneccessary flag conflict checks for --pod-manifest
v.s. other flags (--name, --environment, etc) because they are already
taken care of since they all need to follow an image.

Address https://github.com/coreos/rkt/pull/3205#issuecomment-248854097


So after this gets merged, we can do:

```shell

$ sudo rkt run sha512-70971ee35fce --name=nginx1 --exec=/bin/sleep -- 1000 --- sha512-70971ee35fce --name=nginx2 --exec=/bin/sleep -- 1000 ---
image: using image from file /home/yifan/gopher/src/github.com/coreos/rkt/build-rkt-1.15.0+git/target/bin/stage1-coreos.aci
image: using image from the store with hash sha512-70971ee35fcea3b260eed30840b6d4cf3e589f21c8eaaa52dfe672724a784eb9
image: using image from the store with hash sha512-70971ee35fcea3b260eed30840b6d4cf3e589f21c8eaaa52dfe672724a784eb9
networking: loading networks from /etc/rkt/net.d
networking: loading network default with type ptp
...

$ sudo rkt list
UUID		APP	IMAGE NAME					STATE	CREATED		STARTED		NETWORKS
b5780bfb	nginx1	registry-1.docker.io/library/nginx:latest	running	8 seconds ago	8 seconds ago	default:ip4=172.16.28.13
		    nginx2	registry-1.docker.io/library/nginx:latest	
```


/cc @monder