### PR TITLE
rkt 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 1.16.0
+
+This release contains an important bugfix for the stage1-host flavor, as well as initial internal support for cgroup2 and pod sandboxes as specified by kubernetes CRI (Container Runtime Interface).
+
+### Bug fixes
+- stage1/host: fix systemd-nspawn args ordering ([#3216](https://github.com/coreos/rkt/pull/3216)). Fixes https://github.com/coreos/rkt/issues/3215.
+
+### New features
+- rkt: support for unified cgroups (cgroup2) ([#3032](https://github.com/coreos/rkt/pull/3032)). This implements support for cgroups v2 along support for legacy version.
+- cri: initial implementation of stage1 changes ([#3218](https://github.com/coreos/rkt/pull/3218)). This PR pulls the stage1-based changes from the CRI branch back into
+master, leaving out the changes in stage0 (new app subcommands).
+
+### Other changes
+- doc/using-rkt-with-systemd: fix the go app example ([#3217](https://github.com/coreos/rkt/pull/3217)).
+- rkt: refactor app-level flags handling ([#3209](https://github.com/coreos/rkt/pull/3209)). This is in preparation for https://github.com/coreos/rkt/pull/3205
+- docs/distributions: rearrange, add centos ([#3212](https://github.com/coreos/rkt/pull/3212)).
+- rkt: Correct typos listed by the tool misspell ([#3208](https://github.com/coreos/rkt/pull/3208)).
+
 ## 1.15.0
 
 This relase brings some expanded DNS configuration options, beta support for QEMU, recursive volume mounts, and improved sd_notify support.

--- a/Documentation/running-fly-stage1.md
+++ b/Documentation/running-fly-stage1.md
@@ -60,14 +60,14 @@ $ ./autogen.sh && ./configure --with-stage1-flavors=fly && make
 ```
 
 For more details about configure parameters, see the [configure script parameters documentation](build-configure.md).
-This will build the rkt binary and the stage1-fly.aci in `build-rkt-1.15.0+git/bin/`.
+This will build the rkt binary and the stage1-fly.aci in `build-rkt-1.16.0+git/bin/`.
 
 ### Selecting stage1 at runtime
 
 Here is a quick example of how to use a container with the official fly stage1:
 
 ```
-# rkt run --stage1-name=coreos.com/rkt/stage1-fly:1.15.0 coreos.com/etcd:v2.2.5
+# rkt run --stage1-name=coreos.com/rkt/stage1-fly:1.16.0 coreos.com/etcd:v2.2.5
 ```
 
 If the image is not in the store, `--stage1-name` will perform discovery and fetch the image.

--- a/Documentation/running-kvm-stage1.md
+++ b/Documentation/running-kvm-stage1.md
@@ -13,7 +13,7 @@ $ ./autogen.sh && ./configure --with-stage1-flavors=kvm --with-stage1-kvm-hyperv
 ```
 
 For more details about configure parameters, see [configure script parameters documentation](build-configure.md).
-This will build the rkt binary and the KVM stage1 aci image in `build-rkt-1.15.0+git/target/bin/`. Depending on the configuration options, it will be `stage1-kvm.aci` (if one hypervisor is set), or `stage1-kvm-lkvm.aci` and `stage1-kvm-qemu.aci` (if you want to have both images built once).
+This will build the rkt binary and the KVM stage1 aci image in `build-rkt-1.16.0+git/target/bin/`. Depending on the configuration options, it will be `stage1-kvm.aci` (if one hypervisor is set), or `stage1-kvm-lkvm.aci` and `stage1-kvm-qemu.aci` (if you want to have both images built once).
 
 Provided you have hardware virtualization support and the [kernel KVM module](http://www.linux-kvm.org/page/Getting_the_kvm_kernel_modules) loaded (refer to your distribution for instructions), you can then run an image like you would normally do with rkt:
 
@@ -84,7 +84,7 @@ If you want to run software that requires hypervisor isolation along with truste
 For example, to use the official kvm stage1:
 
 ```
-# rkt run --stage1-name=coreos.com/rkt/stage1-kvm:1.15.0 coreos.com/etcd:v2.0.9
+# rkt run --stage1-name=coreos.com/rkt/stage1-kvm:1.16.0 coreos.com/etcd:v2.0.9
 ...
 ```
 

--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -8,7 +8,7 @@ Support for overlay fs will be auto-detected if `--no-overlay` is set to `false`
 
 ```
 # rkt prepare --insecure-options=image docker://busybox --exec=/bin/sh
-image: using image from local store for image name coreos.com/rkt/stage1-coreos:1.15.0
+image: using image from local store for image name coreos.com/rkt/stage1-coreos:1.16.0
 image: remote fetching from URL "docker://busybox"
 Downloading sha256:8ddc19f1652 [===============================] 668 KB / 668 KB
 prepare: disabling overlay support: "unsupported filesystem: missing d_type support"
@@ -32,7 +32,7 @@ Therefore, the supported arguments are mostly the same as in `run` except runtim
 ```
 # rkt prepare coreos.com/etcd:v2.0.10
 rkt prepare coreos.com/etcd:v2.0.10
-rkt: using image from local store for image name coreos.com/rkt/stage1-coreos:1.15.0
+rkt: using image from local store for image name coreos.com/rkt/stage1-coreos:1.16.0
 rkt: searching for app image coreos.com/etcd:v2.0.10
 rkt: remote fetching from url https://github.com/coreos/etcd/releases/download/v2.0.10/etcd-v2.0.10-linux-amd64.aci
 prefix: "coreos.com/etcd"

--- a/Documentation/subcommands/version.md
+++ b/Documentation/subcommands/version.md
@@ -6,7 +6,7 @@ This command prints the rkt version, the appc version rkt is built against, and 
 
 ```
 $ rkt version
-rkt Version: 1.15.0
+rkt Version: 1.16.0
 appc Version: 0.8.7
 Go Version: go1.5.3
 Go OS/Arch: linux/amd64

--- a/Documentation/trying-out-rkt.md
+++ b/Documentation/trying-out-rkt.md
@@ -20,9 +20,9 @@ rkt is written in Go and can be compiled for several CPU architectures. The rkt 
 To start running the latest version of rkt on amd64, grab the release directly from the rkt GitHub project:
 
 ```
-wget https://github.com/coreos/rkt/releases/download/v1.15.0/rkt-v1.15.0.tar.gz
-tar xzvf rkt-v1.15.0.tar.gz
-cd rkt-v1.15.0
+wget https://github.com/coreos/rkt/releases/download/v1.16.0/rkt-v1.16.0.tar.gz
+tar xzvf rkt-v1.16.0.tar.gz
+cd rkt-v1.16.0
 ./rkt help
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,28 @@
+# rkt roadmap
+
+This document defines a high level roadmap for rkt development.
+The dates below should not be considered authoritative, but rather indicative of the projected timeline of the project.
+The [milestones defined in GitHub](https://github.com/coreos/rkt/milestones) represent the most up-to-date state of affairs.
+
+rkt is an implementation of the [App Container spec](https://github.com/appc/spec), which is still under active development on an approximately similar timeframe.
+The version of the spec that rkt implements can be seen in the output of `rkt version`.
+
+rkt's version 1.0 release marks the command line user interface and on-disk data structures as stable and reliable for external development. The (optional) API for pod inspection is not yet completely stabilized, but is quite usable.
+
+## Ongoing projects
+
+- [CRI](https://github.com/coreos/rkt/projects/1): implementation of the new Container Runtime Interface from Kubernetes.
+
+## Next releases
+
+### rkt 1.17.0 (October)
+
+Up-to-date planning at https://github.com/coreos/rkt/milestone/51.
+
+### rkt 1.18.0 (October)
+
+Up-to-date planning at https://github.com/coreos/rkt/milestone/52.
+
+### Upcoming
+
+Future tasks without a specific timeline are tracked at https://github.com/coreos/rkt/milestone/30.

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([rkt], [1.16.0], [https://github.com/coreos/rkt/issues])
+AC_INIT([rkt], [1.16.0+git], [https://github.com/coreos/rkt/issues])
 
 AC_PROG_CC
 AC_PROG_CXX

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([rkt], [1.15.0+git], [https://github.com/coreos/rkt/issues])
+AC_INIT([rkt], [1.16.0], [https://github.com/coreos/rkt/issues])
 
 AC_PROG_CC
 AC_PROG_CXX

--- a/scripts/install-rkt.sh
+++ b/scripts/install-rkt.sh
@@ -4,7 +4,7 @@ set -x
 
 cd $(mktemp -d)
 
-version="1.15.0"
+version="1.16.0"
 
 export DEBIAN_FRONTEND=noninteractive
 

--- a/tests/empty-image/manifest
+++ b/tests/empty-image/manifest
@@ -5,7 +5,7 @@
     "labels": [
         {
             "name": "version",
-            "value": "1.15.0"
+            "value": "1.16.0"
         },
         {
             "name": "arch",

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -5,7 +5,7 @@
     "labels": [
         {
             "name": "version",
-            "value": "1.15.0"
+            "value": "1.16.0"
         },
         {
             "name": "arch",

--- a/tests/rkt-monitor/build-stresser.sh
+++ b/tests/rkt-monitor/build-stresser.sh
@@ -27,7 +27,7 @@ buildImages() {
     acbuild --debug begin
     trap acbuildEnd EXIT
     acbuild --debug set-name appc.io/rkt-"${1}"-stresser
-    acbuild --debug copy build-rkt-1.16.0/target/bin/"${1}"-stresser /worker
+    acbuild --debug copy build-rkt-1.16.0+git/target/bin/"${1}"-stresser /worker
     acbuild --debug set-exec -- /worker
     acbuild --debug write --overwrite "${1}"-stresser.aci
     acbuild --debug end

--- a/tests/rkt-monitor/build-stresser.sh
+++ b/tests/rkt-monitor/build-stresser.sh
@@ -27,7 +27,7 @@ buildImages() {
     acbuild --debug begin
     trap acbuildEnd EXIT
     acbuild --debug set-name appc.io/rkt-"${1}"-stresser
-    acbuild --debug copy build-rkt-1.15.0+git/target/bin/"${1}"-stresser /worker
+    acbuild --debug copy build-rkt-1.16.0/target/bin/"${1}"-stresser /worker
     acbuild --debug set-exec -- /worker
     acbuild --debug write --overwrite "${1}"-stresser.aci
     acbuild --debug end

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.15.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
+	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.16.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
 )
 
 func TestRunOverrideExec(t *testing.T) {

--- a/tests/rkt_image_cat_manifest_test.go
+++ b/tests/rkt_image_cat_manifest_test.go
@@ -29,7 +29,7 @@ import (
 const (
 
 	// The expected image manifest of the 'rkt-inspect-image-cat-manifest.aci'.
-	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"IMG_NAME","labels":[{"name":"version","value":"1.15.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"IMG_NAME","labels":[{"name":"version","value":"1.16.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageCatManifest tests 'rkt image cat-manifest', it will:

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"IMG_NAME","labels":[{"name":"version","value":"1.15.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"IMG_NAME","labels":[{"name":"version","value":"1.16.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageExport tests 'rkt image export', it will import some existing

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"IMG_NAME","labels":[{"name":"version","value":"1.15.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"IMG_NAME","labels":[{"name":"version","value":"1.16.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageRender tests 'rkt image render', it will import some existing empty

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	manifestOSArchTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"IMG_NAME","labels":[{"name":"version","value":"1.15.0"}ARCH_OS],"app":{"exec":["/inspect", "--print-msg=HelloWorld"],"user":"0","group":"0","workingDirectory":"/"}}`
+	manifestOSArchTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.7","name":"IMG_NAME","labels":[{"name":"version","value":"1.16.0"}ARCH_OS],"app":{"exec":["/inspect", "--print-msg=HelloWorld"],"user":"0","group":"0","workingDirectory":"/"}}`
 )
 
 type osArchTest struct {


### PR DESCRIPTION
Release PR for rkt 1.16.0. This also re-introduces a minimal `ROADMAP.md`, just pointing to projects and milestones in GH and providing a month-scoped timeline.

Closes https://github.com/coreos/rkt/issues/3152
Closes https://github.com/coreos/rkt/issues/3206
Closes https://github.com/coreos/rkt/issues/3246