### PR TITLE
tests: use appc schema instead of string templates

### DIFF
--- a/pkg/aci/aci.go
+++ b/pkg/aci/aci.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/appc/spec/aci"
 	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
 	"github.com/hashicorp/errwrap"
 	"golang.org/x/crypto/openpgp"
 )
@@ -107,8 +107,18 @@ func (aw *imageArchiveWriter) Close() error {
 // NewBasicACI creates a new ACI in the given directory with the given name.
 // Used for testing.
 func NewBasicACI(dir string, name string) (*os.File, error) {
-	manifest := fmt.Sprintf(`{"acKind":"ImageManifest","acVersion":"0.8.9","name":"%s"}`, name)
-	return NewACI(dir, manifest, nil)
+	manifest := schema.ImageManifest{
+		ACKind:    schema.ImageManifestKind,
+		ACVersion: schema.AppContainerVersion,
+		Name:      types.ACIdentifier(name),
+	}
+
+	b, err := manifest.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewACI(dir, string(b), nil)
 }
 
 // NewACI creates a new ACI in the given directory with the given image

--- a/pkg/aci/acitest/manifest.go
+++ b/pkg/aci/acitest/manifest.go
@@ -1,0 +1,106 @@
+// Copyright 2017 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package acitest provides utilities for ACI testing.
+package acitest
+
+import (
+	"encoding/json"
+
+	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
+)
+
+var (
+	// zeroVersion specifies an empty instance of the semantic version
+	// used to compare it in the image manifest in order to detect an
+	// unspecified manifest version.
+	zeroVersion types.SemVer
+)
+
+const (
+	// defaultName defines the name of the image manifest that will be
+	// used when name was not specified.
+	defaultName = "example.com/test01"
+)
+
+type (
+	// These types are aliases to the types used in the application
+	// container definition. They used to bypass validations of the
+	// image manifest during serialization to JSON string.
+	aciApp          types.App
+	aciAnnotations  types.Annotations
+	aciDependencies types.Dependencies
+	aciKind         types.ACKind
+	aciLabels       types.Labels
+	aciName         types.ACIdentifier
+
+	// aciManifest completely copies and underlying representation
+	// of the application image manifest. It wraps each attribute of
+	// the manifest into the alias in order to bypass validations.
+	aciManifest struct {
+		ACKind        aciKind         `json:"acKind"`
+		ACVersion     types.SemVer    `json:"acVersion"`
+		Name          aciName         `json:"name"`
+		Labels        aciLabels       `json:"labels,omitempty"`
+		App           *aciApp         `json:"app,omitempty"`
+		Annotations   aciAnnotations  `json:"annotations,omitempty"`
+		Dependencies  aciDependencies `json:"dependencies,omitempty"`
+		PathWhitelist []string        `json:"pathWhitelist,omitempty"`
+	}
+)
+
+// toImageManifest converts the specified application image manifest
+// into the non-checkable image manifest, thus make it possible to
+// create a manifest with mistakes.
+func toImageManifest(m *schema.ImageManifest) *aciManifest {
+	return &aciManifest{
+		ACKind:        aciKind(m.ACKind),
+		ACVersion:     m.ACVersion,
+		Name:          aciName(m.Name),
+		Labels:        aciLabels(m.Labels),
+		App:           (*aciApp)(m.App),
+		Annotations:   aciAnnotations(m.Annotations),
+		Dependencies:  aciDependencies(m.Dependencies),
+		PathWhitelist: m.PathWhitelist,
+	}
+}
+
+// ImageManifestString sets the default attributes to the specified image
+// manifest and returns its JSON string representation.
+func ImageManifestString(im *schema.ImageManifest) (string, error) {
+	// When nil have been passed as an argument, it will create an
+	// empty manifest and define the minimal attributes.
+	if im == nil {
+		im = new(schema.ImageManifest)
+	}
+
+	// Set the default kind of the AC image manifest.
+	if im.ACKind == "" {
+		im.ACKind = schema.ImageManifestKind
+	}
+
+	// Set the default version of the AC image manifest.
+	if im.ACVersion == zeroVersion {
+		im.ACVersion = schema.AppContainerVersion
+	}
+
+	// Set the default name of the AC image manifest.
+	if im.Name == "" {
+		im.Name = defaultName
+	}
+
+	b, err := json.Marshal(toImageManifest(im))
+	return string(b), err
+}

--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 
 	"github.com/coreos/rkt/pkg/aci"
+	"github.com/coreos/rkt/pkg/aci/acitest"
 	dist "github.com/coreos/rkt/pkg/distribution"
 	"github.com/coreos/rkt/pkg/keystore"
 	"github.com/coreos/rkt/pkg/keystore/keystoretest"
@@ -162,11 +163,10 @@ func TestDownloading(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	imj := `{
-			"acKind": "ImageManifest",
-			"acVersion": "0.7.4",
-			"name": "example.com/test01"
-		}`
+	imj, err := acitest.ImageManifestString(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	entries := []*aci.ACIEntry{
 		// An empty file

--- a/store/imagestore/store_test.go
+++ b/store/imagestore/store_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/coreos/rkt/pkg/aci"
+	"github.com/coreos/rkt/pkg/aci/acitest"
 	"github.com/coreos/rkt/pkg/multicall"
 
 	"github.com/appc/spec/schema/types"
@@ -161,11 +162,10 @@ func TestGetImageManifest(t *testing.T) {
 	}
 	defer s.Close()
 
-	imj := `{
-			"acKind": "ImageManifest",
-			"acVersion": "0.8.9",
-			"name": "example.com/test01"
-		}`
+	imj, err := acitest.ImageManifestString(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	aci, err := aci.NewACI(dir, imj, nil)
 	if err != nil {
@@ -356,11 +356,10 @@ func TestRemoveACI(t *testing.T) {
 	}
 	defer s.Close()
 
-	imj := `{
-                    "acKind": "ImageManifest",
-                    "acVersion": "0.8.9",
-                    "name": "example.com/test01"
-                }`
+	imj, err := acitest.ImageManifestString(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	aciFile, err := aci.NewACI(dir, imj, nil)
 	if err != nil {
@@ -396,13 +395,6 @@ func TestRemoveACI(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error")
 	}
-
-	// Simulate error removing from the
-	imj = `{
-                   "acKind": "ImageManifest",
-                   "acVersion": "0.8.9",
-                   "name": "example.com/test01"
-               }`
 
 	aciFile, err = aci.NewACI(dir, imj, nil)
 	if err != nil {

--- a/store/treestore/tree_test.go
+++ b/store/treestore/tree_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/coreos/rkt/pkg/aci"
+	"github.com/coreos/rkt/pkg/aci/acitest"
 	"github.com/coreos/rkt/pkg/sys"
 	"github.com/coreos/rkt/store/imagestore"
 )
@@ -31,13 +32,10 @@ const tstprefix = "treestore-test"
 // TODO(sgotti) when the TreeStore will use an interface, change it to a
 // test implementation without relying on store/imagestore
 func testStoreWriteACI(dir string, s *imagestore.Store) (string, error) {
-	imj := `
-		{
-		    "acKind": "ImageManifest",
-		    "acVersion": "0.8.9",
-		    "name": "example.com/test01"
-		}
-	`
+	imj, err := acitest.ImageManifestString(nil)
+	if err != nil {
+		return "", err
+	}
 
 	entries := []*aci.ACIEntry{
 		// An empty dir
@@ -199,13 +197,10 @@ func TestTreeStore(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	imj := `
-		{
-		    "acKind": "ImageManifest",
-		    "acVersion": "0.8.9",
-		    "name": "example.com/test01"
-		}
-	`
+	imj, err := acitest.ImageManifestString(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	entries := []*aci.ACIEntry{
 		// An empty dir

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -22,14 +22,30 @@ import (
 	"os"
 	"testing"
 
+	"github.com/coreos/rkt/pkg/aci/acitest"
 	"github.com/coreos/rkt/tests/testutils"
-)
 
-const (
-	noappManifestStr = `{"acKind":"ImageManifest","acVersion":"0.8.9","name":"coreos.com/rkt-inspect","labels":[{"name":"version","value":"1.22.0"},{"name":"arch","value":"amd64"},{"name":"os","value":"linux"}]}`
+	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
 )
 
 func TestRunOverrideExec(t *testing.T) {
+	// noappManifest specifies an image manifest configuration without
+	// an application section.
+	noappManifest := schema.ImageManifest{
+		Name: "coreos.com/rkt-inspect",
+		Labels: types.Labels{
+			{"version", "1.22.0"},
+			{"arch", "amd64"},
+			{"os", "linux"},
+		},
+	}
+
+	noappManifestStr, err := acitest.ImageManifestString(&noappManifest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
 	noappManifestFile := "noapp-manifest.json"
 	if err := ioutil.WriteFile(noappManifestFile, []byte(noappManifestStr), 0600); err != nil {
 		t.Fatalf("Cannot write noapp manifest: %v", err)


### PR DESCRIPTION
This patch introduces a new package "pkg/aci/acitest" used to set the
default parameters to the application container image manifest
(precisely: name, version, kind).

It replaces the strings templates used to mock the manifest's JSON to
the types from "github.com/appc/schema" go-package.

Fixes #714