### PR TITLE
fly: ensure the target bin directory exists before building

### DIFF
--- a/stage1_fly/stage1_fly.mk
+++ b/stage1_fly/stage1_fly.mk
@@ -11,7 +11,7 @@ $(call inc-many,$(foreach sd,$(FLY_SUBDIRS),$(sd)/$(sd).mk))
 
 $(call inc-one,stop/stop.mk)
 
-$(call generate-stamp-rule,$(FLY_STAMP),$(FLY_STAMPS) $(ACTOOL_STAMP),, \
+$(call generate-stamp-rule,$(FLY_STAMP),$(FLY_STAMPS) $(ACTOOL_STAMP),$(TARGET_BINDIR), \
 	$(call vb,vt,ACTOOL,$(call vsp,$(FLY_STAGE1))) \
 	"$(ACTOOL)" build --overwrite --owner-root "$(FLY_ACIDIR)" "$(FLY_STAGE1)")
 


### PR DESCRIPTION
We got this failure randomly, and the lack of an explicit dependency on the directory is suspect.

    [amd64-usr] build: Unable to open target /build/amd64-usr/var/tmp/portage/app-emulation/rkt-1.20.0/work/rkt-1.20.0/build-rkt-1.20.0/target/bin/stage1-fly.aci: open /build/amd64-usr/var/tmp/portage/app-emulation/rkt-1.20.0/work/rkt-1.20.0/build-rkt-1.20.0/target/bin/stage1-fly.aci: no such file or directory

I built the package a few dozen times with varying parallel jobs and with this change applied, and there were no failues.