### PR TITLE
pkg/pod: add WaitReady, dry Sandbox methods

### DIFF
--- a/Documentation/subcommands/status.md
+++ b/Documentation/subcommands/status.md
@@ -14,13 +14,16 @@ app-redis=0
 app-etcd=0
 ```
 
-If the pod is still running, you can wait for it to finish and then get the status with `rkt status --wait UUID`
+If the pod is still running, you can wait for it to finish and then get the status with `rkt status --wait UUID`.
+To wait for the pod to become ready, execute `rkt status --wait-ready`.
+Both options also accept a duration. To wait up to 10 seconds until the pod is finished, execute `rkt status --wait=10s UUID`.
 
 ## Options
 
 | Flag | Default | Options | Description |
 | --- | --- | --- | --- |
-| `--wait` |  `false` | `true` or `false` | Toggle waiting for the pod to exit |
+| `--wait` |  `false` | `true` or `false` or duration | Toggle waiting for the pod to finish. |
+| `--wait-ready` |  `false` | `true` or `false` or duration | Toggle waiting until the pod is ready. |
 
 ## Global options
 

--- a/lib/app.go
+++ b/lib/app.go
@@ -104,7 +104,7 @@ func appState(app *App, pod *pkgPod.Pod) error {
 	app.State = AppStateUnknown
 
 	defer func() {
-		if pod.AfterRun() {
+		if pod.IsAfterRun() {
 			// If the pod is hard killed, set the app to 'exited' state.
 			// Other than this case, status file is guaranteed to be written.
 			if app.State != AppStateExited {

--- a/pkg/pod/pods.go
+++ b/pkg/pod/pods.go
@@ -956,7 +956,7 @@ func (p *Pod) AppImageManifest(appName string) (*schema.ImageManifest, error) {
 // CreationTime returns the time when the pod was created.
 // This happens at prepare time.
 func (p *Pod) CreationTime() (time.Time, error) {
-	if !(p.isPrepared || p.isRunning() || p.AfterRun()) {
+	if !(p.isPrepared || p.isRunning() || p.IsAfterRun()) {
 		return time.Time{}, nil
 	}
 	t, err := p.getModTime("pod-created")
@@ -977,7 +977,7 @@ func (p *Pod) StartTime() (time.Time, error) {
 		retErr error
 	)
 
-	if !p.isRunning() && !p.AfterRun() {
+	if !p.isRunning() && !p.IsAfterRun() {
 		// hasn't started
 		return t, nil
 	}
@@ -1184,9 +1184,14 @@ func (p *Pod) PodManifestAvailable() bool {
 	return true
 }
 
-// AfterRun returns true if the pod is in a post-running state, otherwise it returns false.
-func (p *Pod) AfterRun() bool {
+// IsAfterRun returns true if the pod is in a post-running state, otherwise it returns false.
+func (p *Pod) IsAfterRun() bool {
 	return p.isExitedDeleting || p.isDeleting || p.isExited || p.isGarbage
+}
+
+// IsFinshed returns true if the pod is in a terminal state, else false.
+func (p *Pod) IsFinished() bool {
+	return p.isExited || p.isAbortedPrepare || p.isGarbage || p.isGone
 }
 
 // AppExitCode returns the app's exit code.

--- a/pkg/pod/pods.go
+++ b/pkg/pod/pods.go
@@ -645,33 +645,6 @@ func (p *Pod) refreshState() error {
 	return nil
 }
 
-// WaitExited waits for a pod to (run and) exit.
-func (p *Pod) WaitExited() error {
-	// isExited implies isExitedGarbage.
-	for !p.isExited && !p.isAbortedPrepare && !p.isGarbage && !p.isGone {
-		if err := p.SharedLock(); err != nil {
-			return err
-		}
-
-		if err := p.Unlock(); err != nil {
-			return err
-		}
-
-		if err := p.refreshState(); err != nil {
-			return err
-		}
-
-		// if we're in the gap between preparing and running in a split prepare/run-prepared usage, take a nap
-		if p.isPrepared {
-			time.Sleep(time.Second)
-		}
-	}
-
-	// TODO(vc): return error or let caller detect the !p.isExited possibilities?
-
-	return nil
-}
-
 // readFile reads an entire file from a pod's directory.
 func (p *Pod) readFile(path string) ([]byte, error) {
 	f, err := p.openFile(path, syscall.O_RDONLY)

--- a/pkg/pod/pods.go
+++ b/pkg/pod/pods.go
@@ -1189,7 +1189,7 @@ func (p *Pod) IsAfterRun() bool {
 	return p.isExitedDeleting || p.isDeleting || p.isExited || p.isGarbage
 }
 
-// IsFinshed returns true if the pod is in a terminal state, else false.
+// IsFinished returns true if the pod is in a terminal state, else false.
 func (p *Pod) IsFinished() bool {
 	return p.isExited || p.isAbortedPrepare || p.isGarbage || p.isGone
 }

--- a/pkg/pod/sandbox.go
+++ b/pkg/pod/sandbox.go
@@ -1,0 +1,131 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
+	"strconv"
+
+	"github.com/appc/spec/schema"
+	"github.com/coreos/rkt/common"
+	"github.com/coreos/rkt/pkg/lock"
+	"github.com/hashicorp/errwrap"
+)
+
+// ErrImmutable is the error that is returned by SandboxManifest if the pod is immutable,
+// hence changes on the pod manifest are not allowed.
+var ErrImmutable = errors.New("immutable pod")
+
+// SandboxManifest loads the underlying pod manifest and checks whether mutable operations are allowed.
+// It returns ErrImmutable if the pod does not allow mutable operations or any other error if the operation failed.
+// Upon success a reference to the pod manifest is returned and mutable operations are possible.
+func (p *Pod) SandboxManifest() (*schema.PodManifest, error) {
+	_, pm, err := p.PodManifest() // this takes the lock fd to load the manifest, hence path is not needed here
+	if err != nil {
+		return nil, errwrap.Wrap(errors.New("error loading pod manifest"), err)
+	}
+
+	ms, ok := pm.Annotations.Get("coreos.com/rkt/stage1/mutable")
+	if ok {
+		p.mutable, err = strconv.ParseBool(ms)
+		if err != nil {
+			return nil, errwrap.Wrap(errors.New("error parsing mutable annotation"), err)
+		}
+	}
+
+	if !p.mutable {
+		return nil, ErrImmutable
+	}
+
+	return pm, nil
+}
+
+// UpdateManifest updates the given pod manifest in the given path atomically on the file system.
+// The pod manifest has to be locked using LockManifest first to avoid races in case of concurrent writes.
+func (p *Pod) UpdateManifest(m *schema.PodManifest, path string) error {
+	if !p.mutable {
+		return ErrImmutable
+	}
+
+	mpath := common.PodManifestPath(path)
+	mstat, err := os.Stat(mpath)
+	if err != nil {
+		return err
+	}
+
+	tmpf, err := ioutil.TempFile(path, "")
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		tmpf.Close()
+		os.Remove(tmpf.Name())
+	}()
+
+	if err := tmpf.Chmod(mstat.Mode().Perm()); err != nil {
+		return err
+	}
+
+	if err := json.NewEncoder(tmpf).Encode(m); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpf.Name(), mpath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ExclusiveLockManifest gets an exclusive lock on only the pod manifest in the app sandbox.
+// Since the pod is already running, we won't be able to get an exclusive lock on the pod itself.
+func (p *Pod) ExclusiveLockManifest() error {
+	if !p.isRunning() {
+		return errors.New("pod is not running")
+	}
+
+	if p.manifestLock != nil {
+		return p.manifestLock.ExclusiveLock() // This is idempotent
+	}
+
+	l, err := lock.ExclusiveLock(common.PodManifestLockPath(p.Path()), lock.RegFile)
+	if err != nil {
+		return err
+	}
+
+	p.manifestLock = l
+	return nil
+}
+
+// UnlockManifest unlocks the pod manifest lock.
+func (p *Pod) UnlockManifest() error {
+	if !p.isRunning() {
+		return errors.New("pod is not running")
+	}
+
+	if p.manifestLock == nil {
+		return nil
+	}
+
+	if err := p.manifestLock.Close(); err != nil {
+		return err
+	}
+	p.manifestLock = nil
+	return nil
+}

--- a/pkg/pod/wait.go
+++ b/pkg/pod/wait.go
@@ -1,0 +1,95 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// WaitExited waits for a pod to (run and) exit.
+// This method blocks indefinitely and refreshes the pod state.
+func (p *Pod) WaitExited() error {
+	// isExited implies isExitedGarbage.
+	for !p.isExited && !p.isAbortedPrepare && !p.isGarbage && !p.isGone {
+		// this blocks (waits) as long as the pod is locked, i.e. in pepare, run, exitedGarbage, garbage state
+		if err := p.SharedLock(); err != nil {
+			return err
+		}
+
+		// unlock immediately
+		if err := p.Unlock(); err != nil {
+			return err
+		}
+
+		if err := p.refreshState(); err != nil {
+			return err
+		}
+
+		// if we're in the gap between preparing and running in a split prepare/run-prepared usage, take a nap
+		if p.isPrepared {
+			time.Sleep(time.Second)
+		}
+	}
+
+	// TODO(vc): return error or let caller detect the !p.isExited possibilities?
+
+	return nil
+}
+
+// WaitReady blocks until the pod is ready by polling the readiness state every 100 milliseconds
+// or until the given context is cancelled. This method refreshes the pod state.
+func (p *Pod) WaitReady(ctx context.Context) error {
+	f := func() bool {
+		if err := p.refreshState(); err != nil {
+			return false
+		}
+
+		return p.IsSupervisorReady()
+	}
+
+	return retry(ctx, f, 100*time.Millisecond)
+}
+
+// retry calls function f indefinitely with the given delay between invocations
+// until f returns true or the given context is cancelled.
+// It returns immediately without delay in case function f immediately returns true.
+func retry(ctx context.Context, f func() bool, delay time.Duration) error {
+	if f() {
+		return nil
+	}
+
+	ticker := time.NewTicker(delay)
+	errChan := make(chan error)
+
+	go func() {
+		defer close(errChan)
+
+		for {
+			select {
+			case <-ctx.Done():
+				errChan <- ctx.Err()
+				return
+			case <-ticker.C:
+				if f() {
+					return
+				}
+			}
+		}
+	}()
+
+	return <-errChan
+}

--- a/pkg/pod/wait.go
+++ b/pkg/pod/wait.go
@@ -20,11 +20,12 @@ import (
 	"golang.org/x/net/context"
 )
 
-// WaitExited waits for a pod to (run and) exit.
+// WaitFinished waits for a pod to (run and) finish.
 // This method blocks indefinitely and refreshes the pod state.
-func (p *Pod) WaitExited() error {
+// It is the caller's responsibility to determine the actual terminal state.
+func (p *Pod) WaitFinished() error {
 	// isExited implies isExitedGarbage.
-	for !p.isExited && !p.isAbortedPrepare && !p.isGarbage && !p.isGone {
+	for !p.IsFinished() {
 		// this blocks (waits) as long as the pod is locked, i.e. in pepare, run, exitedGarbage, garbage state
 		if err := p.SharedLock(); err != nil {
 			return err
@@ -44,8 +45,6 @@ func (p *Pod) WaitExited() error {
 			time.Sleep(time.Second)
 		}
 	}
-
-	// TODO(vc): return error or let caller detect the !p.isExited possibilities?
 
 	return nil
 }

--- a/pkg/pod/wait_test.go
+++ b/pkg/pod/wait_test.go
@@ -1,0 +1,57 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+func TestRetryFailure(t *testing.T) {
+	i := 0
+	f := func() bool { i++; return false } // never succeed
+
+	if err := retry(newTimeout(100*time.Millisecond), f, 10*time.Millisecond); err == nil {
+		t.Error("expected failure, but got none")
+		return
+	}
+
+	if i == 0 {
+		t.Error("expected some retries, but got none")
+		return
+	}
+}
+
+func TestRetrySuccess(t *testing.T) {
+	f := func() bool { return true } // always succeed
+
+	if err := retry(newTimeout(5*time.Second), f, 10*time.Millisecond); err != nil {
+		t.Errorf("expected success, but got %v", err)
+	}
+
+	i := 0
+	f = func() bool { i++; return i > 5 } // succeed after 5 times
+
+	if err := retry(newTimeout(5*time.Second), f, 10*time.Millisecond); err != nil {
+		t.Errorf("expected success, but got %v", err)
+	}
+}
+
+func newTimeout(t time.Duration) context.Context {
+	ctx, _ := context.WithTimeout(context.Background(), t) // should never be reached
+	return ctx
+}

--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -593,7 +593,7 @@ func fillPodDetails(store *imagestore.Store, p *pkgPod.Pod, v1pod *v1alpha.Pod) 
 		if p.State() == pkgPod.Running {
 			readStatus = true
 			app.State = v1alpha.AppState_APP_STATE_RUNNING
-		} else if p.AfterRun() {
+		} else if p.IsAfterRun() {
 			readStatus = true
 			app.State = v1alpha.AppState_APP_STATE_EXITED
 		} else {

--- a/rkt/app_stop.go
+++ b/rkt/app_stop.go
@@ -62,7 +62,7 @@ func runAppStop(cmd *cobra.Command, args []string) (exit int) {
 	}
 	defer p.Close()
 
-	if p.AfterRun() {
+	if p.IsAfterRun() {
 		stdout.Printf("pod %q is already stopped", p.UUID)
 		return 0
 	}

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -19,6 +19,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	lib "github.com/coreos/rkt/lib"
@@ -29,14 +30,16 @@ import (
 
 var (
 	cmdStatus = &cobra.Command{
-		Use:   "status [--wait] [--wait-ready=timeout] UUID",
+		Use:   "status [--wait=bool|timeout] [--wait-ready=bool|timeout] UUID",
 		Short: "Check the status of a rkt pod",
-		Long: `Prints assorted information about the pod such as its state, pid and exit
-status`,
+		Long: `Prints assorted information about the pod such as its state, pid and exit status.
+
+The --wait and --wait-ready flags accept boolean or timeout values. If set to true, wait indefinitely. If set to false, don't wait at all.
+They can also be set to a duration. If the duration is less than zero, wait indefinitely. If the duration is zero, don't wait at all.`,
 		Run: runWrapper(runStatus),
 	}
-	flagWait      bool
-	flagWaitReady time.Duration
+	flagWait      string
+	flagWaitReady string
 )
 
 const (
@@ -47,13 +50,28 @@ const (
 
 func init() {
 	cmdRkt.AddCommand(cmdStatus)
-	cmdStatus.Flags().BoolVar(&flagWait, "wait", false, "toggle waiting for the pod to exit")
-	cmdStatus.Flags().DurationVar(&flagWaitReady, "wait-ready", time.Duration(0), "time to wait until the pod is ready. If time is less or equal zero it doesn't wait at all.")
-	cmdStatus.Flags().Var(&flagFormat, "format", "choose the output format, allowed format includes 'json', 'json-pretty'. If empty, then the result is printed as key value pairs")
+	cmdStatus.Flags().StringVar(&flagWait, "wait", "false", `toggles waiting for the pod to finish. Use the output to determine the actual terminal state.`)
+	cmdStatus.Flags().StringVar(&flagWaitReady, "wait-ready", "false", `toggles waiting until the pod is ready.`)
+	cmdStatus.Flags().Var(&flagFormat, "format", `choose the output format. Allowed format includes 'json', 'json-pretty'. If empty, then the result is printed as key value pairs`)
+
+	cmdStatus.Flags().Lookup("wait").NoOptDefVal = "true"
+	cmdStatus.Flags().Lookup("wait-ready").NoOptDefVal = "true"
 }
 
 func runStatus(cmd *cobra.Command, args []string) (exit int) {
 	if len(args) != 1 {
+		cmd.Usage()
+		return 254
+	}
+
+	dWait, err := parseDuration(flagWait)
+	if err != nil {
+		cmd.Usage()
+		return 254
+	}
+
+	dReady, err := parseDuration(flagWaitReady)
+	if err != nil {
 		cmd.Usage()
 		return 254
 	}
@@ -65,17 +83,16 @@ func runStatus(cmd *cobra.Command, args []string) (exit int) {
 	}
 	defer p.Close()
 
-	if flagWaitReady > 0 {
-		ctx, _ := context.WithTimeout(context.Background(), flagWaitReady)
-		if err := p.WaitReady(ctx); err != nil {
-			stderr.PrintE("wait for pod readyiness failed", err)
+	if dReady != 0 {
+		if err := p.WaitReady(newContext(dReady)); err != nil {
+			stderr.PrintE("error waiting for pod readiness", err)
 			return 254
 		}
 	}
 
-	if flagWait {
-		if err := p.WaitFinished(); err != nil {
-			stderr.PrintE("wait for pod exit failed", err)
+	if dWait != 0 {
+		if err := p.WaitFinished(newContext(dWait)); err != nil {
+			stderr.PrintE("error waiting for pod to finish", err)
 			return 254
 		}
 	}
@@ -86,6 +103,37 @@ func runStatus(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	return 0
+}
+
+// parseDuration converts the given string s to a duration value.
+// If it is empty string or a true boolean value according to strconv.ParseBool, a negative duration is returned.
+// If the boolean value is false, a 0 duration is returned.
+// If the string s is a duration value, then it is returned.
+// It returns an error if the duration conversion failed.
+func parseDuration(s string) (time.Duration, error) {
+	if s == "" {
+		return time.Duration(-1), nil
+	}
+
+	b, err := strconv.ParseBool(s)
+
+	switch {
+	case err != nil:
+		return time.ParseDuration(s)
+	case b:
+		return time.Duration(-1), nil
+	}
+
+	return time.Duration(0), nil
+}
+
+// newContext returns a new context with timeout t if t > 0.
+func newContext(t time.Duration) context.Context {
+	ctx := context.Background()
+	if t > 0 {
+		ctx, _ = context.WithTimeout(ctx, t)
+	}
+	return ctx
 }
 
 // getExitStatuses returns a map of the statuses of the pod.

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -74,7 +74,7 @@ func runStatus(cmd *cobra.Command, args []string) (exit int) {
 	}
 
 	if flagWait {
-		if err := p.WaitExited(); err != nil {
+		if err := p.WaitFinished(); err != nil {
 			stderr.PrintE("wait for pod exit failed", err)
 			return 254
 		}

--- a/rkt/stop.go
+++ b/rkt/stop.go
@@ -71,7 +71,7 @@ func runStop(cmd *cobra.Command, args []string) (exit int) {
 			continue
 		}
 
-		if p.AfterRun() {
+		if p.IsAfterRun() {
 			stdout.Printf("pod %q is already stopped", p.UUID)
 			continue
 		}

--- a/tests/rkt_app_sandbox_test.go
+++ b/tests/rkt_app_sandbox_test.go
@@ -75,6 +75,7 @@ func TestAppSandboxSmoke(t *testing.T) {
 	cmd = strings.Fields(fmt.Sprintf("%s app add --debug %s %s --name=%s", ctx.Cmd(), podUUID, imageName, appName))
 	addCmd := exec.Command(cmd[0], cmd[1:]...)
 	addCmd.Env = append(addCmd.Env, "RKT_EXPERIMENT_APP=true")
+	t.Logf("Running command: %v\n", cmd)
 	output, err := addCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v\n%s", err, output)
@@ -83,6 +84,7 @@ func TestAppSandboxSmoke(t *testing.T) {
 	cmd = strings.Fields(fmt.Sprintf("%s app start --debug %s --app=%s", ctx.Cmd(), podUUID, appName))
 	startCmd := exec.Command(cmd[0], cmd[1:]...)
 	startCmd.Env = append(startCmd.Env, "RKT_EXPERIMENT_APP=true")
+	t.Logf("Running command: %v\n", cmd)
 	output, err = startCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v\n%s", err, output)
@@ -95,12 +97,14 @@ func TestAppSandboxSmoke(t *testing.T) {
 	cmd = strings.Fields(fmt.Sprintf("%s app rm --debug %s --app=%s", ctx.Cmd(), podUUID, appName))
 	removeCmd := exec.Command(cmd[0], cmd[1:]...)
 	removeCmd.Env = append(removeCmd.Env, "RKT_EXPERIMENT_APP=true")
+	t.Logf("Running command: %v\n", cmd)
 	output, err = removeCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v\n%s", err, output)
 	}
 
 	cmd = strings.Fields(fmt.Sprintf("%s stop %s", ctx.Cmd(), podUUID))
+	t.Logf("Running command: %v\n", cmd)
 	output, err = exec.Command(cmd[0], cmd[1:]...).CombinedOutput()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v\n%s", err, output)

--- a/tests/rkt_app_sandbox_test.go
+++ b/tests/rkt_app_sandbox_test.go
@@ -67,7 +67,7 @@ func TestAppSandboxSmoke(t *testing.T) {
 	}
 
 	// wait for the sandbox to start
-	podUUID, err := waitPodReady(ctx, uuidFile, actionTimeout)
+	podUUID, err := waitPodReady(ctx, t, uuidFile, actionTimeout)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -144,7 +144,7 @@ func waitOrFail(t *testing.T, child *gexpect.ExpectSubprocess, expectedStatus in
 
 // waitPodReady waits for the pod supervisor to get ready, busy-looping until `timeout`
 // while waiting for it. It returns the pod UUID or an error on failure.
-func waitPodReady(ctx *testutils.RktRunCtx, uuidFile string, timeout time.Duration) (string, error) {
+func waitPodReady(ctx *testutils.RktRunCtx, t *testing.T, uuidFile string, timeout time.Duration) (string, error) {
 	var podUUID []byte
 	var err error
 	interval := 500 * time.Millisecond
@@ -165,10 +165,10 @@ func waitPodReady(ctx *testutils.RktRunCtx, uuidFile string, timeout time.Durati
 	// wait up to one minute for the pod supervisor to be ready
 	cmd := strings.Fields(fmt.Sprintf("%s status --wait-ready=%s %s", ctx.Cmd(), timeout, podUUID))
 	statusCmd := exec.Command(cmd[0], cmd[1:]...)
-	fmt.Printf("Running command: %v\n", cmd)
+	t.Logf("Running command: %v\n", cmd)
 	output, err := statusCmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("Failed to wait for pod readyness, error %v output %v", err, string(output))
+		return "", fmt.Errorf("Failed to wait for pod readiness, error %v output %v", err, string(output))
 	}
 
 	return string(podUUID), nil

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -116,7 +116,7 @@ func patchTestACI(newFileName string, args ...string) string {
 }
 
 func spawnOrFail(t *testing.T, cmd string) *gexpect.ExpectSubprocess {
-	t.Logf("Running command: %v", cmd)
+	t.Logf("Spawning command: %v\n", cmd)
 	child, err := gexpect.Spawn(cmd)
 	if err != nil {
 		t.Fatalf("Cannot exec rkt: %v", err)
@@ -162,20 +162,13 @@ func waitPodReady(ctx *testutils.RktRunCtx, uuidFile string, timeout time.Durati
 		return "", fmt.Errorf("Can't read pod UUID: %v", err)
 	}
 
-	// wait for the pod supervisor to be ready
-	podReadyFile := filepath.Join(ctx.DataDir(), "pods", "run", string(podUUID), "stage1/rootfs/rkt/supervisor-status")
-	target := ""
-	elapsed = time.Duration(0)
-	for elapsed < timeout {
-		time.Sleep(interval)
-		elapsed += interval
-		target, err = os.Readlink(podReadyFile)
-		if err == nil && target == "ready" {
-			break
-		}
-	}
-	if err != nil || target != "ready" {
-		return "", fmt.Errorf("Pod failed to become ready while checking %q", podReadyFile)
+	// wait up to one minute for the pod supervisor to be ready
+	cmd := strings.Fields(fmt.Sprintf("%s status --wait-ready=%s %s", ctx.Cmd(), timeout, podUUID))
+	statusCmd := exec.Command(cmd[0], cmd[1:]...)
+	fmt.Printf("Running command: %v\n", cmd)
+	output, err := statusCmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("Failed to wait for pod readyness, error %v output %v", err, string(output))
 	}
 
 	return string(podUUID), nil


### PR DESCRIPTION
This adds a WaitReady method to be able to wait for pod readiness on the
command line.

It also reduces reduntant implementations in stage1 for checking mutable pods
and pod manifest update logic.

Fixes #3461