### PR TITLE
mount: ensure empty volume paths exist for copy-up

### DIFF
--- a/stage1/app-add/app-add.go
+++ b/stage1/app-add/app-add.go
@@ -97,7 +97,10 @@ func main() {
 	}
 
 	enterCmd := stage1common.PrepareEnterCmd(false)
-	stage1initcommon.AppAddMounts(p, ra, enterCmd)
+	err = stage1initcommon.AppAddMounts(p, ra, enterCmd)
+	if err != nil {
+		log.FatalE("error adding app mounts", err)
+	}
 
 	// when using host cgroups, make the subgroup writable by pod systemd
 	if flavor != "kvm" {

--- a/stage1/init/common/pod.go
+++ b/stage1/init/common/pod.go
@@ -483,7 +483,6 @@ func appToNspawnArgs(p *stage1commontypes.Pod, ra *schema.RuntimeApp) ([]string,
 		return nil, errwrap.Wrap(fmt.Errorf("could not generate app %q mounts", appName), err)
 	}
 	for _, m := range mounts {
-
 		shPath := filepath.Join(sharedVolPath, m.Volume.Name.String())
 
 		absRoot, err := filepath.Abs(p.Root) // Absolute path to the pod's rootfs.

--- a/stage1/init/common/pod.go
+++ b/stage1/init/common/pod.go
@@ -43,8 +43,7 @@ import (
 
 const (
 	// FlavorFile names the file storing the pod's flavor
-	FlavorFile    = "flavor"
-	SharedVolPerm = os.FileMode(0755)
+	FlavorFile = "flavor"
 )
 
 // execEscape uses Golang's string quoting for ", \, \n, and regex for special cases
@@ -464,12 +463,9 @@ func appToNspawnArgs(p *stage1commontypes.Pod, ra *schema.RuntimeApp) ([]string,
 	appName := ra.Name
 	app := ra.App
 
-	sharedVolPath := common.SharedVolumesPath(p.Root)
-	if err := os.MkdirAll(sharedVolPath, SharedVolPerm); err != nil {
-		return nil, errwrap.Wrap(errors.New("could not create shared volumes directory"), err)
-	}
-	if err := os.Chmod(sharedVolPath, SharedVolPerm); err != nil {
-		return nil, errwrap.Wrap(fmt.Errorf("could not change permissions of %q", sharedVolPath), err)
+	sharedVolPath, err := common.CreateSharedVolumesPath(p.Root)
+	if err != nil {
+		return nil, err
 	}
 
 	vols := make(map[types.ACName]types.Volume)


### PR DESCRIPTION
Before this change, the `copy-up` operation could fail with:
`stage1: could not prepare mountpoint: mkdir sharedVolumes/foo: no such file or directory`

This would occur because `CopyTree` does not implicitly create the
target directory, so we must create it prior to calling.

cc @squeed 

TODO:

- [ ] A functional test for this