### PR TITLE
gc: make sure CNI_PATH is same for gc and init

### DIFF
--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -132,6 +132,10 @@ For example, it removes the network namespace of a pod.
 * `--debug` to activate debugging
 * UUID of the pod
 
+
+#### Arguments added in interface version 5
+* `--local-config`: The rkt configuration directory - defaults to `/etc/rkt` if not supplied.
+
 ### rkt stop
 
 `coreos.com/rkt/stage1/stop`

--- a/networking/net_plugin.go
+++ b/networking/net_plugin.go
@@ -119,7 +119,7 @@ func (e *podEnv) execNetPlugin(cmd string, n *activeNet, netns string) ([]byte, 
 	}
 
 	vars := [][2]string{
-		{"CNI_VERSION", "0.3.0"},
+		{"CNI_VERSION", "0.1.0"},
 		{"CNI_COMMAND", cmd},
 		{"CNI_CONTAINERID", e.podID.String()},
 		{"CNI_NETNS", netns},

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -177,7 +177,7 @@ func (n *Networking) enableDefaultLocalnetRouting() error {
 
 // Load creates the Networking object from saved state.
 // Assumes the current netns is that of the host.
-func Load(podRoot string, podID *types.UUID) (*Networking, error) {
+func Load(podRoot string, podID *types.UUID, localConfig string) (*Networking, error) {
 	// the current directory is pod root
 	pdirfd, err := syscall.Open(podRoot, syscall.O_RDONLY|syscall.O_DIRECTORY, 0)
 	if err != nil {
@@ -207,8 +207,9 @@ func Load(podRoot string, podID *types.UUID) (*Networking, error) {
 	}
 
 	p := podEnv{
-		podRoot: podRoot,
-		podID:   *podID,
+		podRoot:     podRoot,
+		podID:       *podID,
+		localConfig: localConfig,
 	}
 
 	err = p.podNSLoad()

--- a/rkt/gc.go
+++ b/rkt/gc.go
@@ -250,7 +250,7 @@ func deletePod(p *pkgPod.Pod) {
 		}
 
 		if err := mountPodStage1(ts, p); err == nil {
-			if err = stage0.GC(p.Path(), p.UUID); err != nil {
+			if err = stage0.GC(p.Path(), p.UUID, globalFlags.LocalConfigDir); err != nil {
 				stderr.PrintE(fmt.Sprintf("problem performing stage1 GC on %q", p.UUID), err)
 			}
 			// an overlay fs can be mounted over itself, let's unmount it here

--- a/stage0/manifest.go
+++ b/stage0/manifest.go
@@ -120,3 +120,7 @@ func interfaceVersionSupportsInsecureOptions(version int) bool {
 func interfaceVersionSupportsDNSConfMode(version int) bool {
 	return version > 3
 }
+
+func interfaceVersionSupportsGCLocalConfig(version int) bool {
+	return version >= 5
+}

--- a/stage1/aci/aci-manifest.in
+++ b/stage1/aci/aci-manifest.in
@@ -51,7 +51,7 @@
         },
         {
             "name": "coreos.com/rkt/stage1/interface-version",
-            "value": "4"
+            "value": "5"
         }
     ]
 }

--- a/stage1/net/rootfs/etc/rkt/net.d/99-default-restricted.conf
+++ b/stage1/net/rootfs/etc/rkt/net.d/99-default-restricted.conf
@@ -1,4 +1,5 @@
 {
+	"cniVersion": "0.1.0",
 	"name": "default-restricted",
 	"type": "ptp",
 	"ipMasq": false,

--- a/stage1/net/rootfs/etc/rkt/net.d/99-default.conf
+++ b/stage1/net/rootfs/etc/rkt/net.d/99-default.conf
@@ -1,4 +1,5 @@
 {
+	"cniVersion": "0.1.0",
 	"name": "default",
 	"type": "ptp",
 	"ipMasq": true,

--- a/stage1_fly/aci/aci-manifest.in
+++ b/stage1_fly/aci/aci-manifest.in
@@ -35,7 +35,7 @@
         },
         {
             "name": "coreos.com/rkt/stage1/interface-version",
-            "value": "4"
+            "value": "5"
         }
     ]
 }

--- a/stage1_fly/gc/main.go
+++ b/stage1_fly/gc/main.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/coreos/rkt/common"
 	rktlog "github.com/coreos/rkt/pkg/log"
 )
 
@@ -29,11 +30,13 @@ const (
 var (
 	debug bool
 
-	diag *rktlog.Logger
+	diag        *rktlog.Logger
+	localConfig string
 )
 
 func init() {
 	flag.BoolVar(&debug, "debug", false, "Run in debug mode")
+	flag.StringVar(&localConfig, "local-config", common.DefaultLocalConfigDir, "Local config path (ignored)")
 }
 
 func main() {


### PR DESCRIPTION
We were not passing the --local-config flag through during gc.

Also passes the right CNI_VERSION environment variable.

Fixes #3133