### PR TITLE
gc: fix cleaning mounts and files

### DIFF
--- a/common/mount.go
+++ b/common/mount.go
@@ -1,0 +1,122 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/coreos/rkt/pkg/fs"
+	rktlog "github.com/coreos/rkt/pkg/log"
+	"github.com/coreos/rkt/pkg/mountinfo"
+)
+
+// ChrootPrivateUnmount cleans up in a safe way all mountpoints existing under
+// `targetPath`. This requires multiple steps:
+//  1. take handles to the current rootdir and workdir (to restore at the end)
+//  2. parse /proc/self/mountinfo to get a list of all mount targets, and filter
+//     out those outside of targetPath
+//  3. chroot into target path, so that all mounts and symlinks can be properly
+//     de-referenced as they appear inside the rootfs
+//  4. mark all mounts as private, so that further operations are not propagated
+//     outside of this rootfs - in descending nest order (parent first)
+//  5. unmount all mount targets - in ascending nest order (children first).
+//     If unmount fails, lazy-detach the mount target so that the kernel can
+//     still clean it up once it ceases to be busy
+//  6. chdir and chroot back to the original state
+func ChrootPrivateUnmount(targetPath string, log *rktlog.Logger, diagf func(string, ...interface{})) error {
+	mounter := fs.NewLoggingMounter(
+		fs.MounterFunc(syscall.Mount),
+		fs.UnmounterFunc(syscall.Unmount),
+		diagf,
+	)
+
+	// getFd checks if dirFile is a directory and returns its fd
+	getFd := func(dirFile *os.File) (int, error) {
+		dirInfo, err := dirFile.Stat()
+		if err != nil {
+			return 0, fmt.Errorf("error getting info on %q: %s", dirFile.Name(), err)
+		}
+		if !dirInfo.IsDir() {
+			return 0, fmt.Errorf("%q is not a directory", dirFile.Name())
+		}
+		return int(dirFile.Fd()), nil
+	}
+
+	// 1a. remember current workdir
+	cwdString, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("error getting current workdir: %s", err)
+	}
+
+	// 1b. take the fd for current rootdir
+	rootFile, err := os.Open("/")
+	if err != nil {
+		return fmt.Errorf("error opening current rootdir: %s", err)
+	}
+	defer rootFile.Close()
+	rootFd, err := getFd(rootFile)
+	if err != nil {
+		return err
+	}
+
+	// 2. list all mounts and keeps only those in targetPath
+	//    (this needs to be done here as /proc may not be available after chroot)
+	mnts, err := mountinfo.ParseMounts(0)
+	if err != nil {
+		return fmt.Errorf("error getting mountinfo: %s", err)
+	}
+	mnts = mnts.Filter(mountinfo.HasPrefix(targetPath))
+
+	// 2. chdir to / (to avoid keeping a dir busy) and chroot to target
+	//    (defers in reverse order to escape the chroot on return)
+	_ = syscall.Fchdir(rootFd)
+	defer os.Chdir(cwdString)
+	err = syscall.Chroot(targetPath)
+	if err != nil {
+		return fmt.Errorf("error chroot-ing to %q: %s", targetPath, err)
+	}
+	defer syscall.Chroot(".")
+	defer syscall.Fchdir(rootFd)
+
+	// 4. mark mounts private, top to bottom
+	//    (mountinfo list contains full-paths captured outside of chroot, prefix-stripping needed)
+	for i := len(mnts) - 1; i >= 0; i-- {
+		mnt := mnts[i]
+		if mnt.NeedsRemountPrivate() {
+			relPath := strings.TrimPrefix(mnt.MountPoint, targetPath)
+			mntPath := filepath.Join("/", relPath)
+			err := mounter.Mount("", mntPath, "", syscall.MS_PRIVATE|syscall.MS_REC, "")
+			if err != nil {
+				log.Printf("skipping %q, not marked as private: %v", mntPath, err)
+			}
+		}
+	}
+	// 5. unmount all targets, bottom to top. If busy, still mark them as detached for later cleanups.
+	//    (mountinfo list contains full-paths captured outside of chroot, prefix-stripping needed)
+	for _, mnt := range mnts {
+		relPath := strings.TrimPrefix(mnt.MountPoint, targetPath)
+		mntPath := filepath.Join("/", relPath)
+		err := mounter.Unmount(mntPath, 0)
+		if err == syscall.EBUSY {
+			log.Printf("mount %q is busy, marking for lazy detach", mntPath)
+			_ = mounter.Unmount(mntPath, syscall.MNT_DETACH)
+		}
+	}
+	return nil
+}

--- a/rkt/gc.go
+++ b/rkt/gc.go
@@ -225,24 +225,25 @@ func mountPodStage1(ts *treestore.Store, p *pkgPod.Pod) error {
 // deletePod cleans up files and resource associated with the pod
 // pod must be under exclusive lock and be in either ExitedGarbage
 // or Garbage state
-func deletePod(p *pkgPod.Pod) {
+func deletePod(p *pkgPod.Pod) bool {
 	podState := p.State()
 	if podState != pkgPod.ExitedGarbage && podState != pkgPod.Garbage {
-		stderr.Panicf("logic error: deletePod called with non-garbage pod %q (status %q)", p.UUID, p.State())
+		stderr.Errorf("non-garbage pod %q (status %q), skipped", p.UUID, p.State())
+		return false
 	}
 
 	if podState == pkgPod.ExitedGarbage {
 		s, err := imagestore.NewStore(storeDir())
 		if err != nil {
 			stderr.PrintE("cannot open store", err)
-			return
+			return false
 		}
 		defer s.Close()
 
 		ts, err := treestore.NewStore(treeStoreDir(), s)
 		if err != nil {
 			stderr.PrintE("cannot open store", err)
-			return
+			return false
 		}
 
 		if globalFlags.Debug {
@@ -269,7 +270,7 @@ func deletePod(p *pkgPod.Pod) {
 		// unmount all leftover mounts
 		if err := stage0.MountGC(p.Path(), p.UUID.String()); err != nil {
 			stderr.PrintE(fmt.Sprintf("GC of leftover mounts for pod %q failed", p.UUID), err)
-			return
+			return false
 		}
 	}
 
@@ -279,13 +280,15 @@ func deletePod(p *pkgPod.Pod) {
 	if err == nil {
 		if e := os.RemoveAll(rootfsPath); e != nil {
 			stderr.PrintE(fmt.Sprintf("unable to remove pod rootfs %q", p.UUID), e)
-			return
+			return false
 		}
 	}
 
 	// finally remove all remaining pieces
 	if err := os.RemoveAll(p.Path()); err != nil {
 		stderr.PrintE(fmt.Sprintf("unable to remove pod %q", p.UUID), err)
-		return
+		return false
 	}
+
+	return true
 }

--- a/rkt/rm.go
+++ b/rkt/rm.go
@@ -126,7 +126,5 @@ func removePod(p *pkgPod.Pod) bool {
 		return false
 	}
 
-	deletePod(p)
-
-	return true
+	return deletePod(p)
 }

--- a/tests/rkt_gc_test.go
+++ b/tests/rkt_gc_test.go
@@ -55,7 +55,7 @@ func TestGC(t *testing.T) {
 
 	pods = podsRemaining(t, ctx)
 	if len(pods) != 0 {
-		t.Fatalf("no pods should exist rkt's data directory, but found: %v", pods)
+		t.Fatalf("no pods should exist in rkt data directory, but found: %s", pods)
 	}
 }
 


### PR DESCRIPTION
This fixes multiple issues in pods GC. In particular, rkt now tries
harder to clean its environment by:
 * looping over all pods, even if one of them is faulty (eg. some files are busy or missing)
 * leaving manifest removal as last step, so next GC run may succeed
 * chroot-ing to pod before cleaning, to avoid chasing wrong symlinks (eg. ending outside of pod)
 * chdir-ing to (host) root, to avoid keeping directories busy
 * loop-unmounting all mountpoints, as single unmount operations may fail (eg. busy mountpoint)
 * detecting busy mounts, and marking them as detached for lazy unmount (ie. `MNT_DETACH`)