### PR TITLE
docs: delete unnecessary go get

### DIFF
--- a/Documentation/hacking.md
+++ b/Documentation/hacking.md
@@ -35,7 +35,7 @@ Alternatively, you can build rkt in a Docker container with the following comman
 Replace `$SRC` with the absolute path to your rkt source code:
 
 ```
-# docker run -v $SRC:/opt/rkt debian:sid /bin/bash -c "cd /opt/rkt && ./scripts/install-deps-debian-sid.sh && go get github.com/appc/spec/... && ./autogen.sh && ./configure && make"
+# docker run -v $SRC:/opt/rkt debian:sid /bin/bash -c "cd /opt/rkt && ./scripts/install-deps-debian-sid.sh && ./autogen.sh && ./configure && make"
 ```
 
 ### Building systemd in stage1 from source


### PR DESCRIPTION
Hello!

As mentioned in #3499 `go get` is not required anymore.