### PR TITLE
rkt: misc systemd-related fixes

### DIFF
--- a/makelib/git.mk
+++ b/makelib/git.mk
@@ -55,6 +55,8 @@ $(_GCL_FULL_PATH_): | $(GCL_DIRECTORY)
 	$(_GCL_GIT_) reset --hard $(call vl3,--quiet) "$${rev}"; \
 	$(call vb,vt,GIT CLEAN,$(call vsp,$(GCL_DIRECTORY))) \
 	$(_GCL_GIT_) clean -ffdx $(call vl3,--quiet); \
+	human_rev="$$($(_GCL_GIT_) describe --always)"; \
+	$(call vb,vt,GIT DESCRIBE,$(GCL_REPOSITORY) ($(GCL_COMMITTISH)) => "$${human_rev}") \
 	touch "$@"
 
 # remove the GCL_DIRECTORY if GCL_REPOSITORY changes

--- a/stage1/init/common/pod.go
+++ b/stage1/init/common/pod.go
@@ -788,7 +788,7 @@ func protectKernelTunables(opts []*unit.UnitOption, appName types.ACName, system
 			opts = append(opts, unit.NewUnitOption("Service", "InaccessiblePaths", fmt.Sprintf("-%s", filepath.Join(common.RelAppRootfsPath(appName), p))))
 		}
 	}
-	if systemdVersion >= 232 {
+	if systemdVersion >= 233 {
 		opts = append(opts, unit.NewUnitOption("Service", "ProtectKernelTunables", "true"))
 	}
 

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -73,7 +73,7 @@
         },
         {
             "name": "appc.io/executor/supports-systemd-notify",
-            "value": "true"
+            "value": "false"
         }
     ]
 }


### PR DESCRIPTION
This PR fixes several systemd-related issues:
 * Fix v232 breakage, deferring `ProtectKernelTunables` after https://github.com/systemd/systemd/issues/4567 (ie. post v233)
 * Print out which commit is being used for src flavor, as requested at https://github.com/systemd/systemd/issues/4752#issuecomment-263160490
 * Adjust rkt-inspect manifest to not lie about supports-systemd-notify status, as it causes some regressions in master, as reported at https://github.com/systemd/systemd/issues/4752#issuecomment-263179016

/cc @evverx @s-urbaniak 