### PR TITLE
rkt 1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.25.0
+
+This minor release contains bugfixes and other improvements related to the KVM flavour, which is now using qemu-kvm by default.
+
+## New Features:
+- Switch default kvm flavour from lkvm to qemu ([#3562](https://github.com/coreos/rkt/pull/3562)).
+
+### Bug fixes
+- stage1/kvm: Change RAM calculation, and increase minimum ([#3572](https://github.com/coreos/rkt/pull/3572)).
+- stage1: Ensure ptmx device usable by non-root for all flavours ([#3484](https://github.com/coreos/rkt/pull/3484)).
+
+## Other changes:
+- tests: fix TestNonRootReadInfo when $HOME is only accessible by current user ([#3580](https://github.com/coreos/rkt/pull/3580)).
+- glide: bump grpc to 1.0.4 ([#3584](https://github.com/coreos/rkt/pull/3584)).
+- vendor: bump docker2aci to 0.16.0 ([#3591](https://github.com/coreos/rkt/pull/3591)).
+
 ## 1.24.0
 
 This release includes experimental support for attaching to a running application's input and output. It also introduces

--- a/Documentation/distributions.md
+++ b/Documentation/distributions.md
@@ -132,19 +132,19 @@ upgrade manually.
 ### rpm-based 
 ```
 gpg --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-wget https://github.com/coreos/rkt/releases/download/v1.24.0/rkt-1.24.0-1.x86_64.rpm
-wget https://github.com/coreos/rkt/releases/download/v1.24.0/rkt-1.24.0-1.x86_64.rpm.asc
-gpg --verify rkt-1.24.0-1.x86_64.rpm.asc
-sudo rpm -Uvh rkt-1.24.0-1.x86_64.rpm
+wget https://github.com/coreos/rkt/releases/download/v1.25.0/rkt-1.25.0-1.x86_64.rpm
+wget https://github.com/coreos/rkt/releases/download/v1.25.0/rkt-1.25.0-1.x86_64.rpm.asc
+gpg --verify rkt-1.25.0-1.x86_64.rpm.asc
+sudo rpm -Uvh rkt-1.25.0-1.x86_64.rpm
 ```
 
 ### deb-based
 ```
 gpg --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-wget https://github.com/coreos/rkt/releases/download/v1.24.0/rkt_1.24.0-1_amd64.deb
-wget https://github.com/coreos/rkt/releases/download/v1.24.0/rkt_1.24.0-1_amd64.deb.asc
-gpg --verify rkt_1.24.0-1_amd64.deb.asc
-sudo dpkg -i rkt_1.24.0-1_amd64.deb
+wget https://github.com/coreos/rkt/releases/download/v1.25.0/rkt_1.25.0-1_amd64.deb
+wget https://github.com/coreos/rkt/releases/download/v1.25.0/rkt_1.25.0-1_amd64.deb.asc
+gpg --verify rkt_1.25.0-1_amd64.deb.asc
+sudo dpkg -i rkt_1.25.0-1_amd64.deb
 ```
 
 [coreos-install-rkt]: install-rkt-in-coreos.md

--- a/Documentation/proposals/oci.md
+++ b/Documentation/proposals/oci.md
@@ -139,6 +139,6 @@ Backwards compatibility: Currently the biggest concern identified is backwards c
 [oci-algorithms]: https://github.com/opencontainers/image-spec/blob/v1.0.0-rc2/descriptor.md#algorithms
 [oci-image-layout]: https://github.com/opencontainers/image-spec/blob/v1.0.0-rc2/image-layout.md
 
-[app-container]: https://github.com/coreos/rkt/blob/v1.24.0/Documentation/app-container.md
-[image-lifecycle]: https://github.com/coreos/rkt/blob/v1.24.0/Documentation/devel/architecture.md#image-lifecycle
-[distribution-point]: https://github.com/coreos/rkt/blob/v1.24.0/Documentation/devel/distribution-point.md
+[app-container]: https://github.com/coreos/rkt/blob/v1.25.0/Documentation/app-container.md
+[image-lifecycle]: https://github.com/coreos/rkt/blob/v1.25.0/Documentation/devel/architecture.md#image-lifecycle
+[distribution-point]: https://github.com/coreos/rkt/blob/v1.25.0/Documentation/devel/distribution-point.md

--- a/Documentation/running-fly-stage1.md
+++ b/Documentation/running-fly-stage1.md
@@ -60,14 +60,14 @@ $ ./autogen.sh && ./configure --with-stage1-flavors=fly && make
 ```
 
 For more details about configure parameters, see the [configure script parameters documentation][build-configure].
-This will build the rkt binary and the stage1-fly.aci in `build-rkt-1.24.0+git/bin/`.
+This will build the rkt binary and the stage1-fly.aci in `build-rkt-1.25.0+git/bin/`.
 
 ### Selecting stage1 at runtime
 
 Here is a quick example of how to use a container with the official fly stage1:
 
 ```
-# rkt run --stage1-name=coreos.com/rkt/stage1-fly:1.24.0 coreos.com/etcd:v2.2.5
+# rkt run --stage1-name=coreos.com/rkt/stage1-fly:1.25.0 coreos.com/etcd:v2.2.5
 ```
 
 If the image is not in the store, `--stage1-name` will perform discovery and fetch the image.

--- a/Documentation/running-kvm-stage1.md
+++ b/Documentation/running-kvm-stage1.md
@@ -13,7 +13,7 @@ $ ./autogen.sh && ./configure --with-stage1-flavors=kvm --with-stage1-kvm-hyperv
 ```
 
 For more details about configure parameters, see [configure script parameters documentation][build-configure].
-This will build the rkt binary and the KVM stage1 aci image in `build-rkt-1.24.0+git/target/bin/`. Depending on the configuration options, it will be `stage1-kvm.aci` (if one hypervisor is set), or `stage1-kvm-lkvm.aci` and `stage1-kvm-qemu.aci` (if you want to have both images built once).
+This will build the rkt binary and the KVM stage1 aci image in `build-rkt-1.25.0+git/target/bin/`. Depending on the configuration options, it will be `stage1-kvm.aci` (if one hypervisor is set), or `stage1-kvm-lkvm.aci` and `stage1-kvm-qemu.aci` (if you want to have both images built once).
 
 Provided you have hardware virtualization support and the [kernel KVM module][kvm-module] loaded (refer to your distribution for instructions), you can then run an image like you would normally do with rkt:
 
@@ -84,7 +84,7 @@ If you want to run software that requires hypervisor isolation along with truste
 For example, to use the official kvm stage1:
 
 ```
-# rkt run --stage1-name=coreos.com/rkt/stage1-kvm:1.24.0 coreos.com/etcd:v2.0.9
+# rkt run --stage1-name=coreos.com/rkt/stage1-kvm:1.25.0 coreos.com/etcd:v2.0.9
 ...
 ```
 

--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -8,7 +8,7 @@ Support for overlay fs will be auto-detected if `--no-overlay` is set to `false`
 
 ```
 # rkt prepare --insecure-options=image docker://busybox --exec=/bin/sh
-image: using image from local store for image name coreos.com/rkt/stage1-coreos:1.24.0
+image: using image from local store for image name coreos.com/rkt/stage1-coreos:1.25.0
 image: remote fetching from URL "docker://busybox"
 Downloading sha256:8ddc19f1652 [===============================] 668 KB / 668 KB
 prepare: disabling overlay support: "unsupported filesystem: missing d_type support"
@@ -32,7 +32,7 @@ Therefore, the supported arguments are mostly the same as in `run` except runtim
 ```
 # rkt prepare coreos.com/etcd:v2.0.10
 rkt prepare coreos.com/etcd:v2.0.10
-rkt: using image from local store for image name coreos.com/rkt/stage1-coreos:1.24.0
+rkt: using image from local store for image name coreos.com/rkt/stage1-coreos:1.25.0
 rkt: searching for app image coreos.com/etcd:v2.0.10
 rkt: remote fetching from url https://github.com/coreos/etcd/releases/download/v2.0.10/etcd-v2.0.10-linux-amd64.aci
 prefix: "coreos.com/etcd"

--- a/Documentation/subcommands/version.md
+++ b/Documentation/subcommands/version.md
@@ -6,7 +6,7 @@ This command prints the rkt version, the appc version rkt is built against, and 
 
 ```
 $ rkt version
-rkt Version: 1.24.0
+rkt Version: 1.25.0
 appc Version: 0.8.10
 Go Version: go1.5.3
 Go OS/Arch: linux/amd64

--- a/Documentation/trying-out-rkt.md
+++ b/Documentation/trying-out-rkt.md
@@ -20,9 +20,9 @@ rkt is written in Go and can be compiled for several CPU architectures. The rkt 
 To start running the latest version of rkt on amd64, grab the release directly from the rkt GitHub project:
 
 ```
-wget https://github.com/coreos/rkt/releases/download/v1.24.0/rkt-v1.24.0.tar.gz
-tar xzvf rkt-v1.24.0.tar.gz
-cd rkt-v1.24.0
+wget https://github.com/coreos/rkt/releases/download/v1.25.0/rkt-v1.25.0.tar.gz
+tar xzvf rkt-v1.25.0.tar.gz
+cd rkt-v1.25.0
 ./rkt help
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,17 +12,6 @@ rkt's version 1.0 release marks the command line user interface and on-disk data
 - [OCI native support](https://github.com/coreos/rkt/projects/4): supporting OCI specs natively in rkt.
 - [appc phase-out](https://github.com/coreos/rkt/projects/5): following OCI evolution and stabilization, appc will be naturally deprecated and phased-out.
 
-## Next releases
-
-### rkt 1.25.0 (February)
-
-Up-to-date planning at https://github.com/coreos/rkt/milestone/59.
-
-### rkt 1.26.0 (February)
-
-Up-to-date planning at https://github.com/coreos/rkt/milestone/60.
-
-
 ### Upcoming
 
 Future tasks without a specific timeline are tracked at https://github.com/coreos/rkt/milestone/30.

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([rkt], [1.24.0+git], [https://github.com/coreos/rkt/issues])
+AC_INIT([rkt], [1.25.0], [https://github.com/coreos/rkt/issues])
 
 AC_PROG_CC
 AC_PROG_CXX

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([rkt], [1.25.0], [https://github.com/coreos/rkt/issues])
+AC_INIT([rkt], [1.25.0+git], [https://github.com/coreos/rkt/issues])
 
 AC_PROG_CC
 AC_PROG_CXX

--- a/scripts/install-rkt.sh
+++ b/scripts/install-rkt.sh
@@ -4,7 +4,7 @@ set -x
 
 cd $(mktemp -d)
 
-version="1.24.0"
+version="1.25.0"
 
 export DEBIAN_FRONTEND=noninteractive
 

--- a/tests/empty-image/manifest
+++ b/tests/empty-image/manifest
@@ -5,7 +5,7 @@
     "labels": [
         {
             "name": "version",
-            "value": "1.24.0"
+            "value": "1.25.0"
         },
         {
             "name": "arch",

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -5,7 +5,7 @@
     "labels": [
         {
             "name": "version",
-            "value": "1.24.0"
+            "value": "1.25.0"
         },
         {
             "name": "arch",

--- a/tests/rkt-monitor/build-stresser.sh
+++ b/tests/rkt-monitor/build-stresser.sh
@@ -27,7 +27,7 @@ buildImages() {
     acbuild --debug begin
     trap acbuildEnd EXIT
     acbuild --debug set-name appc.io/rkt-"${1}"-stresser
-    acbuild --debug copy build-rkt-1.25.0/target/bin/"${1}"-stresser /worker
+    acbuild --debug copy build-rkt-1.25.0+git/target/bin/"${1}"-stresser /worker
     acbuild --debug set-exec -- /worker
     acbuild --debug write --overwrite "${1}"-stresser.aci
     acbuild --debug end

--- a/tests/rkt-monitor/build-stresser.sh
+++ b/tests/rkt-monitor/build-stresser.sh
@@ -27,7 +27,7 @@ buildImages() {
     acbuild --debug begin
     trap acbuildEnd EXIT
     acbuild --debug set-name appc.io/rkt-"${1}"-stresser
-    acbuild --debug copy build-rkt-1.24.0+git/target/bin/"${1}"-stresser /worker
+    acbuild --debug copy build-rkt-1.25.0/target/bin/"${1}"-stresser /worker
     acbuild --debug set-exec -- /worker
     acbuild --debug write --overwrite "${1}"-stresser.aci
     acbuild --debug end

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -35,7 +35,7 @@ func TestRunOverrideExec(t *testing.T) {
 	noappManifest := schema.ImageManifest{
 		Name: "coreos.com/rkt-inspect",
 		Labels: types.Labels{
-			{"version", "1.24.0"},
+			{"version", "1.25.0"},
 			{"arch", "amd64"},
 			{"os", "linux"},
 		},

--- a/tests/rkt_image_cat_manifest_test.go
+++ b/tests/rkt_image_cat_manifest_test.go
@@ -46,7 +46,7 @@ func TestImageCatManifest(t *testing.T) {
 			},
 		},
 		Labels: types.Labels{
-			{"version", "1.24.0"},
+			{"version", "1.25.0"},
 			{"arch", "amd64"},
 			{"os", "linux"},
 		},

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -45,7 +45,7 @@ func TestImageExport(t *testing.T) {
 			},
 		},
 		Labels: types.Labels{
-			{"version", "1.24.0"},
+			{"version", "1.25.0"},
 			{"arch", "amd64"},
 			{"os", "linux"},
 		},

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -55,7 +55,7 @@ func TestImageRender(t *testing.T) {
 			{ImageName: "coreos.com/rkt-inspect"},
 		},
 		Labels: types.Labels{
-			{"version", "1.24.0"},
+			{"version", "1.25.0"},
 			{"arch", "amd64"},
 			{"os", "linux"},
 		},

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -58,7 +58,7 @@ func getMissingOrInvalidTests(t *testing.T, ctx *testutils.RktRunCtx) []osArchTe
 			WorkingDirectory: "/",
 		},
 		Labels: types.Labels{
-			{"version", "1.24.0"},
+			{"version", "1.25.0"},
 		},
 	}
 


### PR DESCRIPTION
## 1.25.0

This minor release contains bugfixes and other improvements related to the KVM flavour, which is now using qemu-kvm by default.

## New Features:
- Switch default kvm flavour from lkvm to qemu ([#3562](https://github.com/coreos/rkt/pull/3562)).

### Bug fixes
- stage1/kvm: Change RAM calculation, and increase minimum ([#3572](https://github.com/coreos/rkt/pull/3572)).
- stage1: Ensure ptmx device usable by non-root for all flavours ([#3484](https://github.com/coreos/rkt/pull/3484)).

## Other changes:
- tests: fix TestNonRootReadInfo when $HOME is only accessible by current user ([#3580](https://github.com/coreos/rkt/pull/3580)).
- glide: bump grpc to 1.0.4 ([#3584](https://github.com/coreos/rkt/pull/3584)).
- vendor: bump docker2aci to 0.16.0 ([#3591](https://github.com/coreos/rkt/pull/3591)).

