### PR TITLE
stage1/kvm/lkvm: chown files and dirs on creation

### DIFF
--- a/stage1/usr_from_kvm/lkvm/patches/p9-chown-files-and-dirs-upon-creation.patch
+++ b/stage1/usr_from_kvm/lkvm/patches/p9-chown-files-and-dirs-upon-creation.patch
@@ -1,0 +1,45 @@
+From c7734dd626a6d47bb946cfc1611e6c9d1dd67372 Mon Sep 17 00:00:00 2001
+From: Graham Whaley <graham.whaley@linux.intel.com>
+Date: Thu, 15 Dec 2016 16:24:55 +0000
+Subject: [PATCH] kvmtool: p9: chown files and dirs upon creation
+
+The protocol passes in a uid and gid, but we are not chowning
+the files to them, just using our default upon creation.
+Apply the passed in id's with a chown.
+
+This was found by mounting /tmp over p9 with the S_ISVTX
+'sticky' bit set, and finding that files created in /tmp
+were not honoring the uid used to create them.
+
+Signed-off-by: Graham Whaley <graham.whaley@intel.com>
+---
+ virtio/9p.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/virtio/9p.c b/virtio/9p.c
+index 49e7c5c..30100a5 100644
+--- a/virtio/9p.c
++++ b/virtio/9p.c
+@@ -286,6 +286,9 @@ static void virtio_p9_create(struct p9_dev *p9dev,
+ 	if (lstat(full_path, &st) < 0)
+ 		goto err_out;
+ 
++	if (lchown(full_path, dfid->uid, gid) < 0)
++		goto err_out;
++
+ 	ret = chmod(full_path, mode & 0777);
+ 	if (ret < 0)
+ 		goto err_out;
+@@ -326,6 +329,9 @@ static void virtio_p9_mkdir(struct p9_dev *p9dev,
+ 	if (lstat(full_path, &st) < 0)
+ 		goto err_out;
+ 
++	if (lchown(full_path, dfid->uid, gid) < 0)
++		goto err_out;
++
+ 	ret = chmod(full_path, mode & 0777);
+ 	if (ret < 0)
+ 		goto err_out;
+-- 
+2.7.4
+


### PR DESCRIPTION
Honor the uid/gid values when creating files and directories

Fixes #2576

As a side effect, it also seems to solve the remaining problems with
'apt-get update' in lkvm, so also:

Fixes #1917