### PR TITLE
rkt 1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 1.22.0
+
+This is a stabilization release which includes better support for environments without systemd, improvements to GC behavior in complex scenarios, and several additional fixes.
+
+### New features and UX changes
+
+- rkt/cat-manifest: add support for --uuid-file ([#3498](https://github.com/coreos/rkt/pull/3498)).
+- stage1: fallback if systemd cgroup doesn't exist ([#3507](https://github.com/coreos/rkt/pull/3507)).
+- vendor: bump gocapability ([#3493](https://github.com/coreos/rkt/pull/3493)). This change renames `sys_psacct` to `sys_pacct`.
+- stage0/app: pass debug flag to entrypoints ([#3469](https://github.com/coreos/rkt/pull/3469)).
+
+### Bug fixes
+- gc: fix cleaning mounts and files ([#3486](https://github.com/coreos/rkt/pull/3486)). This improves GC behavior in case of busy mounts and other complex scenarios.
+- mount: ensure empty volume paths exist for copy-up ([#3468](https://github.com/coreos/rkt/pull/3468)).
+- rkt stop/rm: a pod must be closed after PodFromUUIDString() ([#3492](https://github.com/coreos/rkt/pull/3492)).
+
+### Other changes
+- stage1/kvm: add a dash in kernel LOCALVERSION ([#3489](https://github.com/coreos/rkt/pull/3489)).
+- stage1/kvm: Improve QEMU Makefile rules ([#3474](https://github.com/coreos/rkt/pull/3474)).
+- pkg/pod: use IncludeMostDirs bitmask instead of constructing it ([#3506](https://github.com/coreos/rkt/pull/3506)).
+- pkg/pod: add WaitReady, dry Sandbox methods ([#3462](https://github.com/coreos/rkt/pull/3462)).
+- vendor: bump gexpect to 0.1.1 ([#3467](https://github.com/coreos/rkt/pull/3467)).
+- common: fix 'the the' duplication in comment ([#3497](https://github.com/coreos/rkt/pull/3497)).
+- docs: multiple updates ([#3479](https://github.com/coreos/rkt/pull/3479), [#3501](https://github.com/coreos/rkt/pull/3501), [#3464](https://github.com/coreos/rkt/pull/3464), [#3495](https://github.com/coreos/rkt/pull/3495)).
+
 ## 1.21.0
 
 This release includes bugfixes for the experimental CRI support, more stable integration tests, and some other interesting changes:

--- a/Documentation/distributions.md
+++ b/Documentation/distributions.md
@@ -132,19 +132,19 @@ upgrade manually.
 ### rpm-based 
 ```
 gpg --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-wget https://github.com/coreos/rkt/releases/download/v1.21.0/rkt-1.21.0-1.x86_64.rpm
-wget https://github.com/coreos/rkt/releases/download/v1.21.0/rkt-1.21.0-1.x86_64.rpm.asc
-gpg --verify rkt-1.21.0-1.x86_64.rpm.asc
-sudo rpm -Uvh rkt-1.21.0-1.x86_64.rpm
+wget https://github.com/coreos/rkt/releases/download/v1.22.0/rkt-1.22.0-1.x86_64.rpm
+wget https://github.com/coreos/rkt/releases/download/v1.22.0/rkt-1.22.0-1.x86_64.rpm.asc
+gpg --verify rkt-1.22.0-1.x86_64.rpm.asc
+sudo rpm -Uvh rkt-1.22.0-1.x86_64.rpm
 ```
 
 ### deb-based
 ```
 gpg --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-wget https://github.com/coreos/rkt/releases/download/v1.21.0/rkt_1.21.0-1_amd64.deb
-wget https://github.com/coreos/rkt/releases/download/v1.21.0/rkt_1.21.0-1_amd64.deb.asc
-gpg --verify rkt_1.21.0-1_amd64.deb.asc
-sudo dpkg -i rkt_1.21.0-1_amd64.deb
+wget https://github.com/coreos/rkt/releases/download/v1.22.0/rkt_1.22.0-1_amd64.deb
+wget https://github.com/coreos/rkt/releases/download/v1.22.0/rkt_1.22.0-1_amd64.deb.asc
+gpg --verify rkt_1.22.0-1_amd64.deb.asc
+sudo dpkg -i rkt_1.22.0-1_amd64.deb
 ```
 
 [coreos-install-rkt]: install-rkt-in-coreos.md

--- a/Documentation/proposals/oci.md
+++ b/Documentation/proposals/oci.md
@@ -139,6 +139,6 @@ Backwards compatibility: Currently the biggest concern identified is backwards c
 [oci-algorithms]: https://github.com/opencontainers/image-spec/blob/v1.0.0-rc2/descriptor.md#algorithms
 [oci-image-layout]: https://github.com/opencontainers/image-spec/blob/v1.0.0-rc2/image-layout.md
 
-[app-container]: https://github.com/coreos/rkt/blob/v1.21.0/Documentation/app-container.md
-[image-lifecycle]: https://github.com/coreos/rkt/blob/v1.21.0/Documentation/devel/architecture.md#image-lifecycle
-[distribution-point]: https://github.com/coreos/rkt/blob/v1.21.0/Documentation/devel/distribution-point.md
+[app-container]: https://github.com/coreos/rkt/blob/v1.22.0/Documentation/app-container.md
+[image-lifecycle]: https://github.com/coreos/rkt/blob/v1.22.0/Documentation/devel/architecture.md#image-lifecycle
+[distribution-point]: https://github.com/coreos/rkt/blob/v1.22.0/Documentation/devel/distribution-point.md

--- a/Documentation/running-fly-stage1.md
+++ b/Documentation/running-fly-stage1.md
@@ -60,14 +60,14 @@ $ ./autogen.sh && ./configure --with-stage1-flavors=fly && make
 ```
 
 For more details about configure parameters, see the [configure script parameters documentation][build-configure].
-This will build the rkt binary and the stage1-fly.aci in `build-rkt-1.21.0+git/bin/`.
+This will build the rkt binary and the stage1-fly.aci in `build-rkt-1.22.0+git/bin/`.
 
 ### Selecting stage1 at runtime
 
 Here is a quick example of how to use a container with the official fly stage1:
 
 ```
-# rkt run --stage1-name=coreos.com/rkt/stage1-fly:1.21.0 coreos.com/etcd:v2.2.5
+# rkt run --stage1-name=coreos.com/rkt/stage1-fly:1.22.0 coreos.com/etcd:v2.2.5
 ```
 
 If the image is not in the store, `--stage1-name` will perform discovery and fetch the image.

--- a/Documentation/running-kvm-stage1.md
+++ b/Documentation/running-kvm-stage1.md
@@ -13,7 +13,7 @@ $ ./autogen.sh && ./configure --with-stage1-flavors=kvm --with-stage1-kvm-hyperv
 ```
 
 For more details about configure parameters, see [configure script parameters documentation][build-configure].
-This will build the rkt binary and the KVM stage1 aci image in `build-rkt-1.21.0+git/target/bin/`. Depending on the configuration options, it will be `stage1-kvm.aci` (if one hypervisor is set), or `stage1-kvm-lkvm.aci` and `stage1-kvm-qemu.aci` (if you want to have both images built once).
+This will build the rkt binary and the KVM stage1 aci image in `build-rkt-1.22.0+git/target/bin/`. Depending on the configuration options, it will be `stage1-kvm.aci` (if one hypervisor is set), or `stage1-kvm-lkvm.aci` and `stage1-kvm-qemu.aci` (if you want to have both images built once).
 
 Provided you have hardware virtualization support and the [kernel KVM module][kvm-module] loaded (refer to your distribution for instructions), you can then run an image like you would normally do with rkt:
 
@@ -84,7 +84,7 @@ If you want to run software that requires hypervisor isolation along with truste
 For example, to use the official kvm stage1:
 
 ```
-# rkt run --stage1-name=coreos.com/rkt/stage1-kvm:1.21.0 coreos.com/etcd:v2.0.9
+# rkt run --stage1-name=coreos.com/rkt/stage1-kvm:1.22.0 coreos.com/etcd:v2.0.9
 ...
 ```
 

--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -8,7 +8,7 @@ Support for overlay fs will be auto-detected if `--no-overlay` is set to `false`
 
 ```
 # rkt prepare --insecure-options=image docker://busybox --exec=/bin/sh
-image: using image from local store for image name coreos.com/rkt/stage1-coreos:1.21.0
+image: using image from local store for image name coreos.com/rkt/stage1-coreos:1.22.0
 image: remote fetching from URL "docker://busybox"
 Downloading sha256:8ddc19f1652 [===============================] 668 KB / 668 KB
 prepare: disabling overlay support: "unsupported filesystem: missing d_type support"
@@ -32,7 +32,7 @@ Therefore, the supported arguments are mostly the same as in `run` except runtim
 ```
 # rkt prepare coreos.com/etcd:v2.0.10
 rkt prepare coreos.com/etcd:v2.0.10
-rkt: using image from local store for image name coreos.com/rkt/stage1-coreos:1.21.0
+rkt: using image from local store for image name coreos.com/rkt/stage1-coreos:1.22.0
 rkt: searching for app image coreos.com/etcd:v2.0.10
 rkt: remote fetching from url https://github.com/coreos/etcd/releases/download/v2.0.10/etcd-v2.0.10-linux-amd64.aci
 prefix: "coreos.com/etcd"

--- a/Documentation/subcommands/version.md
+++ b/Documentation/subcommands/version.md
@@ -6,7 +6,7 @@ This command prints the rkt version, the appc version rkt is built against, and 
 
 ```
 $ rkt version
-rkt Version: 1.21.0
+rkt Version: 1.22.0
 appc Version: 0.8.9
 Go Version: go1.5.3
 Go OS/Arch: linux/amd64

--- a/Documentation/trying-out-rkt.md
+++ b/Documentation/trying-out-rkt.md
@@ -20,9 +20,9 @@ rkt is written in Go and can be compiled for several CPU architectures. The rkt 
 To start running the latest version of rkt on amd64, grab the release directly from the rkt GitHub project:
 
 ```
-wget https://github.com/coreos/rkt/releases/download/v1.21.0/rkt-v1.21.0.tar.gz
-tar xzvf rkt-v1.21.0.tar.gz
-cd rkt-v1.21.0
+wget https://github.com/coreos/rkt/releases/download/v1.22.0/rkt-v1.22.0.tar.gz
+tar xzvf rkt-v1.22.0.tar.gz
+cd rkt-v1.22.0
 ./rkt help
 ```
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([rkt], [1.22.0], [https://github.com/coreos/rkt/issues])
+AC_INIT([rkt], [1.22.0+git], [https://github.com/coreos/rkt/issues])
 
 AC_PROG_CC
 AC_PROG_CXX

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([rkt], [1.21.0+git], [https://github.com/coreos/rkt/issues])
+AC_INIT([rkt], [1.22.0], [https://github.com/coreos/rkt/issues])
 
 AC_PROG_CC
 AC_PROG_CXX

--- a/scripts/install-rkt.sh
+++ b/scripts/install-rkt.sh
@@ -4,7 +4,7 @@ set -x
 
 cd $(mktemp -d)
 
-version="1.21.0"
+version="1.22.0"
 
 export DEBIAN_FRONTEND=noninteractive
 

--- a/tests/empty-image/manifest
+++ b/tests/empty-image/manifest
@@ -5,7 +5,7 @@
     "labels": [
         {
             "name": "version",
-            "value": "1.21.0"
+            "value": "1.22.0"
         },
         {
             "name": "arch",

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -5,7 +5,7 @@
     "labels": [
         {
             "name": "version",
-            "value": "1.21.0"
+            "value": "1.22.0"
         },
         {
             "name": "arch",

--- a/tests/rkt-monitor/build-stresser.sh
+++ b/tests/rkt-monitor/build-stresser.sh
@@ -27,7 +27,7 @@ buildImages() {
     acbuild --debug begin
     trap acbuildEnd EXIT
     acbuild --debug set-name appc.io/rkt-"${1}"-stresser
-    acbuild --debug copy build-rkt-1.21.0+git/target/bin/"${1}"-stresser /worker
+    acbuild --debug copy build-rkt-1.22.0/target/bin/"${1}"-stresser /worker
     acbuild --debug set-exec -- /worker
     acbuild --debug write --overwrite "${1}"-stresser.aci
     acbuild --debug end

--- a/tests/rkt-monitor/build-stresser.sh
+++ b/tests/rkt-monitor/build-stresser.sh
@@ -27,7 +27,7 @@ buildImages() {
     acbuild --debug begin
     trap acbuildEnd EXIT
     acbuild --debug set-name appc.io/rkt-"${1}"-stresser
-    acbuild --debug copy build-rkt-1.22.0/target/bin/"${1}"-stresser /worker
+    acbuild --debug copy build-rkt-1.22.0+git/target/bin/"${1}"-stresser /worker
     acbuild --debug set-exec -- /worker
     acbuild --debug write --overwrite "${1}"-stresser.aci
     acbuild --debug end

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.8.9","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.21.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
+	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.8.9","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.22.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
 )
 
 func TestRunOverrideExec(t *testing.T) {

--- a/tests/rkt_image_cat_manifest_test.go
+++ b/tests/rkt_image_cat_manifest_test.go
@@ -29,7 +29,7 @@ import (
 const (
 
 	// The expected image manifest of the 'rkt-inspect-image-cat-manifest.aci'.
-	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.9","name":"IMG_NAME","labels":[{"name":"version","value":"1.21.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.9","name":"IMG_NAME","labels":[{"name":"version","value":"1.22.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageCatManifest tests 'rkt image cat-manifest', it will:

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.9","name":"IMG_NAME","labels":[{"name":"version","value":"1.21.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestExportTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.9","name":"IMG_NAME","labels":[{"name":"version","value":"1.22.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageExport tests 'rkt image export', it will import some existing

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.9","name":"IMG_NAME","labels":[{"name":"version","value":"1.21.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
+	manifestRenderTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.9","name":"IMG_NAME","labels":[{"name":"version","value":"1.22.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}],"dependencies":[{"imageName":"coreos.com/rkt-inspect"}],"app":{"exec":["/inspect"],"user":"0","group":"0","workingDirectory":"/","environment":[{"name":"VAR_FROM_MANIFEST","value":"manifest"}]}}`
 )
 
 // TestImageRender tests 'rkt image render', it will import some existing empty

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	manifestOSArchTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.9","name":"IMG_NAME","labels":[{"name":"version","value":"1.21.0"}ARCH_OS],"app":{"exec":["/inspect", "--print-msg=HelloWorld"],"user":"0","group":"0","workingDirectory":"/"}}`
+	manifestOSArchTemplate = `{"acKind":"ImageManifest","acVersion":"0.8.9","name":"IMG_NAME","labels":[{"name":"version","value":"1.22.0"}ARCH_OS],"app":{"exec":["/inspect", "--print-msg=HelloWorld"],"user":"0","group":"0","workingDirectory":"/"}}`
 )
 
 type osArchTest struct {


### PR DESCRIPTION
## 1.22.0

This is a stabilization release which includes better support for environments without systemd, improvements to GC behavior in complex scenarios, and several additional fixes.

### New features and UX changes

- rkt/cat-manifest: add support for --uuid-file ([#3498](https://github.com/coreos/rkt/pull/3498)).
- stage1: fallback if systemd cgroup doesn't exist ([#3507](https://github.com/coreos/rkt/pull/3507)).
- vendor: bump gocapability ([#3493](https://github.com/coreos/rkt/pull/3493)). This change renames `sys_psacct` to `sys_pacct`.
- stage0/app: pass debug flag to entrypoints ([#3469](https://github.com/coreos/rkt/pull/3469)).

### Bug fixes
- gc: fix cleaning mounts and files ([#3486](https://github.com/coreos/rkt/pull/3486)). This improves GC behavior in case of busy mounts and other complex scenarios.
- mount: ensure empty volume paths exist for copy-up ([#3468](https://github.com/coreos/rkt/pull/3468)).
- rkt stop/rm: a pod must be closed after PodFromUUIDString() ([#3492](https://github.com/coreos/rkt/pull/3492)).

### Other changes
- stage1/kvm: add a dash in kernel LOCALVERSION ([#3489](https://github.com/coreos/rkt/pull/3489)).
- stage1/kvm: Improve QEMU Makefile rules ([#3474](https://github.com/coreos/rkt/pull/3474)).
- pkg/pod: use IncludeMostDirs bitmask instead of constructing it ([#3506](https://github.com/coreos/rkt/pull/3506)).
- pkg/pod: add WaitReady, dry Sandbox methods ([#3462](https://github.com/coreos/rkt/pull/3462)).
- vendor: bump gexpect to 0.1.1 ([#3467](https://github.com/coreos/rkt/pull/3467)).
- common: fix 'the the' duplication in comment ([#3497](https://github.com/coreos/rkt/pull/3497)).
- docs: multiple updates ([#3479](https://github.com/coreos/rkt/pull/3479), [#3501](https://github.com/coreos/rkt/pull/3501), [#3464](https://github.com/coreos/rkt/pull/3464), [#3495](https://github.com/coreos/rkt/pull/3495)).

