### PR TITLE
docs: removed a passage from Debian section about a bug now solved

### DIFF
--- a/Documentation/distributions.md
+++ b/Documentation/distributions.md
@@ -46,12 +46,6 @@ rkt is currently packaged in [Debian sid][pkg-debian] (unstable).
 sudo apt-get install rkt
 ```
 
-Note that due to an [outstanding bug][debian-823322] one has to use the "coreos" stage1 image:
-
-```
-sudo rkt run --insecure-options=image --stage1-name=coreos.com/rkt/stage1-coreos:1.16.0 docker://nginx
-```
-
 If you don't run sid, or wish for a newer version, you can [install manually](#deb-based).
 
 ## Fedora


### PR DESCRIPTION
As the systemd-sysuser bug[1] is now solved i removed the lines that referenced it from the documentation 

[1] https://github.com/coreos/rkt/issues/2571#issuecomment-260627481