### PR TITLE
tests: fix when $HOME is only accessible by current user

### DIFF
--- a/tests/rkt_config_test.go
+++ b/tests/rkt_config_test.go
@@ -453,6 +453,7 @@ func TestConfig(t *testing.T) {
 			tt.configFunc(ctx)
 
 			rktCmd := ctx.Cmd() + " --debug --insecure-options=image --pretty-print=false config"
+			nobodyUid, _ := testutils.GetUnprivilegedUidGid()
 			out, status := runRkt(t, rktCmd, nobodyUid, 0)
 
 			if status != 0 {

--- a/tests/rkt_root_commands_test.go
+++ b/tests/rkt_root_commands_test.go
@@ -37,9 +37,12 @@ var rootRequiringCommands = []string{
 // user without them
 func TestCommandsNeedRoot(t *testing.T) {
 	ctx := testutils.NewRktRunCtx()
+
+	uid, gid := ctx.GetUidGidRktBinOwnerNotRoot()
+
 	defer ctx.Cleanup()
 	for _, sc := range rootRequiringCommands {
 		cmd := fmt.Sprintf("%s %s", ctx.Cmd(), sc)
-		runRktAsUidGidAndCheckOutput(t, cmd, "cannot run as unprivileged user", true, nobodyUid, nobodyGid)
+		runRktAsUidGidAndCheckOutput(t, cmd, "cannot run as unprivileged user", true, uid, gid)
 	}
 }

--- a/tests/testutils/ctx.go
+++ b/tests/testutils/ctx.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/coreos/gexpect"
 	"github.com/coreos/rkt/tests/testutils/logger"
@@ -218,6 +219,23 @@ func (ctx *RktRunCtx) rktBin() string {
 		abs = rkt
 	}
 	return abs
+}
+
+func (ctx *RktRunCtx) GetUidGidRktBinOwnerNotRoot() (int, int) {
+	s, err := os.Stat(ctx.rktBin())
+	if err != nil {
+		return GetUnprivilegedUidGid()
+	}
+
+	uid := int(s.Sys().(*syscall.Stat_t).Uid)
+	gid := int(s.Sys().(*syscall.Stat_t).Gid)
+
+	// If owner is root, fallback to user "nobody"
+	if uid == 0 {
+		return GetUnprivilegedUidGid()
+	}
+
+	return uid, gid
 }
 
 func (ctx *RktRunCtx) rktOptions() []string {

--- a/tests/testutils/utils.go
+++ b/tests/testutils/utils.go
@@ -21,6 +21,15 @@ import (
 	"time"
 )
 
+const (
+	nobodyUid = 65534
+	nobodyGid = 65534
+)
+
+func GetUnprivilegedUidGid() (int, int) {
+	return nobodyUid, nobodyGid
+}
+
 func GetValueFromEnvOrPanic(envVar string) string {
 	path := os.Getenv(envVar)
 	if path == "" {


### PR DESCRIPTION
Previously CommandsNeedRoot tested by executing rkt binary with user
"nobody". This fails when the ~/ folder of the user is only accessible
by the user itself. Now the test first chooses the owner of the rkt
binary file and if that is root it uses the "nobody" user as a fallback.

Fixes #1737