### PR TITLE
stage1/fly: evaluate symlinks in mount targets

### DIFF
--- a/tests/rkt_mount_test.go
+++ b/tests/rkt_mount_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build host coreos src
-
 package main
 
 import (
@@ -125,7 +123,7 @@ func TestMountSymlink(t *testing.T) {
 
 		// Read the actual file.
 		rktCmd := fmt.Sprintf(
-			"%s --insecure-options=image run %s --set-env=FILE=%s %s",
+			"%s --insecure-options=image --debug run %s --set-env=FILE=%s %s",
 			ctx.Cmd(), paramMount, tt.actualFile, image,
 		)
 		t.Logf("%s\n", rktCmd)


### PR DESCRIPTION
This PR fixes stage1-fly logic when performing bind-mounts. It was previously following symlinks outside of application rootfs, resulting in wrong mounts being performed.
It now uses the same logic introduced in https://github.com/coreos/rkt/pull/3490 for resolving symlinks inside chroot.

Fixes https://github.com/coreos/rkt/issues/3228