### PR TITLE
cri: correct 'created' timestamp

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -109,6 +109,12 @@ func PodManifestPath(root string) string {
 	return filepath.Join(root, "pod")
 }
 
+// PodCreatedPath returns the path in root to the Pod Created file used to
+// denote the time of creation.
+func PodCreatedPath(root string) string {
+	return filepath.Join(root, "pod-created")
+}
+
 // PodManifestLockPath returns the path in root to the Pod Manifest lock file.
 // This must be different from the PodManifestPath since mutations on the pod manifest file
 // happen by overwriting the original file.

--- a/lib/app.go
+++ b/lib/app.go
@@ -168,7 +168,7 @@ func appState(app *App, pod *pkgPod.Pod) error {
 	// Read exit code.
 	exitCode, err := readExitCode(appStatusFile)
 	if err != nil {
-		return fmt.Errorf("cannot read exit code: %v", err)
+		return err
 	}
 	app.ExitCode = &exitCode
 

--- a/pkg/pod/pods.go
+++ b/pkg/pod/pods.go
@@ -971,10 +971,18 @@ func (p *Pod) AppImageManifest(appName string) (*schema.ImageManifest, error) {
 // CreationTime returns the time when the pod was created.
 // This happens at prepare time.
 func (p *Pod) CreationTime() (time.Time, error) {
-	if p.isPrepared || p.isRunning() || p.AfterRun() {
-		return p.getModTime("pod")
+	if !(p.isPrepared || p.isRunning() || p.AfterRun()) {
+		return time.Time{}, nil
 	}
-	return time.Time{}, nil
+	t, err := p.getModTime("pod-created")
+	if err == nil {
+		return t, nil
+	}
+	if !os.IsNotExist(err) {
+		return t, err
+	}
+	// backwards compatibility with rkt before v1.20
+	return p.getModTime("pod")
 }
 
 // StartTime returns the time when the pod was started.

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -498,6 +498,12 @@ func Prepare(cfg PrepareConfig, dir string, uuid *types.UUID) error {
 		return errwrap.Wrap(errors.New("error writing pod manifest"), err)
 	}
 
+	f, err = os.OpenFile(common.PodCreatedPath(dir), os.O_CREATE|os.O_RDWR, common.DefaultRegularFilePerm)
+	if err != nil {
+		return err
+	}
+	f.Close()
+
 	if cfg.UseOverlay {
 		// mark the pod as prepared with overlay
 		f, err := os.Create(filepath.Join(dir, common.OverlayPreparedFilename))

--- a/tests/rkt_api_service_test.go
+++ b/tests/rkt_api_service_test.go
@@ -397,7 +397,7 @@ func NewAPIServiceListInspectPodsTest() testutils.Test {
 						},
 					},
 				},
-				"non-existed-network",
+				"non-existent-network",
 				254,
 			},
 		}


### PR DESCRIPTION
Prior to this change, the mtime of the 'pod' file is used for the created
timestamp.

This is inaccurate in the case of CRI where the pod manifest is changed
with each app added.

To resolve that problem, a new file is introduced which is not touched
by the app add codepath.