### PR TITLE
stage1: persist debug mode to runtime-pod

### DIFF
--- a/stage1/common/types/pod.go
+++ b/stage1/common/types/pod.go
@@ -53,6 +53,7 @@ type RuntimePod struct {
 	PrivateUsers       string         `json:"PrivateUsers"`
 	MDSToken           string         `json:"MDSToken"`
 	Hostname           string         `json:"Hostname"`
+	Debug              bool           `json:"Debug"`
 	Mutable            bool           `json:"Mutable"`
 	ResolvConfMode     string         `json:"ResolvConfMode"`
 	EtcHostsMode       string         `json:"EtcHostsMode"`

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -137,6 +137,7 @@ func parseFlags() *stage1commontypes.RuntimePod {
 
 	flag.Parse()
 
+	rp.Debug = debug
 	rp.ResolvConfMode = dnsConfMode.Pairs["resolv"]
 	rp.EtcHostsMode = dnsConfMode.Pairs["hosts"]
 

--- a/stage1_fly/run/main.go
+++ b/stage1_fly/run/main.go
@@ -101,6 +101,7 @@ func parseFlags() *stage1commontypes.RuntimePod {
 
 	flag.Parse()
 
+	rp.Debug = debug
 	rp.ResolvConfMode = dnsConfMode.Pairs["resolv"]
 	rp.EtcHostsMode = dnsConfMode.Pairs["hosts"]
 


### PR DESCRIPTION
This adds the debug mode to the persisted runtime-pod, in order to be later re-used when setting debug mode for pod sidecars (eg. iottymux).