### PR TITLE
CRI: Support volume creation at app add time

### DIFF
--- a/common/apps/apps.go
+++ b/common/apps/apps.go
@@ -135,6 +135,9 @@ func (al *Apps) Validate() error {
 
 	f := func(mnts []schema.Mount) error {
 		for _, m := range mnts {
+			if m.AppVolume != nil { // allow app-specific volumes
+				continue
+			}
 			if _, ok := vs[m.Volume]; !ok {
 				return fmt.Errorf("dangling mount point %q: volume %q not found", m.Path, m.Volume)
 			}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e46e7753f21a9e40ec5ea564528bf072f6d95fdf41cd84fb2425ecba6997fad0
-updated: 2016-10-07T16:19:41.626284078+02:00
+hash: d4f696c75b3692bcd02b8bf9213877c29ba64e88d7f2d6f2135e90758fbb077a
+updated: 2016-10-07T17:16:38.289201403+02:00
 imports:
 - name: github.com/appc/docker2aci
   version: 15d68b33bfee95a448c4da37dbe876baa8fcb5b6
@@ -206,6 +206,8 @@ imports:
   version: 19b0b332c9e4516a6370a0456e6182c3b5036720
 - name: github.com/klauspost/pgzip
   version: 95e8170c5d4da28db9c64dfc9ec3138ea4466fd4
+- name: github.com/kr/pretty
+  version: cfb55aafdaf3ec08f0db22699ab822c50091b1c4
 - name: github.com/kr/pty
   version: f7ee69f31298ecbe5d2b349c711e2547a617d398
 - name: github.com/pborman/uuid
@@ -297,4 +299,6 @@ imports:
   - pkg/api/resource
   - pkg/conversion
   - third_party/forked/reflect
-testImports: []
+testImports:
+- name: github.com/kr/text
+  version: 7cafcd837844e784b526369c9bce262804aebc60

--- a/glide.yaml
+++ b/glide.yaml
@@ -290,3 +290,5 @@ import:
   - spew
 - package: github.com/hashicorp/golang-lru
   version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
+- package: github.com/kr/pretty
+  version: cfb55aafdaf3ec08f0db22699ab822c50091b1c4

--- a/rkt/app_add.go
+++ b/rkt/app_add.go
@@ -42,6 +42,9 @@ func init() {
 	addAppFlags(cmdAppAdd)
 	addIsolatorFlags(cmdAppAdd, false)
 
+	// Add per-app volume mounts only for sandbox for now
+	cmdAppAdd.Flags().Var((*appMountVolume)(&rktApps), "mnt-volume", "Configure a per-app mount and volume directly")
+
 	// Disable interspersed flags to stop parsing after the first non flag
 	// argument. All the subsequent parsing will be done by parseApps.
 	// This is needed to correctly handle image args

--- a/stage0/app.go
+++ b/stage0/app.go
@@ -186,6 +186,7 @@ func AddApp(cfg AddConfig) error {
 			ID:     cfg.Image,
 			Labels: am.Labels,
 		},
+		Mounts:         MergeMounts(cfg.Apps.Mounts, app.Mounts),
 		ReadOnlyRootFS: app.ReadOnlyRootFS,
 	}
 

--- a/stage1/app-add/app-add.go
+++ b/stage1/app-add/app-add.go
@@ -128,6 +128,8 @@ func main() {
 		}
 	}
 
+	stage1initcommon.AppAddMounts(p, ra, enterCmd)
+
 	/* write service file */
 	binPath, err := stage1initcommon.FindBinPath(p, ra)
 	if err != nil {

--- a/stage1/init/common/mount.go
+++ b/stage1/init/common/mount.go
@@ -16,7 +16,9 @@ package common
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"syscall"
@@ -27,6 +29,8 @@ import (
 	"github.com/appc/spec/schema"
 	"github.com/appc/spec/schema/types"
 	"github.com/hashicorp/errwrap"
+
+	stage1commontypes "github.com/coreos/rkt/stage1/common/types"
 )
 
 /*
@@ -38,32 +42,19 @@ import (
 // mountWrapper is a wrapper around a schema.Mount with an additional field indicating
 // whether it is an implicit empty volume converted from a Docker image.
 type mountWrapper struct {
-	schema.Mount
+	Mount          schema.Mount
+	Volume         types.Volume
 	DockerImplicit bool
+	ReadOnly       bool
 }
 
-func isMPReadOnly(mountPoints []types.MountPoint, name types.ACName) bool {
-	for _, mp := range mountPoints {
-		if mp.Name == name {
-			return mp.ReadOnly
-		}
+// ConvertedFromDocker determines if an app's image has been converted
+// from docker. This is needed because implicit docker empty volumes have
+// different behavior from AppC
+func ConvertedFromDocker(im *schema.ImageManifest) bool {
+	if im == nil { // nil sometimes sneaks in here due to unit tests
+		return false
 	}
-
-	return false
-}
-
-// IsMountReadOnly returns if a mount should be readOnly.
-// If the readOnly flag in the pod manifest is not nil, it overrides the
-// readOnly flag in the image manifest.
-func IsMountReadOnly(vol types.Volume, mountPoints []types.MountPoint) bool {
-	if vol.ReadOnly != nil {
-		return *vol.ReadOnly
-	}
-
-	return isMPReadOnly(mountPoints, vol.Name)
-}
-
-func convertedFromDocker(im *schema.ImageManifest) bool {
 	ann := im.Annotations
 	_, ok := ann.Get("appc.io/docker/repository")
 	return ok
@@ -72,27 +63,69 @@ func convertedFromDocker(im *schema.ImageManifest) bool {
 // GenerateMounts maps MountPoint paths to volumes, returning a list of mounts,
 // each with a parameter indicating if it's an implicit empty volume from a
 // Docker image.
-func GenerateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume, imageManifest *schema.ImageManifest) []mountWrapper {
+func GenerateMounts(ra *schema.RuntimeApp, podVolumes []types.Volume, convertedFromDocker bool) ([]mountWrapper, error) {
 	app := ra.App
 
 	var genMnts []mountWrapper
 
+	vols := make(map[types.ACName]types.Volume)
+	for _, v := range podVolumes {
+		vols[v.Name] = v
+	}
+
+	// RuntimeApps have mounts, whereas Apps have mountPoints. mountPoints are partially for
+	// Docker compat; since apps can declare mountpoints. However, if we just run with rkt run,
+	// then we'll only have a Mount and no corresponding MountPoint.
+	// Furthermore, Mounts can have embedded volumes in the case of the CRI.
+	// So, we generate a pile of Mounts and their corresponding Volume
+
+	// Map of hostpath -> Mount
 	mnts := make(map[string]schema.Mount)
+
+	// Check runtimeApp's Mounts
 	for _, m := range ra.Mounts {
 		mnts[m.Path] = m
+
+		vol := m.AppVolume // Mounts can supply a volume
+		if vol == nil {
+			vv, ok := vols[m.Volume]
+			if !ok {
+				return nil, fmt.Errorf("could not find volume %s", m.Volume)
+			}
+			vol = &vv
+		}
+
+		// Find a corresponding MountPoint, which is optional
+		ro := false
+		for _, mp := range ra.App.MountPoints {
+			if mp.Name == m.Volume {
+				ro = mp.ReadOnly
+				break
+			}
+		}
+		if vol.ReadOnly != nil {
+			ro = *vol.ReadOnly
+		}
+
 		genMnts = append(genMnts,
 			mountWrapper{
 				Mount:          m,
 				DockerImplicit: false,
+				ReadOnly:       ro,
+				Volume:         *vol,
 			})
 	}
 
+	// Now, match up MountPoints with Mounts or Volumes
+	// If there's no Mount and no Volume, generate an empty volume
 	for _, mp := range app.MountPoints {
-		// there's already an injected mount for this target path, skip
+		// there's already a Mount for this MountPoint, stop
 		if _, ok := mnts[mp.Path]; ok {
 			continue
 		}
-		vol, ok := volumes[mp.Name]
+
+		// No Mount, try to match based on volume name
+		vol, ok := vols[mp.Name]
 		// there is no volume for this mount point, creating an "empty" volume
 		// implicitly
 		if !ok {
@@ -108,34 +141,41 @@ func GenerateMounts(ra *schema.RuntimeApp, volumes map[types.ACName]types.Volume
 				GID:  &defaultGID,
 			}
 
-			dockerImplicit := convertedFromDocker(imageManifest)
 			log.Printf("warning: no volume specified for mount point %q, implicitly creating an \"empty\" volume. This volume will be removed when the pod is garbage-collected.", mp.Name)
-			if dockerImplicit {
+			if convertedFromDocker {
 				log.Printf("Docker converted image, initializing implicit volume with data contained at the mount point %q.", mp.Name)
 			}
 
-			volumes[uniqName] = emptyVol
+			vols[uniqName] = emptyVol
 			genMnts = append(genMnts,
 				mountWrapper{
 					Mount: schema.Mount{
 						Volume: uniqName,
 						Path:   mp.Path,
 					},
-					DockerImplicit: dockerImplicit,
+					Volume:         emptyVol,
+					ReadOnly:       mp.ReadOnly,
+					DockerImplicit: convertedFromDocker,
 				})
 		} else {
+			ro := mp.ReadOnly
+			if vol.ReadOnly != nil {
+				ro = *vol.ReadOnly
+			}
 			genMnts = append(genMnts,
 				mountWrapper{
 					Mount: schema.Mount{
 						Volume: vol.Name,
 						Path:   mp.Path,
 					},
+					Volume:         vol,
+					ReadOnly:       ro,
 					DockerImplicit: false,
 				})
 		}
 	}
 
-	return genMnts
+	return genMnts, nil
 }
 
 // PrepareMountpoints creates and sets permissions for empty volumes.
@@ -237,4 +277,148 @@ func ensureDestinationExists(source, destination string) error {
 		}
 	}
 	return nil
+}
+
+func AppAddMounts(p *stage1commontypes.Pod, ra *schema.RuntimeApp, enterCmd []string) {
+	vols := make(map[types.ACName]types.Volume)
+	for _, v := range p.Manifest.Volumes {
+		vols[v.Name] = v
+	}
+
+	imageManifest := p.Images[ra.Name.String()]
+
+	mounts, err := GenerateMounts(ra, p.Manifest.Volumes, ConvertedFromDocker(imageManifest))
+	if err != nil {
+		log.FatalE("Could not generate mounts", err)
+		os.Exit(1)
+	}
+
+	for _, m := range mounts {
+		AppAddOneMount(p, ra, m.Volume.Source, m.Mount.Path, m.ReadOnly, enterCmd)
+	}
+}
+
+/* AppAddOneMount bind-mounts "sourcePath" from the host into "dstPath" in
+ * the container.
+ *
+ * We use the propagation mechanism of systemd-nspawn. In all systemd-nspawn
+ * containers, the directory "/run/systemd/nspawn/propagate/$MACHINE_ID" on
+ * the host is propagating mounts to the directory
+ * "/run/systemd/nspawn/incoming/" in the container mount namespace. Once a
+ * bind mount is propagated, we simply move to its correct location.
+ *
+ * The algorithm is the same as in "machinectl bind":
+ * https://github.com/systemd/systemd/blob/v231/src/machine/machine-dbus.c#L865
+ * except that we don't use setns() to enter the mount namespace of the pod
+ * because Linux does not allow multithreaded applications (such as Go
+ * programs) to change mount namespaces with setns. Instead, we fork another
+ * process written in C (single-threaded) to enter the mount namespace. The
+ * command used is specified by the "enterCmd" parameter.
+ *
+ * Users might request a bind mount to be set up read-only. This complicates
+ * things a bit because on Linux, setting up a read-only bind mount involves
+ * two mount() calls, so it is not atomic. We don't want the container to see
+ * the mount in read-write mode, even for a short time, so we don't create the
+ * bind mount directly in "/run/systemd/nspawn/propagate/$MACHINE_ID" to avoid
+ * an immediate propagation to the container. Instead, we create a temporary
+ * playground in "/tmp/rkt.propagate.XXXX" and create the bind mount in
+ * "/tmp/rkt.propagate.XXXX/mount" with the correct read-only attribute before
+ * moving it.
+ *
+ * Another complication is that the playground cannot be on a shared mount
+ * because Linux does not allow MS_MOVE to be applied to mounts with MS_SHARED
+ * parent mounts. But by default, systemd mounts everything as shared, see:
+ * https://github.com/systemd/systemd/blob/v231/src/core/mount-setup.c#L392
+ * We set up the temporary playground as a slave bind mount to avoid this
+ * limitation.
+ */
+func AppAddOneMount(p *stage1commontypes.Pod, ra *schema.RuntimeApp, sourcePath string, dstPath string, readOnly bool, enterCmd []string) {
+	/* The general plan:
+	 * - bind-mount sourcePath to mountTmp
+	 * - MS_MOVE mountTmp to mountOutside, the systemd propagate dir
+	 * - systemd moves mountOutside to mountInside
+	 * - in the stage1 namespace, bind mountInside to the app's rootfs
+	 */
+
+	/* Prepare a temporary playground that is not a shared mount */
+	playgroundMount, err := ioutil.TempDir("", "rkt.propagate.")
+	if err != nil {
+		log.FatalE("error creating temporary propagation directory", err)
+		os.Exit(1)
+	}
+	defer os.Remove(playgroundMount)
+
+	err = syscall.Mount(playgroundMount, playgroundMount, "bind", syscall.MS_BIND, "")
+	if err != nil {
+		log.FatalE("error mounting temporary directory", err)
+		os.Exit(1)
+	}
+	defer syscall.Unmount(playgroundMount, 0)
+
+	err = syscall.Mount("", playgroundMount, "none", syscall.MS_SLAVE, "")
+	if err != nil {
+		log.FatalE("error mounting temporary directory", err)
+		os.Exit(1)
+	}
+
+	/* Bind mount the source into the playground, possibly read-only */
+	mountTmp := filepath.Join(playgroundMount, "mount")
+	if err := ensureDestinationExists(sourcePath, mountTmp); err != nil {
+		log.FatalE("error creating temporary mountpoint", err)
+		os.Exit(1)
+	}
+	defer os.Remove(mountTmp)
+
+	err = syscall.Mount(sourcePath, mountTmp, "bind", syscall.MS_BIND, "")
+	if err != nil {
+		log.FatalE("error mounting temporary mountpoint", err)
+		os.Exit(1)
+	}
+	defer syscall.Unmount(mountTmp, 0)
+
+	if readOnly {
+		err = syscall.Mount("", mountTmp, "bind", syscall.MS_REMOUNT|syscall.MS_RDONLY|syscall.MS_BIND, "")
+		if err != nil {
+			log.FatalE("error remounting temporary mountpoint read-only", err)
+			os.Exit(1)
+		}
+	}
+
+	/* Now that the bind mount has the correct attributes (RO or RW), move
+	 * it to the propagation directory prepared by systemd-nspawn */
+	mountOutside := filepath.Join("/run/systemd/nspawn/propagate/", "rkt-"+p.UUID.String(), "rkt.mount")
+	mountInside := filepath.Join("/run/systemd/nspawn/incoming/", filepath.Base(mountOutside))
+	if err := ensureDestinationExists(sourcePath, mountOutside); err != nil {
+		log.FatalE("error creating propagate mountpoint", err)
+		os.Exit(1)
+	}
+	defer os.Remove(mountOutside)
+
+	err = syscall.Mount(mountTmp, mountOutside, "", syscall.MS_MOVE, "")
+	if err != nil {
+		log.FatalE("error moving temporary mountpoint to propagate directory", err)
+		os.Exit(1)
+	}
+	defer syscall.Unmount(mountOutside, 0)
+
+	/* Finally move the bind mount at the correct place inside the container. */
+	mountDst := filepath.Join("/opt/stage2", ra.Name.String(), "rootfs", dstPath)
+	mountDstOutside := filepath.Join(p.Root, "stage1/rootfs", mountDst)
+	if err := ensureDestinationExists(sourcePath, mountDstOutside); err != nil {
+		log.FatalE("error creating destination directory", err)
+		os.Exit(1)
+	}
+
+	args := enterCmd
+	args = append(args, "/bin/mount", "--move", mountInside, mountDst)
+
+	cmd := exec.Cmd{
+		Path: args[0],
+		Args: args,
+	}
+
+	if err := cmd.Run(); err != nil {
+		log.PrintE("error executing mount move", err)
+		os.Exit(1)
+	}
 }

--- a/stage1/init/common/mount_test.go
+++ b/stage1/init/common/mount_test.go
@@ -1,0 +1,189 @@
+// Copyright 2014 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kr/pretty"
+
+	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
+)
+
+func TestGenerateMounts(t *testing.T) {
+	tests := []struct {
+		ra         *schema.RuntimeApp
+		vols       []types.Volume
+		fromDocker bool
+		hasErr     bool
+		expected   []mountWrapper
+	}{
+		{ // Test matching ra.mount to volume via name w/o/ mountpoint
+			ra: &schema.RuntimeApp{
+				Mounts: []schema.Mount{
+					{
+						Volume: *types.MustACName("foo-mount"),
+						Path:   "/app/foo",
+					},
+				},
+				App: &types.App{
+					MountPoints: nil,
+				},
+			},
+			vols: []types.Volume{
+				{
+					Name:     *types.MustACName("foo-mount"),
+					Kind:     "host",
+					Source:   "/host/foo",
+					ReadOnly: &falseVar,
+				},
+			},
+			fromDocker: false,
+			hasErr:     false,
+			expected: []mountWrapper{
+				{
+					Mount: schema.Mount{
+						Volume: *types.MustACName("foo-mount"),
+						Path:   "/app/foo",
+					},
+					Volume: types.Volume{
+						Name:     *types.MustACName("foo-mount"),
+						Kind:     "host",
+						Source:   "/host/foo",
+						ReadOnly: &falseVar,
+					},
+					DockerImplicit: false,
+					ReadOnly:       false,
+				},
+			},
+		},
+		{ // Test matching app's mountpoint to a volume w/o a mount
+			ra: &schema.RuntimeApp{
+				Mounts: nil,
+				App: &types.App{
+					MountPoints: []types.MountPoint{
+						{
+							Name:     *types.MustACName("foo-mp"),
+							Path:     "/app/foo-mp",
+							ReadOnly: false,
+						},
+					},
+				},
+			},
+			vols: []types.Volume{
+				{
+					Name:     *types.MustACName("foo-mount"),
+					Kind:     "host",
+					Source:   "/host/foo",
+					ReadOnly: &falseVar,
+				},
+				{
+					Name:     *types.MustACName("foo-mp"),
+					Kind:     "host",
+					Source:   "/host/bar",
+					ReadOnly: &falseVar,
+				},
+			},
+			fromDocker: false,
+			hasErr:     false,
+			expected: []mountWrapper{
+				{
+					Mount: schema.Mount{
+						Volume: *types.MustACName("foo-mp"),
+						Path:   "/app/foo-mp",
+					},
+					Volume: types.Volume{
+						Name:     *types.MustACName("foo-mp"),
+						Kind:     "host",
+						Source:   "/host/bar",
+						ReadOnly: &falseVar,
+					},
+					DockerImplicit: false,
+					ReadOnly:       false,
+				},
+			},
+		},
+		{ // Test that app's Mount can override the volume
+			ra: &schema.RuntimeApp{
+				Mounts: []schema.Mount{
+					{
+						Volume: *types.MustACName("foo-mount"),
+						Path:   "/app/foo",
+						AppVolume: &types.Volume{
+							Name:     *types.MustACName("foo-mount"),
+							Kind:     "host",
+							Source:   "/host/overridden",
+							ReadOnly: nil,
+						},
+					},
+				},
+
+				App: &types.App{
+					MountPoints: nil,
+				},
+			},
+			vols: []types.Volume{
+				{
+					Name:     *types.MustACName("foo-mount"),
+					Kind:     "host",
+					Source:   "/host/foo",
+					ReadOnly: &falseVar,
+				},
+				{
+					Name:     *types.MustACName("foo-mp"),
+					Kind:     "host",
+					Source:   "/host/bar",
+					ReadOnly: &falseVar,
+				},
+			},
+			fromDocker: false,
+			hasErr:     false,
+			expected: []mountWrapper{
+				{
+					Mount: schema.Mount{
+						Volume: *types.MustACName("foo-mount"),
+						Path:   "/app/foo",
+						AppVolume: &types.Volume{
+							Name:     *types.MustACName("foo-mount"),
+							Kind:     "host",
+							Source:   "/host/overridden",
+							ReadOnly: nil,
+						},
+					},
+					Volume: types.Volume{
+						Name:     *types.MustACName("foo-mount"),
+						Kind:     "host",
+						Source:   "/host/overridden",
+						ReadOnly: nil,
+					},
+					DockerImplicit: false,
+					ReadOnly:       false,
+				},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		result, err := GenerateMounts(tt.ra, tt.vols, tt.fromDocker)
+		if (err != nil) != tt.hasErr {
+			t.Errorf("test %d expected error status %t, didn't get it", i, tt.hasErr)
+		}
+		if !reflect.DeepEqual(result, tt.expected) {
+			t.Errorf("test %d, result != expected, %+v", i, pretty.Diff(tt.expected, result))
+		}
+	}
+}

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -698,6 +698,7 @@ func stage1() int {
 			return 1
 		}
 	}
+	diag.Println(args)
 
 	err = stage1common.WithClearedCloExec(lfd, func() error {
 		return syscall.Exec(args[0], args, env)

--- a/tests/rkt_volume_mount_test.go
+++ b/tests/rkt_volume_mount_test.go
@@ -180,7 +180,7 @@ var (
 								{"FILE", mountFilePath},
 							},
 							MountPoints: []types.MountPoint{
-								{mountName, mountDir, false, nil},
+								{mountName, mountDir, false},
 							},
 						},
 					},
@@ -213,7 +213,7 @@ var (
 								{"CONTENT", "should-not-see-me"},
 							},
 							MountPoints: []types.MountPoint{
-								{mountName, mountDir, false, nil},
+								{mountName, mountDir, false},
 							},
 						},
 					},
@@ -249,7 +249,7 @@ var (
 								{"CONTENT", "host:foo"},
 							},
 							MountPoints: []types.MountPoint{
-								{mountName, mountDir, false, nil},
+								{mountName, mountDir, false},
 							},
 						},
 						ReadOnlyRootFS: true,
@@ -285,7 +285,7 @@ var (
 								{"FILE", mountFilePath},
 							},
 							MountPoints: []types.MountPoint{
-								{mountName, mountDir, false, nil},
+								{mountName, mountDir, false},
 							},
 						},
 					},

--- a/tests/rkt_volume_test.go
+++ b/tests/rkt_volume_test.go
@@ -271,7 +271,7 @@ func TestDockerVolumeSemanticsPodManifest(t *testing.T) {
 							{"FILE", fmt.Sprintf("%s/file", tt.dir)},
 						},
 						MountPoints: []types.MountPoint{
-							{"mydir", tt.dir, false, nil},
+							{"mydir", tt.dir, false},
 						},
 					},
 					Image: schema.RuntimeImage{

--- a/vendor/github.com/kr/pretty/License
+++ b/vendor/github.com/kr/pretty/License
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright 2012 Keith Rarick
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/kr/pretty/diff.go
+++ b/vendor/github.com/kr/pretty/diff.go
@@ -1,0 +1,265 @@
+package pretty
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+)
+
+type sbuf []string
+
+func (p *sbuf) Printf(format string, a ...interface{}) {
+	s := fmt.Sprintf(format, a...)
+	*p = append(*p, s)
+}
+
+// Diff returns a slice where each element describes
+// a difference between a and b.
+func Diff(a, b interface{}) (desc []string) {
+	Pdiff((*sbuf)(&desc), a, b)
+	return desc
+}
+
+// wprintfer calls Fprintf on w for each Printf call
+// with a trailing newline.
+type wprintfer struct{ w io.Writer }
+
+func (p *wprintfer) Printf(format string, a ...interface{}) {
+	fmt.Fprintf(p.w, format+"\n", a...)
+}
+
+// Fdiff writes to w a description of the differences between a and b.
+func Fdiff(w io.Writer, a, b interface{}) {
+	Pdiff(&wprintfer{w}, a, b)
+}
+
+type Printfer interface {
+	Printf(format string, a ...interface{})
+}
+
+// Pdiff prints to p a description of the differences between a and b.
+// It calls Printf once for each difference, with no trailing newline.
+// The standard library log.Logger is a Printfer.
+func Pdiff(p Printfer, a, b interface{}) {
+	diffPrinter{w: p}.diff(reflect.ValueOf(a), reflect.ValueOf(b))
+}
+
+type Logfer interface {
+	Logf(format string, a ...interface{})
+}
+
+// logprintfer calls Fprintf on w for each Printf call
+// with a trailing newline.
+type logprintfer struct{ l Logfer }
+
+func (p *logprintfer) Printf(format string, a ...interface{}) {
+	p.l.Logf(format, a...)
+}
+
+// Ldiff prints to l a description of the differences between a and b.
+// It calls Logf once for each difference, with no trailing newline.
+// The standard library testing.T and testing.B are Logfers.
+func Ldiff(l Logfer, a, b interface{}) {
+	Pdiff(&logprintfer{l}, a, b)
+}
+
+type diffPrinter struct {
+	w Printfer
+	l string // label
+}
+
+func (w diffPrinter) printf(f string, a ...interface{}) {
+	var l string
+	if w.l != "" {
+		l = w.l + ": "
+	}
+	w.w.Printf(l+f, a...)
+}
+
+func (w diffPrinter) diff(av, bv reflect.Value) {
+	if !av.IsValid() && bv.IsValid() {
+		w.printf("nil != %# v", formatter{v: bv, quote: true})
+		return
+	}
+	if av.IsValid() && !bv.IsValid() {
+		w.printf("%# v != nil", formatter{v: av, quote: true})
+		return
+	}
+	if !av.IsValid() && !bv.IsValid() {
+		return
+	}
+
+	at := av.Type()
+	bt := bv.Type()
+	if at != bt {
+		w.printf("%v != %v", at, bt)
+		return
+	}
+
+	switch kind := at.Kind(); kind {
+	case reflect.Bool:
+		if a, b := av.Bool(), bv.Bool(); a != b {
+			w.printf("%v != %v", a, b)
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if a, b := av.Int(), bv.Int(); a != b {
+			w.printf("%d != %d", a, b)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		if a, b := av.Uint(), bv.Uint(); a != b {
+			w.printf("%d != %d", a, b)
+		}
+	case reflect.Float32, reflect.Float64:
+		if a, b := av.Float(), bv.Float(); a != b {
+			w.printf("%v != %v", a, b)
+		}
+	case reflect.Complex64, reflect.Complex128:
+		if a, b := av.Complex(), bv.Complex(); a != b {
+			w.printf("%v != %v", a, b)
+		}
+	case reflect.Array:
+		n := av.Len()
+		for i := 0; i < n; i++ {
+			w.relabel(fmt.Sprintf("[%d]", i)).diff(av.Index(i), bv.Index(i))
+		}
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		if a, b := av.Pointer(), bv.Pointer(); a != b {
+			w.printf("%#x != %#x", a, b)
+		}
+	case reflect.Interface:
+		w.diff(av.Elem(), bv.Elem())
+	case reflect.Map:
+		ak, both, bk := keyDiff(av.MapKeys(), bv.MapKeys())
+		for _, k := range ak {
+			w := w.relabel(fmt.Sprintf("[%#v]", k))
+			w.printf("%q != (missing)", av.MapIndex(k))
+		}
+		for _, k := range both {
+			w := w.relabel(fmt.Sprintf("[%#v]", k))
+			w.diff(av.MapIndex(k), bv.MapIndex(k))
+		}
+		for _, k := range bk {
+			w := w.relabel(fmt.Sprintf("[%#v]", k))
+			w.printf("(missing) != %q", bv.MapIndex(k))
+		}
+	case reflect.Ptr:
+		switch {
+		case av.IsNil() && !bv.IsNil():
+			w.printf("nil != %# v", formatter{v: bv, quote: true})
+		case !av.IsNil() && bv.IsNil():
+			w.printf("%# v != nil", formatter{v: av, quote: true})
+		case !av.IsNil() && !bv.IsNil():
+			w.diff(av.Elem(), bv.Elem())
+		}
+	case reflect.Slice:
+		lenA := av.Len()
+		lenB := bv.Len()
+		if lenA != lenB {
+			w.printf("%s[%d] != %s[%d]", av.Type(), lenA, bv.Type(), lenB)
+			break
+		}
+		for i := 0; i < lenA; i++ {
+			w.relabel(fmt.Sprintf("[%d]", i)).diff(av.Index(i), bv.Index(i))
+		}
+	case reflect.String:
+		if a, b := av.String(), bv.String(); a != b {
+			w.printf("%q != %q", a, b)
+		}
+	case reflect.Struct:
+		for i := 0; i < av.NumField(); i++ {
+			w.relabel(at.Field(i).Name).diff(av.Field(i), bv.Field(i))
+		}
+	default:
+		panic("unknown reflect Kind: " + kind.String())
+	}
+}
+
+func (d diffPrinter) relabel(name string) (d1 diffPrinter) {
+	d1 = d
+	if d.l != "" && name[0] != '[' {
+		d1.l += "."
+	}
+	d1.l += name
+	return d1
+}
+
+// keyEqual compares a and b for equality.
+// Both a and b must be valid map keys.
+func keyEqual(av, bv reflect.Value) bool {
+	if !av.IsValid() && !bv.IsValid() {
+		return true
+	}
+	if !av.IsValid() || !bv.IsValid() || av.Type() != bv.Type() {
+		return false
+	}
+	switch kind := av.Kind(); kind {
+	case reflect.Bool:
+		a, b := av.Bool(), bv.Bool()
+		return a == b
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		a, b := av.Int(), bv.Int()
+		return a == b
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		a, b := av.Uint(), bv.Uint()
+		return a == b
+	case reflect.Float32, reflect.Float64:
+		a, b := av.Float(), bv.Float()
+		return a == b
+	case reflect.Complex64, reflect.Complex128:
+		a, b := av.Complex(), bv.Complex()
+		return a == b
+	case reflect.Array:
+		for i := 0; i < av.Len(); i++ {
+			if !keyEqual(av.Index(i), bv.Index(i)) {
+				return false
+			}
+		}
+		return true
+	case reflect.Chan, reflect.UnsafePointer, reflect.Ptr:
+		a, b := av.Pointer(), bv.Pointer()
+		return a == b
+	case reflect.Interface:
+		return keyEqual(av.Elem(), bv.Elem())
+	case reflect.String:
+		a, b := av.String(), bv.String()
+		return a == b
+	case reflect.Struct:
+		for i := 0; i < av.NumField(); i++ {
+			if !keyEqual(av.Field(i), bv.Field(i)) {
+				return false
+			}
+		}
+		return true
+	default:
+		panic("invalid map key type " + av.Type().String())
+	}
+}
+
+func keyDiff(a, b []reflect.Value) (ak, both, bk []reflect.Value) {
+	for _, av := range a {
+		inBoth := false
+		for _, bv := range b {
+			if keyEqual(av, bv) {
+				inBoth = true
+				both = append(both, av)
+				break
+			}
+		}
+		if !inBoth {
+			ak = append(ak, av)
+		}
+	}
+	for _, bv := range b {
+		inBoth := false
+		for _, av := range a {
+			if keyEqual(av, bv) {
+				inBoth = true
+				break
+			}
+		}
+		if !inBoth {
+			bk = append(bk, bv)
+		}
+	}
+	return
+}

--- a/vendor/github.com/kr/pretty/formatter.go
+++ b/vendor/github.com/kr/pretty/formatter.go
@@ -1,0 +1,328 @@
+package pretty
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/kr/text"
+)
+
+type formatter struct {
+	v     reflect.Value
+	force bool
+	quote bool
+}
+
+// Formatter makes a wrapper, f, that will format x as go source with line
+// breaks and tabs. Object f responds to the "%v" formatting verb when both the
+// "#" and " " (space) flags are set, for example:
+//
+//     fmt.Sprintf("%# v", Formatter(x))
+//
+// If one of these two flags is not set, or any other verb is used, f will
+// format x according to the usual rules of package fmt.
+// In particular, if x satisfies fmt.Formatter, then x.Format will be called.
+func Formatter(x interface{}) (f fmt.Formatter) {
+	return formatter{v: reflect.ValueOf(x), quote: true}
+}
+
+func (fo formatter) String() string {
+	return fmt.Sprint(fo.v.Interface()) // unwrap it
+}
+
+func (fo formatter) passThrough(f fmt.State, c rune) {
+	s := "%"
+	for i := 0; i < 128; i++ {
+		if f.Flag(i) {
+			s += string(i)
+		}
+	}
+	if w, ok := f.Width(); ok {
+		s += fmt.Sprintf("%d", w)
+	}
+	if p, ok := f.Precision(); ok {
+		s += fmt.Sprintf(".%d", p)
+	}
+	s += string(c)
+	fmt.Fprintf(f, s, fo.v.Interface())
+}
+
+func (fo formatter) Format(f fmt.State, c rune) {
+	if fo.force || c == 'v' && f.Flag('#') && f.Flag(' ') {
+		w := tabwriter.NewWriter(f, 4, 4, 1, ' ', 0)
+		p := &printer{tw: w, Writer: w, visited: make(map[visit]int)}
+		p.printValue(fo.v, true, fo.quote)
+		w.Flush()
+		return
+	}
+	fo.passThrough(f, c)
+}
+
+type printer struct {
+	io.Writer
+	tw      *tabwriter.Writer
+	visited map[visit]int
+	depth   int
+}
+
+func (p *printer) indent() *printer {
+	q := *p
+	q.tw = tabwriter.NewWriter(p.Writer, 4, 4, 1, ' ', 0)
+	q.Writer = text.NewIndentWriter(q.tw, []byte{'\t'})
+	return &q
+}
+
+func (p *printer) printInline(v reflect.Value, x interface{}, showType bool) {
+	if showType {
+		io.WriteString(p, v.Type().String())
+		fmt.Fprintf(p, "(%#v)", x)
+	} else {
+		fmt.Fprintf(p, "%#v", x)
+	}
+}
+
+// printValue must keep track of already-printed pointer values to avoid
+// infinite recursion.
+type visit struct {
+	v   uintptr
+	typ reflect.Type
+}
+
+func (p *printer) printValue(v reflect.Value, showType, quote bool) {
+	if p.depth > 10 {
+		io.WriteString(p, "!%v(DEPTH EXCEEDED)")
+		return
+	}
+
+	switch v.Kind() {
+	case reflect.Bool:
+		p.printInline(v, v.Bool(), showType)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		p.printInline(v, v.Int(), showType)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		p.printInline(v, v.Uint(), showType)
+	case reflect.Float32, reflect.Float64:
+		p.printInline(v, v.Float(), showType)
+	case reflect.Complex64, reflect.Complex128:
+		fmt.Fprintf(p, "%#v", v.Complex())
+	case reflect.String:
+		p.fmtString(v.String(), quote)
+	case reflect.Map:
+		t := v.Type()
+		if showType {
+			io.WriteString(p, t.String())
+		}
+		writeByte(p, '{')
+		if nonzero(v) {
+			expand := !canInline(v.Type())
+			pp := p
+			if expand {
+				writeByte(p, '\n')
+				pp = p.indent()
+			}
+			keys := v.MapKeys()
+			for i := 0; i < v.Len(); i++ {
+				showTypeInStruct := true
+				k := keys[i]
+				mv := v.MapIndex(k)
+				pp.printValue(k, false, true)
+				writeByte(pp, ':')
+				if expand {
+					writeByte(pp, '\t')
+				}
+				showTypeInStruct = t.Elem().Kind() == reflect.Interface
+				pp.printValue(mv, showTypeInStruct, true)
+				if expand {
+					io.WriteString(pp, ",\n")
+				} else if i < v.Len()-1 {
+					io.WriteString(pp, ", ")
+				}
+			}
+			if expand {
+				pp.tw.Flush()
+			}
+		}
+		writeByte(p, '}')
+	case reflect.Struct:
+		t := v.Type()
+		if v.CanAddr() {
+			addr := v.UnsafeAddr()
+			vis := visit{addr, t}
+			if vd, ok := p.visited[vis]; ok && vd < p.depth {
+				p.fmtString(t.String()+"{(CYCLIC REFERENCE)}", false)
+				break // don't print v again
+			}
+			p.visited[vis] = p.depth
+		}
+
+		if showType {
+			io.WriteString(p, t.String())
+		}
+		writeByte(p, '{')
+		if nonzero(v) {
+			expand := !canInline(v.Type())
+			pp := p
+			if expand {
+				writeByte(p, '\n')
+				pp = p.indent()
+			}
+			for i := 0; i < v.NumField(); i++ {
+				showTypeInStruct := true
+				if f := t.Field(i); f.Name != "" {
+					io.WriteString(pp, f.Name)
+					writeByte(pp, ':')
+					if expand {
+						writeByte(pp, '\t')
+					}
+					showTypeInStruct = labelType(f.Type)
+				}
+				pp.printValue(getField(v, i), showTypeInStruct, true)
+				if expand {
+					io.WriteString(pp, ",\n")
+				} else if i < v.NumField()-1 {
+					io.WriteString(pp, ", ")
+				}
+			}
+			if expand {
+				pp.tw.Flush()
+			}
+		}
+		writeByte(p, '}')
+	case reflect.Interface:
+		switch e := v.Elem(); {
+		case e.Kind() == reflect.Invalid:
+			io.WriteString(p, "nil")
+		case e.IsValid():
+			pp := *p
+			pp.depth++
+			pp.printValue(e, showType, true)
+		default:
+			io.WriteString(p, v.Type().String())
+			io.WriteString(p, "(nil)")
+		}
+	case reflect.Array, reflect.Slice:
+		t := v.Type()
+		if showType {
+			io.WriteString(p, t.String())
+		}
+		if v.Kind() == reflect.Slice && v.IsNil() && showType {
+			io.WriteString(p, "(nil)")
+			break
+		}
+		if v.Kind() == reflect.Slice && v.IsNil() {
+			io.WriteString(p, "nil")
+			break
+		}
+		writeByte(p, '{')
+		expand := !canInline(v.Type())
+		pp := p
+		if expand {
+			writeByte(p, '\n')
+			pp = p.indent()
+		}
+		for i := 0; i < v.Len(); i++ {
+			showTypeInSlice := t.Elem().Kind() == reflect.Interface
+			pp.printValue(v.Index(i), showTypeInSlice, true)
+			if expand {
+				io.WriteString(pp, ",\n")
+			} else if i < v.Len()-1 {
+				io.WriteString(pp, ", ")
+			}
+		}
+		if expand {
+			pp.tw.Flush()
+		}
+		writeByte(p, '}')
+	case reflect.Ptr:
+		e := v.Elem()
+		if !e.IsValid() {
+			writeByte(p, '(')
+			io.WriteString(p, v.Type().String())
+			io.WriteString(p, ")(nil)")
+		} else {
+			pp := *p
+			pp.depth++
+			writeByte(pp, '&')
+			pp.printValue(e, true, true)
+		}
+	case reflect.Chan:
+		x := v.Pointer()
+		if showType {
+			writeByte(p, '(')
+			io.WriteString(p, v.Type().String())
+			fmt.Fprintf(p, ")(%#v)", x)
+		} else {
+			fmt.Fprintf(p, "%#v", x)
+		}
+	case reflect.Func:
+		io.WriteString(p, v.Type().String())
+		io.WriteString(p, " {...}")
+	case reflect.UnsafePointer:
+		p.printInline(v, v.Pointer(), showType)
+	case reflect.Invalid:
+		io.WriteString(p, "nil")
+	}
+}
+
+func canInline(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Map:
+		return !canExpand(t.Elem())
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			if canExpand(t.Field(i).Type) {
+				return false
+			}
+		}
+		return true
+	case reflect.Interface:
+		return false
+	case reflect.Array, reflect.Slice:
+		return !canExpand(t.Elem())
+	case reflect.Ptr:
+		return false
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		return false
+	}
+	return true
+}
+
+func canExpand(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Map, reflect.Struct,
+		reflect.Interface, reflect.Array, reflect.Slice,
+		reflect.Ptr:
+		return true
+	}
+	return false
+}
+
+func labelType(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Interface, reflect.Struct:
+		return true
+	}
+	return false
+}
+
+func (p *printer) fmtString(s string, quote bool) {
+	if quote {
+		s = strconv.Quote(s)
+	}
+	io.WriteString(p, s)
+}
+
+func writeByte(w io.Writer, b byte) {
+	w.Write([]byte{b})
+}
+
+func getField(v reflect.Value, i int) reflect.Value {
+	val := v.Field(i)
+	if val.Kind() == reflect.Interface && !val.IsNil() {
+		val = val.Elem()
+	}
+	return val
+}

--- a/vendor/github.com/kr/pretty/pretty.go
+++ b/vendor/github.com/kr/pretty/pretty.go
@@ -1,0 +1,108 @@
+// Package pretty provides pretty-printing for Go values. This is
+// useful during debugging, to avoid wrapping long output lines in
+// the terminal.
+//
+// It provides a function, Formatter, that can be used with any
+// function that accepts a format string. It also provides
+// convenience wrappers for functions in packages fmt and log.
+package pretty
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"reflect"
+)
+
+// Errorf is a convenience wrapper for fmt.Errorf.
+//
+// Calling Errorf(f, x, y) is equivalent to
+// fmt.Errorf(f, Formatter(x), Formatter(y)).
+func Errorf(format string, a ...interface{}) error {
+	return fmt.Errorf(format, wrap(a, false)...)
+}
+
+// Fprintf is a convenience wrapper for fmt.Fprintf.
+//
+// Calling Fprintf(w, f, x, y) is equivalent to
+// fmt.Fprintf(w, f, Formatter(x), Formatter(y)).
+func Fprintf(w io.Writer, format string, a ...interface{}) (n int, error error) {
+	return fmt.Fprintf(w, format, wrap(a, false)...)
+}
+
+// Log is a convenience wrapper for log.Printf.
+//
+// Calling Log(x, y) is equivalent to
+// log.Print(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Log(a ...interface{}) {
+	log.Print(wrap(a, true)...)
+}
+
+// Logf is a convenience wrapper for log.Printf.
+//
+// Calling Logf(f, x, y) is equivalent to
+// log.Printf(f, Formatter(x), Formatter(y)).
+func Logf(format string, a ...interface{}) {
+	log.Printf(format, wrap(a, false)...)
+}
+
+// Logln is a convenience wrapper for log.Printf.
+//
+// Calling Logln(x, y) is equivalent to
+// log.Println(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Logln(a ...interface{}) {
+	log.Println(wrap(a, true)...)
+}
+
+// Print pretty-prints its operands and writes to standard output.
+//
+// Calling Print(x, y) is equivalent to
+// fmt.Print(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Print(a ...interface{}) (n int, errno error) {
+	return fmt.Print(wrap(a, true)...)
+}
+
+// Printf is a convenience wrapper for fmt.Printf.
+//
+// Calling Printf(f, x, y) is equivalent to
+// fmt.Printf(f, Formatter(x), Formatter(y)).
+func Printf(format string, a ...interface{}) (n int, errno error) {
+	return fmt.Printf(format, wrap(a, false)...)
+}
+
+// Println pretty-prints its operands and writes to standard output.
+//
+// Calling Print(x, y) is equivalent to
+// fmt.Println(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Println(a ...interface{}) (n int, errno error) {
+	return fmt.Println(wrap(a, true)...)
+}
+
+// Sprint is a convenience wrapper for fmt.Sprintf.
+//
+// Calling Sprint(x, y) is equivalent to
+// fmt.Sprint(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Sprint(a ...interface{}) string {
+	return fmt.Sprint(wrap(a, true)...)
+}
+
+// Sprintf is a convenience wrapper for fmt.Sprintf.
+//
+// Calling Sprintf(f, x, y) is equivalent to
+// fmt.Sprintf(f, Formatter(x), Formatter(y)).
+func Sprintf(format string, a ...interface{}) string {
+	return fmt.Sprintf(format, wrap(a, false)...)
+}
+
+func wrap(a []interface{}, force bool) []interface{} {
+	w := make([]interface{}, len(a))
+	for i, x := range a {
+		w[i] = formatter{v: reflect.ValueOf(x), force: force}
+	}
+	return w
+}

--- a/vendor/github.com/kr/pretty/zero.go
+++ b/vendor/github.com/kr/pretty/zero.go
@@ -1,0 +1,41 @@
+package pretty
+
+import (
+	"reflect"
+)
+
+func nonzero(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Bool:
+		return v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() != 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() != 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() != 0
+	case reflect.Complex64, reflect.Complex128:
+		return v.Complex() != complex(0, 0)
+	case reflect.String:
+		return v.String() != ""
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if nonzero(getField(v, i)) {
+				return true
+			}
+		}
+		return false
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if nonzero(v.Index(i)) {
+				return true
+			}
+		}
+		return false
+	case reflect.Map, reflect.Interface, reflect.Slice, reflect.Ptr, reflect.Chan, reflect.Func:
+		return !v.IsNil()
+	case reflect.UnsafePointer:
+		return v.Pointer() != 0
+	}
+	return true
+}

--- a/vendor/github.com/kr/text/License
+++ b/vendor/github.com/kr/text/License
@@ -1,0 +1,19 @@
+Copyright 2012 Keith Rarick
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/kr/text/doc.go
+++ b/vendor/github.com/kr/text/doc.go
@@ -1,0 +1,3 @@
+// Package text provides rudimentary functions for manipulating text in
+// paragraphs.
+package text

--- a/vendor/github.com/kr/text/indent.go
+++ b/vendor/github.com/kr/text/indent.go
@@ -1,0 +1,74 @@
+package text
+
+import (
+	"io"
+)
+
+// Indent inserts prefix at the beginning of each non-empty line of s. The
+// end-of-line marker is NL.
+func Indent(s, prefix string) string {
+	return string(IndentBytes([]byte(s), []byte(prefix)))
+}
+
+// IndentBytes inserts prefix at the beginning of each non-empty line of b.
+// The end-of-line marker is NL.
+func IndentBytes(b, prefix []byte) []byte {
+	var res []byte
+	bol := true
+	for _, c := range b {
+		if bol && c != '\n' {
+			res = append(res, prefix...)
+		}
+		res = append(res, c)
+		bol = c == '\n'
+	}
+	return res
+}
+
+// Writer indents each line of its input.
+type indentWriter struct {
+	w   io.Writer
+	bol bool
+	pre [][]byte
+	sel int
+	off int
+}
+
+// NewIndentWriter makes a new write filter that indents the input
+// lines. Each line is prefixed in order with the corresponding
+// element of pre. If there are more lines than elements, the last
+// element of pre is repeated for each subsequent line.
+func NewIndentWriter(w io.Writer, pre ...[]byte) io.Writer {
+	return &indentWriter{
+		w:   w,
+		pre: pre,
+		bol: true,
+	}
+}
+
+// The only errors returned are from the underlying indentWriter.
+func (w *indentWriter) Write(p []byte) (n int, err error) {
+	for _, c := range p {
+		if w.bol {
+			var i int
+			i, err = w.w.Write(w.pre[w.sel][w.off:])
+			w.off += i
+			if err != nil {
+				return n, err
+			}
+		}
+		_, err = w.w.Write([]byte{c})
+		if err != nil {
+			return n, err
+		}
+		n++
+		w.bol = c == '\n'
+		if w.bol {
+			w.off = 0
+			if w.sel < len(w.pre)-1 {
+				w.sel++
+			}
+		}
+	}
+	return n, nil
+}

--- a/vendor/github.com/kr/text/wrap.go
+++ b/vendor/github.com/kr/text/wrap.go
@@ -1,0 +1,86 @@
+package text
+
+import (
+	"bytes"
+	"math"
+)
+
+var (
+	nl = []byte{'\n'}
+	sp = []byte{' '}
+)
+
+const defaultPenalty = 1e5
+
+// Wrap wraps s into a paragraph of lines of length lim, with minimal
+// raggedness.
+func Wrap(s string, lim int) string {
+	return string(WrapBytes([]byte(s), lim))
+}
+
+// WrapBytes wraps b into a paragraph of lines of length lim, with minimal
+// raggedness.
+func WrapBytes(b []byte, lim int) []byte {
+	words := bytes.Split(bytes.Replace(bytes.TrimSpace(b), nl, sp, -1), sp)
+	var lines [][]byte
+	for _, line := range WrapWords(words, 1, lim, defaultPenalty) {
+		lines = append(lines, bytes.Join(line, sp))
+	}
+	return bytes.Join(lines, nl)
+}
+
+// WrapWords is the low-level line-breaking algorithm, useful if you need more
+// control over the details of the text wrapping process. For most uses, either
+// Wrap or WrapBytes will be sufficient and more convenient.
+//
+// WrapWords splits a list of words into lines with minimal "raggedness",
+// treating each byte as one unit, accounting for spc units between adjacent
+// words on each line, and attempting to limit lines to lim units. Raggedness
+// is the total error over all lines, where error is the square of the
+// difference of the length of the line and lim. Too-long lines (which only
+// happen when a single word is longer than lim units) have pen penalty units
+// added to the error.
+func WrapWords(words [][]byte, spc, lim, pen int) [][][]byte {
+	n := len(words)
+
+	length := make([][]int, n)
+	for i := 0; i < n; i++ {
+		length[i] = make([]int, n)
+		length[i][i] = len(words[i])
+		for j := i + 1; j < n; j++ {
+			length[i][j] = length[i][j-1] + spc + len(words[j])
+		}
+	}
+
+	nbrk := make([]int, n)
+	cost := make([]int, n)
+	for i := range cost {
+		cost[i] = math.MaxInt32
+	}
+	for i := n - 1; i >= 0; i-- {
+		if length[i][n-1] <= lim || i == n-1 {
+			cost[i] = 0
+			nbrk[i] = n
+		} else {
+			for j := i + 1; j < n; j++ {
+				d := lim - length[i][j-1]
+				c := d*d + cost[j]
+				if length[i][j-1] > lim {
+					c += pen // too-long lines get a worse penalty
+				}
+				if c < cost[i] {
+					cost[i] = c
+					nbrk[i] = j
+				}
+			}
+		}
+	}
+
+	var lines [][][]byte
+	i := 0
+	for i < n {
+		lines = append(lines, words[i:nbrk[i]])
+		i = nbrk[i]
+	}
+	return lines
+}


### PR DESCRIPTION
This subsumes #3239, adding the ability to add a per-app mount + volume at `app add` time. It also cleans up and centralizes the MountPoint -> Mount -> Volume matching logic, including some unit tests, yay.

Fortunately, the required systemd changes are in the current CoreOS alpha build.

Fixes #3195.