### PR TITLE
kvm: fix for breaking change in Debian Sid GCC default options

### DIFF
--- a/stage1/usr_from_kvm/kernel/patches/0002-for-debian-gcc.patch
+++ b/stage1/usr_from_kvm/kernel/patches/0002-for-debian-gcc.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index b249529..bedd4ab 100644
+--- a/Makefile
++++ b/Makefile
+@@ -346,7 +346,7 @@ include scripts/Kbuild.include
+ # Make variables (CC, etc...)
+ AS		= $(CROSS_COMPILE)as
+ LD		= $(CROSS_COMPILE)ld
+-CC		= $(CROSS_COMPILE)gcc
++CC		= $(CROSS_COMPILE)gcc -no-pie -fno-pic
+ CPP		= $(CC) -E
+ AR		= $(CROSS_COMPILE)ar
+ NM		= $(CROSS_COMPILE)nm

--- a/stage1/usr_from_kvm/lkvm.mk
+++ b/stage1/usr_from_kvm/lkvm.mk
@@ -5,7 +5,7 @@ LKVM_BINARY := $(LKVM_SRCDIR)/lkvm-static
 LKVM_ACI_BINARY := $(HV_ACIROOTFSDIR)/lkvm
 LKVM_GIT := https://kernel.googlesource.com/pub/scm/linux/kernel/git/will/kvmtool
 # just last published version (for reproducible builds), not for any other reason
-LKVM_VERSION := d62653e177597251c24494a6dda60acd6d846671
+LKVM_VERSION := 1cd6f516264ad2ad83fad3dc1264d6ff4bcd17b2
 
 LKVM_STUFFDIR := $(MK_SRCDIR)/lkvm
 LKVM_PATCHESDIR := $(LKVM_STUFFDIR)/patches


### PR DESCRIPTION
With change introduced to Debian Sid default gcc flags: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=841368 both lkvm and linux kernel wouldn't compile, here is fix for this.

Fixes #3343