### PR TITLE
stage1-fly: don't share /dev,/proc,sys by default

### DIFF
--- a/stage1_fly/run/main.go
+++ b/stage1_fly/run/main.go
@@ -299,15 +299,9 @@ func stage1(rp *stage1commontypes.RuntimePod) int {
 
 	effectiveMounts := append(
 		[]flyMount{
-			{"", "", "/dev", "none", syscall.MS_REC | syscall.MS_SHARED},
 			{"/dev", rfs, "/dev", "none", syscall.MS_BIND | syscall.MS_REC},
-
-			{"", "", "/proc", "none", syscall.MS_REC | syscall.MS_SHARED},
 			{"/proc", rfs, "/proc", "none", syscall.MS_BIND | syscall.MS_REC},
-
-			{"", "", "/sys", "none", syscall.MS_REC | syscall.MS_SHARED},
 			{"/sys", rfs, "/sys", "none", syscall.MS_BIND | syscall.MS_REC},
-
 			{"tmpfs", rfs, "/tmp", "tmpfs", 0},
 		},
 		argFlyMounts...,


### PR DESCRIPTION
If the user wishes these bindmounts to be shared, manually specifying
them should make it so again.

This is technically backwards incompatible, but in general I don't think additional mounts are pretty much ever created under these directories and I think that sharing them in the first place might have been an oversight.