### PR TITLE
Change the subnet for the default-restricted network 

### DIFF
--- a/stage1/net/rootfs/etc/rkt/net.d/99-default-restricted.conf
+++ b/stage1/net/rootfs/etc/rkt/net.d/99-default-restricted.conf
@@ -5,6 +5,6 @@
 	"ipMasq": false,
 	"ipam": {
 		"type": "host-local",
-		"subnet": "172.16.28.0/24"
+		"subnet": "172.16.29.0/24"
 	}
 }

--- a/tests/rkt_net_test.go
+++ b/tests/rkt_net_test.go
@@ -1171,7 +1171,7 @@ func NewNetDefaultIPArgTest() testutils.Test {
 	}
 	return testutils.TestFunc(func(t *testing.T) {
 		doTest("default:IP=172.16.28.123", "172.16.28.123", t)
-		doTest("default-restricted:IP=172.16.28.42", "172.16.28.42", t)
+		doTest("default-restricted:IP=172.16.29.42", "172.16.29.42", t)
 	})
 }
 

--- a/tests/rkt_net_test.go
+++ b/tests/rkt_net_test.go
@@ -380,9 +380,11 @@ var (
 	bridgeLoDiffPortFwdCase = PortFwdCase{"127.0.0.1", 1024, "", "--net=" + portFwdBridge.Name, true}
 )
 
-func (ct PortFwdCase) Execute(t *testing.T, ctx *testutils.RktRunCtx) {
-	netdir := prepareTestNet(t, ctx, portFwdBridge)
-	defer os.RemoveAll(netdir)
+func (ct PortFwdCase) Execute(t *testing.T) {
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	prepareTestNet(t, ctx, portFwdBridge)
 
 	httpPort, err := testutils.GetNextFreePort4Banned(bannedPorts)
 	if err != nil {
@@ -447,11 +449,8 @@ func (ct PortFwdCase) Execute(t *testing.T, ctx *testutils.RktRunCtx) {
 type portFwdTest []PortFwdCase
 
 func (ct portFwdTest) Execute(t *testing.T) {
-	ctx := testutils.NewRktRunCtx()
-	defer ctx.Cleanup()
-
 	for _, testCase := range ct {
-		testCase.Execute(t, ctx)
+		testCase.Execute(t)
 	}
 }
 
@@ -622,8 +621,7 @@ func testNetCustomDual(t *testing.T, nt networkTemplateT) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	netdir := prepareTestNet(t, ctx, nt)
-	defer os.RemoveAll(netdir)
+	prepareTestNet(t, ctx, nt)
 
 	container1IPv4, container1Hostname := make(chan string), make(chan string)
 	ga := testutils.NewGoroutineAssistant(t)
@@ -695,8 +693,7 @@ func testNetCustomNatConnectivity(t *testing.T, nt networkTemplateT) {
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	netdir := prepareTestNet(t, ctx, nt)
-	defer os.RemoveAll(netdir)
+	prepareTestNet(t, ctx, nt)
 
 	httpPort, err := testutils.GetNextFreePort4()
 	if err != nil {
@@ -792,7 +789,6 @@ func NewNetCNIEnvTest() testutils.Test {
 
 		// bring the networking up, copy the proxy
 		netdir := prepareTestNet(t, ctx, nt)
-		defer os.RemoveAll(netdir)
 
 		appCmd := "--exec=/inspect -- --print-defaultgwv4 "
 		cmd := fmt.Sprintf("%s --debug --insecure-options=image run --net=%v --mds-register=false %s %s",
@@ -901,8 +897,7 @@ func NewNetCNIDNSTest() testutils.Test {
 		}
 
 		// bring the networking up, copy the proxy
-		netdir := prepareTestNet(t, ctx, nt)
-		defer os.RemoveAll(netdir)
+		prepareTestNet(t, ctx, nt)
 
 		ga := testutils.NewGoroutineAssistant(t)
 		ga.Add(1)
@@ -959,8 +954,7 @@ func NewNetCNIDNSArgTest() testutils.Test {
 		}
 
 		// bring the networking up, copy the proxy
-		netdir := prepareTestNet(t, ctx, nt)
-		defer os.RemoveAll(netdir)
+		prepareTestNet(t, ctx, nt)
 
 		appCmd := "--exec=/inspect -- --read-file --file-name=/etc/resolv.conf"
 		cmd := fmt.Sprintf("%s --debug --insecure-options=image run --net=%v --mds-register=false --dns=244.244.244.244 %s %s",
@@ -1009,8 +1003,7 @@ func NewNetCNIDNSArgNoneTest() testutils.Test {
 		}
 
 		// bring the networking up, copy the proxy
-		netdir := prepareTestNet(t, ctx, nt)
-		defer os.RemoveAll(netdir)
+		prepareTestNet(t, ctx, nt)
 
 		appCmd := "--exec=/inspect -- --stat-file --file-name=/etc/resolv.conf"
 		cmd := fmt.Sprintf("%s --debug --insecure-options=image run --net=%v --mds-register=false --dns=none %s %s",
@@ -1124,8 +1117,7 @@ func NewNetOverrideTest() testutils.Test {
 			},
 		}
 
-		netdir := prepareTestNet(t, ctx, nt)
-		defer os.RemoveAll(netdir)
+		prepareTestNet(t, ctx, nt)
 
 		testImageArgs := []string{"--exec=/inspect --print-ipv4=eth0"}
 		testImage := patchTestACI("rkt-inspect-networking1.aci", testImageArgs...)
@@ -1291,12 +1283,11 @@ func NewNetPreserveNetNameTest() testutils.Test {
 		ctx := testutils.NewRktRunCtx()
 		defer ctx.Cleanup()
 
-		netdir, ntFlannel, err := mockFlannelNetwork(t, ctx)
+		_, ntFlannel, err := mockFlannelNetwork(t, ctx)
 		if err != nil {
 			t.Errorf("Can't mock flannel network: %v", err)
 		}
 
-		defer os.RemoveAll(netdir)
 		defer os.Remove(ntFlannel.SubnetFile)
 
 		podUUIDFile := filepath.Join(ctx.DataDir(), "pod_uuid")
@@ -1353,12 +1344,11 @@ func NewNetDefaultGWTest() testutils.Test {
 		ctx := testutils.NewRktRunCtx()
 		defer ctx.Cleanup()
 
-		netdir, ntFlannel, err := mockFlannelNetwork(t, ctx)
+		_, ntFlannel, err := mockFlannelNetwork(t, ctx)
 		if err != nil {
 			t.Errorf("Can't mock flannel network: %v", err)
 		}
 
-		defer os.RemoveAll(netdir)
 		defer os.Remove(ntFlannel.SubnetFile)
 
 		testImageArgs := []string{"--exec=/inspect --print-defaultgwv4"}


### PR DESCRIPTION
There was a collision between `default` and `default-restricted`.

Also fixes some silly issues with the network test that led to IP leaks.
Fixes #3438 
Fixes #2943 