### PR TITLE
remove isReallyNil()

### DIFF
--- a/rkt/image/common.go
+++ b/rkt/image/common.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"time"
 
@@ -90,36 +89,6 @@ func ensureLogger(debug bool) {
 	if !debug {
 		diag.SetOutput(ioutil.Discard)
 	}
-}
-
-// isReallyNil makes sure that the passed value is really really
-// nil. So it returns true if value is plain nil or if it is e.g. an
-// interface with non-nil type but nil-value (which normally is
-// different from nil itself).
-func isReallyNil(iface interface{}) bool {
-	// this catches the cases when you pass non-interface nil
-	// directly, like:
-	//
-	// isReallyNil(nil)
-	// var m map[string]string
-	// isReallyNil(m)
-	if iface == nil {
-		return true
-	}
-	// get a reflect value
-	v := reflect.ValueOf(iface)
-	// only channels, functions, interfaces, maps, pointers and
-	// slices are nillable
-	switch v.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
-		// this catches the cases when you pass some interface
-		// with nil value, like:
-		//
-		// var v io.Closer = func(){var f *os.File; return f}()
-		// isReallyNil(v)
-		return v.IsNil()
-	}
-	return false
 }
 
 // useCached checks if downloadTime plus maxAge is before/after the current time.

--- a/rkt/image/common_test.go
+++ b/rkt/image/common_test.go
@@ -15,10 +15,7 @@
 package image
 
 import (
-	"io"
-	"io/ioutil"
 	"net/url"
-	"os"
 	"testing"
 	"time"
 
@@ -179,52 +176,6 @@ func TestUseCached(t *testing.T) {
 		got := useCached(age, maxAge)
 		if got != tt.use {
 			t.Errorf("expected useCached(%v, %v) to return %v, but it returned %v", age, maxAge, tt.use, got)
-		}
-	}
-}
-
-func TestIsReallyNil(t *testing.T) {
-	tests := []struct {
-		name  string
-		iface interface{}
-		isNil bool
-	}{
-		// plain nil
-		{
-			name:  "plain nil",
-			iface: nil,
-			isNil: true,
-		},
-		// some pointer
-		{
-			name:  "some pointer",
-			iface: &struct{}{},
-			isNil: false,
-		},
-		// a nil interface
-		{
-			name:  "a nil interface",
-			iface: func() io.Closer { return nil }(),
-			isNil: true,
-		},
-		// a non-nil interface with nil value
-		{
-			name:  "a non-nil interface with nil value",
-			iface: func() io.Closer { var v *os.File; return v }(),
-			isNil: true,
-		},
-		// a non-nil interface with non-nil value
-		{
-			name:  "a non-nil interface with non-nil value",
-			iface: func() io.Closer { return ioutil.NopCloser(nil) }(),
-			isNil: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Log(tt.name)
-		got := isReallyNil(tt.iface)
-		if tt.isNil != got {
-			t.Errorf("expected isReallyNil(%#v) to return %v, but got %v", tt.iface, tt.isNil, got)
 		}
 	}
 }

--- a/rkt/image/downloader.go
+++ b/rkt/image/downloader.go
@@ -52,7 +52,6 @@ type downloader struct {
 // Download tries to fetch the passed URL and write the contents into
 // a given writeSyncer instance.
 func (d *downloader) Download(u *url.URL, out writeSyncer) error {
-	d.ensureSession()
 	client, err := d.Session.Client()
 	if err != nil {
 		return err
@@ -84,12 +83,6 @@ func (d *downloader) Download(u *url.URL, out writeSyncer) error {
 	}
 
 	return nil
-}
-
-func (d *downloader) ensureSession() {
-	if isReallyNil(d.Session) {
-		d.Session = &defaultDownloadSession{}
-	}
 }
 
 // default DownloadSession is very simple implementation of

--- a/rkt/image/io.go
+++ b/rkt/image/io.go
@@ -43,6 +43,18 @@ type readSeekCloser interface {
 	io.Closer
 }
 
+type nopReadSeekCloser struct {
+	io.ReadSeeker
+}
+
+func (nopReadSeekCloser) Close() error { return nil }
+
+// NopReadSeekCloser wraps the given ReadSeeker
+// and returns one that does nothing when Close() is being invoked.
+func NopReadSeekCloser(rs io.ReadSeeker) readSeekCloser {
+	return nopReadSeekCloser{rs}
+}
+
 // getIoProgressReader returns a reader that wraps the HTTP response
 // body, so it prints a pretty progress bar when reading data from it.
 func getIoProgressReader(label string, res *http.Response) io.Reader {
@@ -93,6 +105,9 @@ func (f *removeOnClose) Seek(offset int64, whence int) (int64, error) {
 // Close closes the file and then removes it from disk. No error is
 // returned if the file did not exist at the point of removal.
 func (f *removeOnClose) Close() error {
+	if f == nil || f.File == nil {
+		return nil
+	}
 	name := f.File.Name()
 	if err := f.File.Close(); err != nil {
 		return err
@@ -115,6 +130,7 @@ func getTmpROC(s *imagestore.Store, path string) (*removeOnClose, error) {
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("error setting up temporary file"), err)
 	}
+
 	// let's lock the file to avoid concurrent writes to the temporary file, it
 	// will go away when removing the temp file
 	_, err = lock.TryExclusiveLock(tmp.Name(), lock.RegFile)
@@ -128,14 +144,6 @@ func getTmpROC(s *imagestore.Store, path string) (*removeOnClose, error) {
 			return nil, errwrap.Wrap(errors.New("failed to lock temporary file"), err)
 		}
 	}
-	roc := &removeOnClose{File: tmp}
-	return roc, nil
-}
 
-// maybeClose is a convenient function for closing io.Closers if they
-// are not nil. Useful in defers.
-func maybeClose(c io.Closer) {
-	if !isReallyNil(c) {
-		c.Close()
-	}
+	return &removeOnClose{File: tmp}, nil
 }

--- a/rkt/image/namefetcher.go
+++ b/rkt/image/namefetcher.go
@@ -121,7 +121,7 @@ func (f *nameFetcher) fetchImageFromSingleEndpoint(app *discovery.App, aciURL st
 	if err != nil {
 		return "", err
 	}
-	defer func() { maybeClose(aciFile) }()
+	defer aciFile.Close()
 
 	if key := maybeUseCached(rem, cd); key != "" {
 		return key, nil
@@ -174,6 +174,9 @@ func (f *nameFetcher) fetch(app *discovery.App, aciURL string, a *asc, etag stri
 }
 
 func (f *nameFetcher) fetchVerifiedURL(app *discovery.App, u *url.URL, a *asc, etag string) (readSeekCloser, *cacheData, error) {
+	var aciFile readSeekCloser // closed on error
+	var errClose error         // error signaling to close aciFile
+
 	appName := app.Name.String()
 	f.maybeFetchPubKeys(appName)
 
@@ -182,7 +185,7 @@ func (f *nameFetcher) fetchVerifiedURL(app *discovery.App, u *url.URL, a *asc, e
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() { maybeClose(ascFile) }()
+	defer ascFile.Close()
 
 	if !retry {
 		if err := f.checkIdentity(appName, ascFile); err != nil {
@@ -194,24 +197,33 @@ func (f *nameFetcher) fetchVerifiedURL(app *discovery.App, u *url.URL, a *asc, e
 	if err != nil {
 		return nil, nil, err
 	}
-	defer func() { maybeClose(aciFile) }()
+
+	defer func() {
+		if errClose != nil {
+			aciFile.Close()
+		}
+	}()
+
 	if cd.UseCached {
+		aciFile.Close()
 		return nil, cd, nil
 	}
 
 	if retry {
-		ascFile, err = o.DownloadSignatureAgain(a)
-		if err != nil {
-			return nil, nil, err
+		ascFile.Close()
+		ascFile, errClose = o.DownloadSignatureAgain(a)
+		if errClose != nil {
+			ascFile = NopReadSeekCloser(nil)
+			return nil, nil, errClose
 		}
 	}
 
-	if err := f.validate(app, aciFile, ascFile); err != nil {
-		return nil, nil, err
+	errClose = f.validate(app, aciFile, ascFile)
+	if errClose != nil {
+		return nil, nil, errClose
 	}
-	retAciFile := aciFile
-	aciFile = nil
-	return retAciFile, cd, nil
+
+	return aciFile, cd, nil
 }
 
 func (f *nameFetcher) maybeFetchPubKeys(appName string) {


### PR DESCRIPTION
This PR implements the NopCloser()-like function NopReadSeekCloser() and some other cleanups related to the removing of isReallyNil().

Fixes #2922

Supersedes #3120