### PR TITLE
rkt/image*: align image selection behavior for the rm subcommand

### DIFF
--- a/Documentation/subcommands/image.md
+++ b/Documentation/subcommands/image.md
@@ -132,7 +132,7 @@ sha512-96323da393621d846c632e71551b77089ac0b004ceb5c2362be4f5ced2212db9   regist
 
 ## rkt image rm
 
-Given an image ID or image name you can remove it from the local store.
+Given multiple image IDs or image names you can remove them from the local store.
 
 ```
 # rkt image rm sha512-a03f6bad952b coreos.com/etcd

--- a/rkt/image.go
+++ b/rkt/image.go
@@ -20,6 +20,19 @@ var (
 	cmdImage = &cobra.Command{
 		Use:   "image [command]",
 		Short: "Operate on image(s) in the local store",
+		Long: `This subcommand operates on image(s) in the local store.
+
+The "cat-manifest", "export", "extract", "render", and "rm" subcommands
+take the ID or image name to reference images in the local store.
+
+The ID can be specified using the long or short version, i.e. "sha512-78c08a541997",
+or "sha512-78c08a5419979fff71e615f27aad75b84362a3cd9a13703b9d47ec27d1cfd029".
+
+The image name can be specified including the version tag as stored in the local store,
+i.e. "quay.io/coreos/etcd:latest", or "quay.io/coreos/etcd:v3.0.13".
+
+The version tag may be left out, i.e. "quay.io/coreos/etcd".
+In case of ambiguity, the least recently fetched image with this name will be chosen.`,
 	}
 )
 

--- a/rkt/image_cat_manifest.go
+++ b/rkt/image_cat_manifest.go
@@ -26,7 +26,7 @@ var (
 	cmdImageCatManifest = &cobra.Command{
 		Use:   "cat-manifest IMAGE",
 		Short: "Inspect and print the image manifest",
-		Long:  `IMAGE should be a string referencing an image; either a hash or an image name.`,
+		Long:  `IMAGE should be a string referencing an image; either a ID or an image name.`,
 		Run:   runWrapper(runImageCatManifest),
 	}
 	flagPrettyPrint bool

--- a/rkt/image_export.go
+++ b/rkt/image_export.go
@@ -28,7 +28,7 @@ var (
 	cmdImageExport = &cobra.Command{
 		Use:   "export IMAGE OUTPUT_ACI_FILE",
 		Short: "Export a stored image to an ACI file",
-		Long: `IMAGE should be a string referencing an image: either a hash or an image name.
+		Long: `IMAGE should be a string referencing an image: either an ID or an image name.
 
 Note that images must be fetched prior to running export and that this command
 always returns uncompressed ACIs`,

--- a/rkt/image_extract.go
+++ b/rkt/image_extract.go
@@ -32,7 +32,7 @@ var (
 	cmdImageExtract = &cobra.Command{
 		Use:   "extract IMAGE OUTPUT_DIR",
 		Short: "Extract a stored image to a directory",
-		Long: `IMAGE should be a string referencing an image: either a hash or an image name.
+		Long: `IMAGE should be a string referencing an image: either a ID or an image name.
 
 Note that in order to make cleaning up easy (just rm -rf), extract does not use
 overlayfs or any other mechanism.`,

--- a/rkt/image_render.go
+++ b/rkt/image_render.go
@@ -32,7 +32,7 @@ var (
 	cmdImageRender = &cobra.Command{
 		Use:   "render IMAGE OUTPUT_DIR",
 		Short: "Render a stored image to a directory with all its dependencies",
-		Long: `IMAGE should be a string referencing an image: either a hash or an image name.
+		Long: `IMAGE should be a string referencing an image: either a ID or an image name.
 
 This differs from extract in that the rendered image is in the state the app
 would see when running in rkt, dependencies and all.

--- a/tests/rkt_image_rm_test.go
+++ b/tests/rkt_image_rm_test.go
@@ -296,7 +296,7 @@ func TestImagePrepareRmDuplicate(t *testing.T) {
 }
 
 func getImageName(t *testing.T, ctx *testutils.RktRunCtx, name string) string {
-	cmd := fmt.Sprintf(`/bin/sh -c "%s image list --fields=name --no-legend | grep %s | cut -d: -f1"`, ctx.Cmd(), name)
+	cmd := fmt.Sprintf(`/bin/sh -c "%s image list --fields=name --no-legend | grep %s"`, ctx.Cmd(), name)
 	child := spawnOrFail(t, cmd)
 	imageName, err := child.ReadLine()
 	imageName = strings.TrimSpace(imageName)


### PR DESCRIPTION
Currently the `rkt image rm` subcommand has a custom logic for selecting
images to be deleted.

This aligns the behavior of the `rm` subcommand with the other `rkt
image` subcommands, and updates the documentation.

Fixes #3329