### PR TITLE
stage0: improve list --format behavior and flags

### DIFF
--- a/pkg/pod/pods.go
+++ b/pkg/pod/pods.go
@@ -980,24 +980,29 @@ func (p *Pod) CreationTime() (time.Time, error) {
 // StartTime returns the time when the pod was started.
 func (p *Pod) StartTime() (time.Time, error) {
 	var (
-		t   time.Time
-		err error
+		t      time.Time
+		retErr error
 	)
-	if p.isRunning() || p.AfterRun() {
-		// check pid and ppid files, since stage1 implementations can choose
-		// which one to implement.
-		t, err = p.getModTime("pid")
-		if os.IsNotExist(err) {
-			t, err = p.getModTime("ppid")
-			// if there's an error starting the pod, it can be "exited" without
-			// the "ppid" (or "pid") files being created, return an error only
-			// if it's different than ENOENT.
-			if os.IsNotExist(err) {
-				err = nil
-			}
+
+	if !p.isRunning() && !p.AfterRun() {
+		// hasn't started
+		return t, nil
+	}
+
+	// check pid and ppid since stage1s can choose one xor the other
+	for _, ctimeFile := range []string{"pid", "ppid"} {
+		t, err := p.getModTime(ctimeFile)
+		if err == nil {
+			return t, nil
+		}
+		// if there's an error starting the pod, it can go to "exited" without
+		// creating a ppid/pid file, so ignore not-exist errors.
+		if !os.IsNotExist(err) {
+			retErr = err
 		}
 	}
-	return t, err
+
+	return t, retErr
 }
 
 // GCMarkedTime returns the time when the pod is marked by gc.
@@ -1154,6 +1159,17 @@ func (p *Pod) isRunning() bool {
 	// when none of these things, running!
 	return !p.isEmbryo && !p.isAbortedPrepare && !p.isPreparing && !p.isPrepared &&
 		!p.isExited && !p.isExitedGarbage && !p.isExitedDeleting && !p.isGarbage && !p.isDeleting && !p.isGone
+}
+
+// PodManifestAvailable returns whether the caller should reasonably expect
+// PodManifest to function in the pod's current state.
+// Namely, in Preparing, AbortedPrepare, and Deleting it's possible for the
+// manifest to not be present
+func (p *Pod) PodManifestAvailable() bool {
+	if p.isPreparing || p.isAbortedPrepare || p.isDeleting {
+		return false
+	}
+	return true
 }
 
 // AfterRun returns true if the pod is in a post-running state, otherwise it returns false.

--- a/rkt/app_status.go
+++ b/rkt/app_status.go
@@ -36,7 +36,7 @@ var (
 func init() {
 	cmdApp.AddCommand(cmdAppStatus)
 	cmdAppStatus.Flags().StringVar(&flagAppName, "app", "", "choose app within the pod, this flag must be set")
-	cmdAppStatus.Flags().StringVar(&flagFormat, "format", "", "choose the output format, allowed format includes 'json', 'json-pretty'. If empty, then the result is printed as key value pairs")
+	cmdAppStatus.Flags().Var(&flagFormat, "format", "choose the output format, allowed format includes 'json', 'json-pretty'. If empty, then the result is printed as key value pairs")
 }
 
 func printApp(app *rkt.App) {
@@ -112,14 +112,14 @@ func runAppStatus(cmd *cobra.Command, args []string) (exit int) {
 
 	// TODO(yifan): Print yamls.
 	switch flagFormat {
-	case "json":
+	case outputFormatJSON:
 		result, err := json.Marshal(apps[0])
 		if err != nil {
 			stderr.PrintE("error marshaling the app status", err)
 			return 1
 		}
 		stdout.Print(string(result))
-	case "json-pretty":
+	case outputFormatPrettyJSON:
 		result, err := json.MarshalIndent(apps[0], "", "\t")
 		if err != nil {
 			stderr.PrintE("error marshaling the app status", err)

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -46,7 +46,7 @@ const (
 func init() {
 	cmdRkt.AddCommand(cmdStatus)
 	cmdStatus.Flags().BoolVar(&flagWait, "wait", false, "toggle waiting for the pod to exit")
-	cmdStatus.Flags().StringVar(&flagFormat, "format", "", "choose the output format, allowed format includes 'json', 'json-pretty'. If empty, then the result is printed as key value pairs")
+	cmdStatus.Flags().Var(&flagFormat, "format", "choose the output format, allowed format includes 'json', 'json-pretty'. If empty, then the result is printed as key value pairs")
 }
 
 func runStatus(cmd *cobra.Command, args []string) (exit int) {
@@ -97,19 +97,19 @@ func getExitStatuses(p *pkgPod.Pod) (map[string]int, error) {
 
 // printStatus prints the pod's pid and per-app status codes
 func printStatus(p *pkgPod.Pod) error {
-	if flagFormat != "" {
+	if flagFormat != outputFormatTabbed {
 		pod, err := lib.NewPodFromInternalPod(p)
 		if err != nil {
 			return fmt.Errorf("error converting pod: %v", err)
 		}
 		switch flagFormat {
-		case "json":
+		case outputFormatJSON:
 			result, err := json.Marshal(pod)
 			if err != nil {
 				return fmt.Errorf("error marshaling the pod: %v", err)
 			}
 			stdout.Print(string(result))
-		case "json-pretty":
+		case outputFormatPrettyJSON:
 			result, err := json.MarshalIndent(pod, "", "\t")
 			if err != nil {
 				return fmt.Errorf("error marshaling the pod: %v", err)


### PR DESCRIPTION
This change reuses the `image list` flag parsing for `list`.

It also makes `list` and `list --format=json` have more similar behavior
in when the pod manifest is skipped.

Fixes #3402 

I'd also like to add more tests since I wouldn't be surprised if the coverage is a bit low here.