### PR TITLE
stage1: ensure systemd-tmpfiles is available in pod

### DIFF
--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -193,6 +193,10 @@ func installAssets() error {
 	if err != nil {
 		return err
 	}
+	systemdTmpfilesBin, err := common.LookupPath("systemd-tmpfiles", os.Getenv("PATH"))
+	if err != nil {
+		return err
+	}
 	bashBin, err := common.LookupPath("bash", os.Getenv("PATH"))
 	if err != nil {
 		return err
@@ -226,6 +230,7 @@ func installAssets() error {
 		proj2aci.GetAssetString("/usr/lib/systemd/systemd", systemdBin),
 		proj2aci.GetAssetString("/usr/bin/systemctl", systemctlBin),
 		proj2aci.GetAssetString("/usr/bin/systemd-sysusers", systemdSysusersBin),
+		proj2aci.GetAssetString("/usr/bin/systemd-tmpfiles", systemdTmpfilesBin),
 		proj2aci.GetAssetString("/usr/lib/systemd/systemd-journald", systemdJournaldBin),
 		proj2aci.GetAssetString("/usr/bin/bash", bashBin),
 		proj2aci.GetAssetString("/bin/mount", mountBin),

--- a/stage1/usr_from_host/usr_from_host.mk
+++ b/stage1/usr_from_host/usr_from_host.mk
@@ -3,6 +3,8 @@ $(call setup-stamp-file,UFH_STAMP)
 S1_RF_USR_STAMPS += $(UFH_STAMP)
 
 $(call generate-stamp-rule,$(UFH_STAMP),,$(S1_RF_ACIROOTFSDIR), \
+	$(call vb,v2,LN SF,usr/bin $(S1_RF_ACIROOTFSDIR)/bin) \
+	ln -sf usr/bin "$(S1_RF_ACIROOTFSDIR)/bin" && \
 	$(call vb,v2,LN SF,host $(S1_RF_ACIROOTFSDIR)/flavor) \
 	ln -sf 'host' "$(S1_RF_ACIROOTFSDIR)/flavor" && \
 	mkdir -p "$(S1_RF_ACIROOTFSDIR)/usr/lib" && \
@@ -10,8 +12,12 @@ $(call generate-stamp-rule,$(UFH_STAMP),,$(S1_RF_ACIROOTFSDIR), \
 	ln -sf usr/lib "$(S1_RF_ACIROOTFSDIR)/lib64"&& \
 	ln -sf lib "$(S1_RF_ACIROOTFSDIR)/usr/lib64")
 
-
-CLEAN_SYMLINKS += $(S1_RF_ACIROOTFSDIR)/flavor $(S1_RF_ACIROOTFSDIR)/lib $(S1_RF_ACIROOTFSDIR)/lib64 $(S1_RF_ACIROOTFSDIR)/usr/lib64
+CLEAN_SYMLINKS += \
+	$(S1_RF_ACIROOTFSDIR)/bin \
+	$(S1_RF_ACIROOTFSDIR)/flavor \
+	$(S1_RF_ACIROOTFSDIR)/lib \
+	$(S1_RF_ACIROOTFSDIR)/lib64 \
+	$(S1_RF_ACIROOTFSDIR)/usr/lib64
 
 CLEAN_DIRS += $(S1_RF_ACIROOTFSDIR)/usr/lib
 

--- a/stage1/usr_from_src/usr_from_src.mk
+++ b/stage1/usr_from_src/usr_from_src.mk
@@ -126,6 +126,8 @@ $(call generate-stamp-rule,$(UFS_SYSTEMD_BUILD_STAMP),$(UFS_SYSTEMD_CLONE_AND_PA
 	$(call vb,v2,CONFIGURE,systemd) \
 	"$(abspath $(UFS_SYSTEMD_SRCDIR))/configure" \
 		$(call vl3,--quiet) \
+		--enable-seccomp \
+		--enable-tmpfiles \
 		--disable-dbus \
 		--disable-kmod \
 		--disable-blkid \
@@ -142,7 +144,6 @@ $(call generate-stamp-rule,$(UFS_SYSTEMD_BUILD_STAMP),$(UFS_SYSTEMD_CLONE_AND_PA
 		--disable-binfmt \
 		--disable-vconsole \
 		--disable-quotacheck \
-		--disable-tmpfiles \
 		--disable-randomseed \
 		--disable-backlight \
 		--disable-rfkill \
@@ -163,8 +164,7 @@ $(call generate-stamp-rule,$(UFS_SYSTEMD_BUILD_STAMP),$(UFS_SYSTEMD_CLONE_AND_PA
 		--disable-hibernate \
 		--disable-hwdb \
 		--disable-importd \
-		--disable-firstboot \
-		--enable-seccomp; \
+		--disable-firstboot; \
 	popd $(call vl3,>/dev/null); \
 	$(call vb,v2,BUILD EXT,systemd) \
 	$$(MAKE) -C "$(UFS_SYSTEMD_BUILDDIR)" all V=0 $(call vl2,>/dev/null))


### PR DESCRIPTION
`TestAppSandboxSmoke` is currently failing on host and src flavors because:
 * stage1-host is missing a `/bin` directory
 * stage1-host doesn't install systemd-tmpfiles from host
 * stage1-src is built without systemd-tmpfiles

This should fix testsuite failures on those flavors.