### PR TITLE
Switch default kvm flavour from lkvm to qemu

### DIFF
--- a/Documentation/build-configure.md
+++ b/Documentation/build-configure.md
@@ -15,7 +15,7 @@ Note that specifying this parameter does not necessarily mean that rkt will use 
 Available flavors are:
 
 - `coreos` - it takes systemd and bash from a CoreOS PXE image; uses systemd-nspawn
-- `kvm` - it takes systemd, bash and other binaries from a CoreOS PXE image; uses lkvm
+- `kvm` - it takes systemd, bash and other binaries from a CoreOS PXE image; uses lkvm or qemu
 - `src` - it builds systemd, takes bash from the host at build time; uses built systemd-nspawn
 - `host` - it takes systemd and bash from host at runtime; uses systemd-nspawn from the host
 - `fly` - chroot-only approach for single-application minimal isolation containers; native Go implementation

--- a/Documentation/dependencies.md
+++ b/Documentation/dependencies.md
@@ -58,7 +58,7 @@ For the most part the codebase is self-contained (e.g. all dependencies are vend
   * bc
   * binutils
   * openssl
-* build dependencies for lkvm
+* build dependencies for lkvm and/or qemu
 
 ### Specific dependencies for the src flavor
 

--- a/Documentation/subcommands/stop.md
+++ b/Documentation/subcommands/stop.md
@@ -9,7 +9,7 @@ Given a list of pod UUIDs, rkt stop will shut them down, for the shipped stage1 
 The `--force` flag will stop a pod forcibly, that is:
 
 * default systemd-nspawn stage1: the container is killed.
-* kvm stage1: the lkvm process receives a KILL signal.
+* kvm stage1: the qemu or lkvm process receives a KILL signal.
 * rkt fly stage1: the app receives a KILL signal.
 
 ```

--- a/configure.ac
+++ b/configure.ac
@@ -124,9 +124,9 @@ AC_ARG_WITH([stage1-systemd-revision],
 # STAGE1 - kvm hypervisor. lkvm or/and qemu can be chosen
 AC_ARG_WITH([stage1-kvm-hypervisors],
             [AS_HELP_STRING([--with-stage1-kvm-hypervisors],
-                            [select hypervisors for kvm flavor; build stage1 aci for each of them. select "lkvm", "qemu" or both (default: 'lkvm')])],
+                            [select hypervisors for kvm flavor; build stage1 aci for each of them. select "lkvm", "qemu" or both (default: 'qemu')])],
             [RKT_STAGE1_KVM_HV="${withval}"],
-            [RKT_STAGE1_KVM_HV='lkvm'])
+            [RKT_STAGE1_KVM_HV='qemu'])
 
 ## STAGE1 - path to coreos pxe and its systemd version for kvm and coreos flavors
 


### PR DESCRIPTION
A private semaphoreCI run on this branch shows:

- No test failures (same as `lkvm`)
- The same number of test passes


