### PR TITLE
tests: fix some potential gexpect hangs

### DIFF
--- a/tests/rkt_app_sandbox_test.go
+++ b/tests/rkt_app_sandbox_test.go
@@ -128,7 +128,5 @@ func TestAppSandboxSmoke(t *testing.T) {
 		t.Fatalf("Unexpected error: %v\n%s", err, output)
 	}
 
-	if err := child.Wait(); err != nil {
-		t.Fatalf("rkt didn't terminate correctly: %v", err)
-	}
+	waitOrFail(t, child, 0)
 }

--- a/tests/rkt_etc_hosts_test.go
+++ b/tests/rkt_etc_hosts_test.go
@@ -107,10 +107,7 @@ func TestEtcHosts(t *testing.T) {
 			t.Fatalf("Test %d %v %v", i, err, out)
 		}
 
-		err = child.Wait()
-		if err != nil {
-			t.Fatalf("rkt didn't terminate correctly: %v", err)
-		}
+		waitOrFail(t, child, 0)
 	}
 }
 

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -78,7 +78,7 @@ func testFetchFromFile(t *testing.T, arg string, image string) {
 	if err := expectWithOutput(child, fetchFromFileMsg); err != nil {
 		t.Fatalf("%q should be found: %v", fetchFromFileMsg, err)
 	}
-	child.Wait()
+	waitOrFail(t, child, 0)
 
 	// 1. Run cmd again, should get $fetchFromFileMsg.
 	runRktAndCheckOutput(t, cmd, fetchFromFileMsg, false)

--- a/tests/rkt_image_gc_test.go
+++ b/tests/rkt_image_gc_test.go
@@ -46,9 +46,7 @@ func TestImageGCTreeStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cannot exec: %v", err)
 	}
-	if err := child.Wait(); err != nil {
-		t.Fatalf("rkt didn't terminate correctly: %v", err)
-	}
+	waitOrFail(t, child, 0)
 
 	treeStoreIDs, err := getTreeStoreIDs(ctx)
 	if err != nil {

--- a/tests/rkt_stop_test.go
+++ b/tests/rkt_stop_test.go
@@ -107,10 +107,10 @@ func TestRktStop(t *testing.T) {
 			t.Fatalf("Expected pod %q to be exited, but it is %q", podUUID, podInfo.state)
 		}
 
+		exitStatus := 0
 		if tt.expectKill {
-			child.Wait()
-		} else {
-			waitOrFail(t, child, 0)
+			exitStatus = -1
 		}
+		waitOrFail(t, child, exitStatus)
 	}
 }

--- a/tests/rkt_userns_test.go
+++ b/tests/rkt_userns_test.go
@@ -96,11 +96,7 @@ func TestUserns(t *testing.T) {
 				if err != nil || result[0] == tt.expectGid {
 					t.Fatalf("Expected %q but not found: %v", tt.expectGid, result)
 				}
-
-				err = child.Wait()
-				if err != nil {
-					t.Fatalf("rkt didn't terminate correctly: %v", err)
-				}
+				waitOrFail(t, child, 0)
 
 				ctx.Reset()
 			}


### PR DESCRIPTION
gexpect `Wait()` may let the child deadlock, blocked on a write. This replace some potentially dangerous occurrences with a `waitOrFail()` which drains child output.

Reference https://github.com/coreos/rkt/pull/3434
Fixes https://github.com/coreos/rkt/pull/3439#issuecomment-264538581