### PR TITLE
stage1/fly: drop mount log messages to diagnostic

### DIFF
--- a/stage1_fly/run/main.go
+++ b/stage1_fly/run/main.go
@@ -381,7 +381,7 @@ func stage1() int {
 	}
 
 	for _, mount := range effectiveMounts {
-		log.Printf("Processing %+v", mount)
+		diag.Printf("Processing %+v", mount)
 
 		var (
 			err            error


### PR DESCRIPTION
These messages are more appropriately diagnostic, and elsewhere in the
fly stage1 the only thing sent to the log is critical messages on
shutdown.

Addresses a small part of #2622.