### PR TITLE
MAINTAINERS: update emails, remove Tamer, add Casey

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,6 @@
 Alban Crequy <alban@kinvolk.io> (@alban) pkg: *
 Brandon Philips <brandon.philips@coreos.com> (@philips) pkg: *
+Casey Callendrello <casey.callendrello@coreos.com> (@squeed) pkg: *
 Derek Gonyeo <derek.gonyeo@coreos.com> (@dgonyeo) pkg: *
 Euan Kemp <euan.kemp@coreos.com> (@euank) pkg: *
 Iago López Galeiras <iago@kinvolk.io> (@iaguis) pkg: *

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,14 +1,13 @@
-Alban Crequy <alban.crequy@coreos.com> (@alban) pkg: *
+Alban Crequy <alban@kinvolk.io> (@alban) pkg: *
 Brandon Philips <brandon.philips@coreos.com> (@philips) pkg: *
 Derek Gonyeo <derek.gonyeo@coreos.com> (@dgonyeo) pkg: *
 Euan Kemp <euan.kemp@coreos.com> (@euank) pkg: *
-Iago López Galeiras <iago.lopez@coreos.com> (@iaguis) pkg: *
+Iago López Galeiras <iago@kinvolk.io> (@iaguis) pkg: *
 Jonathan Boulle <jonathan.boulle@coreos.com> (@jonboulle) pkg: *
 Krzesimir Nowak <krzesimir@kinvolk.io> (@krnowak) pkg: *
 Luca Bruno <luca.bruno@coreos.com> (@lucab) pkg: *
 Sergiusz Urbaniak <sergiusz.urbaniak@coreos.com> (@s-urbaniak) pkg: *
 Stefan Junker <stefan.junker@coreos.com> (@steveeJ) pkg: *
-Tamer Tas <tamer.tas@coreos.com> (@tmrts) pkg: *
 Yifan Gu <yifan.gu@coreos.com> (@yifan-gu) pkg: *
 
 Piotr Skamruk <piotr.skamruk@gmail.com> (@jellonek) pkg: *kvm*


### PR DESCRIPTION
Tamer is no longer with CoreOS or actively working on the project; fix
Alban/Iago's emails to refer to their Kinvolk addresses.