### PR TITLE
api-service: stop erroring when a pod is running

### DIFF
--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -602,7 +602,7 @@ func fillPodDetails(store *imagestore.Store, p *pkgPod.Pod, v1pod *v1alpha.Pod) 
 
 		if readStatus {
 			exitCode, err := p.AppExitCode(app.Name)
-			if err != nil {
+			if err != nil && !os.IsNotExist(err) {
 				stderr.PrintE(fmt.Sprintf("failed to read status for app %q", app.Name), err)
 			}
 			app.ExitCode = int32(exitCode)


### PR DESCRIPTION
Fixes #3504 

This silences this silly error message. This logic isn't exactly correct, but I've filed another issue to fix that.