### PR TITLE
tests: remove gexpect from TestAppUserGroup

### DIFF
--- a/tests/rkt_run_user_group_test.go
+++ b/tests/rkt_run_user_group_test.go
@@ -118,7 +118,7 @@ func TestAppUserGroup(t *testing.T) {
 					image, tt.rktParams,
 					imageDummy,
 				)
-				runRktAndCheckOutput(t, rktCmd, tt.expected, false)
+				runRktAndCheckRegexOutput(t, rktCmd, tt.expected)
 
 				// run the user/group overridden app last
 				rktCmd = fmt.Sprintf(
@@ -128,7 +128,7 @@ func TestAppUserGroup(t *testing.T) {
 					imageDummy,
 					image, tt.rktParams,
 				)
-				runRktAndCheckOutput(t, rktCmd, tt.expected, false)
+				runRktAndCheckRegexOutput(t, rktCmd, tt.expected)
 			}
 		}()
 	}


### PR DESCRIPTION
TestAppUserGroup currently uses gexpect but does not need any
interactivity. This commit switches it away to use golang process
spawning and regexp matching.

Fixes https://github.com/coreos/rkt/issues/3560