### PR TITLE
stage1: remount entire subcgroup r/w, instead of each knob

### DIFF
--- a/Documentation/devel/cgroups.md
+++ b/Documentation/devel/cgroups.md
@@ -4,13 +4,15 @@
 
 [Control Groups][cgroups] are a Linux feature for organizing processes in hierarchical groups and applying resources limits to them. Each rkt pod is placed in a different cgroup to separate the processes of the pod from the processes of the host. Memory and CPU isolators are also implemented with cgroups.
 
-## Which cgroups are used
+## What cgroup does rkt use?
+
+Every pod and application within that pod is run within its own cgroup.
 
 ### `rkt` started from the command line
 
 When a recent version of systemd is running on the host and `rkt` is not started as a systemd service (typically, from the command line), `rkt` will call `systemd-nspawn` with `--register=true`. This will cause `systemd-nspawn` to call the D-Bus method `CreateMachineWithNetwork` on `systemd-machined` and the cgroup `/machine.slice/machine-rkt...` will be created. This requires systemd v216+ as detected by the [machinedRegister][machinedRegister] function in stage1's `init`.
 
-When systemd is not running on the host, or the systemd version is too old (< v216) to support the D-Bus method `CreateMachineWithNetwork`, `rkt` uses `systemd-nspawn` with the `--register=false` parameter. In this case, `systemd-nspawn` or other systemd components will not create new cgroups for rkt. On older `rkt` versions (<= 0.13.0), the pod was staying in the same cgroup as the caller. For example, it could be something like `/user.slice/user-1000.slice/session-1.scope`. Since [#1844][rkt-1844] (rkt >= 0.14.0), `rkt` creates a new cgroup for each pod, like `$CALLER_CGROUP/machine-some-id.slice`.
+When systemd is not running on the host, or the systemd version is too old (< v216), `rkt` uses `systemd-nspawn` with the `--register=false` parameter. In this case, `systemd-nspawn` or other systemd components will not create new cgroups for rkt. Instead, `rkt` creates a new cgroup for each pod under the current cgroup, like `$CALLER_CGROUP/machine-some-id.slice`.
 
 ### `rkt` started as a systemd service
 
@@ -24,7 +26,38 @@ It will result in `/machine.slice/servicename.service` when the user select that
 
 1. `/machine.slice/machine-rkt...` when started on the command line with systemd v216+.
 2. `/$SLICE.slice/servicename.service` when started from a systemd service.
-3. `$CALLER_CGROUP/machine-some-id.slice` without systemd-v216+, since rkt >= 0.14.0.
+3. `$CALLER_CGROUP/machine-some-id.slice` without systemd, or with systemd pre-v216
+
+For example, a simple pod run interactively on a system with systemd would look like:
+
+```
+├─machine.slice
+│ └─machine-rkt\x2df28d074b\x2da8bb\x2d4246\x2d96a5\x2db961e1fe7035.scope
+│   ├─init.scope
+│   │ └─/usr/lib/systemd/systemd
+│   └─system.slice
+│     ├─alpine-sh.service
+│     │ ├─/bin/sh 
+│     └─systemd-journald.service
+│       └─/usr/lib/systemd/systemd-journald
+```
+
+
+## What subsystems does rkt use?
+
+Right now, rkt uses the `cpu`, `cpuset`, and `memory` subsystems.
+
+### How are they mounted?
+
+When the stage1 starts, it mounts `/sys` . Then, for every subsystem, it:
+
+1. Mounts the subsystem (on `<rootfs>/sys/fs/cgroup/<subsystem>`)
+2. Bind-mounts the subcgroup on top of itself (e.g `<rootfs>/sys/fs/cgroup/memory/machine.slice/machine-rkt-UUID.scope/`)
+3. Remounts the subsystem readonly
+
+This is so that the pod itself cannot escape the cgroup. Currently the cgroup filesystems are not accessible to applications within the pod, but that may change.
+
+(N.B. `rkt` prior to v1.23 mounted each individual *knob* read-write. E.g. `.../memory/machine.slice/machine-rkt-UUID.scope/system.slice/etcd.service/{memory.limit_in_bytes, cgroup.procs}`)
 
 ## Future work
 

--- a/common/cgroup/cgroup.go
+++ b/common/cgroup/cgroup.go
@@ -18,7 +18,6 @@ package cgroup
 
 import (
 	"errors"
-	"os"
 	"path/filepath"
 	"syscall"
 
@@ -53,18 +52,7 @@ func IsIsolatorSupported(isolator string) (bool, error) {
 		}
 		return false, nil
 	}
-
-	if files := v1.CgroupControllerRWFiles(isolator); len(files) > 0 {
-		for _, f := range files {
-			isolatorPath := filepath.Join("/sys/fs/cgroup/", isolator, f)
-			if _, err := os.Stat(isolatorPath); os.IsNotExist(err) {
-				return false, nil
-			}
-		}
-		return true, nil
-	}
-
-	return false, nil
+	return v1.IsControllerMounted(isolator)
 }
 
 // IsCgroupUnified checks if cgroup mounted at /sys/fs/cgroup is


### PR DESCRIPTION
This remounts the entire subcgroup (machine slice) read-write, instead of only the exact knobs per-app we need.

This is needed for runc (since it wants to manage cgroups for itself). It also simplifies `app add`, since we no longer need to manipulate cgroups after pod start time. It also reduces the number of bind mounts to one per controller, making various operations more efficient. (Before, we had one bind mount per controller knob per app).