### PR TITLE
Documentation: remove docker2aci mention

### DIFF
--- a/Documentation/running-docker-images.md
+++ b/Documentation/running-docker-images.md
@@ -67,8 +67,3 @@ After the image has been retrieved, it can be run by referencing this hash:
 ```
 # rkt --insecure-options=image run sha512-c6d6efd98f506380ff128e473ca239ed
 ```
-
-## How does it work?
-
-rkt leverages the [`docker2aci`](https://github.com/appc/docker2aci) library to transparently convert Docker images into rkt's native ACI format.
-To convert Docker images to ACI without necessarily having to run them, refer to the [docker2aci documentation](https://github.com/appc/docker2aci/blob/master/README.md).


### PR DESCRIPTION
docker2aci is not critical to this user facing doc, just remove it.