### PR TITLE
Docs: edited Documentation/distributions.md#centos

### DIFF
--- a/Documentation/distributions.md
+++ b/Documentation/distributions.md
@@ -20,6 +20,7 @@ sudo pacman -S rkt
 ## CentOS
 
 rkt is available in the [CentOS Community Build Service](https://cbs.centos.org/koji/packageinfo?packageID=4464) for CentOS 7.
+However, this is [not yet ready for production use](https://github.com/coreos/rkt/issues/1305) due to pending systemd upgrade issues.
 
 ## CoreOS
 


### PR DESCRIPTION
The CentOS community build for rkt is not ready due to pending systemd
upgrade issues. The docs should reflect this.