### PR TITLE
[RFC] list: no need to print unnecessary legend if there are no pods

### DIFF
--- a/rkt/list.go
+++ b/rkt/list.go
@@ -199,6 +199,15 @@ func runList(cmd *cobra.Command, args []string) int {
 		return 1
 	}
 
+	if len(pods) == 0 {
+		if len(errors) > 0 {
+			printErrors(errors, "listing pods")
+			return 1
+		}
+		stdout.Print("No pods")
+		return 0
+	}
+
 	switch flagFormat {
 	case "":
 		tabOut.Flush()


### PR DESCRIPTION
Let's print 'No pods' instead or something like this instead of
legend or not very clear 'null' in a case when --format is used.