### PR TITLE
app-start: set up unit files/cgroups during app-add

### DIFF
--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -139,9 +139,9 @@ In the bundled rkt stage 1, the entrypoint is sending SIGTERM signal to systemd-
 * `--force` to force the stopping of the pod. E.g. in the bundled rkt stage 1, stop sends SIGKILL
 * UUID of the pod
 
-### rkt app start
+### rkt app add
 
-`coreos.com/rkt/stage1/app/start`
+`coreos.com/rkt/stage1/app/add`
 
 #### Arguments
 
@@ -152,6 +152,16 @@ In the bundled rkt stage 1, the entrypoint is sending SIGTERM signal to systemd-
 * `--disable-paths` disables inaccessible and read-only paths (such as `/proc/sysrq-trigger`)
 * `--disable-seccomp` disables seccomp (overrides `retain-set` and `remove-set`)
 * `--private-users=$SHIFT` to define a UID/GID shift when using user namespaces. SHIFT is a two-value colon-separated parameter, the first value is the host UID to assign to the container and the second one is the number of host UIDs to assign.
+
+### rkt app start
+
+`coreos.com/rkt/stage1/app/start`
+
+#### Arguments
+
+`start $OPTIONS UUID APPNAME ENTERENTRYPOINT PID`
+
+* `--debug` to activate debugging
 
 ### rkt app stop
 

--- a/rkt/app_start.go
+++ b/rkt/app_start.go
@@ -78,14 +78,10 @@ func runAppStart(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	scfg := stage0.StartConfig{
-		CommonConfig:         &cfg,
-		Dir:                  p.Path(),
-		UsesOverlay:          p.UsesOverlay(),
-		AppName:              appName,
-		PodPID:               podPID,
-		InsecureCapabilities: globalFlags.InsecureFlags.SkipCapabilities(),
-		InsecurePaths:        globalFlags.InsecureFlags.SkipPaths(),
-		InsecureSeccomp:      globalFlags.InsecureFlags.SkipSeccomp(),
+		CommonConfig: &cfg,
+		Dir:          p.Path(),
+		AppName:      appName,
+		PodPID:       podPID,
 	}
 
 	err = stage0.StartApp(scfg)

--- a/stage0/manifest.go
+++ b/stage0/manifest.go
@@ -34,6 +34,7 @@ const (
 	gcEntrypoint    = "coreos.com/rkt/stage1/gc"
 	stopEntrypoint  = "coreos.com/rkt/stage1/stop"
 
+	appAddEntrypoint   = "coreos.com/rkt/stage1/app/add"
 	appRmEntrypoint    = "coreos.com/rkt/stage1/app/rm"
 	appStartEntrypoint = "coreos.com/rkt/stage1/app/start"
 	appStopEntrypoint  = "coreos.com/rkt/stage1/app/stop"

--- a/stage1/aci/aci-manifest.in
+++ b/stage1/aci/aci-manifest.in
@@ -34,6 +34,10 @@
             "value": "@RKT_STAGE1_STOP@"
         },
         {
+            "name": "coreos.com/rkt/stage1/app/add",
+            "value": "/app-add"
+        },
+        {
             "name": "coreos.com/rkt/stage1/app/rm",
             "value": "/app-rm"
         },

--- a/stage1/app-add/app-add.go
+++ b/stage1/app-add/app-add.go
@@ -1,0 +1,169 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/coreos/go-systemd/unit"
+	"github.com/coreos/rkt/common/cgroup"
+	rktlog "github.com/coreos/rkt/pkg/log"
+	stage1types "github.com/coreos/rkt/stage1/common/types"
+	stage1initcommon "github.com/coreos/rkt/stage1/init/common"
+
+	"github.com/appc/spec/schema/types"
+)
+
+var (
+	debug               bool
+	disableCapabilities bool
+	disablePaths        bool
+	disableSeccomp      bool
+	privateUsers        string
+	log                 *rktlog.Logger
+	diag                *rktlog.Logger
+)
+
+func init() {
+	flag.BoolVar(&debug, "debug", false, "Run in debug mode")
+	flag.BoolVar(&disableCapabilities, "disable-capabilities-restriction", false, "Disable capability restrictions")
+	flag.BoolVar(&disablePaths, "disable-paths", false, "Disable paths restrictions")
+	flag.BoolVar(&disableSeccomp, "disable-seccomp", false, "Disable seccomp restrictions")
+	flag.StringVar(&privateUsers, "private-users", "", "Run within user namespace. Can be set to [=UIDBASE[:NUIDS]]")
+}
+
+// TODO use named flags instead of positional
+func main() {
+	flag.Parse()
+
+	stage1initcommon.InitDebug(debug)
+
+	log, diag, _ = rktlog.NewLogSet("stage1", debug)
+	if !debug {
+		diag.SetOutput(ioutil.Discard)
+	}
+
+	uuid, err := types.NewUUID(flag.Arg(0))
+	if err != nil {
+		log.PrintE("UUID is missing or malformed", err)
+		os.Exit(1)
+	}
+
+	appName, err := types.NewACName(flag.Arg(1))
+	if err != nil {
+		log.PrintE("invalid app name", err)
+		os.Exit(1)
+	}
+
+	enterCmd := []string{flag.Arg(2)}
+	enterCmd = append(enterCmd, fmt.Sprintf("--pid=%s", flag.Arg(3)), "--")
+
+	root := "."
+	p, err := stage1types.LoadPod(root, uuid)
+	if err != nil {
+		log.PrintE("failed to load pod", err)
+		os.Exit(1)
+	}
+
+	insecureOptions := stage1initcommon.Stage1InsecureOptions{
+		DisablePaths:        disablePaths,
+		DisableCapabilities: disableCapabilities,
+		DisableSeccomp:      disableSeccomp,
+	}
+
+	ra := p.Manifest.Apps.Get(*appName)
+	if ra == nil {
+		log.Printf("failed to get app")
+		os.Exit(1)
+	}
+
+	if ra.App.WorkingDirectory == "" {
+		ra.App.WorkingDirectory = "/"
+	}
+
+	/* prepare cgroups */
+	isUnified, err := cgroup.IsCgroupUnified("/")
+	if err != nil {
+		log.FatalE("failed to determine the cgroup version", err)
+		os.Exit(1)
+	}
+
+	if !isUnified {
+		enabledCgroups, err := cgroup.GetEnabledV1Cgroups()
+		if err != nil {
+			log.FatalE("error getting cgroups", err)
+			os.Exit(1)
+		}
+
+		b, err := ioutil.ReadFile(filepath.Join(p.Root, "subcgroup"))
+		if err == nil {
+			subcgroup := string(b)
+			serviceName := stage1initcommon.ServiceUnitName(ra.Name)
+
+			if err := cgroup.RemountCgroupKnobsRW(enabledCgroups, subcgroup, serviceName, enterCmd); err != nil {
+				log.FatalE("error restricting container cgroups", err)
+				os.Exit(1)
+			}
+		} else {
+			log.PrintE("continuing with per-app isolators disabled", err)
+		}
+	}
+
+	/* write service file */
+	binPath, err := stage1initcommon.FindBinPath(p, ra)
+	if err != nil {
+		log.PrintE("failed to find bin path", err)
+		os.Exit(1)
+	}
+
+	w := stage1initcommon.NewUnitWriter(p)
+
+	w.AppUnit(ra, binPath, privateUsers, insecureOptions,
+		unit.NewUnitOption("Unit", "Before", "halt.target"),
+		unit.NewUnitOption("Unit", "Conflicts", "halt.target"),
+		unit.NewUnitOption("Service", "StandardOutput", "journal+console"),
+		unit.NewUnitOption("Service", "StandardError", "journal+console"),
+	)
+
+	w.AppReaperUnit(ra.Name, binPath)
+
+	if err := w.Error(); err != nil {
+		log.PrintE("error generating app units", err)
+		os.Exit(1)
+	}
+
+	args := enterCmd
+	args = append(args, "/usr/bin/systemctl")
+	args = append(args, "daemon-reload")
+
+	cmd := exec.Cmd{
+		Path: args[0],
+		Args: args,
+	}
+
+	if err := cmd.Run(); err != nil {
+		log.PrintE(`error executing "systemctl daemon-reload"`, err)
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}

--- a/stage1/app-add/app-add.mk
+++ b/stage1/app-add/app-add.mk
@@ -1,0 +1,1 @@
+include stage1/makelib/aci_simple_go_bin.mk

--- a/stage1/secondary-stuff.mk
+++ b/stage1/secondary-stuff.mk
@@ -12,6 +12,7 @@ _S1_SS_SUBDIRS_ := \
 	reaper \
 	stop \
 	stop_kvm \
+	app-add \
 	app-rm \
 	app-start \
 	app-stop \


### PR DESCRIPTION
Currently we set up the app's service during app-start which is not the
right place.

This implements the proper logic to set up systemd service files, as
well as any remounts of cgroups during app-add.