### PR TITLE
tests: fix TestExport for the KVM+overlay case

### DIFF
--- a/tests/rkt_export_fly_test.go
+++ b/tests/rkt_export_fly_test.go
@@ -20,14 +20,17 @@ import (
 	"testing"
 
 	"github.com/coreos/rkt/common"
+	"github.com/coreos/rkt/tests/testutils"
 )
 
 func TestExport(t *testing.T) {
 	if err := common.SupportsOverlay(); err != nil {
 		t.Skipf("Overlay fs not supported: %v", err)
 	}
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
 
 	// TODO(iaguis): we need a new function to unmount the fly pod so we can also test
 	// overlaySimulateReboot
-	NewTestExport(overlaySimpleTest).Execute(t)
+	exportTestCases["overlaySimpleTest"].Execute(t, ctx)
 }

--- a/tests/rkt_export_test.go
+++ b/tests/rkt_export_test.go
@@ -36,12 +36,14 @@ type ExportTestCase struct {
 	expectedResult string
 	unmountOverlay bool
 	multiAppPod    bool
+	NeedsOverlay   bool
+	NeedsUserNS    bool
 }
 
 type exportTest []ExportTestCase
 
-var (
-	noOverlaySimpleTest = ExportTestCase{
+var exportTestCases = map[string]ExportTestCase{
+	"noOverlaySimpleTest": {
 		"--no-overlay --insecure-options=image",
 		"--write-file --file-name=" + testFile + " --content=" + testContent,
 		"--read-file --file-name=" + testFile,
@@ -49,9 +51,11 @@ var (
 		testContent,
 		false,
 		false,
-	}
+		false,
+		false,
+	},
 
-	specifiedAppTest = ExportTestCase{
+	"specifiedAppTest": {
 		"--no-overlay --insecure-options=image",
 		"--write-file --file-name=" + testFile + " --content=" + testContent,
 		"--read-file --file-name=" + testFile,
@@ -59,9 +63,11 @@ var (
 		testContent,
 		false,
 		false,
-	}
+		false,
+		false,
+	},
 
-	multiAppPodTest = ExportTestCase{
+	"multiAppPodTest": {
 		"--no-overlay --insecure-options=image",
 		"--write-file --file-name=" + testFile + " --content=" + testContent,
 		"--read-file --file-name=" + testFile,
@@ -69,9 +75,11 @@ var (
 		testContent,
 		false,
 		true,
-	}
+		false,
+		false,
+	},
 
-	userNS = ExportTestCase{
+	"userNS": {
 		"--private-users --no-overlay --insecure-options=image",
 		"--write-file --file-name=" + testFile + " --content=" + testContent,
 		"--read-file --file-name=" + testFile,
@@ -79,9 +87,11 @@ var (
 		testContent,
 		false,
 		false,
-	}
+		false,
+		true,
+	},
 
-	overlaySimpleTest = ExportTestCase{
+	"overlaySimpleTest": {
 		"--insecure-options=image",
 		"--write-file --file-name=" + testFile + " --content=" + testContent,
 		"--read-file --file-name=" + testFile,
@@ -89,9 +99,11 @@ var (
 		testContent,
 		false,
 		false,
-	}
+		true,
+		false,
+	},
 
-	overlaySimulateReboot = ExportTestCase{
+	"overlaySimulateReboot": {
 		"--insecure-options=image",
 		"--write-file --file-name=" + testFile + " --content=" + testContent,
 		"--read-file --file-name=" + testFile,
@@ -99,16 +111,9 @@ var (
 		testContent,
 		true,
 		false,
-	}
-)
-
-func (ct exportTest) Execute(t *testing.T) {
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
-
-	for _, testCase := range ct {
-		testCase.Execute(t, ctx)
-	}
+		true,
+		false,
+	},
 }
 
 func (ct ExportTestCase) Execute(t *testing.T, ctx *testutils.RktRunCtx) {
@@ -161,8 +166,4 @@ func (ct ExportTestCase) Execute(t *testing.T, ctx *testutils.RktRunCtx) {
 	// run garbage collector on pods and images
 	runGC(t, ctx)
 	runImageGC(t, ctx)
-}
-
-func NewTestExport(cases ...ExportTestCase) testutils.Test {
-	return exportTest(cases)
 }

--- a/tests/rkt_flavor_coreos.go
+++ b/tests/rkt_flavor_coreos.go
@@ -17,10 +17,6 @@
 package main
 
 var TestedFlavor = Flavor{
-	true,
-	false,
-	false,
-	false,
-	false,
-	true,
+	Coreos:              true,
+	ExitStatusPreserved: true,
 }

--- a/tests/rkt_flavor_fly.go
+++ b/tests/rkt_flavor_fly.go
@@ -17,10 +17,6 @@
 package main
 
 var TestedFlavor = Flavor{
-	false,
-	false,
-	false,
-	false,
-	true,
-	true,
+	Fly:                 true,
+	ExitStatusPreserved: true,
 }

--- a/tests/rkt_flavor_host.go
+++ b/tests/rkt_flavor_host.go
@@ -17,10 +17,6 @@
 package main
 
 var TestedFlavor = Flavor{
-	false,
-	true,
-	false,
-	false,
-	false,
-	true,
+	Host:                true,
+	ExitStatusPreserved: true,
 }

--- a/tests/rkt_flavor_kvm.go
+++ b/tests/rkt_flavor_kvm.go
@@ -17,10 +17,5 @@
 package main
 
 var TestedFlavor = Flavor{
-	false,
-	false,
-	false,
-	false,
-	true,
-	false,
+	Kvm: true,
 }

--- a/tests/rkt_flavor_src.go
+++ b/tests/rkt_flavor_src.go
@@ -17,10 +17,6 @@
 package main
 
 var TestedFlavor = Flavor{
-	false,
-	false,
-	true,
-	false,
-	false,
-	true,
+	Src:                 true,
+	ExitStatusPreserved: true,
 }

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -866,12 +866,17 @@ func unmountPod(t *testing.T, ctx *testutils.RktRunCtx, uuid string, rmNetns boo
 	podDir := filepath.Join(ctx.DataDir(), "pods", "run", uuid)
 	stage1MntPath := filepath.Join(podDir, "stage1", "rootfs")
 	stage2MntPath := filepath.Join(stage1MntPath, "opt", "stage2", "rkt-inspect", "rootfs")
+
 	netnsPath := filepath.Join(podDir, "netns")
 	podNetNSPathBytes, err := ioutil.ReadFile(netnsPath)
+	// There may be no netns, e.g. kvm or --net=host
 	if err != nil {
-		t.Fatalf(`cannot read "netns" stage1: %v`, err)
+		if !os.IsNotExist(err) {
+			t.Fatalf(`cannot read "netns" stage1: %v`, err)
+		} else {
+			rmNetns = false
+		}
 	}
-	podNetNSPath := string(podNetNSPathBytes)
 
 	if err := syscall.Unmount(stage2MntPath, 0); err != nil {
 		t.Fatalf("cannot umount stage2: %v", err)
@@ -881,11 +886,13 @@ func unmountPod(t *testing.T, ctx *testutils.RktRunCtx, uuid string, rmNetns boo
 		t.Fatalf("cannot umount stage1: %v", err)
 	}
 
-	if err := syscall.Unmount(podNetNSPath, 0); err != nil {
-		t.Fatalf("cannot umount pod netns: %v", err)
-	}
-
 	if rmNetns {
+		podNetNSPath := string(podNetNSPathBytes)
+
+		if err := syscall.Unmount(podNetNSPath, 0); err != nil {
+			t.Fatalf("cannot umount pod netns: %v", err)
+		}
+
 		_ = os.RemoveAll(podNetNSPath)
 	}
 }


### PR DESCRIPTION
This testcase didn't work for kvm with kernels with overlayfs.