### PR TITLE
MAINTAINERS: remove @jellonek

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -10,5 +10,3 @@ Luca Bruno <luca.bruno@coreos.com> (@lucab) pkg: *
 Sergiusz Urbaniak <sergiusz.urbaniak@coreos.com> (@s-urbaniak) pkg: *
 Stefan Junker <stefan.junker@coreos.com> (@steveeJ) pkg: *
 Yifan Gu <yifan.gu@coreos.com> (@yifan-gu) pkg: *
-
-Piotr Skamruk <piotr.skamruk@gmail.com> (@jellonek) pkg: *kvm*


### PR DESCRIPTION
As you can see on issue tracker - I have too little time to maintain kvm component and even recently in review (https://github.com/coreos/rkt/pull/3304#discussion_r84576995) I missed quite important thing.

This is why I think that I should be no longer maintainer or this component.

I wanted to suggest someone from my old Intel team, but IMO this could be at first discussed on syncup, so I'm leaving that part without any suggestion.