### PR TITLE
stage1: Ensure ptmx device usable by non-root for all flavours.

### DIFF
--- a/stage1/prepare-app/prepare-app.c
+++ b/stage1/prepare-app/prepare-app.c
@@ -249,6 +249,7 @@ int main(int argc, char *argv[])
 		"/dev/tty",
 		"/dev/net/tun",
 		"/dev/console",
+		"/dev/ptmx",
 		NULL
 	};
 	static const mount_point dirs_mount_table[] = {
@@ -384,11 +385,6 @@ int main(int argc, char *argv[])
 				"Mounting \"%s\" on \"%s\" failed", mnt->source, to);
 	}
 
-	/* /dev/ptmx -> /dev/pts/ptmx */
-	exit_if(snprintf(to, sizeof(to), "%s/dev/ptmx", root) >= sizeof(to),
-		"Path too long: \"%s\"", to);
-	pexit_if(symlink("/dev/pts/ptmx", to) == -1 && errno != EEXIST,
-		"Failed to create /dev/ptmx symlink");
 
 	/* Copy symlinks to device node volumes to "/dev/.rkt" so they can be
 	 * used in the DeviceAllow= option of the app's unit file (systemd


### PR DESCRIPTION
kvm-based stage1 flavours previously used a sym-link from /dev/ptmx to
/dev/pts/ptmx. However, the /dev/pts/ptmx device has perms 000 meaning
that non-root users could not access the device. Creating /dev/ptmx
unconditionally works with all flavours and matches behaviour on current
distributions.

Fixes #3252.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>