### PR TITLE
gc: Clean up some GC leaks

### DIFF
--- a/networking/networking.go
+++ b/networking/networking.go
@@ -25,7 +25,6 @@ import (
 	"syscall"
 
 	"github.com/appc/spec/schema/types"
-	"github.com/containernetworking/cni/pkg/ns"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/hashicorp/errwrap"
 	"github.com/vishvananda/netlink"
@@ -33,8 +32,6 @@ import (
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/networking/netinfo"
 	"github.com/coreos/rkt/pkg/log"
-
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -74,12 +71,6 @@ func Setup(podRoot string, podID types.UUID, fps []ForwardedPort, netList common
 		return kvmSetup(podRoot, podID, fps, netList, localConfig, noDNS)
 	}
 
-	// Create namespace for Pod and write path to a file
-	podNS, err := ns.NewNS()
-	if err != nil {
-		return nil, err
-	}
-
 	// TODO(jonboulle): currently podRoot is _always_ ".", and behaviour in other
 	// circumstances is untested. This should be cleaned up.
 	n := Networking{
@@ -88,8 +79,13 @@ func Setup(podRoot string, podID types.UUID, fps []ForwardedPort, netList common
 			podID:        podID,
 			netsLoadList: netList,
 			localConfig:  localConfig,
-			podNS:        podNS,
 		},
+	}
+
+	// Create the network namespace (and save its name in a file)
+	err := n.podNSCreate()
+	if err != nil {
+		return nil, err
 	}
 
 	n.nets, err = n.loadNets()
@@ -116,7 +112,7 @@ func Setup(podRoot string, podID types.UUID, fps []ForwardedPort, netList common
 	}
 
 	// Switch to the podNS
-	if err := podNS.Set(); err != nil {
+	if err := n.podNS.Set(); err != nil {
 		return nil, err
 	}
 
@@ -210,11 +206,10 @@ func Load(podRoot string, podID *types.UUID) (*Networking, error) {
 		podID:   *podID,
 	}
 
-	podNS, err := p.podNSLoad()
+	err = p.podNSLoad()
 	if err != nil {
 		return nil, err
 	}
-	p.podNS = podNS
 
 	return &Networking{
 		podEnv: p,
@@ -278,29 +273,13 @@ func (n *Networking) Teardown(flavor string, debug bool) {
 		stderr.PrintE("error removing forwarded ports", err)
 	}
 
-	podNS, err := n.podNSLoad()
+	err := n.podNSLoad()
 	if err != nil {
 		stderr.PrintE("error loading podNS", err)
 	}
-	if podNS != nil {
-		defer func() {
-			n.podNS.Close()
 
-			if err := syscall.Unmount(n.podNS.Path(), unix.MNT_DETACH); err != nil {
-				// if already unmounted, umount(2) returns EINVAL
-				if !os.IsNotExist(err) && err != syscall.EINVAL {
-					stderr.PrintE(fmt.Sprintf("error unmounting %q", n.podNS.Path()), err)
-				}
-			}
-
-			if err := os.RemoveAll(n.podNS.Path()); err != nil {
-				stderr.PrintE(fmt.Sprintf("failed to remove namespace %s", n.podNS.Path()), err)
-			}
-		}()
-	}
-
-	n.podNS = podNS
 	n.teardownNets(n.nets)
+	n.podNSDestroy()
 }
 
 // Save writes out the info about active nets
@@ -319,6 +298,21 @@ func (e *Networking) Save() error {
 	}
 
 	return netinfo.Save(e.podRoot, nis)
+}
+
+// CleanUpGarbage can be called when Load fails, but there may still
+// be some garbage lying around. Right now, this deletes the namespace.
+func CleanUpGarbage(podRoot string, podID *types.UUID) error {
+	p := podEnv{
+		podRoot: podRoot,
+		podID:   *podID,
+	}
+
+	err := p.podNSLoad()
+	if err != nil {
+		return err
+	}
+	return p.podNSDestroy()
 }
 
 func loUp() error {

--- a/stage1/gc/gc.go
+++ b/stage1/gc/gc.go
@@ -102,7 +102,10 @@ func gcNetworking(podID *types.UUID) error {
 	case err == nil:
 		n.Teardown(flavor, debug)
 	case os.IsNotExist(err):
-		// probably ran with --net=host
+		// either ran with --net=host, or failed during setup
+		if err := networking.CleanUpGarbage(".", podID); err != nil {
+			diag.PrintE("failed cleaning up nework NS", err)
+		}
 	default:
 		return errwrap.Wrap(errors.New("failed loading networking state"), err)
 	}
@@ -142,7 +145,7 @@ func cleanupV1Cgroups() error {
 	if err != nil {
 		if os.IsNotExist(err) {
 			diag.Printf("subcgroup file missing, probably a failed pod. Skipping cgroup cleanup.")
-			return nil // Probably a failed startup
+			return nil
 		}
 		return errwrap.Wrap(errors.New("error reading subcgroup file"), err)
 	}


### PR DESCRIPTION
- Don't fail to gc if subcgroup doesn't exist (fixes #2804)
- Don't leak network namespaces (fixes #3114)

The biggest change is a minor cleanup of the netns creation code. Previously, we checkpointed its name only after successful network creation. Now we write as soon as the NS is generated.
