### PR TITLE
stage0: Create an mtab symlink if not present

### DIFF
--- a/stage0/run.go
+++ b/stage0/run.go
@@ -779,7 +779,7 @@ func ensureMtabExists(rootfs string) error {
 		return nil
 	}
 	if err != nil {
-		return errwrap.Wrap(errors.New("error determining if /etc existed in the image", err))
+		return errwrap.Wrap(errors.New("error determining if /etc existed in the image"), err)
 	}
 	if !stat.IsDir() {
 		return nil
@@ -796,7 +796,7 @@ func ensureMtabExists(rootfs string) error {
 	target := "../proc/self/mounts"
 	err = os.Symlink(target, mtabPath)
 	if err != nil {
-		return errwrap.Wrap(errors.New("error creating mtab symlink", err))
+		return errwrap.Wrap(errors.New("error creating mtab symlink"), err)
 	}
 	return nil
 }

--- a/tests/inspect/inspect.go
+++ b/tests/inspect/inspect.go
@@ -58,6 +58,7 @@ var (
 		WriteFile          bool
 		StatFile           bool
 		HashFile           bool
+		FileSymlinkTarget  bool
 		Sleep              int
 		PreSleep           int
 		PrintMemoryLimit   bool
@@ -102,6 +103,7 @@ func init() {
 	globalFlagset.BoolVar(&globalFlags.WriteFile, "write-file", false, "Write $CONTENT in the file $FILE")
 	globalFlagset.BoolVar(&globalFlags.StatFile, "stat-file", false, "Print the ownership and mode of the file $FILE")
 	globalFlagset.BoolVar(&globalFlags.HashFile, "hash-file", false, "Print the SHA1SUM of the file $FILE")
+	globalFlagset.BoolVar(&globalFlags.FileSymlinkTarget, "file-symlink-target", false, "Print the symlink target of $FILE")
 	globalFlagset.IntVar(&globalFlags.Sleep, "sleep", -1, "Sleep before exiting (in seconds)")
 	globalFlagset.IntVar(&globalFlags.PreSleep, "pre-sleep", -1, "Sleep before executing (in seconds)")
 	globalFlagset.BoolVar(&globalFlags.PrintMemoryLimit, "print-memorylimit", false, "Print cgroup memory limit")
@@ -387,6 +389,21 @@ func main() {
 		}
 
 		fmt.Printf("sha1sum: %x\n", sha1.Sum(dat))
+	}
+
+	if globalFlags.FileSymlinkTarget {
+		fileName := os.Getenv("FILE")
+		if globalFlags.FileName != "" {
+			fileName = globalFlags.FileName
+		}
+
+		dst, err := os.Readlink(fileName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Cannot read file target %q: %v\n", fileName, err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("symlink: %q -> %q\n", fileName, dst)
 	}
 
 	if globalFlags.PrintCwd {

--- a/tests/rkt_mtab_test.go
+++ b/tests/rkt_mtab_test.go
@@ -1,0 +1,36 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/coreos/rkt/tests/testutils"
+)
+
+// TestMtabExistence tests the happy path for the creation of the /etc/mtab
+// symlink
+func TestMtabExistence(t *testing.T) {
+	imageFile := patchTestACI("rkt-inspect-exit.aci", "--exec=/inspect --print-msg=Hello --file-symlink-target")
+	defer os.Remove(imageFile)
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	expectedLine := `symlink: "/etc/mtab" -> "../proc/self/mounts"`
+	rktCmd := fmt.Sprintf(`%s --insecure-options=image run --set-env=FILE=/etc/mtab %s`, ctx.Cmd(), imageFile)
+	runRktAndCheckOutput(t, rktCmd, expectedLine, false)
+}


### PR DESCRIPTION
Several Linux tools expect this to exist, but several images do not
include it. This creates it when it does not exist.

Fixes #3264 