### PR TITLE
stage1: Ensure ptmx device usable by non-root for all flavours.

### DIFF
--- a/stage1/init/common/units.go
+++ b/stage1/init/common/units.go
@@ -72,7 +72,7 @@ func MutableEnv(p *stage1commontypes.Pod) error {
 		unit.NewUnitOption("Service", "ExecStart", "/prepare-app %I"),
 		unit.NewUnitOption("Service", "User", "0"),
 		unit.NewUnitOption("Service", "Group", "0"),
-		unit.NewUnitOption("Service", "CapabilityBoundingSet", "CAP_SYS_ADMIN CAP_DAC_OVERRIDE"),
+		unit.NewUnitOption("Service", "CapabilityBoundingSet", "CAP_SYS_ADMIN CAP_DAC_OVERRIDE CAP_MKNOD"),
 	)
 
 	w.WriteUnit(
@@ -132,7 +132,7 @@ func ImmutableEnv(p *stage1commontypes.Pod) error {
 		unit.NewUnitOption("Service", "ExecStart", "/prepare-app %I"),
 		unit.NewUnitOption("Service", "User", "0"),
 		unit.NewUnitOption("Service", "Group", "0"),
-		unit.NewUnitOption("Service", "CapabilityBoundingSet", "CAP_SYS_ADMIN CAP_DAC_OVERRIDE"),
+		unit.NewUnitOption("Service", "CapabilityBoundingSet", "CAP_SYS_ADMIN CAP_DAC_OVERRIDE CAP_MKNOD"),
 	)
 
 	uw.WriteUnit(

--- a/tests/rkt_non_root_test.go
+++ b/tests/rkt_non_root_test.go
@@ -119,12 +119,12 @@ func TestNonRootFetchRmGCImage(t *testing.T) {
 	// We can't touch the treestores even as members of the rkt group.
 	imgGCCmd := fmt.Sprintf("%s image gc", ctx.Cmd())
 	t.Logf("Running %s", imgGCCmd)
-	runRktAsUidGidAndCheckOutput(t, imgGCCmd, "permission denied", true, uid, rktGid)
+	runRktAsUidGidAndCheckOutput(t, imgGCCmd, "permission denied", false, true, uid, rktGid)
 
 	// Should be able to remove the image fetched by root since we're in the rkt group.
 	imgRmCmd := fmt.Sprintf("%s image rm %s", ctx.Cmd(), rootImgHash)
 	t.Logf("Running %s", imgRmCmd)
-	runRktAsUidGidAndCheckOutput(t, imgRmCmd, "successfully removed", false, uid, rktGid)
+	runRktAsUidGidAndCheckOutput(t, imgRmCmd, "successfully removed", false, false, uid, rktGid)
 
 	// Should be able to remove the image fetched by ourselves.
 	nonrootImg := patchTestACI("rkt-inspect-non-root-rm.aci", "--exec=/inspect")
@@ -136,5 +136,5 @@ func TestNonRootFetchRmGCImage(t *testing.T) {
 
 	imgRmCmd = fmt.Sprintf("%s image rm %s", ctx.Cmd(), nonrootImgHash)
 	t.Logf("Running %s", imgRmCmd)
-	runRktAsUidGidAndCheckOutput(t, imgRmCmd, "successfully removed", false, uid, rktGid)
+	runRktAsUidGidAndCheckOutput(t, imgRmCmd, "successfully removed", false, false, uid, rktGid)
 }

--- a/tests/rkt_paths_test.go
+++ b/tests/rkt_paths_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build coreos src
+// +build coreos src kvm
 
 package main
 
@@ -27,6 +27,10 @@ import (
 // TestPathsWrite checks whether access to paths like /proc/sysrq-trigger are
 // restricted
 func TestPathsWrite(t *testing.T) {
+	if TestedFlavor.Kvm == true {
+		t.Skip("Not running test for kvm flavour")
+	}
+
 	imageFile := patchTestACI("rkt-inspect-paths.aci",
 		"--exec=/inspect --write-file --print-msg=testing-insecure-option")
 	defer os.Remove(imageFile)
@@ -84,25 +88,32 @@ func TestPathsWrite(t *testing.T) {
 	}
 }
 
-// TestPathsStat checks that access to inaccessible paths under
+// TestProcPathsStat checks that access to inaccessible paths under
 // /proc or /sys is correctly restricted:
 // https://github.com/coreos/rkt/issues/2484
-func TestPathsStat(t *testing.T) {
+func TestProcPathsStat(t *testing.T) {
 	tests := []struct {
 		Path         string
 		ExpectedMode string
+		SkipUnderKvm bool
 	}{
 		{
 			Path:         "/sys/firmware",
 			ExpectedMode: "d---------",
+			SkipUnderKvm: false,
 		},
 		{
 			Path:         "/proc/kcore",
 			ExpectedMode: "----------",
+			SkipUnderKvm: true,
 		},
 	}
 
 	for _, tt := range tests {
+		if TestedFlavor.Kvm == true && tt.SkipUnderKvm == true {
+			t.Skip("Not running test for kvm flavour")
+		}
+
 		hiddenImage := patchTestACI("rkt-inspect-stat-procfs.aci", fmt.Sprintf("--exec=/inspect --stat-file --file-name %s", tt.Path))
 		defer os.Remove(hiddenImage)
 
@@ -118,5 +129,51 @@ func TestPathsStat(t *testing.T) {
 		uuid := runRktAndGetUUID(t, hiddenCmd)
 		hiddenCmd = fmt.Sprintf("%s --debug run-prepared --mds-register=false %s", hiddenCtx.Cmd(), uuid)
 		runRktAndCheckOutput(t, hiddenCmd, hiddenExpectedLine, false)
+	}
+}
+
+// TestDevPathsStat checks that particular devices have been created as
+// expected.
+func TestDevPathsStat(t *testing.T) {
+	tests := []struct {
+		Path          string
+		ExpectedMode  string
+		ExpectedOwner int
+		ExpectedGroup int
+	}{
+		{
+			Path:          "/dev/ptmx",
+			ExpectedMode:  "Dcrw-rw-rw-",
+			ExpectedOwner: 0,
+			ExpectedGroup: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		hiddenImage := patchTestACI("rkt-inspect-stat-devices.aci", fmt.Sprintf("--exec=/inspect --stat-file --file-name %s", tt.Path))
+		defer os.Remove(hiddenImage)
+
+		hiddenCtx := testutils.NewRktRunCtx()
+		defer hiddenCtx.Cleanup()
+
+		//run
+		hiddenCmd := fmt.Sprintf("%s --debug --insecure-options=image run %s", hiddenCtx.Cmd(), hiddenImage)
+
+		lines := ""
+		lines += fmt.Sprintf("%s: mode: %s.*", tt.Path, tt.ExpectedMode)
+		lines += fmt.Sprintf("%s: user: %d.*", tt.Path, tt.ExpectedOwner)
+		lines += fmt.Sprintf("%s: group: %d.*", tt.Path, tt.ExpectedGroup)
+
+		// enable multi-line matching and search for all substrings
+		hiddenExpectedLines := fmt.Sprintf("(?s:.*%s)", lines)
+
+		runRktAndCheckREOutput(t, hiddenCmd, hiddenExpectedLines, false)
+
+		// run-prepared
+		hiddenCmd = fmt.Sprintf(`%s --insecure-options=image prepare %s`, hiddenCtx.Cmd(), hiddenImage)
+		uuid := runRktAndGetUUID(t, hiddenCmd)
+		hiddenCmd = fmt.Sprintf("%s --debug run-prepared --mds-register=false %s", hiddenCtx.Cmd(), uuid)
+
+		runRktAndCheckREOutput(t, hiddenCmd, hiddenExpectedLines, false)
 	}
 }

--- a/tests/rkt_root_commands_test.go
+++ b/tests/rkt_root_commands_test.go
@@ -43,6 +43,6 @@ func TestCommandsNeedRoot(t *testing.T) {
 	defer ctx.Cleanup()
 	for _, sc := range rootRequiringCommands {
 		cmd := fmt.Sprintf("%s %s", ctx.Cmd(), sc)
-		runRktAsUidGidAndCheckOutput(t, cmd, "cannot run as unprivileged user", true, uid, gid)
+		runRktAsUidGidAndCheckOutput(t, cmd, "cannot run as unprivileged user", false, true, uid, gid)
 	}
 }

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -400,14 +400,17 @@ func runRktAsUidGidAndCheckOutput(t *testing.T, rktCmd, expectedLine string, lin
 
 	if expectedLine != "" {
 		if lineIsRegex == true {
-			_, _, err = expectRegexWithOutput(child, expectedLine)
+			_, _, err := expectRegexWithOutput(child, expectedLine)
+			if err != nil {
+				t.Fatalf("didn't receive expected regex %q in output: %v", expectedLine, err)
+			}
 		} else {
 			err = expectWithOutput(child, expectedLine)
+			if err != nil {
+				t.Fatalf("didn't receive expected output %q: %v", expectedLine, err)
+			}
 		}
 
-		if err != nil {
-			t.Fatalf("didn't receive expected output %q (regex=%v): %v", expectedLine, lineIsRegex, err)
-		}
 	}
 }
 

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -514,6 +514,10 @@ func runRktAndCheckOutput(t *testing.T, rktCmd, expectedLine string, expectError
 	runRktAsGidAndCheckOutput(t, rktCmd, expectedLine, expectError, 0)
 }
 
+func runRktAndCheckREOutput(t *testing.T, rktCmd, expectedLine string, expectError bool) {
+	runRktAsGidAndCheckREOutput(t, rktCmd, expectedLine, expectError, 0)
+}
+
 func startRktAndCheckOutput(t *testing.T, rktCmd, expectedLine string) *gexpect.ExpectSubprocess {
 	return startRktAsGidAndCheckOutput(t, rktCmd, expectedLine, 0)
 }


### PR DESCRIPTION
kvm-based stage1 flavours previously used a sym-link from /dev/ptmx to
/dev/pts/ptmx. However, the /dev/pts/ptmx device has perms 000 meaning
that non-root users could not access the device. Creating /dev/ptmx
unconditionally works with all flavours and matches behaviour on current
distributions.

Fixes #3252.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>