### PR TITLE
release: rkt 1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 1.19.0
+
+This release contains multiple changes to rkt core, bringing it more in line with the new Container Runtime Interface (CRI) from Kubernetes.
+
+A new experimental `app` subcommand has been introduced, which allows creating a "pod sandbox" and dynamically mutating it at runtime. This feature is not yet completely stabilized, and is currently gated behind an experimental flag.
+
+### New features and UX changes
+- rkt: experimental support for pod sandbox ([#3318](https://github.com/coreos/rkt/pull/3318)). This PR introduces an experimental `app` subcommand and many additional app-level options.
+- rkt/image: align image selection behavior for the rm subcommand ([#3353](https://github.com/coreos/rkt/pull/3353)).
+- stage1/init: leave privileged pods without stage2 mount-ns ([#3290](https://github.com/coreos/rkt/pull/3290)).
+- stage0/image: list images output in JSON format ([#3334](https://github.com/coreos/rkt/pull/3334)).
+- stage0/arch: initial support for ppc64le platform ([#3315](https://github.com/coreos/rkt/pull/3315)).
+
+### Bug fixes:
+- gc: make sure `CNI_PATH` is same for gc and init ([#3348](https://github.com/coreos/rkt/pull/3348)).
+- gc: clean up some GC leaks ([#3317](https://github.com/coreos/rkt/pull/3317)).
+- stage0: minor wording fixes ([#3351](https://github.com/coreos/rkt/pull/3351)).
+- setup-data-dir.sh: fallback to the `mkdir/chmod`s if the rkt.conf doesn't exist ([#3335](https://github.com/coreos/rkt/pull/3335)).
+- scripts: add gpg to Debian dependencies ([#3339](https://github.com/coreos/rkt/pull/3339)).
+- kvm: fix for breaking change in Debian Sid GCC default options ([#3354](https://github.com/coreos/rkt/pull/3354)).
+- image/list: bring back field filtering in plaintext mode ([#3361](https://github.com/coreos/rkt/pull/3361)).
+
+### Other changes
+- cgroup/v1: introduce mount flags to mountFsRO ([#3350](https://github.com/coreos/rkt/pull/3350)).
+- kvm: update QEMU version to 2.7.0 ([#3341](https://github.com/coreos/rkt/pull/3341)).
+- kvm: bump kernel version to 4.8.6, updated config ([#3342](https://github.com/coreos/rkt/pull/3342)). 
+- vendor: introduce kr/pretty and bump go-systemd ([#3333](https://github.com/coreos/rkt/pull/3333)).
+- vendor: update docker2aci to 0.14.0 ([#3356](https://github.com/coreos/rkt/pull/3356)).
+- tests: add the --debug option to more tests ([#3340](https://github.com/coreos/rkt/pull/3340)).
+- scripts/build-rir: bump rkt-builder version to 1.1.1 ([#3360](https://github.com/coreos/rkt/pull/3360)).
+- Documentation updates: [#3321](https://github.com/coreos/rkt/pull/3321), [#3331](https://github.com/coreos/rkt/pull/3331), [#3325](https://github.com/coreos/rkt/pull/3325).
+
 ## 1.18.0
 
 This minor release contains bugfixes, UX enhancements, and other improvements.

--- a/Documentation/distributions.md
+++ b/Documentation/distributions.md
@@ -143,19 +143,19 @@ upgrade manually.
 ### rpm-based 
 ```
 gpg --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-wget https://github.com/coreos/rkt/releases/download/v1.18.0/rkt-1.18.0-1.x86_64.rpm
-wget https://github.com/coreos/rkt/releases/download/v1.18.0/rkt-1.18.0-1.x86_64.rpm.asc
-gpg --verify rkt-1.18.0-1.x86_64.rpm.asc
-sudo rpm -Uvh rkt-1.18.0-1.x86_64.rpm
+wget https://github.com/coreos/rkt/releases/download/v1.19.0/rkt-1.19.0-1.x86_64.rpm
+wget https://github.com/coreos/rkt/releases/download/v1.19.0/rkt-1.19.0-1.x86_64.rpm.asc
+gpg --verify rkt-1.19.0-1.x86_64.rpm.asc
+sudo rpm -Uvh rkt-1.19.0-1.x86_64.rpm
 ```
 
 ### deb-based
 ```
 gpg --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-wget https://github.com/coreos/rkt/releases/download/v1.18.0/rkt_1.18.0-1_amd64.deb
-wget https://github.com/coreos/rkt/releases/download/v1.18.0/rkt_1.18.0-1_amd64.deb.asc
-gpg --verify rkt_1.18.0-1_amd64.deb.asc
-sudo dpkg -i rkt_1.18.0-1_amd64.deb
+wget https://github.com/coreos/rkt/releases/download/v1.19.0/rkt_1.19.0-1_amd64.deb
+wget https://github.com/coreos/rkt/releases/download/v1.19.0/rkt_1.19.0-1_amd64.deb.asc
+gpg --verify rkt_1.19.0-1_amd64.deb.asc
+sudo dpkg -i rkt_1.19.0-1_amd64.deb
 ```
 
 [coreos-install-rkt]: install-rkt-in-coreos.md

--- a/Documentation/running-fly-stage1.md
+++ b/Documentation/running-fly-stage1.md
@@ -60,14 +60,14 @@ $ ./autogen.sh && ./configure --with-stage1-flavors=fly && make
 ```
 
 For more details about configure parameters, see the [configure script parameters documentation][build-configure].
-This will build the rkt binary and the stage1-fly.aci in `build-rkt-1.18.0+git/bin/`.
+This will build the rkt binary and the stage1-fly.aci in `build-rkt-1.19.0+git/bin/`.
 
 ### Selecting stage1 at runtime
 
 Here is a quick example of how to use a container with the official fly stage1:
 
 ```
-# rkt run --stage1-name=coreos.com/rkt/stage1-fly:1.18.0 coreos.com/etcd:v2.2.5
+# rkt run --stage1-name=coreos.com/rkt/stage1-fly:1.19.0 coreos.com/etcd:v2.2.5
 ```
 
 If the image is not in the store, `--stage1-name` will perform discovery and fetch the image.

--- a/Documentation/running-kvm-stage1.md
+++ b/Documentation/running-kvm-stage1.md
@@ -13,7 +13,7 @@ $ ./autogen.sh && ./configure --with-stage1-flavors=kvm --with-stage1-kvm-hyperv
 ```
 
 For more details about configure parameters, see [configure script parameters documentation][build-configure].
-This will build the rkt binary and the KVM stage1 aci image in `build-rkt-1.18.0+git/target/bin/`. Depending on the configuration options, it will be `stage1-kvm.aci` (if one hypervisor is set), or `stage1-kvm-lkvm.aci` and `stage1-kvm-qemu.aci` (if you want to have both images built once).
+This will build the rkt binary and the KVM stage1 aci image in `build-rkt-1.19.0+git/target/bin/`. Depending on the configuration options, it will be `stage1-kvm.aci` (if one hypervisor is set), or `stage1-kvm-lkvm.aci` and `stage1-kvm-qemu.aci` (if you want to have both images built once).
 
 Provided you have hardware virtualization support and the [kernel KVM module][kvm-module] loaded (refer to your distribution for instructions), you can then run an image like you would normally do with rkt:
 
@@ -84,7 +84,7 @@ If you want to run software that requires hypervisor isolation along with truste
 For example, to use the official kvm stage1:
 
 ```
-# rkt run --stage1-name=coreos.com/rkt/stage1-kvm:1.18.0 coreos.com/etcd:v2.0.9
+# rkt run --stage1-name=coreos.com/rkt/stage1-kvm:1.19.0 coreos.com/etcd:v2.0.9
 ...
 ```
 

--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -8,7 +8,7 @@ Support for overlay fs will be auto-detected if `--no-overlay` is set to `false`
 
 ```
 # rkt prepare --insecure-options=image docker://busybox --exec=/bin/sh
-image: using image from local store for image name coreos.com/rkt/stage1-coreos:1.18.0
+image: using image from local store for image name coreos.com/rkt/stage1-coreos:1.19.0
 image: remote fetching from URL "docker://busybox"
 Downloading sha256:8ddc19f1652 [===============================] 668 KB / 668 KB
 prepare: disabling overlay support: "unsupported filesystem: missing d_type support"
@@ -32,7 +32,7 @@ Therefore, the supported arguments are mostly the same as in `run` except runtim
 ```
 # rkt prepare coreos.com/etcd:v2.0.10
 rkt prepare coreos.com/etcd:v2.0.10
-rkt: using image from local store for image name coreos.com/rkt/stage1-coreos:1.18.0
+rkt: using image from local store for image name coreos.com/rkt/stage1-coreos:1.19.0
 rkt: searching for app image coreos.com/etcd:v2.0.10
 rkt: remote fetching from url https://github.com/coreos/etcd/releases/download/v2.0.10/etcd-v2.0.10-linux-amd64.aci
 prefix: "coreos.com/etcd"

--- a/Documentation/subcommands/version.md
+++ b/Documentation/subcommands/version.md
@@ -6,7 +6,7 @@ This command prints the rkt version, the appc version rkt is built against, and 
 
 ```
 $ rkt version
-rkt Version: 1.18.0
+rkt Version: 1.19.0
 appc Version: 0.8.8
 Go Version: go1.5.3
 Go OS/Arch: linux/amd64

--- a/Documentation/trying-out-rkt.md
+++ b/Documentation/trying-out-rkt.md
@@ -20,9 +20,9 @@ rkt is written in Go and can be compiled for several CPU architectures. The rkt 
 To start running the latest version of rkt on amd64, grab the release directly from the rkt GitHub project:
 
 ```
-wget https://github.com/coreos/rkt/releases/download/v1.18.0/rkt-v1.18.0.tar.gz
-tar xzvf rkt-v1.18.0.tar.gz
-cd rkt-v1.18.0
+wget https://github.com/coreos/rkt/releases/download/v1.19.0/rkt-v1.19.0.tar.gz
+tar xzvf rkt-v1.19.0.tar.gz
+cd rkt-v1.19.0
 ./rkt help
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,17 +15,13 @@ rkt's version 1.0 release marks the command line user interface and on-disk data
 
 ## Next releases
 
-### rkt 1.18.0 (October)
-
-Up-to-date planning at https://github.com/coreos/rkt/milestone/52.
-
-### rkt 1.19.0 (November)
-
-Up-to-date planning at https://github.com/coreos/rkt/milestone/53.
-
 ### rkt 1.20.0 (November)
 
 Up-to-date planning at https://github.com/coreos/rkt/milestone/54.
+
+### rkt 1.21.0 (December)
+
+Up-to-date planning at https://github.com/coreos/rkt/milestone/55.
 
 ### Upcoming
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([rkt], [1.19.0], [https://github.com/coreos/rkt/issues])
+AC_INIT([rkt], [1.19.0+git], [https://github.com/coreos/rkt/issues])
 
 AC_PROG_CC
 AC_PROG_CXX

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([rkt], [1.18.0+git], [https://github.com/coreos/rkt/issues])
+AC_INIT([rkt], [1.19.0], [https://github.com/coreos/rkt/issues])
 
 AC_PROG_CC
 AC_PROG_CXX

--- a/scripts/install-rkt.sh
+++ b/scripts/install-rkt.sh
@@ -4,7 +4,7 @@ set -x
 
 cd $(mktemp -d)
 
-version="1.18.0"
+version="1.19.0"
 
 export DEBIAN_FRONTEND=noninteractive
 

--- a/tests/empty-image/manifest
+++ b/tests/empty-image/manifest
@@ -5,7 +5,7 @@
     "labels": [
         {
             "name": "version",
-            "value": "1.18.0"
+            "value": "1.19.0"
         },
         {
             "name": "arch",

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -5,7 +5,7 @@
     "labels": [
         {
             "name": "version",
-            "value": "1.18.0"
+            "value": "1.19.0"
         },
         {
             "name": "arch",

--- a/tests/rkt-monitor/build-stresser.sh
+++ b/tests/rkt-monitor/build-stresser.sh
@@ -27,7 +27,7 @@ buildImages() {
     acbuild --debug begin
     trap acbuildEnd EXIT
     acbuild --debug set-name appc.io/rkt-"${1}"-stresser
-    acbuild --debug copy build-rkt-1.18.0+git/target/bin/"${1}"-stresser /worker
+    acbuild --debug copy build-rkt-1.19.0/target/bin/"${1}"-stresser /worker
     acbuild --debug set-exec -- /worker
     acbuild --debug write --overwrite "${1}"-stresser.aci
     acbuild --debug end

--- a/tests/rkt-monitor/build-stresser.sh
+++ b/tests/rkt-monitor/build-stresser.sh
@@ -27,7 +27,7 @@ buildImages() {
     acbuild --debug begin
     trap acbuildEnd EXIT
     acbuild --debug set-name appc.io/rkt-"${1}"-stresser
-    acbuild --debug copy build-rkt-1.19.0/target/bin/"${1}"-stresser /worker
+    acbuild --debug copy build-rkt-1.19.0+git/target/bin/"${1}"-stresser /worker
     acbuild --debug set-exec -- /worker
     acbuild --debug write --overwrite "${1}"-stresser.aci
     acbuild --debug end

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.8.8","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.18.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
+	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.8.8","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.19.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
 )
 
 func TestRunOverrideExec(t *testing.T) {

--- a/tests/rkt_image_cat_manifest_test.go
+++ b/tests/rkt_image_cat_manifest_test.go
@@ -29,7 +29,7 @@ import (
 const (
 
 	// The expected image manifest of the 'rkt-inspect-image-cat-manifest.aci'.
-	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.8","name":"IMG_NAME","labels":[{"name":"version","value":"1.18.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.8","name":"IMG_NAME","labels":[{"name":"version","value":"1.19.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageCatManifest tests 'rkt image cat-manifest', it will:

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.8","name":"IMG_NAME","labels":[{"name":"version","value":"1.18.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.8","name":"IMG_NAME","labels":[{"name":"version","value":"1.19.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageExport tests 'rkt image export', it will import some existing

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.8","name":"IMG_NAME","labels":[{"name":"version","value":"1.18.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.8","name":"IMG_NAME","labels":[{"name":"version","value":"1.19.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageRender tests 'rkt image render', it will import some existing empty

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	manifestOSArchTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.8","name":"IMG_NAME","labels":[{"name":"version","value":"1.18.0"}ARCH_OS],"app":{"exec":["/inspect", "--print-msg=HelloWorld"],"user":"0","group":"0","workingDirectory":"/"}}`
+	manifestOSArchTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.8","name":"IMG_NAME","labels":[{"name":"version","value":"1.19.0"}ARCH_OS],"app":{"exec":["/inspect", "--print-msg=HelloWorld"],"user":"0","group":"0","workingDirectory":"/"}}`
 )
 
 type osArchTest struct {


### PR DESCRIPTION
## 1.19.0

This release contains multiple changes to rkt core, bringing it more in line with the new Container Runtime Interface (CRI) from Kubernetes.

A new experimental `app` subcommand has been introduced, which allows creating a "pod sandbox" and dynamically mutating it at runtime. This feature is not yet completely stabilized, and is currently gated behind an experimental flag.
