### PR TITLE
tests: tentative fixes for sporadic host and kvm failures

### DIFF
--- a/tests/rkt_net_test.go
+++ b/tests/rkt_net_test.go
@@ -798,7 +798,6 @@ func NewNetCNIEnvTest() testutils.Test {
 		cmd := fmt.Sprintf("%s --debug --insecure-options=image run --net=%v --mds-register=false %s %s",
 			ctx.Cmd(), nt.NetParameter(), getInspectImagePath(), appCmd)
 		child := spawnOrFail(t, cmd)
-		waitOrFail(t, child, 0)
 
 		expectedRegex := "DefaultGWv4: 11.11.3.1"
 
@@ -806,6 +805,7 @@ func NewNetCNIEnvTest() testutils.Test {
 		if err != nil {
 			t.Fatalf("Error: %v\nOutput: %v", err, out)
 		}
+		waitOrFail(t, child, 0)
 
 		// Parse the log file
 		cniLogFilename := filepath.Join(netdir, "output.json")

--- a/tests/rkt_stop_test.go
+++ b/tests/rkt_stop_test.go
@@ -95,7 +95,7 @@ func TestRktStop(t *testing.T) {
 		// Make sure the pod is stopped
 		var podInfo *podInfo
 		exitedSuccessfully := false
-		for i := 0; i < 10; i++ {
+		for i := 0; i < 30; i++ {
 			time.Sleep(500 * time.Millisecond)
 			podInfo = getPodInfo(t, ctx, podUUID)
 			if podInfo.state == "exited" {


### PR DESCRIPTION
This PR tentatively fixes the following flakes:
 * multiple jenkins-master failures, possibly due to debug output leading to a children blocked on write()
 * kvm stop failures, possibly due to a too short timeout (or https://github.com/coreos/rkt/issues/3382, to be determined)