### PR TITLE
cri: mount volumes in the app

### DIFF
--- a/rkt/app_sandbox.go
+++ b/rkt/app_sandbox.go
@@ -57,6 +57,7 @@ func init() {
 	cmdAppSandbox.Flags().Var(&flagDNSOpt, "dns-opt", "DNS options to write in /etc/resolv.conf")
 	cmdAppSandbox.Flags().StringVar(&flagHostname, "hostname", "", `pod's hostname. If empty, it will be "rkt-$PODUUID"`)
 	cmdAppSandbox.Flags().Var(&flagAppPorts, "port", "ports to forward. format: \"name:proto:podPort:hostIP:hostPort\"")
+	cmdAppSandbox.Flags().Var((*appsVolume)(&rktApps), "volume", "volumes to make available in the pod")
 
 	flagAppPorts = appPortList{}
 	cmdAppSandbox.Flags().Var(&flagAnnotations, "annotation", "optional, set the pod's annotations in the form of key=value")

--- a/stage1/app-start/app-start.go
+++ b/stage1/app-start/app-start.go
@@ -127,6 +127,9 @@ func main() {
 		}
 	}
 
+	/* prepare mounts */
+	stage1initcommon.AppAddMounts(p, ra, enterCmd)
+
 	/* write service file */
 	binPath, err := stage1initcommon.FindBinPath(p, ra)
 	if err != nil {


### PR DESCRIPTION
This requires systemd with the following fix: https://github.com/systemd/systemd/pull/4152 (see also https://github.com/coreos/bugs/issues/1578).

It can be tested with the following commands:
```
sh autogen.sh
./configure --with-stage1-flavors=coreos,src,host \
  --with-stage1-systemd-src=https://github.com/kinvolk/systemd.git \
  --with-stage1-systemd-version=alban/mount-setup-shared-2 \
  --disable-tpm --enable-functional-tests
make -j 4
sudo cp build-rkt-1.15.0+git/target/bin/* /usr/bin/
```
```
sudo rkt app sandbox --insecure-options=image \
  --stage1-path=/usr/bin/stage1-src.aci --debug \
  --volume=foo,kind=host,source=/home/alban/tmp/shared/
```
```
sudo rkt app add $UUID quay.io/coreos/alpine-sh:latest \
  --mount=volume=foo,target=/mnt
  --exec=/bin/sh -- -c 'echo Hello World ; sleep 500'

sudo rkt app start $UUID --app=alpine-sh
```

TODO:
- [ ] Merge the mounts between the image manifest and the mounts passed
  on the command line

-----

/cc @squeed @s-urbaniak 