### PR TITLE
scripts: add gpg to Debian dependencies

### DIFF
--- a/scripts/install-deps-debian-sid.sh
+++ b/scripts/install-deps-debian-sid.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-DEBIAN_SID_DEPS="ca-certificates gcc libc6-dev make automake wget git golang-go coreutils cpio squashfs-tools realpath autoconf file xz-utils patch bc locales libacl1-dev libssl-dev libtspi-dev libsystemd-dev"
+DEBIAN_SID_DEPS="ca-certificates gcc libc6-dev gpg make automake wget git golang-go coreutils cpio squashfs-tools realpath autoconf file xz-utils patch bc locales libacl1-dev libssl-dev libtspi-dev libsystemd-dev"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update


### PR DESCRIPTION
This is required for the default build and is
included in the Fedora ones.