### PR TITLE
image: export `ImageListEntry` type for image list

### DIFF
--- a/lib/types.go
+++ b/lib/types.go
@@ -81,4 +81,19 @@ type (
 		// UserLabels are the pod user labels.
 		UserLabels map[string]string `json:"user_labels,omitempty"`
 	}
+
+	ImageListEntry struct {
+		// ID is the Image ID for this image
+		ID string `json:"id"`
+		// Name is the name of this image, such as example.com/some/image
+		Name string `json:"name"`
+		// ImportTime indicates when this image was imported in nanoseconds
+		// since the unix epoch
+		ImportTime int64 `json:"import_time"`
+		// LastUsedTime indicates when was last used in nanoseconds since the
+		// unix epoch
+		LastUsedTime int64 `json:"last_used_time"`
+		// Size is the size of this image in bytes
+		Size int64 `json:"size"`
+	}
 )


### PR DESCRIPTION
This allows external consumers to just directly unmarshal json into this
exported type.

I modified the types of some of its values for consistency with other
exported types as well. This is unfortunately backwards incompatible.