### PR TITLE
pkg/log: correctly handle var-arg printf params

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -113,7 +113,7 @@ func (l *Logger) Error(e error) {
 
 // Errorf is a convenience function for formatting and printing errors.
 func (l *Logger) Errorf(format string, a ...interface{}) {
-	l.Print(l.formatErr(fmt.Errorf(format, a), ""))
+	l.Print(l.formatErr(fmt.Errorf(format, a...), ""))
 }
 
 // FatalE prints a string and error then calls os.Exit(254).
@@ -124,16 +124,11 @@ func (l *Logger) FatalE(msg string, e error) {
 
 // Fatalf prints an error then calls os.Exit(254).
 func (l *Logger) Fatalf(format string, a ...interface{}) {
-	l.Print(l.formatErr(fmt.Errorf(format, a), ""))
+	l.Print(l.formatErr(fmt.Errorf(format, a...), ""))
 	os.Exit(254)
 }
 
 // PanicE prints a string and error then calls panic.
 func (l *Logger) PanicE(msg string, e error) {
 	l.Panic(l.formatErr(e, msg))
-}
-
-// Panicf prints an error then calls panic.
-func (l *Logger) Panicf(format string, a ...interface{}) {
-	l.Panic(l.formatErr(fmt.Errorf(format, a), ""))
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -64,3 +64,16 @@ func TestLogOutput(t *testing.T) {
 		}
 	}
 }
+
+func TestLogFormatting(t *testing.T) {
+	var logBuf bytes.Buffer
+	l := New(&logBuf, "prefix", false)
+
+	l.Errorf("format args: %s %d", "string", 1)
+
+	expected := "prefix: format args: string 1\n"
+
+	if logBuf.String() != expected {
+		t.Errorf("expected %q, got %q", expected, logBuf.String())
+	}
+}


### PR DESCRIPTION
I deleted `Panicf` too because there were no callers and I really don't think there should be any ever again 😄 