### PR TITLE
stage0/app-add: CLI args should override image ones

### DIFF
--- a/stage0/app_add.go
+++ b/stage0/app_add.go
@@ -162,7 +162,7 @@ func AddApp(cfg AddConfig) error {
 	}
 
 	if app.Args != nil {
-		ra.App.Exec = append(ra.App.Exec, app.Args...)
+		ra.App.Exec = append(ra.App.Exec[:1], app.Args...)
 	}
 
 	if app.WorkingDir != "" {


### PR DESCRIPTION
This commit uniforms app args and exec command, so that in both cases
CLI parameters always override image ones.