### PR TITLE
stage1: persist runtime parameters

### DIFF
--- a/stage0/app.go
+++ b/stage0/app.go
@@ -262,27 +262,6 @@ func AddApp(cfg AddConfig) error {
 		fmt.Sprintf("--app=%s", appName),
 	}
 
-	if cfg.InsecureCapabilities {
-		args = append(args, "--disable-capabilities-restriction")
-	}
-
-	if cfg.InsecurePaths {
-		args = append(args, "--disable-paths")
-	}
-
-	if cfg.InsecureSeccomp {
-		args = append(args, "--disable-seccomp")
-	}
-
-	privateUsers, err := preparedWithPrivateUsers(cfg.PodPath)
-	if err != nil {
-		log.FatalE("error reading user namespace information", err)
-	}
-
-	if privateUsers != "" {
-		args = append(args, fmt.Sprintf("--private-users=%s", privateUsers))
-	}
-
 	if _, err := os.Create(common.AppCreatedPath(pod.Path(), appName.String())); err != nil {
 		return err
 	}

--- a/stage1/init/common/pod_test.go
+++ b/stage1/init/common/pod_test.go
@@ -156,8 +156,7 @@ func TestAppToNspawnArgsOverridesImageManifestReadOnly(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 
 		p := &stage1commontypes.Pod{Manifest: podManifest, Root: tmpDir}
-		insecureOptions := Stage1InsecureOptions{}
-		output, err := appToNspawnArgs(p, appManifest, insecureOptions)
+		output, err := appToNspawnArgs(p, appManifest)
 		if err != nil {
 			t.Errorf("#%d: unexpected error: `%v`", i, err)
 		}
@@ -235,7 +234,7 @@ func TestAppToNspawnArgsRecursive(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 
 		p := &stage1commontypes.Pod{Manifest: podManifest, Root: tmpDir}
-		output, err := appToNspawnArgs(p, appManifest, Stage1InsecureOptions{})
+		output, err := appToNspawnArgs(p, appManifest)
 		if err != nil {
 			t.Errorf("#%d: unexpected error: `%v`", i, err)
 		}


### PR DESCRIPTION
This stores runtime parameters such as insecure options and the MDS
token to disk in the stage1. These are provided during init, but are
necessary during app add. This also simplifies the signature of some of
the stage1 methods.