### PR TITLE
run/prepare/fetch: replace --no-store and --store-only with --pull-policy

### DIFF
--- a/Documentation/image-fetching-behavior.md
+++ b/Documentation/image-fetching-behavior.md
@@ -2,18 +2,19 @@
 
 When fetching, rkt will try to avoid unnecessary network transfers: if an updated image is already in the local store there's no need to download it again.
 
-This behavior can be controlled with the `--store-only` and `--no-store` flags.
+This behavior can be controlled with the `--pull-policy` flag.
 
 ## General Behavior
 
-The following table describes the meaning of the `--store-only` and `--no-store` flags.
+The following table describes the meaning of the `--pull-policy` flag.
 
-Flags                     | Description
+This flag accepts one of three options:
+
+Option                    | Description
 ------------------------- | ---------------------------------------------------------------------------------------------------
-_no flags_                | **Default behavior.** Do `store` and if it doesn't return an image do `remote`.
-`--store-only`            | Check the local store only.
-`--no-store`              | Execute a remote download, while handling caching logic for `http(s)://` and `docker://`.
-`--store-only --no-store` | Invalid option.
+`new`                     | __Default behavior in run and prepare__ Check the store, and if the image is missing fetch from remote
+`update`                  | __Default behavior in fetch__ Attempt to fetch from remote, but if the remote image matches something in our store don't pull it
+`never`                   | Only check the store, and don't fetch from remote.
 
 ## Details
 

--- a/Documentation/subcommands/fetch.md
+++ b/Documentation/subcommands/fetch.md
@@ -70,8 +70,8 @@ Docker images do not support signature verification.
 When fetching, rkt will try to avoid unnecessary network transfers.
 For example, if an image is already in the local store, rkt will use HTTP's ETag and Cache-Control to avoid downloading it again unless the image was updated on the remote server.
 
-This behavior can be changed by using the `--store-only` and `--no-store` flags.
-Their meanings are detailed in the [image fetching behavior][img-fetch] documentation.
+This behavior can be changed by using the `--pull-policy` flag.
+Usage of this flag is detailed in the [image fetching behavior][img-fetch] documentation.
 
 ## Authentication
 
@@ -86,9 +86,8 @@ Note that the configuration kind for images downloaded via https:// and images d
 | Flag | Default | Options | Description |
 | --- | --- | --- | --- |
 | `--full` |  `false` | `true` or `false` | Print the full image hash after fetching |
-| `--no-store` |  `false` | `true` or `false` | Fetch images ignoring the local store. See [image fetching behavior][img-fetch] |
 | `--signature` |  `` | A file path | Local signature file to use in validating the preceding image |
-| `--store-only` |  `false` | `true` or `false` | Use only available images in the store (do not discover or download from remote URLs). See [image fetching behavior][img-fetch] |
+| `--pull-policy` | `new` | `never`, `new`, or `update` | Sets the policy for when to fetch an image. See [image fetching behavior][img-fetch] |
 
 ## Global options
 

--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -63,7 +63,7 @@ c9fad0e6-8236-4fc2-ad17-55d0a4c7d742
 | `--mount` | none | Mount syntax (ex. `--mount volume=NAME,target=PATH`) | Mount point binding a volume to a path within an app. See [Mounting Volumes without Mount Points][vol-no-mount]. |
 | `--name` | none | Name of the app | Set the name of the app (example: '--name=foo'). If not set, then the app name default to the image's name |
 | `--no-overlay` | `false` | `true` or `false` | Disable the overlay filesystem. |
-| `--no-store` | `false` | `true` or `false` | Fetch images, ignoring the local store. See [image fetching behavior][img-fetch] |
+| `--pull-policy` | `new` | `never`, `new`, or `update` | Sets the policy for when to fetch an image. See [image fetching behavior][img-fetch] |
 | `--pod-manifest` | none | A path | The path to the pod manifest. If it's non-empty, then only `--net`, `--no-overlay` and `--interactive` will have effect. |
 | `--port` | none | A port name and number pair | Container port name to expose through host port number. Requires [contained network][contained]. Syntax: `--port=NAME:HOSTPORT` The NAME is that given in the ACI. By convention, Docker containers' EXPOSEd ports are given a name formed from the port number, a hyphen, and the protocol, e.g., `80-tcp`, giving something like `--port=80-tcp:8080` |
 | `--private-users` |  `false` | `true` or `false` | Run within user namespaces |
@@ -76,7 +76,6 @@ c9fad0e6-8236-4fc2-ad17-55d0a4c7d742
 | `--stage1-name` |  `` | A name of a stage1 image. Will perform a discovery if the image is not in the store | Image to use as stage1 |
 | `--stage1-hash` |  `` | A hash of a stage1 image. The image must exist in the store | Image to use as stage1 |
 | `--stage1-from-dir` |  `` | A stage1 image file inside the default stage1 images directory | Image to use as stage1 |
-| `--store-only` |  `false` | `true` or `false` | Use only available images in the store (do not discover or download from remote URLs). See [image fetching behavior][img-fetch] |
 | `--user` | none | uid, username or file path | user override for the preceding image (example: '--user=user') |
 | `--volume` |  `` | Volume syntax (`NAME,kind=KIND,source=PATH,readOnly=BOOL,recursive=BOOL`). See [Mount Volumes into a Pod][mount-vol] | Volumes to make available in the pod |
 

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -407,7 +407,6 @@ This feature will be disabled automatically if the underlying filesystem does no
 | `--name` | none | Name of the app | Set the name of the app (example: '--name=foo'). If not set, then the app name default to the image's name |
 | `--net` | `default` | A comma-separated list of networks. (e.g. `--net[=n[:args], ...]`) | Configure the pod's networking. Optionally, pass a list of user-configured networks to load and set arguments to pass to each network, respectively. |
 | `--no-overlay` | `false` | `true` or `false` | Disable the overlay filesystem. |
-| `--no-store` | `false` | `true` or `false` | Fetch images, ignoring the local store. See [image fetching behavior][img-fetch]. |
 | `--pod-manifest` | none | A path | The path to the pod manifest. If it's non-empty, then only `--net`, `--no-overlay` and `--interactive` will have effect. |
 | `--port` | none | A port name and number pair | Container port name to expose through host port number. Requires [contained network][contained]. Syntax: `--port=NAME:HOSTPORT` The NAME is that given in the ACI. By convention, Docker containers' EXPOSEd ports are given a name formed from the port number, a hyphen, and the protocol, e.g., `80-tcp`, giving something like `--port=80-tcp:8080`. |
 | `--private-users` | `false` | `true` or `false` | Run within user namespaces. |
@@ -419,7 +418,7 @@ This feature will be disabled automatically if the underlying filesystem does no
 | `--stage1-name` | none | Image name (e.g. `--stage1-name=coreos.com/rkt/stage1-coreos`) | A name of a stage1 image. Will perform a discovery if the image is not in the store. |
 | `--stage1-path` | none | Absolute or relative path | A path to a stage1 image. |
 | `--stage1-url` | none | URL with protocol | A URL to a stage1 image. HTTP/HTTPS/File/Docker URLs are supported. |
-| `--store-only` | `false` | `true` or `false` | Use only available images in the store (do not discover or download from remote URLs). See [image fetching behavior][img-fetch]. |
+| `--pull-policy` | `new` | `never`, `new`, or `update` | Sets the policy for when to fetch an image. See [image fetching behavior][img-fetch] |
 | `--user` | none | uid, username or file path (e.g. `--user=core`) | User override for the preceding image. |
 | `--uuid-file-save` | none | A file path | Write out the pod UUID to a file. |
 | `--volume` | none | Volume syntax (e.g. `--volume NAME,kind=KIND,source=PATH,readOnly=BOOL`) | Volumes to make available in the pod. See [Mount Volumes into a Pod](#mount-volumes-into-a-pod). |

--- a/rkt/app_add.go
+++ b/rkt/app_add.go
@@ -101,8 +101,7 @@ func runAppAdd(cmd *cobra.Command, args []string) (exit int) {
 		Ts: ts,
 		Ks: getKeystore(),
 
-		StoreOnly: true,
-		NoStore:   false,
+		PullPolicy: image.PullPolicyNever,
 	}
 
 	img, err := fn.FindImage(args[1], "")

--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -561,7 +561,7 @@ func TestFetchImageCache(t *testing.T) {
 			Ks:            ks,
 			InsecureFlags: secureFlags,
 			// Skip local store
-			NoStore: true,
+			PullPolicy: image.PullPolicyUpdate,
 		}
 		u, err := url.Parse(aciURL)
 		if err != nil {

--- a/rkt/image/common.go
+++ b/rkt/image/common.go
@@ -42,6 +42,10 @@ type imageStringType int
 const (
 	imageStringName imageStringType = iota // image type to be guessed
 	imageStringPath                        // absolute or relative path
+
+	PullPolicyNever  = "never"
+	PullPolicyNew    = "new"
+	PullPolicyUpdate = "update"
 )
 
 // action is a common type for Finder and Fetcher
@@ -69,13 +73,9 @@ type action struct {
 	// via the https protocol can be trusted
 	TrustKeysFromHTTPS bool
 
-	// StoreOnly tells whether to avoid getting images from a
-	// local filesystem or a remote location.
-	StoreOnly bool
-	// NoStore tells whether to avoid getting images from the
-	// store. Note that transport caching (like http Etags) can be still
-	// used to avoid refetching.
-	NoStore bool
+	// PullPolicy controls when to pull images from remote, versus using a copy
+	// on the local filesystem, versus checking for updates to local images
+	PullPolicy string
 	// NoCache tells to ignore transport caching.
 	NoCache bool
 	// WithDeps tells whether image dependencies should be

--- a/rkt/image/fetcher.go
+++ b/rkt/image/fetcher.go
@@ -233,7 +233,7 @@ func (f *Fetcher) fetchSingleImageByDockerURL(d *dist.Docker) (string, error) {
 }
 
 func (f *Fetcher) maybeCheckRemoteFromStore(rem *imagestore.Remote) string {
-	if f.NoStore || rem == nil {
+	if f.PullPolicy == PullPolicyUpdate || rem == nil {
 		return ""
 	}
 	diag.Printf("using image from local store for url %s", rem.ACIURL)
@@ -241,7 +241,7 @@ func (f *Fetcher) maybeCheckRemoteFromStore(rem *imagestore.Remote) string {
 }
 
 func (f *Fetcher) maybeFetchHTTPURLFromRemote(rem *imagestore.Remote, u *url.URL, a *asc) (string, error) {
-	if !f.StoreOnly {
+	if f.PullPolicy != PullPolicyNever {
 		diag.Printf("remote fetching from URL %q", u.String())
 		hf := &httpFetcher{
 			InsecureFlags: f.InsecureFlags,
@@ -257,7 +257,7 @@ func (f *Fetcher) maybeFetchHTTPURLFromRemote(rem *imagestore.Remote, u *url.URL
 }
 
 func (f *Fetcher) maybeFetchDockerURLFromRemote(u *url.URL) (string, error) {
-	if !f.StoreOnly {
+	if f.PullPolicy != PullPolicyNever {
 		diag.Printf("remote fetching from URL %q", u.String())
 		df := &dockerFetcher{
 			InsecureFlags: f.InsecureFlags,
@@ -313,7 +313,7 @@ func (f *Fetcher) fetchSingleImageByName(db *distBundle, a *asc) (string, error)
 }
 
 func (f *Fetcher) maybeCheckStoreForApp(db *distBundle) (string, error) {
-	if !f.NoStore {
+	if f.PullPolicy != PullPolicyUpdate {
 		key, err := f.getStoreKeyFromApp(db)
 		if err == nil {
 			diag.Printf("using image from local store for image name %s", db.image)
@@ -348,7 +348,7 @@ func (f *Fetcher) getStoreKeyFromApp(db *distBundle) (string, error) {
 }
 
 func (f *Fetcher) maybeFetchImageFromRemote(db *distBundle, a *asc) (string, error) {
-	if !f.StoreOnly {
+	if f.PullPolicy != PullPolicyNever {
 		app := db.dist.(*dist.Appc).App()
 		nf := &nameFetcher{
 			InsecureFlags:      f.InsecureFlags,

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -64,7 +64,10 @@ func init() {
 	cmdPrepare.Flags().Var(&flagExplicitEnv, "set-env", "environment variable to set for all the apps in the form key=value, this will be overriden by --environment")
 	cmdPrepare.Flags().Var(&flagEnvFromFile, "set-env-file", "the path to an environment variables file")
 	cmdPrepare.Flags().BoolVar(&flagStoreOnly, "store-only", false, "use only available images in the store (do not discover or download from remote URLs)")
+	cmdPrepare.Flags().MarkDeprecated("store-only", "please use --pull-policy=never")
 	cmdPrepare.Flags().BoolVar(&flagNoStore, "no-store", false, "fetch images ignoring the local store")
+	cmdPrepare.Flags().MarkDeprecated("no-store", "please use --pull-policy=update")
+	cmdPrepare.Flags().StringVar(&flagPullPolicy, "pull-policy", image.PullPolicyNew, "when to pull an image")
 	cmdPrepare.Flags().StringVar(&flagPodManifest, "pod-manifest", "", "the path to the pod manifest. If it's non-empty, then only '--quiet' and '--no-overlay' will have effect")
 	cmdPrepare.Flags().Var((*appsVolume)(&rktApps), "volume", "volumes to make available in the pod")
 
@@ -94,6 +97,12 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		stderr.Print("both --store-only and --no-store specified")
 		return 254
 	}
+	if flagStoreOnly {
+		flagPullPolicy = image.PullPolicyNever
+	}
+	if flagNoStore {
+		flagPullPolicy = image.PullPolicyUpdate
+	}
 
 	if flagPrivateUsers {
 		if !common.SupportsUserNS() {
@@ -110,8 +119,9 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 
 	if len(flagPodManifest) > 0 && (rktApps.Count() > 0 ||
 		(*appsVolume)(&rktApps).String() != "" || (*appMount)(&rktApps).String() != "" ||
-		len(flagPorts) > 0 || flagStoreOnly || flagNoStore ||
-		flagInheritEnv || !flagExplicitEnv.IsEmpty() || !flagEnvFromFile.IsEmpty()) {
+		len(flagPorts) > 0 || flagPullPolicy == image.PullPolicyNever ||
+		flagPullPolicy == image.PullPolicyUpdate || flagInheritEnv ||
+		!flagExplicitEnv.IsEmpty() || !flagEnvFromFile.IsEmpty()) {
 		stderr.Print("conflicting flags set with --pod-manifest (see --help)")
 		return 254
 	}
@@ -155,9 +165,8 @@ func runPrepare(cmd *cobra.Command, args []string) (exit int) {
 		Debug:              globalFlags.Debug,
 		TrustKeysFromHTTPS: globalFlags.TrustKeysFromHTTPS,
 
-		StoreOnly: flagStoreOnly,
-		NoStore:   flagNoStore,
-		WithDeps:  true,
+		PullPolicy: flagPullPolicy,
+		WithDeps:   true,
 	}
 	if err := fn.FindImages(&rktApps); err != nil {
 		stderr.PrintE("error finding images", err)

--- a/rkt/stage1hash.go
+++ b/rkt/stage1hash.go
@@ -302,11 +302,12 @@ func getConfiguredStage1Hash(s *imagestore.Store, ts *treestore.Store, imgRef, i
 	}
 	fn := getStage1Finder(s, ts, !trusted)
 	if !strings.HasSuffix(imgRef, "-dirty") {
-		fn.StoreOnly = true
+		oldPolicy := fn.PullPolicy
+		fn.PullPolicy = image.PullPolicyNever
 		if hash, err := fn.FindImage(imgRef, ""); err == nil {
 			return hash, nil
 		}
-		fn.StoreOnly = false
+		fn.PullPolicy = oldPolicy
 	}
 	if imgLoc == "" && imgFileName == "" {
 		return nil, fmt.Errorf("neither the location of the default stage1 image nor its filename are set, use --stage1-{path,url,name,hash,from-dir} flag")
@@ -327,9 +328,8 @@ func getStage1Finder(s *imagestore.Store, ts *treestore.Store, withKeystore bool
 		InsecureFlags:      globalFlags.InsecureFlags,
 		TrustKeysFromHTTPS: globalFlags.TrustKeysFromHTTPS,
 
-		StoreOnly: false,
-		NoStore:   false,
-		WithDeps:  false,
+		PullPolicy: image.PullPolicyNew,
+		WithDeps:   false,
 	}
 
 	if withKeystore {

--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -119,9 +119,9 @@ func TestFetchAny(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		testFetchDefault(t, tt.args, tt.image, tt.imageArgs, tt.finalURL)
-		testFetchStoreOnly(t, tt.args, tt.image, tt.imageArgs, tt.finalURL)
-		testFetchNoStore(t, tt.args, tt.image, tt.imageArgs, tt.finalURL)
+		testFetchNew(t, tt.args, tt.image, tt.imageArgs, tt.finalURL)
+		testFetchNever(t, tt.args, tt.image, tt.imageArgs, tt.finalURL)
+		testFetchUpdate(t, tt.args, tt.image, tt.imageArgs, tt.finalURL)
 	}
 }
 
@@ -150,7 +150,7 @@ func TestFetchFullHash(t *testing.T) {
 	}
 }
 
-func testFetchDefault(t *testing.T, arg string, image string, imageArgs string, finalURL string) {
+func testFetchNew(t *testing.T, arg string, image string, imageArgs string, finalURL string) {
 	remoteFetchMsgTpl := `remote fetching from URL %q`
 	storeMsgTpl := `using image from local store for .* %s`
 	if finalURL == "" {
@@ -162,7 +162,7 @@ func testFetchDefault(t *testing.T, arg string, image string, imageArgs string, 
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	cmd := fmt.Sprintf("%s %s %s %s", ctx.Cmd(), arg, image, imageArgs)
+	cmd := fmt.Sprintf("%s --pull-policy=new %s %s %s", ctx.Cmd(), arg, image, imageArgs)
 
 	// 1. Run cmd with the image not available in the store, should get $remoteFetchMsg.
 	err := runRktAndCheckRegexOutput(t, cmd, remoteFetchMsg)
@@ -176,7 +176,7 @@ func testFetchDefault(t *testing.T, arg string, image string, imageArgs string, 
 	runRktAndCheckRegexOutput(t, cmd, storeMsg)
 }
 
-func testFetchStoreOnly(t *testing.T, args string, image string, imageArgs string, finalURL string) {
+func testFetchNever(t *testing.T, args string, image string, imageArgs string, finalURL string) {
 	cannotFetchMsgTpl := `unable to fetch.* image from .* %q`
 	storeMsgTpl := `using image from local store for .* %s`
 	cannotFetchMsg := fmt.Sprintf(cannotFetchMsgTpl, image)
@@ -185,7 +185,7 @@ func testFetchStoreOnly(t *testing.T, args string, image string, imageArgs strin
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	cmd := fmt.Sprintf("%s --store-only %s %s %s", ctx.Cmd(), args, image, imageArgs)
+	cmd := fmt.Sprintf("%s --pull-policy=never %s %s %s", ctx.Cmd(), args, image, imageArgs)
 
 	// 1. Run cmd with the image not available in the store should get $cannotFetchMsg.
 	runRktAndCheckRegexOutput(t, cmd, cannotFetchMsg)
@@ -198,7 +198,7 @@ func testFetchStoreOnly(t *testing.T, args string, image string, imageArgs strin
 	runRktAndCheckRegexOutput(t, cmd, storeMsg)
 }
 
-func testFetchNoStore(t *testing.T, args string, image string, imageArgs string, finalURL string) {
+func testFetchUpdate(t *testing.T, args string, image string, imageArgs string, finalURL string) {
 	remoteFetchMsgTpl := `remote fetching from URL %q`
 	remoteFetchMsg := fmt.Sprintf(remoteFetchMsgTpl, finalURL)
 
@@ -209,7 +209,7 @@ func testFetchNoStore(t *testing.T, args string, image string, imageArgs string,
 		t.Skip(fmt.Sprintf("%v, probably a network failure. Skipping...", err))
 	}
 
-	cmd := fmt.Sprintf("%s --no-store %s %s %s", ctx.Cmd(), args, image, imageArgs)
+	cmd := fmt.Sprintf("%s --pull-policy=update %s %s %s", ctx.Cmd(), args, image, imageArgs)
 
 	// 1. Run cmd with the image available in the store, should get $remoteFetchMsg.
 	err := runRktAndCheckRegexOutput(t, cmd, remoteFetchMsg)

--- a/tests/rkt_image_dependencies_test.go
+++ b/tests/rkt_image_dependencies_test.go
@@ -265,7 +265,7 @@ func TestRenderOnFetch(t *testing.T) {
 		}
 	}
 
-	fetchCmd := fmt.Sprintf("%s --debug --insecure-options=image,tls fetch %s", ctx.Cmd(), topImage)
+	fetchCmd := fmt.Sprintf("%s --debug --insecure-options=image,tls fetch --pull-policy=new %s", ctx.Cmd(), topImage)
 	child := spawnOrFail(t, fetchCmd)
 
 	treeStoreDir := filepath.Join(ctx.DataDir(), "cas", "tree")

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -234,13 +234,13 @@ func createFileOrPanic(dirName, fileName string) string {
 
 func importImageAndFetchHashAsGid(t *testing.T, ctx *testutils.RktRunCtx, img string, fetchArgs string, gid int) (string, error) {
 	// Import the test image into store manually.
-	cmd := fmt.Sprintf("%s --insecure-options=image,tls fetch %s %s", ctx.Cmd(), fetchArgs, img)
+	cmd := fmt.Sprintf("%s --insecure-options=image,tls fetch --pull-policy=new %s %s", ctx.Cmd(), fetchArgs, img)
 
 	// TODO(jonboulle): non-root user breaks trying to read root-written
 	// config directories. Should be a better way to approach this. Should
 	// config directories be readable by the rkt group too?
 	if gid != 0 {
-		cmd = fmt.Sprintf("%s --insecure-options=image,tls fetch %s %s", ctx.CmdNoConfig(), fetchArgs, img)
+		cmd = fmt.Sprintf("%s --insecure-options=image,tls fetch --pull-policy=new %s %s", ctx.CmdNoConfig(), fetchArgs, img)
 	}
 	child, err := gexpect.Command(cmd)
 	if err != nil {


### PR DESCRIPTION
This replaces the `--no-store` and `--store-only` flags with a singular
flag `--pull-policy` that can accept one of three things, `never`,
`new`, and `update`. This is purely a cli change, there are no under the
hood impacts. `--no-store` has been aliased to `--pull-policy=update`
and `--store-only` has been aliased to `--pull-policy=never` for
compatibility reasons.

These changes come from a discussion in https://github.com/coreos/rkt/issues/2937.