### PR TITLE
rkt: gate diagnostic output behind `--debug`

### DIFF
--- a/networking/networking.go
+++ b/networking/networking.go
@@ -58,13 +58,17 @@ type NetConf struct {
 	IsDefaultGateway bool `json:"isDefaultGateway"`
 }
 
-var stderr *log.Logger
+var (
+	stderr   *log.Logger
+	debuglog bool
+)
 
 // Setup creates a new networking namespace and executes network plugins to
 // set up networking. It returns in the new pod namespace
 func Setup(podRoot string, podID types.UUID, fps []ForwardedPort, netList common.NetList, localConfig, flavor string, noDNS, debug bool) (*Networking, error) {
 
 	stderr = log.New(os.Stderr, "networking", debug)
+	debuglog = debug
 
 	if flavor == "kvm" {
 		return kvmSetup(podRoot, podID, fps, netList, localConfig, noDNS)
@@ -260,6 +264,7 @@ func (n *Networking) GetIfacesByIP(ifaceIP net.IP) ([]net.Interface, error) {
 func (n *Networking) Teardown(flavor string, debug bool) {
 
 	stderr = log.New(os.Stderr, "networking", debug)
+	debuglog = debug
 
 	// Teardown everything in reverse order of setup.
 	// This should be idempotent -- be tolerant of missing stuff

--- a/networking/podenv.go
+++ b/networking/podenv.go
@@ -182,7 +182,9 @@ func (e *podEnv) setupNets(nets []activeNet, noDNS bool) error {
 	podHasResolvConf := err == nil
 
 	for i, n = range nets {
-		stderr.Printf("loading network %v with type %v", n.conf.Name, n.conf.Type)
+		if debuglog {
+			stderr.Printf("loading network %v with type %v", n.conf.Name, n.conf.Type)
+		}
 
 		n.runtime.IfName = fmt.Sprintf(IfNamePattern, i)
 		if n.runtime.ConfPath, err = copyFileToDir(n.runtime.ConfPath, e.netDir()); err != nil {
@@ -219,7 +221,9 @@ func (e *podEnv) setupNets(nets []activeNet, noDNS bool) error {
 func (e *podEnv) teardownNets(nets []activeNet) {
 
 	for i := len(nets) - 1; i >= 0; i-- {
-		stderr.Printf("teardown - executing net-plugin %v", nets[i].conf.Type)
+		if debuglog {
+			stderr.Printf("teardown - executing net-plugin %v", nets[i].conf.Type)
+		}
 
 		podNSpath := ""
 		if e.podNS != nil {
@@ -320,7 +324,9 @@ func loadUserNets(localConfig string, netsLoadList common.NetList) ([]activeNet,
 	}
 
 	userNetPath := filepath.Join(localConfig, UserNetPathSuffix)
-	stderr.Printf("loading networks from %v", userNetPath)
+	if debuglog {
+		stderr.Printf("loading networks from %v", userNetPath)
+	}
 
 	files, err := listFiles(userNetPath)
 	if err != nil {

--- a/rkt/image/common.go
+++ b/rkt/image/common.go
@@ -16,6 +16,7 @@ package image
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -78,12 +79,16 @@ type action struct {
 
 var (
 	log    *rktlog.Logger
-	stdout *rktlog.Logger = rktlog.New(os.Stdout, "", false)
+	diag   *rktlog.Logger
+	stdout *rktlog.Logger
 )
 
 func ensureLogger(debug bool) {
-	if log == nil {
-		log = rktlog.New(os.Stderr, "image", debug)
+	if log == nil || diag == nil || stdout == nil {
+		log, diag, stdout = rktlog.NewLogSet("image", debug)
+	}
+	if !debug {
+		diag.SetOutput(ioutil.Discard)
 	}
 }
 

--- a/rkt/image/dockerfetcher.go
+++ b/rkt/image/dockerfetcher.go
@@ -63,9 +63,7 @@ func (f *dockerFetcher) fetchImageFrom(u *url.URL, latest bool) (string, error) 
 		return "", fmt.Errorf("signature verification for docker images is not supported (try --insecure-options=image)")
 	}
 
-	if f.Debug {
-		log.Printf("fetching image from %s", u.String())
-	}
+	diag.Printf("fetching image from %s", u.String())
 
 	aciFile, err := f.fetch(u)
 	if err != nil {

--- a/rkt/image/fetcher.go
+++ b/rkt/image/fetcher.go
@@ -198,13 +198,13 @@ func (f *Fetcher) maybeCheckRemoteFromStore(rem *imagestore.Remote) string {
 	if f.NoStore || rem == nil {
 		return ""
 	}
-	log.Printf("using image from local store for url %s", rem.ACIURL)
+	diag.Printf("using image from local store for url %s", rem.ACIURL)
 	return rem.BlobKey
 }
 
 func (f *Fetcher) maybeFetchHTTPURLFromRemote(rem *imagestore.Remote, u *url.URL, a *asc) (string, error) {
 	if !f.StoreOnly {
-		log.Printf("remote fetching from URL %q", u.String())
+		diag.Printf("remote fetching from URL %q", u.String())
 		hf := &httpFetcher{
 			InsecureFlags: f.InsecureFlags,
 			S:             f.S,
@@ -220,7 +220,7 @@ func (f *Fetcher) maybeFetchHTTPURLFromRemote(rem *imagestore.Remote, u *url.URL
 
 func (f *Fetcher) maybeFetchDockerURLFromRemote(u *url.URL) (string, error) {
 	if !f.StoreOnly {
-		log.Printf("remote fetching from URL %q", u.String())
+		diag.Printf("remote fetching from URL %q", u.String())
 		df := &dockerFetcher{
 			InsecureFlags: f.InsecureFlags,
 			DockerAuth:    f.DockerAuth,
@@ -233,7 +233,7 @@ func (f *Fetcher) maybeFetchDockerURLFromRemote(u *url.URL) (string, error) {
 }
 
 func (f *Fetcher) fetchSingleImageByPath(path string, a *asc) (string, error) {
-	log.Printf("using image from file %s", path)
+	diag.Printf("using image from file %s", path)
 	ff := &fileFetcher{
 		InsecureFlags: f.InsecureFlags,
 		S:             f.S,
@@ -287,7 +287,7 @@ func (f *Fetcher) maybeCheckStoreForApp(app *appBundle) (string, error) {
 	if !f.NoStore {
 		key, err := f.getStoreKeyFromApp(app)
 		if err == nil {
-			log.Printf("using image from local store for image name %s", app.Str)
+			diag.Printf("using image from local store for image name %s", app.Str)
 			return key, nil
 		}
 		switch err.(type) {

--- a/rkt/image/finder.go
+++ b/rkt/image/finder.go
@@ -80,6 +80,6 @@ func (f *Finder) getHashFromStore(img string) (*types.Hash, error) {
 		// should never happen
 		log.PanicE("got an invalid hash from the store, looks like it is corrupted", err)
 	}
-	log.Printf("using image from the store with hash %s", h.String())
+	diag.Printf("using image from the store with hash %s", h.String())
 	return h, nil
 }

--- a/rkt/image/httpfetcher.go
+++ b/rkt/image/httpfetcher.go
@@ -47,16 +47,12 @@ func (f *httpFetcher) Hash(u *url.URL, a *asc) (string, error) {
 
 	if !f.NoCache && f.Rem != nil {
 		if useCached(f.Rem.DownloadTime, f.Rem.CacheMaxAge) {
-			if f.Debug {
-				log.Printf("image for %s isn't expired, not fetching.", urlStr)
-			}
+			diag.Printf("image for %s isn't expired, not fetching.", urlStr)
 			return f.Rem.BlobKey, nil
 		}
 	}
 
-	if f.Debug {
-		log.Printf("fetching image from %s", urlStr)
-	}
+	diag.Printf("fetching image from %s", urlStr)
 
 	aciFile, cd, err := f.fetchURL(u, a, eTag(f.Rem))
 	if err != nil {

--- a/rkt/image/httpops.go
+++ b/rkt/image/httpops.go
@@ -42,7 +42,7 @@ type httpOps struct {
 // this function will return true and no error and no file.
 func (o *httpOps) DownloadSignature(a *asc) (readSeekCloser, bool, error) {
 	ensureLogger(o.Debug)
-	log.Printf("downloading signature from %v", a.Location)
+	diag.Printf("downloading signature from %v", a.Location)
 	ascFile, err := a.Get()
 	if err == nil {
 		return ascFile, false, nil

--- a/rkt/image/namefetcher.go
+++ b/rkt/image/namefetcher.go
@@ -50,7 +50,7 @@ type nameFetcher struct {
 func (f *nameFetcher) Hash(app *discovery.App, a *asc) (string, error) {
 	ensureLogger(f.Debug)
 	name := app.Name.String()
-	log.Printf("searching for app image %s", name)
+	diag.Printf("searching for app image %s", name)
 	ep, err := f.discoverApp(app)
 	if err != nil {
 		return "", errwrap.Wrap(fmt.Errorf("discovery failed for %q", name), err)
@@ -94,15 +94,13 @@ func (f *nameFetcher) fetchImageFromEndpoints(app *discovery.App, ep discovery.A
 	// maybeOverrideAscFetcherWithRemote on the clone
 	aciURL := ep[0].ACI
 	ascURL := ep[0].ASC
-	log.Printf("remote fetching from URL %q", aciURL)
+	diag.Printf("remote fetching from URL %q", aciURL)
 	f.maybeOverrideAscFetcherWithRemote(ascURL, a)
 	return f.fetchImageFromSingleEndpoint(app, aciURL, a, latest)
 }
 
 func (f *nameFetcher) fetchImageFromSingleEndpoint(app *discovery.App, aciURL string, a *asc, latest bool) (string, error) {
-	if f.Debug {
-		log.Printf("fetching image from %s", aciURL)
-	}
+	diag.Printf("fetching image from %s", aciURL)
 
 	u, err := url.Parse(aciURL)
 	if err != nil {
@@ -114,9 +112,7 @@ func (f *nameFetcher) fetchImageFromSingleEndpoint(app *discovery.App, aciURL st
 	}
 	if !f.NoCache && rem != nil {
 		if useCached(rem.DownloadTime, rem.CacheMaxAge) {
-			if f.Debug {
-				log.Printf("image for %s isn't expired, not fetching.", aciURL)
-			}
+			diag.Printf("image for %s isn't expired, not fetching.", aciURL)
 			return rem.BlobKey, nil
 		}
 	}

--- a/rkt/stage1hash.go
+++ b/rkt/stage1hash.go
@@ -340,6 +340,7 @@ func getStage1Finder(s *imagestore.Store, ts *treestore.Store, withKeystore bool
 	fn := &image.Finder{
 		S:                  s,
 		Ts:                 ts,
+		Debug:              globalFlags.Debug,
 		InsecureFlags:      globalFlags.InsecureFlags,
 		TrustKeysFromHTTPS: globalFlags.TrustKeysFromHTTPS,
 

--- a/stage1_fly/run/main.go
+++ b/stage1_fly/run/main.go
@@ -381,7 +381,7 @@ func stage1() int {
 	}
 
 	for _, mount := range effectiveMounts {
-		log.Printf("Processing %+v", mount)
+		diag.Printf("Processing %+v", mount)
 
 		var (
 			err            error
@@ -407,7 +407,7 @@ func stage1() int {
 		switch {
 		case (mount.Flags & syscall.MS_REMOUNT) != 0:
 			{
-				log.Printf("don't attempt to create files for remount of %q", absTargetPath)
+				diag.Printf("don't attempt to create files for remount of %q", absTargetPath)
 			}
 		case targetPathInfo == nil:
 			absTargetPathParent, _ := filepath.Split(absTargetPath)

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -48,15 +48,15 @@ func TestFetchFromFile(t *testing.T) {
 		args  string
 		image string
 	}{
-		{"--insecure-options=image fetch", imagePath},
-		{"--insecure-options=image fetch --store-only", imagePath},
-		{"--insecure-options=image fetch --no-store", imagePath},
-		{"--insecure-options=image run --mds-register=false", imagePath},
-		{"--insecure-options=image run --mds-register=false --store-only", imagePath},
-		{"--insecure-options=image run --mds-register=false --no-store", imagePath},
-		{"--insecure-options=image prepare", imagePath},
-		{"--insecure-options=image prepare --store-only", imagePath},
-		{"--insecure-options=image prepare --no-store", imagePath},
+		{"--insecure-options=image --debug fetch", imagePath},
+		{"--insecure-options=image --debug fetch --store-only", imagePath},
+		{"--insecure-options=image --debug fetch --no-store", imagePath},
+		{"--insecure-options=image --debug run --mds-register=false", imagePath},
+		{"--insecure-options=image --debug run --mds-register=false --store-only", imagePath},
+		{"--insecure-options=image --debug run --mds-register=false --no-store", imagePath},
+		{"--insecure-options=image --debug prepare", imagePath},
+		{"--insecure-options=image --debug prepare --store-only", imagePath},
+		{"--insecure-options=image --debug prepare --no-store", imagePath},
 	}
 
 	for _, tt := range tests {
@@ -98,20 +98,20 @@ func TestFetch(t *testing.T) {
 		imageArgs string
 		finalURL  string
 	}{
-		{"--insecure-options=image fetch", "coreos.com/etcd:v2.1.2", "", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci"},
-		{"--insecure-options=image fetch", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci", "", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci"},
-		{"--insecure-options=image fetch", "docker://busybox", "", "docker://busybox"},
-		{"--insecure-options=image fetch", "docker://busybox:latest", "", "docker://busybox:latest"},
-		{"--insecure-options=image run --mds-register=false", "coreos.com/etcd:v2.1.2", "--exec /etcdctl", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci"},
-		{"--insecure-options=image run --mds-register=false", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci", "--exec /etcdctl", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci"},
-		{"--insecure-options=image run --mds-register=false", "docker://busybox", "", "docker://busybox"},
-		{"--insecure-options=image run --mds-register=false", "docker://busybox:latest", "", "docker://busybox:latest"},
-		{"--insecure-options=image prepare", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci", "", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci"},
-		{"--insecure-options=image prepare", "coreos.com/etcd:v2.1.2", "", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci"},
+		{"--insecure-options=image --debug fetch", "coreos.com/etcd:v2.1.2", "", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci"},
+		{"--insecure-options=image --debug fetch", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci", "", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci"},
+		{"--insecure-options=image --debug fetch", "docker://busybox", "", "docker://busybox"},
+		{"--insecure-options=image --debug fetch", "docker://busybox:latest", "", "docker://busybox:latest"},
+		{"--insecure-options=image --debug run --mds-register=false", "coreos.com/etcd:v2.1.2", "--exec /etcdctl", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci"},
+		{"--insecure-options=image --debug run --mds-register=false", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci", "--exec /etcdctl", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci"},
+		{"--insecure-options=image --debug run --mds-register=false", "docker://busybox", "", "docker://busybox"},
+		{"--insecure-options=image --debug run --mds-register=false", "docker://busybox:latest", "", "docker://busybox:latest"},
+		{"--insecure-options=image --debug prepare", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci", "", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci"},
+		{"--insecure-options=image --debug prepare", "coreos.com/etcd:v2.1.2", "", "https://github.com/coreos/etcd/releases/download/v2.1.2/etcd-v2.1.2-linux-amd64.aci"},
 		// test --insecure-options=tls to make sure
 		// https://github.com/coreos/rkt/issues/1829 is not an issue anymore
-		{"--insecure-options=image,tls prepare", "docker://busybox", "", "docker://busybox"},
-		{"--insecure-options=image prepare", "docker://busybox:latest", "", "docker://busybox:latest"},
+		{"--insecure-options=image,tls --debug prepare", "docker://busybox", "", "docker://busybox"},
+		{"--insecure-options=image --debug prepare", "docker://busybox:latest", "", "docker://busybox:latest"},
 	}
 
 	for _, tt := range tests {

--- a/tests/rkt_gc_test.go
+++ b/tests/rkt_gc_test.go
@@ -107,7 +107,7 @@ func TestGCAfterUnmount(t *testing.T) {
 			t.Fatalf("pods should still be present in rkt's data directory")
 		}
 
-		gcCmd := fmt.Sprintf("%s gc --mark-only=false --expire-prepared=0 --grace-period=0", ctx.Cmd())
+		gcCmd := fmt.Sprintf("%s gc --debug --mark-only=false --expire-prepared=0 --grace-period=0", ctx.Cmd())
 		// check we don't get any output (an error) after "executing net-plugin..."
 		runRktAndCheckRegexOutput(t, gcCmd, `executing net-plugin .*\n\z`)
 

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -281,7 +281,7 @@ func runRktAndGetUUID(t *testing.T, rktCmd string) string {
 	child := spawnOrFail(t, rktCmd)
 	defer waitOrFail(t, child, 0)
 
-	result, out, err := expectRegexWithOutput(child, "\n[0-9a-f-]{36}")
+	result, out, err := expectRegexWithOutput(child, "[0-9a-f-]{36}")
 	if err != nil || len(result) != 1 {
 		t.Fatalf("Error: %v\nOutput: %v", err, out)
 	}


### PR DESCRIPTION
This PR turns off by default all image and networking diagnostic output, moving it behind explicit `--debug` flag. This turns an error-free rkt execution from this:
```
$ sudo rkt run quay.io/coreos/alpine-sh --exec echo -- "hello world!"
image: using image from local store for image name coreos.com/rkt/stage1-coreos:1.17.0
image: using image from local store for image name quay.io/coreos/alpine-sh
networking: loading networks from /etc/rkt/net.d
networking: loading network default with type ptp
[18489.453547] alpine-sh[5]: hello world!
```
into this:
```
$ sudo ./rkt run  quay.io/coreos/alpine-sh --exec echo -- "hello world!"
[18521.078185] alpine-sh[5]: hello world!
```

This makes rkt strictly following the UNIX rule of silence, but in the long term we need a better way of handling level/structured logging across all packages and more granular verbosity-switches for CLI (`--verbose=<level>`). A complete switch to [logrus](https://github.com/Sirupsen/logrus) is being considered, but out of scope here.

Fixes https://github.com/coreos/rkt/issues/2622