### PR TITLE
dist: use multi-user.target instead of default.target

### DIFF
--- a/dist/init/systemd/rkt-gc.timer
+++ b/dist/init/systemd/rkt-gc.timer
@@ -6,4 +6,4 @@ OnActiveSec=0s
 OnUnitActiveSec=12h
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target


### PR DESCRIPTION
The behavior of the default.target alias can be inconsistent and change
between systemd releases. Also it is customary to use multi-user.target
anyway. Switch to avoid potential surprise breakage.

Note: Container Linux isn't impacted since when this unit is enabled by
the ebuild it explicitly uses multi-user.target.

See https://github.com/coreos/coreos-overlay/pull/2484 for an example of default.target breaking.