### PR TITLE
rkt/run: validates pod manifest to make sure it contains at least one app.

### DIFF
--- a/rkt/run.go
+++ b/rkt/run.go
@@ -384,6 +384,11 @@ func runRun(cmd *cobra.Command, args []string) (exit int) {
 		stderr.PrintE("cannot get the pod manifest", err)
 		return 254
 	}
+
+	if len(manifest.Apps) == 0 {
+		stderr.Print("pod must contain at least one application")
+		return 254
+	}
 	rcfg.Apps = manifest.Apps
 	stage0.Run(rcfg, p.Path(), getDataDir()) // execs, never returns
 

--- a/tests/rkt_run_pod_manifest_test.go
+++ b/tests/rkt_run_pod_manifest_test.go
@@ -1281,3 +1281,24 @@ func TestPodManifest(t *testing.T) {
 		}
 	}
 }
+
+func TestPodManifestWithEmptyApps(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	tmpdir := createTempDirOrPanic("rkt-tests.")
+	defer os.RemoveAll(tmpdir)
+
+	manifest := &schema.PodManifest{
+		Apps:      []schema.RuntimeApp{},
+		ACKind:    schema.PodManifestKind,
+		ACVersion: schema.AppContainerVersion,
+	}
+
+	manifestFile := generatePodManifestFile(t, manifest)
+	defer os.Remove(manifestFile)
+
+	runCmd := fmt.Sprintf("%s run --mds-register=false --pod-manifest=%s", ctx.Cmd(), manifestFile)
+	runEmptyAppsMsg := "pod must contain at least one application"
+	runRktAndCheckOutput(t, runCmd, runEmptyAppsMsg, true)
+}


### PR DESCRIPTION
@s-urbaniak PTAL

When using --pod-manifest we need to make sure that the pod manifest
contains at least one defined app.

Fixes: #3338