### PR TITLE
common/overlay: allow data directory name with colon character

### DIFF
--- a/common/overlay/overlay_test.go
+++ b/common/overlay/overlay_test.go
@@ -1,0 +1,44 @@
+// Copyright 2017 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package overlay
+
+import (
+	"testing"
+)
+
+func TestMountOpts(t *testing.T) {
+	tests := []struct {
+		cfg  MountCfg
+		want string
+	}{
+		{MountCfg{"/tmp/a", "/tmp/b", "/tmp/c", "", ""},
+			`lowerdir=/tmp/a,upperdir=/tmp/b,workdir=/tmp/c`},
+		{MountCfg{"/1", "/2", "/3", "", ""},
+			`lowerdir=/1,upperdir=/2,workdir=/3`},
+		{MountCfg{"/tmp/test:1", "/tmp/test:2", "/tmp/test:3", "", ""},
+			`lowerdir=/tmp/test\:1,upperdir=/tmp/test\:2,workdir=/tmp/test\:3`},
+		{MountCfg{"/tmp/test,1", "/tmp/test,2", "/tmp/test,3", "", ""},
+			`lowerdir=/tmp/test\,1,upperdir=/tmp/test\,2,workdir=/tmp/test\,3`},
+		{MountCfg{"/tmp/,1,1", "/tmp/,,2", "/tmp/,3,", "", ""},
+			`lowerdir=/tmp/\,1\,1,upperdir=/tmp/\,\,2,workdir=/tmp/\,3\,`},
+	}
+
+	for i, tt := range tests {
+		opts := tt.cfg.Opts()
+		if opts != tt.want {
+			t.Errorf("#%d: got: '%s', want: '%s'", i, opts, tt.want)
+		}
+	}
+}

--- a/tests/rkt_mount_overlay_test.go
+++ b/tests/rkt_mount_overlay_test.go
@@ -1,0 +1,87 @@
+// Copyright 2017 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build host coreos src kvm
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/coreos/rkt/common"
+	"github.com/coreos/rkt/common/overlay"
+)
+
+func overlayMount(cfg overlay.MountCfg) error {
+	// Create temporary directories with a configured prefix.
+
+	// Lower and Upper directories will create two text files
+	// to ensure the merging completed successfully.
+	cfg.Lower = createTempDirOrPanic(cfg.Lower)
+	createFileOrPanic(cfg.Lower, "1.txt")
+
+	cfg.Upper = createTempDirOrPanic(cfg.Upper)
+	createFileOrPanic(cfg.Upper, "2.txt")
+
+	cfg.Work = createTempDirOrPanic(cfg.Work)
+	cfg.Dest = createTempDirOrPanic(cfg.Dest)
+
+	// Ensure temporary directories will be removed after tests.
+	defer os.RemoveAll(cfg.Lower)
+	defer os.RemoveAll(cfg.Upper)
+	defer os.RemoveAll(cfg.Work)
+	defer os.RemoveAll(cfg.Dest)
+
+	err := overlay.Mount(&cfg)
+	if err != nil {
+		return err
+	}
+
+	// Unmount the destination directory when time comes.
+	defer syscall.Unmount(cfg.Dest, 0)
+
+	// Ensure both, 1.txt and 2.txt have been merged into the
+	// destination directory.
+	for _, ff := range []string{"1.txt", "2.txt"} {
+		_, err := os.Stat(filepath.Join(cfg.Dest, ff))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func TestOverlayMount(t *testing.T) {
+	if err := common.SupportsOverlay(); err != nil {
+		t.Skipf("Overlay fs not supported: %v", err)
+	}
+
+	tests := []overlay.MountCfg{
+		{"test1", "test2", "test3", "merged", ""},
+		{"test:1", "test:2", "test:3", "merged:1", ""},
+		{"test,1", "test,2", "test,3", "merged,1", ""},
+	}
+
+	for i, tt := range tests {
+		err := overlayMount(tt)
+		if err != nil {
+			text := "#%d: expected to mount at %s, got error (err=%v)"
+			t.Errorf(text, i, tt.Dest, err)
+		}
+	}
+}

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -219,6 +219,19 @@ func createTempDirOrPanic(dirName string) string {
 	return tmpDir
 }
 
+// createFileOrPanic creates an empty file within the given directory
+// with a specified name. Panics if file creation fails for any reason.
+func createFileOrPanic(dirName, fileName string) string {
+	name := filepath.Join(dirName, fileName)
+	file, err := os.Create(name)
+	if err != nil {
+		panic(err)
+	}
+
+	defer file.Close()
+	return name
+}
+
 func importImageAndFetchHashAsGid(t *testing.T, ctx *testutils.RktRunCtx, img string, fetchArgs string, gid int) (string, error) {
 	// Import the test image into store manually.
 	cmd := fmt.Sprintf("%s --insecure-options=image,tls fetch %s %s", ctx.Cmd(), fetchArgs, img)


### PR DESCRIPTION
This patch provides an sanitizing function used to escape the colon characters in the directory names of the ```mount``` command.

According to the Linux documentation https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt it
is used as a separator symbol in case of multi lower-layer mount.

It also provides the unit tests for common/overlay package, that is possible to execute only with superuser privileges.

Fixes #3448