### PR TITLE
stage1: use systemd protection for kernel tunables

### DIFF
--- a/stage1/init/common/pod.go
+++ b/stage1/init/common/pod.go
@@ -741,9 +741,10 @@ func getAppNoNewPrivileges(isolators types.Isolators) bool {
 	return false
 }
 
-// restrictProcFS restricts access to some security-sensitive paths under
+// protectKernelTunables restricts access to some security-sensitive paths under
 // /proc and /sys. Entries are either hidden or just made read-only to app.
-func protectSystemFiles(opts []*unit.UnitOption, appName types.ACName) []*unit.UnitOption {
+// This protection is enabled by default.
+func protectKernelTunables(opts []*unit.UnitOption, appName types.ACName, systemdVersion int) []*unit.UnitOption {
 	roPaths := []string{
 		"/proc/bus/",
 		"/proc/sys/kernel/core_pattern",
@@ -757,27 +758,38 @@ func protectSystemFiles(opts []*unit.UnitOption, appName types.ACName) []*unit.U
 		"/sys/devices/",
 		"/sys/kernel/",
 	}
-	hiddenPaths := []string{
-		// TODO(lucab): file-paths restrictions need support in systemd first
-		//"/proc/config.gz",
-		//"/proc/kallsyms",
-		//"/proc/sched_debug",
-		//"/proc/kcore",
-		//"/proc/kmem",
-		//"/proc/mem",
+	hiddenDirs := []string{
 		"/sys/firmware/",
 		"/sys/fs/",
 		"/sys/hypervisor/",
 		"/sys/module/",
 		"/sys/power/",
 	}
+	hiddenPaths := []string{
+		"/proc/config.gz",
+		"/proc/kallsyms",
+		"/proc/sched_debug",
+		"/proc/kcore",
+		"/proc/kmem",
+		"/proc/mem",
+	}
+
 	// Paths prefixed with "-" are ignored if they do not exist:
 	// https://www.freedesktop.org/software/systemd/man/systemd.exec.html#ReadWriteDirectories=
-	for _, p := range hiddenPaths {
-		opts = append(opts, unit.NewUnitOption("Service", "InaccessibleDirectories", fmt.Sprintf("-%s", filepath.Join(common.RelAppRootfsPath(appName), p))))
-	}
 	for _, p := range roPaths {
 		opts = append(opts, unit.NewUnitOption("Service", "ReadOnlyDirectories", fmt.Sprintf("-%s", filepath.Join(common.RelAppRootfsPath(appName), p))))
 	}
+	for _, p := range hiddenDirs {
+		opts = append(opts, unit.NewUnitOption("Service", "InaccessibleDirectories", fmt.Sprintf("-%s", filepath.Join(common.RelAppRootfsPath(appName), p))))
+	}
+	if systemdVersion >= 231 {
+		for _, p := range hiddenPaths {
+			opts = append(opts, unit.NewUnitOption("Service", "InaccessiblePaths", fmt.Sprintf("-%s", filepath.Join(common.RelAppRootfsPath(appName), p))))
+		}
+	}
+	if systemdVersion >= 232 {
+		opts = append(opts, unit.NewUnitOption("Service", "ProtectKernelTunables", "true"))
+	}
+
 	return opts
 }

--- a/stage1/init/common/units.go
+++ b/stage1/init/common/units.go
@@ -429,6 +429,9 @@ func (uw *UnitWriter) AppUnit(
 			rwDirs = append(rwDirs, filepath.Join(common.RelAppRootfsPath(appName), mntPath))
 		}
 	}
+	if len(rwDirs) > 0 {
+		opts = append(opts, unit.NewUnitOption("Service", "ReadWriteDirectories", strings.Join(rwDirs, " ")))
+	}
 
 	// Restrict access to sensitive paths (eg. procfs) and devices. For kvm flavor,
 	// these paths are stored inside the vm, without influence to the host.
@@ -445,7 +448,6 @@ func (uw *UnitWriter) AppUnit(
 		}
 	}
 
-	opts = append(opts, unit.NewUnitOption("Service", "ReadWriteDirectories", strings.Join(rwDirs, " ")))
 	// When an app fails, we shut down the pod
 	opts = append(opts, unit.NewUnitOption("Unit", "OnFailure", "halt.target"))
 


### PR DESCRIPTION
systemd recently introduced additional protections for procfs and sysfs paths,
available via `InacessiblePaths=` (in v231) and `ProtectKernelTunables=` (in v232)
properties.
This align rkt on it for improved procfs/sysfs limits.

Closes #2484