### PR TITLE
gc: don't unshare shared mounts

### DIFF
--- a/pkg/mountinfo/types.go
+++ b/pkg/mountinfo/types.go
@@ -33,7 +33,6 @@ type FilterFunc func(m *Mount) bool
 // leaking to parents.
 func (m *Mount) NeedsRemountPrivate() bool {
 	for _, key := range []string{
-		"shared",
 		"master",
 	} {
 		if _, needsRemount := m.Opts[key]; needsRemount {


### PR DESCRIPTION
I recall concerns that making a change like this could result on incidentally unmounting filesystem's on the host.

Fixes #3181 

TODO:

- [ ] Verify that this doesn't break mounts created by kubelet inside kubelet-wrapper (e.g. restarts of kubelet wrapper shouldn't unmount the mounts it created on the host)

I suspect this will break the above, but I have an idea for fixing that too which I'll explore after verifying.

Basically, my idea to further fix this is to either write the mounts the stage1 made to a file and not unshare just those, or to read the mounts from the pod manifest and do roughly the same.