### PR TITLE
Bump appc/docker2aci library version to 0.15.0

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: d539e0ee23575e8a3fbb83bd56ccd2d59b7e2bd9ac0058863800a61841fb35ae
-updated: 2016-12-22T11:41:11.44338079-05:00
+hash: d4d89bbae9978ca0305ddeb4f80bf28a1e7697215fa3fe2e11271240d234038e
+updated: 2017-01-16T13:12:04.012198138+03:00
 imports:
 - name: github.com/appc/docker2aci
-  version: 64543c1e0a7306b17d0d214549ec08049b234abc
+  version: cfd196b05e02185b34aa3a844eff07b943c7e3ec
   subpackages:
   - lib
   - lib/common
@@ -300,7 +300,7 @@ imports:
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: k8s.io/kubernetes
-  version: ba5b2fcee9d938dae74d4474f68d9d0933f3ec04
+  version: 5aadd18b051c7c156ee9815055beb180c8365309
   subpackages:
   - pkg/api/resource
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/StackExchange/wmi
   version: f3e2bae1e0cb5aef83e319133eabfee30013a4a5
 - package: github.com/appc/docker2aci
-  version: v0.14.0
+  version: v0.15.0
   subpackages:
   - lib
   - lib/common

--- a/vendor/github.com/appc/docker2aci/lib/version.go
+++ b/vendor/github.com/appc/docker2aci/lib/version.go
@@ -16,5 +16,5 @@ package docker2aci
 
 import "github.com/appc/spec/schema"
 
-var Version = "0.14.0"
+var Version = "0.15.0"
 var AppcVersion = schema.AppContainerVersion

--- a/vendor/github.com/appc/docker2aci/main.go
+++ b/vendor/github.com/appc/docker2aci/main.go
@@ -136,12 +136,8 @@ func runDocker2ACI(arg string) error {
 		return err
 	}
 
-	if err := printConvertedVolumes(*manifest); err != nil {
-		return err
-	}
-	if err := printConvertedPorts(*manifest); err != nil {
-		return err
-	}
+	printConvertedVolumes(*manifest)
+	printConvertedPorts(*manifest)
 
 	fmt.Printf("\nGenerated ACI(s):\n")
 	for _, aciFile := range aciLayerPaths {
@@ -151,33 +147,29 @@ func runDocker2ACI(arg string) error {
 	return nil
 }
 
-func printConvertedVolumes(manifest schema.ImageManifest) error {
-	if manifest.App != nil && manifest.App.MountPoints != nil {
-		mps := manifest.App.MountPoints
-		if len(mps) > 0 {
-			fmt.Printf("\nConverted volumes:\n")
-			for _, mp := range mps {
-				fmt.Printf("\tname: %q, path: %q, readOnly: %v\n", mp.Name, mp.Path, mp.ReadOnly)
-			}
+func printConvertedVolumes(manifest schema.ImageManifest) {
+	if manifest.App == nil {
+		return
+	}
+	if mps := manifest.App.MountPoints; len(mps) > 0 {
+		fmt.Printf("\nConverted volumes:\n")
+		for _, mp := range mps {
+			fmt.Printf("\tname: %q, path: %q, readOnly: %v\n", mp.Name, mp.Path, mp.ReadOnly)
 		}
 	}
-
-	return nil
 }
 
-func printConvertedPorts(manifest schema.ImageManifest) error {
-	if manifest.App != nil && manifest.App.Ports != nil {
-		ports := manifest.App.Ports
-		if len(ports) > 0 {
-			fmt.Printf("\nConverted ports:\n")
-			for _, port := range ports {
-				fmt.Printf("\tname: %q, protocol: %q, port: %v, count: %v, socketActivated: %v\n",
-					port.Name, port.Protocol, port.Port, port.Count, port.SocketActivated)
-			}
+func printConvertedPorts(manifest schema.ImageManifest) {
+	if manifest.App == nil {
+		return
+	}
+	if ports := manifest.App.Ports; len(ports) > 0 {
+		fmt.Printf("\nConverted ports:\n")
+		for _, port := range ports {
+			fmt.Printf("\tname: %q, protocol: %q, port: %v, count: %v, socketActivated: %v\n",
+				port.Name, port.Protocol, port.Port, port.Count, port.SocketActivated)
 		}
 	}
-
-	return nil
 }
 
 func getManifest(aciPath string) (*schema.ImageManifest, error) {
@@ -197,9 +189,9 @@ func getManifest(aciPath string) (*schema.ImageManifest, error) {
 
 func usage() {
 	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
-	fmt.Fprintf(os.Stderr, "docker2aci [--debug] [--nosquash] [--compression=(gzip|none)] IMAGE\n")
+	fmt.Fprintf(os.Stderr, "docker2aci [-debug] [-nosquash] [-compression=(gzip|none)] IMAGE\n")
 	fmt.Fprintf(os.Stderr, "  Where IMAGE is\n")
-	fmt.Fprintf(os.Stderr, "    [--image=IMAGE_NAME[:TAG]] FILEPATH\n")
+	fmt.Fprintf(os.Stderr, "    [-image=IMAGE_NAME[:TAG]] FILEPATH\n")
 	fmt.Fprintf(os.Stderr, "  or\n")
 	fmt.Fprintf(os.Stderr, "    docker://[REGISTRYURL/]IMAGE_NAME[:TAG]\n")
 	fmt.Fprintf(os.Stderr, "Flags:\n")
@@ -216,7 +208,7 @@ func main() {
 		return
 	}
 
-	if len(args) < 1 {
+	if len(args) != 1 {
 		usage()
 		os.Exit(2)
 	}

--- a/vendor/k8s.io/kubernetes/pkg/api/resource/generated.pb.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/resource/generated.pb.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This patch bumps the version of the appc/docker2aci library to 0.15.0
in order to support the conversion of the images with various os/arch.

fixes #3526