### PR TITLE
stage1/fly: record pgid and let stop fallback to it

### DIFF
--- a/stage1_fly/run/main.go
+++ b/stage1_fly/run/main.go
@@ -430,7 +430,15 @@ func stage1(rp *stage1commontypes.RuntimePod) int {
 		}
 	}
 
+	// stage1 interface: pod-leader pid
 	if err = stage1common.WritePid(os.Getpid(), "pid"); err != nil {
+		log.Error(err)
+		return 254
+	}
+
+	// stage1-fly internal: pod pgid
+	// (used by stop, as fly has weak pod-grouping of processes)
+	if err = stage1common.WritePid(syscall.Getpgrp(), "pgid"); err != nil {
 		log.Error(err)
 		return 254
 	}


### PR DESCRIPTION
This introduces an additional "pgid" file, specific to stage1-fly
implementation, to record the process group of the pod.
It is used by stop as a fallback mechanism if the pod-leader process
is gone but some daemonized children still exist, leaving the pod
in an unkillable status.

Fixes #3295