### PR TITLE
namefetcher: fix nil pointer dereference

### DIFF
--- a/rkt/image/namefetcher.go
+++ b/rkt/image/namefetcher.go
@@ -206,7 +206,7 @@ func (f *nameFetcher) fetchVerifiedURL(app *discovery.App, u *url.URL, a *asc, e
 
 	if cd.UseCached {
 		aciFile.Close()
-		return nil, cd, nil
+		return NopReadSeekCloser(nil), cd, nil
 	}
 
 	if retry {


### PR DESCRIPTION
Currently (rkt v1.22.0) e.g.

   rkt fetch --no-store coreos.com/etcd:v3.0.15

(run twice to trigger) fails when using cached data due to

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x56200f0b6be5]

goroutine 1 [running, locked to thread]:
panic(0x56200f6f7c40, 0xc4200120d0)
	/usr/lib/go-1.7/src/runtime/panic.go:500 +0x1a1
github.com/coreos/rkt/rkt/image.(*nameFetcher).fetchImageFromSingleEndpoint(0xc4205338b0, 0xc42022ab00, 0xc420498cc0, 0x3f, 0xc420533a38, 0x0, 0x0, 0x0, 0x0, 0x0)
	/go/src/github.com/coreos/rkt/build-rkt-1.22.0/gopath/src/github.com/coreos/rkt/rkt/image/namefetcher.go:124 +0x245
github.com/coreos/rkt/rkt/image.(*nameFetcher).fetchImageFromEndpoints(0xc4205338b0, 0xc42022ab00, 0xc4203afaa0, 0x1, 0x1, 0xc420533a38, 0x0, 0xc420214990, 0xc42022ab00, 0x56200f7c064c, ...)
	/go/src/github.com/coreos/rkt/build-rkt-1.22.0/gopath/src/github.com/coreos/rkt/rkt/image/namefetcher.go:99 +0x19d
github.com/coreos/rkt/rkt/image.(*nameFetcher).Hash(0xc4205338b0, 0xc42022ab00, 0xc420533a38, 0xc42022c5b0, 0x7, 0x56200f7c0a2f, 0x5)
	/go/src/github.com/coreos/rkt/build-rkt-1.22.0/gopath/src/github.com/coreos/rkt/rkt/image/namefetcher.go:63 +0x3a5
github.com/coreos/rkt/rkt/image.(*Fetcher).maybeFetchImageFromRemote(0xc420533c28, 0xc420533a78, 0xc420533a38, 0x0, 0x0, 0x0, 0xc420057940)
	/go/src/github.com/coreos/rkt/build-rkt-1.22.0/gopath/src/github.com/coreos/rkt/rkt/image/fetcher.go:362 +0xe7

...
```