### PR TITLE
tests: Repair functional tests on semaphoreci

### DIFF
--- a/tests/rkt_non_root_test.go
+++ b/tests/rkt_non_root_test.go
@@ -84,7 +84,7 @@ func TestNonRootReadInfo(t *testing.T) {
 
 	imgListCmd := fmt.Sprintf("%s image list", ctx.Cmd())
 	t.Logf("Running %s", imgListCmd)
-	runRktAsUidGidAndCheckOutput(t, imgListCmd, "inspect-", false, uid, rktGid)
+	runRktAsUidGidAndCheckOutput(t, imgListCmd, "inspect-", false, false, uid, rktGid)
 }
 
 // TestNonRootFetchRmGCImage tests that non-root users can remove all images but


### PR DESCRIPTION
This patch repairs functional tests on semaphoreci after the
unsuccessful merge of the pull request (an argument was forgotten).