### PR TITLE
image/list: bring back field filtering in plaintext mode

### DIFF
--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -81,17 +81,33 @@ var (
 type printedImage struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`
-	ImportTime string `json:"import_time"`
-	LastUsed   string `json:"last_used"`
+	ImportTime string `json:"importtime"`
+	LastUsed   string `json:"lastused"`
 	Size       string `json:"size"`
 }
 
-func (r *printedImage) attributes() []string {
-	return []string{r.ID, r.Name, r.Size, r.ImportTime, r.LastUsed}
+func (pi *printedImage) attributes(fields *rktflag.OptionList) []string {
+	if fields == nil {
+		return []string{pi.ID, pi.Name, pi.Size, pi.ImportTime, pi.LastUsed}
+	}
+	optionMapping := map[string]string{
+		l(id):         pi.ID,
+		l(name):       pi.Name,
+		l(size):       pi.Size,
+		l(importTime): pi.ImportTime,
+		l(lastUsed):   pi.LastUsed,
+	}
+	attrs := []string{}
+	for _, f := range fields.Options {
+		if a, ok := optionMapping[f]; ok {
+			attrs = append(attrs, a)
+		}
+	}
+	return attrs
 }
 
-func (r *printedImage) printableString() string {
-	return strings.Join(r.attributes(), "\t")
+func (pi *printedImage) printableString(fields *rktflag.OptionList) string {
+	return strings.Join(pi.attributes(fields), "\t")
 }
 
 type outputFormat int
@@ -285,7 +301,7 @@ func runImages(cmd *cobra.Command, args []string) int {
 			fmt.Fprintf(tabOut, "%s\n", strings.Join(headerFields, "\t"))
 		}
 		for _, image := range imagesToPrint {
-			fmt.Fprintf(tabOut, "%s\n", image.printableString())
+			fmt.Fprintf(tabOut, "%s\n", image.printableString(flagImagesFields))
 		}
 	case outputFormatJSON:
 		result, err := json.Marshal(imagesToPrint)

--- a/tests/rkt_image_list_test.go
+++ b/tests/rkt_image_list_test.go
@@ -60,6 +60,82 @@ func (imgID *ImageID) containsConflictingHash(imgIDs []ImageID) (imgIDPair []Ima
 	return
 }
 
+func TestImageList(t *testing.T) {
+	imageName := "coreos.com/rkt/test-image-list-plaintext"
+	imageFile := patchTestACI(unreferencedACI, fmt.Sprintf("--name=%s", imageName))
+	defer os.Remove(imageFile)
+	imageLongHash := "sha512-" + getHashOrPanic(imageFile)[:64]
+	imageShortHash := "sha512-" + getHashOrPanic(imageFile)[:32]
+	imageTruncatedHash := "sha512-" + getHashOrPanic(imageFile)[:12]
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+	fetchCmd := fmt.Sprintf("%s --insecure-options=image fetch %s", ctx.Cmd(), imageFile)
+	runRktAndCheckOutput(t, fetchCmd, imageShortHash, false)
+
+	tests := []struct {
+		testName      string
+		options       string
+		lookupKeyword string
+		expect        string
+		shouldFail    bool
+	}{
+		{
+			"--no-legend suppress header",
+			"--no-legend",
+			"ID",
+			"",
+			true,
+		},
+		{
+			"--fields emits selected fields (truncated hash)",
+			"--fields=id",
+			"",
+			imageTruncatedHash,
+			false,
+		},
+		{
+			"--fields does not emit unwanted fields",
+			"--no-legend --fields=name",
+			"sha",
+			"",
+			true,
+		},
+		{
+			"--full emits long hash",
+			"--fields=id --full",
+			"sha",
+			imageLongHash,
+			false,
+		},
+		{
+			"--format=json suppress header",
+			"--format=json",
+			"ID",
+			"",
+			true,
+		},
+		{
+			"--format=json prints a JSON array",
+			"--format=json",
+			"",
+			"[{",
+			false,
+		},
+		{
+			"--format=json-pretty introduces proper spacing",
+			"--format=json-pretty",
+			"",
+			`"id": "`,
+			false,
+		},
+	}
+	for i, tt := range tests {
+		t.Logf("image-list test #%d: %s", i, tt.testName)
+		runCmd := fmt.Sprintf(`/bin/sh -c '%s image list %s | grep "%s" || exit 254'`, ctx.Cmd(), tt.options, tt.lookupKeyword)
+		runRktAndCheckOutput(t, runCmd, tt.expect, tt.shouldFail)
+	}
+}
+
 func TestImageSize(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/coreos/rkt/pull/3334,
where the `--field` flag is not anymore working for plaintext output.
Tests around image listing are also introduced here to catch future regressions.

Fixes https://github.com/coreos/rkt/issues/3359