### PR TITLE
stage0/arch: initial support for ppc64le platform

### DIFF
--- a/stage0/arch.go
+++ b/stage0/arch.go
@@ -16,5 +16,5 @@ package stage0
 
 // ValidOSArch contains the supported ACI image OS/architecture combinations.
 var ValidOSArch = map[string][]string{
-	"linux": {"amd64", "i386", "aarch64", "aarch64_be", "armv6l", "armv7l", "armv7b"},
+	"linux": {"amd64", "i386", "aarch64", "aarch64_be", "armv6l", "armv7l", "armv7b", "ppc64le"},
 }


### PR DESCRIPTION
After rkt's dependencies implementing ppc64le code, it is now time
to enable it on rkt.
With this patch, and upgrading rkt's dependencies (gopsutils, appc),
I am able to run a container image on rkt on Power processors.
