### PR TITLE
stage0/image: set proxy if InsecureSkipVerify is set

### DIFF
--- a/rkt/image/resumablesession.go
+++ b/rkt/image/resumablesession.go
@@ -278,6 +278,7 @@ func (s *resumableSession) getClient() *http.Client {
 	transport := http.DefaultTransport
 	if s.InsecureSkipTLSVerify {
 		transport = &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 	}


### PR DESCRIPTION
If InsecureSkipVerify is set to true, we skip setting the Proxy argument
in http.Transport. This fixes it.

Fixes #2590