### PR TITLE
pkg/mountinfo: move mountinfo parser to its own package

### DIFF
--- a/pkg/mountinfo/mountinfo.go
+++ b/pkg/mountinfo/mountinfo.go
@@ -1,0 +1,141 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mountinfo
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/errwrap"
+)
+
+// HasPrefix returns a FilterFunc which returns true if
+// the mountpoint of a given mount has prefix p, else false.
+func HasPrefix(p string) FilterFunc {
+	return FilterFunc(func(m *Mount) bool {
+		return strings.HasPrefix(m.MountPoint, p)
+	})
+}
+
+// ParseMounts returns all mountpoints associated with a process mount namespace.
+// The special value 0 as pid argument is used to specify the current process.
+func ParseMounts(pid uint) (Mounts, error) {
+	var procPath string
+	if pid == 0 {
+		procPath = "/proc/self/mountinfo"
+	} else {
+		procPath = fmt.Sprintf("/proc/%d/mountinfo", pid)
+	}
+
+	mi, err := os.Open(procPath)
+	if err != nil {
+		return nil, err
+	}
+	defer mi.Close()
+
+	return parseMountinfo(mi)
+}
+
+// parseMountinfo parses mi (/proc/<pid>/mountinfo) and returns mounts information
+// according to https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+func parseMountinfo(mi io.Reader) (Mounts, error) {
+	var podMounts Mounts
+	sc := bufio.NewScanner(mi)
+	var (
+		mountID    int
+		parentID   int
+		major      int
+		minor      int
+		root       string
+		mountPoint string
+		opt        map[string]struct{}
+	)
+
+	for sc.Scan() {
+		line := sc.Text()
+		columns := strings.Split(line, " ")
+		if len(columns) < 7 {
+			return nil, fmt.Errorf("Not enough fields from line %q: %+v", line, columns)
+		}
+
+		opt = map[string]struct{}{}
+		for i, col := range columns {
+			if col == "-" {
+				// separator: a single hyphen "-" marks the end of "optional fields"
+				break
+			}
+			var err error
+			switch i {
+			case 0:
+				mountID, err = strconv.Atoi(col)
+			case 1:
+				parentID, err = strconv.Atoi(col)
+			case 2:
+				split := strings.Split(col, ":")
+				if len(split) != 2 {
+					err = fmt.Errorf("found unexpected key:value field with more than two colons: %s", col)
+					break
+				}
+				major, err = strconv.Atoi(split[0])
+				if err != nil {
+					break
+				}
+				minor, err = strconv.Atoi(split[1])
+				if err != nil {
+					break
+				}
+			case 3:
+				root = col
+			case 4:
+				mountPoint = col
+			default:
+				split := strings.Split(col, ":")
+				switch len(split) {
+				case 1:
+					// we ignore modes like rw, relatime, etc.
+				case 2:
+					opt[split[0]] = struct{}{}
+				default:
+					err = fmt.Errorf("found unexpected key:value field with more than two colons: %s", col)
+				}
+			}
+			if err != nil {
+				return nil, errwrap.Wrap(fmt.Errorf("could not parse mountinfo line %q", line), err)
+			}
+		}
+
+		mnt := &Mount{
+			ID:         mountID,
+			Parent:     parentID,
+			Major:      major,
+			Minor:      minor,
+			Root:       root,
+			MountPoint: mountPoint,
+			Opts:       opt,
+		}
+		podMounts = append(podMounts, mnt)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, errwrap.Wrap(errors.New("problem parsing mountinfo"), err)
+	}
+	sort.Sort(podMounts)
+	return podMounts, nil
+}

--- a/pkg/mountinfo/mountinfo_test.go
+++ b/pkg/mountinfo/mountinfo_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The rkt Authors
+// Copyright 2016 The rkt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package stage0
+// +build linux
+
+package mountinfo
 
 import (
+	"bytes"
 	"fmt"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
 
 var mountinfo = `39 21 0:36 / /tmp rw shared:91 -
+18 39 0:18 / /sys rw,nosuid,nodev,noexec,relatime shared:7 - sysfs sysfs rw
+19 39 0:4 / /proc rw,nosuid,nodev,noexec,relatime shared:13 - proc proc rw
 71 21 0:39 / /var/lib/rkt rw,relatime shared:26 -
 69 21 0:19 /home /home rw,relatime shared:27 -
 70 20 0:41 / /run/user/1000 rw,nosuid,nodev,relatime shared:28 -
@@ -79,6 +86,22 @@ var mountinfo = `39 21 0:36 / /tmp rw shared:91 -
 255 193 179:1 / /prefix/stage1/rootfs/opt/stage2/busybox/rootfs/rootfs/mnt/unknown ro,relatime -
 `
 
+// safeOrder checks for transitivity and (un)mount order sanity
+func safeOrder(ms Mounts) error {
+	for i, m := range ms {
+		for j, mnext := range ms[i:] {
+			k := i + j
+			if !ms.Less(i, k) {
+				return fmt.Errorf("Transitivity check failed for %d(%d) and %d(%d)", i, m.ID, k, mnext.ID)
+			}
+			if strings.HasPrefix(mnext.MountPoint, m.MountPoint+string(filepath.Separator)) {
+				return fmt.Errorf("Must not unmount \n%q before\n%q.", m.MountPoint, mnext.MountPoint)
+			}
+		}
+	}
+	return nil
+}
+
 func TestMountOrdering(t *testing.T) {
 	tests := []struct {
 		prefix     string
@@ -98,15 +121,16 @@ func TestMountOrdering(t *testing.T) {
 
 	for i, tt := range tests {
 		mi := strings.NewReader(tt.mi)
-		mnts, err := getMountsForPrefix(tt.prefix, mi)
+		mnts, err := parseMountinfo(mi)
 		if err != nil {
 			t.Errorf("problems finding mount points: %v", err)
 		}
+		mnts = mnts.Filter(HasPrefix(tt.prefix))
 
 		requestedRemounts := 0
 		for i := len(mnts) - 1; i >= 0; i-- {
 			mnt := mnts[i]
-			if needsRemountPrivate(mnt) {
+			if mnt.NeedsRemountPrivate() {
 				t.Logf("remounting: %+v", mnt)
 				requestedRemounts++
 			}
@@ -121,7 +145,7 @@ func TestMountOrdering(t *testing.T) {
 		}
 
 		for _, mntCur := range mnts {
-			t.Logf("Unmounting %d: %q", mntCur.id, mntCur.MountPoint)
+			t.Logf("Unmounting %d: %q", mntCur.ID, mntCur.MountPoint)
 		}
 
 		if err := safeOrder(mnts); err != nil {
@@ -130,18 +154,63 @@ func TestMountOrdering(t *testing.T) {
 	}
 }
 
-// safeOrder checks for transitivity and (un)mount order sanity
-func safeOrder(m mounts) error {
-	for i, mntCur := range m {
-		for j, mntNext := range m[(i + 1):] {
-			j := i + j
-			if !m.Less(i, j) {
-				return fmt.Errorf("Transitivity check failed for %d(%d) and %d(%d)", i, mntCur.id, j, mntNext.id)
+func TestMountinfoParser(t *testing.T) {
+	mountTests := []struct {
+		mountinfo string
+		prefix    string
+
+		winfos Mounts
+		werr   bool
+	}{
+		{
+			"plaintext garbage",
+			"",
+
+			nil,
+			true,
+		},
+		{
+			mountinfo,
+			"/proc",
+
+			Mounts{&Mount{19, 39, 0, 4, "/", "/proc", map[string]struct{}{"shared": {}}}},
+			false,
+		},
+		{
+			mountinfo,
+			"/nonexisting",
+
+			nil,
+			false,
+		},
+	}
+
+	for i, tt := range mountTests {
+		mi := bytes.NewBufferString(tt.mountinfo)
+		mnts, err := parseMountinfo(mi)
+		if err != nil && !tt.werr {
+			t.Errorf("#%d: got unexpected error %v", i, err)
+		}
+		if err == nil && tt.werr {
+			t.Errorf("#%d: expected error, got nil", i)
+		}
+
+		mnts = mnts.Filter(HasPrefix(tt.prefix))
+		if mnts == nil && tt.winfos != nil {
+			t.Errorf("#%d: expected mounts %v, got nil", i, tt.winfos)
+		}
+		if len(mnts) > 0 {
+			if len(tt.winfos) == 0 {
+				t.Errorf("#%d: no mounts expected, got %v", i, mnts)
 			}
-			if strings.HasPrefix(mntNext.MountPoint, mntCur.MountPoint) {
-				return fmt.Errorf("Must not unmount \n%q before\n%q.", mntCur.MountPoint, mntNext.MountPoint)
+			for j, m := range mnts {
+				if m == nil {
+					t.Errorf("#%d.%d: got nil mountinfo entry", i, j)
+				}
+				if !reflect.DeepEqual(m, tt.winfos[j]) {
+					t.Errorf("#%d.%d: expected mountinfo %v, got %v", i, j, tt.winfos[j], m)
+				}
 			}
 		}
 	}
-	return nil
 }

--- a/pkg/mountinfo/types.go
+++ b/pkg/mountinfo/types.go
@@ -1,0 +1,87 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mountinfo
+
+// Mount contains information about a single mountpoint entry
+type Mount struct {
+	ID         int
+	Parent     int
+	Major      int
+	Minor      int
+	Root       string
+	MountPoint string
+	Opts       map[string]struct{}
+}
+
+// FilterFunc is a functional type which returns true if the given Mount should be filtered, else false.
+type FilterFunc func(m *Mount) bool
+
+// NeedsRemountPrivate checks if this mountPoint needs to be remounted
+// as private, in order for children to be properly unmounted without
+// leaking to parents.
+func (m *Mount) NeedsRemountPrivate() bool {
+	for _, key := range []string{
+		"shared",
+		"master",
+	} {
+		if _, needsRemount := m.Opts[key]; needsRemount {
+			return true
+		}
+	}
+	return false
+}
+
+// Mounts represents a sortable set of mountpoint entries.
+// It implements sort.Interface according to unmount order (children first).
+type Mounts []*Mount
+
+// Filter returns a filtered copy of Mounts
+func (ms Mounts) Filter(f FilterFunc) Mounts {
+	filtered := make([]*Mount, 0, len(ms))
+
+	for _, m := range ms {
+		if f(m) {
+			filtered = append(filtered, m)
+		}
+	}
+
+	return Mounts(filtered)
+}
+
+// Less ensures that mounts are sorted in an order we can unmount; descendant before ancestor.
+// The requirement of transitivity for Less has to be fulfilled otherwise the sort algorithm will fail.
+func (ms Mounts) Less(i, j int) (result bool) { return ms.mountDepth(i) >= ms.mountDepth(j) }
+
+func (ms Mounts) Len() int { return len(ms) }
+
+func (ms Mounts) Swap(i, j int) { ms[i], ms[j] = ms[j], ms[i] }
+
+// mountDepth determines and returns the number of ancestors of the mount at index i
+func (ms Mounts) mountDepth(i int) int {
+	ancestorCount := 0
+	current := ms[i]
+	for found := true; found; {
+		found = false
+		for _, mnt := range ms {
+			if mnt.ID == current.Parent {
+				ancestorCount++
+				current = mnt
+				found = true
+				break
+			}
+		}
+	}
+	return ancestorCount
+}

--- a/stage1/init/kvm.go
+++ b/stage1/init/kvm.go
@@ -28,7 +28,7 @@ import (
 	"github.com/coreos/go-systemd/util"
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/networking"
-	"github.com/coreos/rkt/stage0"
+	"github.com/coreos/rkt/pkg/mountinfo"
 	stage1commontypes "github.com/coreos/rkt/stage1/common/types"
 	stage1initcommon "github.com/coreos/rkt/stage1/init/common"
 	"github.com/coreos/rkt/stage1/init/kvm"
@@ -133,10 +133,11 @@ func doBindMount(source, destination string, readOnly bool, recursive *bool) err
 	if readOnly && recursiveBool {
 		// Sub-mounts are still read-write, so find them and remount them read-only
 
-		mnts, err := stage0.GetMountsForPrefix(source + "/")
+		mnts, err := mountinfo.ParseMounts(0)
 		if err != nil {
 			return errwrap.Wrap(fmt.Errorf("error getting mounts under %q from mountinfo", source), err)
 		}
+		mnts = mnts.Filter(mountinfo.HasPrefix(source + "/"))
 
 		for _, mnt := range mnts {
 			innerAbsPath := destination + strings.Replace(mnt.MountPoint, source, "", -1)

--- a/stage1_fly/gc/main.go
+++ b/stage1_fly/gc/main.go
@@ -23,10 +23,6 @@ import (
 	rktlog "github.com/coreos/rkt/pkg/log"
 )
 
-const (
-	mountinfoPath = "/proc/self/mountinfo"
-)
-
 var (
 	debug bool
 

--- a/stage1_fly/run/main.go
+++ b/stage1_fly/run/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"bufio"
 	"errors"
 	"flag"
 	"fmt"
@@ -34,9 +33,9 @@ import (
 	"github.com/coreos/rkt/pkg/fileutil"
 	pkgflag "github.com/coreos/rkt/pkg/flag"
 	rktlog "github.com/coreos/rkt/pkg/log"
+	"github.com/coreos/rkt/pkg/mountinfo"
 	"github.com/coreos/rkt/pkg/sys"
 	"github.com/coreos/rkt/pkg/user"
-	"github.com/coreos/rkt/stage0"
 	stage1common "github.com/coreos/rkt/stage1/common"
 	stage1commontypes "github.com/coreos/rkt/stage1/common/types"
 )
@@ -243,10 +242,11 @@ func evaluateMounts(rfs string, app string, p *stage1commontypes.Pod) ([]flyMoun
 
 			if recursive {
 				// Every sub-mount needs to be remounted read-only separately
-				mnts, err := stage0.GetMountsForPrefix(tuple.V.Source + "/")
+				mnts, err := mountinfo.ParseMounts(0)
 				if err != nil {
 					return nil, errwrap.Wrap(fmt.Errorf("error getting mounts under %q from mountinfo", tuple.V.Source), err)
 				}
+				mnts = mnts.Filter(mountinfo.HasPrefix(tuple.V.Source + "/"))
 
 				for _, mnt := range mnts {
 					innerRelPath := tuple.M.Path + strings.Replace(mnt.MountPoint, tuple.V.Source, "", -1)


### PR DESCRIPTION
This PR deduplicates and moves all our `/proc/<pid>/mountinfo` parsing logic to its own package.
It will be later needed for https://github.com/coreos/rkt/issues/3411.