### PR TITLE
setup-data-dir.sh: fallback to the `mkdir/chmod`s if the rkt.conf doesn't exist

### DIFF
--- a/dist/scripts/setup-data-dir.sh
+++ b/dist/scripts/setup-data-dir.sh
@@ -55,8 +55,7 @@ getent group rkt-admin || groupadd --force --system rkt-admin
 getent group rkt || groupadd --force --system rkt
 
 if which systemd-tmpfiles; then
-    systemd-tmpfiles --create /usr/lib/tmpfiles.d/rkt.conf
-    exit
+    systemd-tmpfiles --create "$(realpath "$(dirname "$0")")/../init/systemd/tmpfiles.d/rkt.conf" && exit
 fi
 
 make_directory "${datadir}" 2750 "rkt"


### PR DESCRIPTION
This is a follow-up for 65fc1fb935acda

Fixes:
```
$ sudo bash -x rkt-v1.18.0/scripts/setup-data-dir.sh
...
+ systemd-tmpfiles --create /usr/lib/tmpfiles.d/rkt.conf
Failed to open '/usr/lib/tmpfiles.d/rkt.conf', ignoring: No such file or directory

$ echo $?
1
```